### PR TITLE
fix: Adapt to nom-locate style

### DIFF
--- a/benchmarks/benches/arithmetic.rs
+++ b/benchmarks/benches/arithmetic.rs
@@ -5,6 +5,8 @@ extern crate criterion;
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use criterion::Criterion;
+use nom::input::IntoOutput;
+use nom::input::Located;
 use nom::{
   branch::alt,
   bytes::one_of,
@@ -16,7 +18,7 @@ use nom::{
 
 // Parser definition
 
-type Input<'i> = &'i [u8];
+type Input<'i> = Located<&'i [u8]>;
 
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.
@@ -70,14 +72,14 @@ fn arithmetic(c: &mut Criterion) {
   let data = b"  2*2 / ( 5 - 1) + 3 / 4 * (2 - 7 + 567 *12 /2) + 3*(1+2*( 45 /2));";
 
   assert_eq!(
-    expr(data),
+    expr(Located::new(data)).map(|(i, o)| (i.into_output(), o)),
     Ok((
       &b";"[..],
       2 * 2 / (5 - 1) + 3 / 4 * (2 - 7 + 567 * 12 / 2) + 3 * (1 + 2 * (45 / 2)),
     ))
   );
   c.bench_function("arithmetic", |b| {
-    b.iter(|| expr(data).unwrap());
+    b.iter(|| expr(Located::new(data)).unwrap());
   });
 }
 

--- a/benchmarks/benches/http.rs
+++ b/benchmarks/benches/http.rs
@@ -4,9 +4,10 @@
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use criterion::*;
+use nom::input::Located;
 use nom::{IResult, bytes::{tag, one_of, take_while1}, character::{line_ending}, multi::many1};
 
-type Input<'i> = &'i [u8];
+type Input<'i> = Located<&'i [u8]>;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[derive(Debug)]
@@ -113,7 +114,7 @@ fn request(input: Input<'_>) -> IResult<Input<'_>, (Request<'_>, Vec<Header<'_>>
 
 
 fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
-  let mut buf = &data[..];
+  let mut buf = Located::new(&data[..]);
   let mut v = Vec::new();
   loop {
     match request(buf) {

--- a/benchmarks/benches/ini.rs
+++ b/benchmarks/benches/ini.rs
@@ -3,6 +3,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use criterion::*;
 
+use nom::input::Located;
 use nom::{
   bytes::{one_of, take_while},
   character::{alphanumeric1 as alphanumeric, multispace1 as multispace, space1 as space},
@@ -14,7 +15,7 @@ use nom::{
 use std::collections::HashMap;
 use std::str;
 
-type Input<'i> = &'i [u8];
+type Input<'i> = Located<&'i [u8]>;
 
 fn category(i: Input<'_>) -> IResult<Input<'_>, &str> {
   delimited(one_of('['), take_while(|c| c != b']'), one_of(']'))
@@ -56,7 +57,7 @@ file=payroll.dat
   let mut group = c.benchmark_group("ini");
   group.throughput(Throughput::Bytes(str.len() as u64));
   group.bench_function(BenchmarkId::new("parse", str.len()), |b| {
-    b.iter(|| categories(str.as_bytes()).unwrap())
+    b.iter(|| categories(Located::new(str.as_bytes())).unwrap())
   });
 }
 
@@ -73,7 +74,7 @@ file=payroll.dat
   let mut group = c.benchmark_group("ini keys and values");
   group.throughput(Throughput::Bytes(str.len() as u64));
   group.bench_function(BenchmarkId::new("parse", str.len()), |b| {
-    b.iter(|| acc(str.as_bytes()).unwrap())
+    b.iter(|| acc(Located::new(str.as_bytes())).unwrap())
   });
 }
 
@@ -83,7 +84,7 @@ fn bench_ini_key_value(c: &mut Criterion) {
   let mut group = c.benchmark_group("ini key value");
   group.throughput(Throughput::Bytes(str.len() as u64));
   group.bench_function(BenchmarkId::new("parse", str.len()), |b| {
-    b.iter(|| key_value(str.as_bytes()).unwrap())
+    b.iter(|| key_value(Located::new(str.as_bytes())).unwrap())
   });
 }
 

--- a/benchmarks/benches/ini_str.rs
+++ b/benchmarks/benches/ini_str.rs
@@ -3,6 +3,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use criterion::*;
 
+use nom::input::Located;
 use nom::{
   bytes::{one_of, tag, take_till, take_while, take_while1},
   character::{alphanumeric1 as alphanumeric, not_line_ending, space0 as space},
@@ -14,7 +15,7 @@ use nom::{
 
 use std::collections::HashMap;
 
-type Input<'i> = &'i str;
+type Input<'i> = Located<&'i str>;
 
 fn is_line_ending_or_comment(chr: char) -> bool {
   chr == ';' || chr == '\n'
@@ -81,7 +82,7 @@ file=payroll.dat
   let mut group = c.benchmark_group("ini str");
   group.throughput(Throughput::Bytes(s.len() as u64));
   group.bench_function(BenchmarkId::new("parse", s.len()), |b| {
-    b.iter(|| categories(s).unwrap())
+    b.iter(|| categories(Located::new(s)).unwrap())
   });
 }
 

--- a/benchmarks/benches/json.rs
+++ b/benchmarks/benches/json.rs
@@ -5,6 +5,7 @@ extern crate criterion;
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use criterion::Criterion;
+use nom::input::Located;
 use nom::{
   branch::alt,
   bytes::{any, none_of, one_of, tag, take},
@@ -17,7 +18,7 @@ use nom::{
 
 use std::collections::HashMap;
 
-type Input<'i> = &'i str;
+type Input<'i> = Located<&'i str>;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum JsonValue {
@@ -147,7 +148,7 @@ fn json_bench(c: &mut Criterion) {
 
   // println!("data:\n{:?}", json(data));
   c.bench_function("json", |b| {
-    b.iter(|| json(data).unwrap());
+    b.iter(|| json(Located::new(data)).unwrap());
   });
 }
 


### PR DESCRIPTION
This builds on #63 to re-implement nom-locate

This took the json benchmark from  1.4362 µs (pori) to 1.9520 µs