### PR TITLE
fix!: Transition from `Parser::parse` to `Parser::parse_next`

### DIFF
--- a/benchmarks/benches/ini.rs
+++ b/benchmarks/benches/ini.rs
@@ -16,15 +16,15 @@ type Input<'i> = &'i [u8];
 fn category(i: Input<'_>) -> IResult<Input<'_>, &str> {
   delimited(one_of('['), take_while(|c| c != b']'), one_of(']'))
     .map_res(str::from_utf8)
-    .parse(i)
+    .parse_next(i)
 }
 
 fn key_value(i: Input<'_>) -> IResult<Input<'_>, (&str, &str)> {
-  let (i, key) = alphanumeric.map_res(str::from_utf8).parse(i)?;
-  let (i, _) = (opt(space), one_of('='), opt(space)).parse(i)?;
+  let (i, key) = alphanumeric.map_res(str::from_utf8).parse_next(i)?;
+  let (i, _) = (opt(space), one_of('='), opt(space)).parse_next(i)?;
   let (i, val) = take_while(|c| c != b'\n' && c != b';')
     .map_res(str::from_utf8)
-    .parse(i)?;
+    .parse_next(i)?;
   let (i, _) = opt((one_of(';'), take_while(|c| c != b'\n')))(i)?;
   Ok((i, (key, val)))
 }
@@ -36,7 +36,7 @@ fn categories(i: Input<'_>) -> IResult<Input<'_>, HashMap<&str, HashMap<&str, &s
     many0(terminated(key_value, opt(multispace))).map(|vec: Vec<_>| vec.into_iter().collect()),
   ))
   .map(|vec: Vec<_>| vec.into_iter().collect())
-  .parse(i)
+  .parse_next(i)
 }
 
 fn bench_ini(c: &mut Criterion) {

--- a/benchmarks/benches/ini_str.rs
+++ b/benchmarks/benches/ini_str.rs
@@ -30,7 +30,7 @@ fn category(i: Input<'_>) -> IResult<Input<'_>, &str> {
 
 fn key_value(i: Input<'_>) -> IResult<Input<'_>, (&str, &str)> {
   let (i, key) = alphanumeric(i)?;
-  let (i, _) = (opt(space), tag("="), opt(space)).parse(i)?;
+  let (i, _) = (opt(space), tag("="), opt(space)).parse_next(i)?;
   let (i, val) = take_till(is_line_ending_or_comment)(i)?;
   let (i, _) = opt(space)(i)?;
   let (i, _) = opt((tag(";"), not_line_ending))(i)?;
@@ -50,7 +50,7 @@ fn keys_and_values(input: Input<'_>) -> IResult<Input<'_>, HashMap<&str, &str>> 
 }
 
 fn category_and_keys(i: Input<'_>) -> IResult<Input<'_>, (&str, HashMap<&str, &str>)> {
-  (category, keys_and_values).parse(i)
+  (category, keys_and_values).parse_next(i)
 }
 
 #[allow(clippy::type_complexity)]

--- a/benchmarks/benches/json.rs
+++ b/benchmarks/benches/json.rs
@@ -33,7 +33,7 @@ fn boolean(input: Input<'_>) -> IResult<Input<'_>, bool> {
 fn u16_hex(input: Input<'_>) -> IResult<Input<'_>, u16> {
   take(4usize)
     .map_res(|s| u16::from_str_radix(s, 16))
-    .parse(input)
+    .parse_next(input)
 }
 
 fn unicode_escape(input: Input<'_>) -> IResult<Input<'_>, char> {
@@ -55,7 +55,7 @@ fn unicode_escape(input: Input<'_>) -> IResult<Input<'_>, char> {
     // Could probably be replaced with .unwrap() or _unchecked due to the verify checks
     std::char::from_u32,
   )
-  .parse(input)
+  .parse_next(input)
 }
 
 fn character(input: Input<'_>) -> IResult<Input<'_>, char> {
@@ -115,7 +115,7 @@ fn object(input: Input<'_>) -> IResult<Input<'_>, HashMap<String, JsonValue>> {
     one_of('}'),
   )
   .map(|key_values| key_values.into_iter().collect())
-  .parse(input)
+  .parse_next(input)
 }
 
 fn json_value(input: Input<'_>) -> IResult<Input<'_>, JsonValue> {
@@ -132,7 +132,7 @@ fn json_value(input: Input<'_>) -> IResult<Input<'_>, JsonValue> {
 }
 
 fn json(input: Input<'_>) -> IResult<Input<'_>, JsonValue> {
-  ws(json_value).parse(input)
+  ws(json_value).parse_next(input)
 }
 
 fn json_bench(c: &mut Criterion) {

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -78,7 +78,7 @@ fn boolean<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, bool,
 }
 
 fn null<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, (), E> {
-  tag("null").value(()).parse(input)
+  tag("null").value(()).parse_next(input)
 }
 
 /// this parser combines the previous `parse_str` parser, that recognizes the
@@ -97,7 +97,7 @@ fn string<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
 ) -> IResult<&'a str, &'a str, E> {
   preceded('\"', cut(terminated(parse_str, '\"')))
     .context("string")
-    .parse(i)
+    .parse_next(i)
 }
 
 /// some combinators, like `separated_list0` or `many0`, will call a parser repeatedly,
@@ -115,7 +115,7 @@ fn array<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
     )),
   )
   .context("array")
-  .parse(i)
+  .parse_next(i)
 }
 
 fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
@@ -140,7 +140,7 @@ fn hash<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
     )),
   )
   .context("map")
-  .parse(i)
+  .parse_next(i)
 }
 
 /// here, we apply the space parser before trying to parse a value

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -217,7 +217,7 @@ fn parse_str<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str
 fn string(i: &str) -> IResult<&str, &str> {
   preceded('\"', cut(terminated(parse_str, '\"')))
     .context("string")
-    .parse(i)
+    .parse_next(i)
 }
 
 fn boolean(input: &str) -> IResult<&str, bool> {
@@ -233,7 +233,7 @@ fn array(i: &str) -> IResult<&str, ()> {
     )),
   )
   .context("array")
-  .parse(i)
+  .parse_next(i)
 }
 
 fn key_value(i: &str) -> IResult<&str, (&str, ())> {
@@ -249,7 +249,7 @@ fn hash(i: &str) -> IResult<&str, ()> {
     )),
   )
   .context("map")
-  .parse(i)
+  .parse_next(i)
 }
 
 fn value(i: &str) -> IResult<&str, ()> {

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -114,7 +114,7 @@ fn parse_keyword(i: &str) -> IResult<&str, Atom, VerboseError<&str>> {
   preceded(":", cut(alpha1))
     .context("keyword")
     .map(|sym_str: &str| Atom::Keyword(sym_str.to_string()))
-    .parse(i)
+    .parse_next(i)
 }
 
 /// Next up is number parsing. We're keeping it simple here by accepting any number (> 1)
@@ -139,7 +139,7 @@ fn parse_atom(i: &str) -> IResult<&str, Atom, VerboseError<&str>> {
 
 /// We then add the Expr layer on top
 fn parse_constant(i: &str) -> IResult<&str, Expr, VerboseError<&str>> {
-  parse_atom.map(Expr::Constant).parse(i)
+  parse_atom.map(Expr::Constant).parse_next(i)
 }
 
 /// Before continuing, we need a helper function to parse lists.
@@ -217,7 +217,7 @@ fn parse_quote(i: &str) -> IResult<&str, Expr, VerboseError<&str>> {
   preceded("'", cut(s_exp(many0(parse_expr))))
     .context("quote")
     .map(Expr::Quote)
-    .parse(i)
+    .parse_next(i)
 }
 
 /// We tie them all together again, making a top-level expression parser!

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -54,7 +54,7 @@ where
   // the function returns None, map_opt returns an error. In this case, because
   // not all u32 values are valid unicode code points, we have to fallibly
   // convert to char with from_u32.
-  parse_u32.map_opt(std::char::from_u32).parse(input)
+  parse_u32.map_opt(std::char::from_u32).parse_next(input)
 }
 
 /// Parse an escaped character: \n, \t, \r, \u{00AC}, etc.
@@ -102,7 +102,9 @@ fn parse_literal<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str,
   // the parser. The verification function accepts out output only if it
   // returns true. In this case, we want to ensure that the output of take_till1
   // is non-empty.
-  not_quote_slash.verify(|s: &str| !s.is_empty()).parse(input)
+  not_quote_slash
+    .verify(|s: &str| !s.is_empty())
+    .parse_next(input)
 }
 
 /// A string fragment contains a fragment of a string being parsed: either

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -70,7 +70,7 @@
 //! {
 //!   pair('%', take_till1("\n\r"))
 //!     .value(()) // Output is thrown away.
-//!     .parse(i)
+//!     .parse_next(i)
 //! }
 //! ```
 //!
@@ -93,7 +93,7 @@
 //!     "*)"
 //!   )
 //!     .value(()) // Output is thrown away.
-//!     .parse(i)
+//!     .parse_next(i)
 //! }
 //! ```
 //!
@@ -120,7 +120,7 @@
 //!     many0_count(alt((alphanumeric1, "_")))
 //!   )
 //!      .recognize()
-//!      .parse(input)
+//!      .parse_next(input)
 //! }
 //! ```
 //!
@@ -194,7 +194,7 @@
 //!     ).recognize()
 //!   ).map_res(
 //!     |out: &str| i64::from_str_radix(&str::replace(&out, "_", ""), 16)
-//!   ).parse(input)
+//!   ).parse_next(input)
 //! }
 //! ```
 //!
@@ -258,7 +258,7 @@
 //!     terminated(one_of("0123456789"), many0('_'))
 //!   )
 //!     .recognize()
-//!     .parse(input)
+//!     .parse_next(input)
 //! }
 //! ```
 //!
@@ -313,7 +313,7 @@
 //!     terminated(one_of("0123456789"), many0('_'))
 //!   )
 //!     .recognize()
-//!     .parse(input)
+//!     .parse_next(input)
 //! }
 //! ```
 //!

--- a/src/_tutorial.rs
+++ b/src/_tutorial.rs
@@ -128,7 +128,7 @@
 //!
 //!   // A tuple of parsers will evaluate each parser sequentally and return a tuple of the results
 //!   let (input, (method, _, url, _, version, _)) =
-//!     (method, &space, url, &space, http_version, line_ending).parse(i)?;
+//!     (method, &space, url, &space, http_version, line_ending).parse_next(i)?;
 //!
 //!   Ok((input, Request { method, url, version }))
 //! }
@@ -203,7 +203,7 @@
 //! use winnow::bytes::tag;
 //!
 //! fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!   tag("abcd").dbg_err("tag").parse(i)
+//!   tag("abcd").dbg_err("tag").parse_next(i)
 //! }
 //!
 //! let a = &b"efghijkl"[..];

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -45,7 +45,7 @@ where
   I: Slice<RangeFrom<usize>>,
   P: Parser<(I, usize), O, E1>,
 {
-  move |input: I| match parser.parse((input, 0)) {
+  move |input: I| match parser.parse_next((input, 0)) {
     Ok(((rest, offset), result)) => {
       // If the next byte has been partially read, it will be sliced away as well.
       // The parser functions might already slice away all fully read bytes.
@@ -97,7 +97,7 @@ where
       input.slice((offset / 8)..)
     };
     let i = (input, offset);
-    match parser.parse(inner) {
+    match parser.parse_next(inner) {
       Ok((rest, res)) => Ok(((rest, 0), res)),
       Err(Err::Incomplete(Needed::Unknown)) => Err(Err::Incomplete(Needed::Unknown)),
       Err(Err::Incomplete(Needed::Size(sz))) => Err(match sz.get().checked_mul(8) {

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -132,7 +132,7 @@ macro_rules! alt_trait_impl(
     > Alt<Input, Output, Error> for ( $($id),+ ) {
 
       fn choice(&mut self, input: Input) -> IResult<Input, Output, Error> {
-        match self.0.parse(input.clone()) {
+        match self.0.parse_next(input.clone()) {
           Err(Err::Error(e)) => alt_trait_inner!(1, self, input, e, $($id)+),
           res => res,
         }
@@ -143,7 +143,7 @@ macro_rules! alt_trait_impl(
 
 macro_rules! alt_trait_inner(
   ($it:tt, $self:expr, $input:expr, $err:expr, $head:ident $($id:ident)+) => (
-    match $self.$it.parse($input.clone()) {
+    match $self.$it.parse_next($input.clone()) {
       Err(Err::Error(e)) => {
         let err = $err.or(e);
         succ!($it, alt_trait_inner!($self, $input, err, $($id)+))
@@ -163,7 +163,7 @@ impl<Input, Output, Error: ParseError<Input>, A: Parser<Input, Output, Error>>
   Alt<Input, Output, Error> for (A,)
 {
   fn choice(&mut self, input: Input) -> IResult<Input, Output, Error> {
-    self.0.parse(input)
+    self.0.parse_next(input)
   }
 }
 
@@ -222,7 +222,7 @@ macro_rules! permutation_trait_impl(
 macro_rules! permutation_trait_inner(
   ($it:tt, $self:expr, $input:ident, $res:expr, $err:expr, $head:ident $($id:ident)*) => (
     if $res.$it.is_none() {
-      match $self.$it.parse($input.clone()) {
+      match $self.$it.parse_next($input.clone()) {
         Ok((i, o)) => {
           $input = i;
           $res.$it = Some(o);

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -792,7 +792,7 @@ where
   while i.input_len() > 0 {
     let current_len = i.input_len();
 
-    match normal.parse(i.clone()) {
+    match normal.parse_next(i.clone()) {
       Ok((i2, _)) => {
         // return if we consumed everything or if the normal parser
         // does not consume anything
@@ -815,7 +815,7 @@ where
               ErrorKind::Escaped,
             )));
           } else {
-            match escapable.parse(i.slice(next..)) {
+            match escapable.parse_next(i.slice(next..)) {
               Ok((i2, _)) => {
                 if i2.input_len() == 0 {
                   return Ok((input.slice(input.input_len()..), input)).into_output();
@@ -941,7 +941,7 @@ where
   while index < i.input_len() {
     let current_len = i.input_len();
     let remainder = i.slice(index..);
-    match normal.parse(remainder.clone()) {
+    match normal.parse_next(remainder.clone()) {
       Ok((i2, o)) => {
         o.extend_into(&mut res);
         if i2.input_len() == 0 {
@@ -964,7 +964,7 @@ where
               ErrorKind::EscapedTransform,
             )));
           } else {
-            match transform.parse(i.slice(next..)) {
+            match transform.parse_next(i.slice(next..)) {
               Ok((i2, o)) => {
                 o.extend_into(&mut res);
                 if i2.input_len() == 0 {

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -845,7 +845,7 @@ where
   while i.input_len() > 0 {
     let current_len = i.input_len();
 
-    match normal.parse(i.clone()) {
+    match normal.parse_next(i.clone()) {
       Ok((i2, _)) => {
         if i2.input_len() == 0 {
           return Err(Err::Incomplete(Needed::Unknown));
@@ -863,7 +863,7 @@ where
           if next >= i.input_len() {
             return Err(Err::Incomplete(Needed::new(1)));
           } else {
-            match escapable.parse(i.slice(next..)) {
+            match escapable.parse_next(i.slice(next..)) {
               Ok((i2, _)) => {
                 if i2.input_len() == 0 {
                   return Err(Err::Incomplete(Needed::Unknown));
@@ -982,7 +982,7 @@ where
   while index < i.input_len() {
     let current_len = i.input_len();
     let remainder = i.slice(index..);
-    match normal.parse(remainder.clone()) {
+    match normal.parse_next(remainder.clone()) {
       Ok((i2, o)) => {
         o.extend_into(&mut res);
         if i2.input_len() == 0 {
@@ -1002,7 +1002,7 @@ where
           if next >= input_len {
             return Err(Err::Incomplete(Needed::Unknown));
           } else {
-            match transform.parse(i.slice(next..)) {
+            match transform.parse_next(i.slice(next..)) {
               Ok((i2, o)) => {
                 o.extend_into(&mut res);
                 if i2.input_len() == 0 {

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -151,7 +151,7 @@ fn complete_escape_transform() {
       )),
     )
     .map(to_s)
-    .parse(i)
+    .parse_next(i)
   }
 
   assert_eq!(esc(&b"abcd;"[..]), Ok((&b";"[..], String::from("abcd"))));
@@ -194,7 +194,7 @@ fn complete_escape_transform() {
       )),
     )
     .map(to_s)
-    .parse(i)
+    .parse_next(i)
   }
   assert_eq!(
     esc2(&b"ab&egrave;DEF;"[..]),
@@ -434,7 +434,7 @@ fn streaming_recognize() {
   fn x(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     delimited(tag("<!--"), take(5_usize), tag("-->"))
       .recognize()
-      .parse(i)
+      .parse_next(i)
   }
   let r = x(Streaming(&b"<!-- abc --> aaa"[..]));
   assert_eq!(r, Ok((Streaming(&b" aaa"[..]), &b"<!-- abc -->"[..])));
@@ -442,43 +442,43 @@ fn streaming_recognize() {
   let semicolon = &b";"[..];
 
   fn ya(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    alpha.recognize().parse(i)
+    alpha.recognize().parse_next(i)
   }
   let ra = ya(Streaming(&b"abc;"[..]));
   assert_eq!(ra, Ok((Streaming(semicolon), &b"abc"[..])));
 
   fn yd(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    digit.recognize().parse(i)
+    digit.recognize().parse_next(i)
   }
   let rd = yd(Streaming(&b"123;"[..]));
   assert_eq!(rd, Ok((Streaming(semicolon), &b"123"[..])));
 
   fn yhd(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    hex_digit.recognize().parse(i)
+    hex_digit.recognize().parse_next(i)
   }
   let rhd = yhd(Streaming(&b"123abcDEF;"[..]));
   assert_eq!(rhd, Ok((Streaming(semicolon), &b"123abcDEF"[..])));
 
   fn yod(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    oct_digit.recognize().parse(i)
+    oct_digit.recognize().parse_next(i)
   }
   let rod = yod(Streaming(&b"1234567;"[..]));
   assert_eq!(rod, Ok((Streaming(semicolon), &b"1234567"[..])));
 
   fn yan(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    alphanumeric.recognize().parse(i)
+    alphanumeric.recognize().parse_next(i)
   }
   let ran = yan(Streaming(&b"123abc;"[..]));
   assert_eq!(ran, Ok((Streaming(semicolon), &b"123abc"[..])));
 
   fn ys(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    space.recognize().parse(i)
+    space.recognize().parse_next(i)
   }
   let rs = ys(Streaming(&b" \t;"[..]));
   assert_eq!(rs, Ok((Streaming(semicolon), &b" \t"[..])));
 
   fn yms(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    multispace.recognize().parse(i)
+    multispace.recognize().parse_next(i)
   }
   let rms = yms(Streaming(&b" \t\r\n;"[..]));
   assert_eq!(rms, Ok((Streaming(semicolon), &b" \t\r\n"[..])));
@@ -672,7 +672,7 @@ fn streaming_recognize_take_while() {
     take_while(AsChar::is_alphanum)(i)
   }
   fn y(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
-    x.recognize().parse(i)
+    x.recognize().parse_next(i)
   }
   assert_eq!(
     x(Streaming(&b"ab."[..])),

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -420,7 +420,7 @@ where
 /// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed, Parser};
 /// # use winnow::character::digit1;
 /// fn parser(input: &str) -> IResult<&str, u32> {
-///   digit1.map_res(str::parse).parse(input)
+///   digit1.map_res(str::parse).parse_next(input)
 /// }
 ///
 /// assert_eq!(parser("416"), Ok(("", 416)));

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -218,7 +218,7 @@ impl<'p, P> ByRef<'p, P> {
 }
 
 impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P> {
-  fn parse(&mut self, i: I) -> IResult<I, O, E> {
+  fn parse_next(&mut self, i: I) -> IResult<I, O, E> {
     self.p.parse(i)
   }
 }
@@ -273,7 +273,7 @@ impl<F, G, O1> Map<F, G, O1> {
 }
 
 impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> for Map<F, G, O1> {
-  fn parse(&mut self, i: I) -> IResult<I, O2, E> {
+  fn parse_next(&mut self, i: I) -> IResult<I, O2, E> {
     match self.f.parse(i) {
       Err(e) => Err(e),
       Ok((i, o)) => Ok((i, (self.g)(o))),
@@ -347,7 +347,7 @@ where
   G: FnMut(O1) -> Result<O2, E2>,
   E: FromExternalError<I, E2>,
 {
-  fn parse(&mut self, input: I) -> IResult<I, O2, E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, O2, E> {
     let i = input.clone();
     let (input, o1) = self.f.parse(input)?;
     match (self.g)(o1) {
@@ -423,7 +423,7 @@ where
   G: FnMut(O1) -> Option<O2>,
   E: ParseError<I>,
 {
-  fn parse(&mut self, input: I) -> IResult<I, O2, E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, O2, E> {
     let i = input.clone();
     let (input, o1) = self.f.parse(input)?;
     match (self.g)(o1) {
@@ -488,7 +488,7 @@ impl<F, G, O1> AndThen<F, G, O1> {
 impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, E>
   for AndThen<F, G, O1>
 {
-  fn parse(&mut self, i: I) -> IResult<I, O2, E> {
+  fn parse_next(&mut self, i: I) -> IResult<I, O2, E> {
     let (i, o1) = self.f.parse(i)?;
     let (_, o2) = self.g.parse(o1)?;
     Ok((i, o2))
@@ -549,7 +549,7 @@ impl<F, G, O1> FlatMap<F, G, O1> {
 impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> H, H: Parser<I, O2, E>> Parser<I, O2, E>
   for FlatMap<F, G, O1>
 {
-  fn parse(&mut self, i: I) -> IResult<I, O2, E> {
+  fn parse_next(&mut self, i: I) -> IResult<I, O2, E> {
     let (i, o1) = self.f.parse(i)?;
     (self.g)(o1).parse(i)
   }
@@ -601,7 +601,7 @@ impl<F, G> And<F, G> {
 }
 
 impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<I, O2, E>> Parser<I, (O1, O2), E> for And<F, G> {
-  fn parse(&mut self, i: I) -> IResult<I, (O1, O2), E> {
+  fn parse_next(&mut self, i: I) -> IResult<I, (O1, O2), E> {
     let (i, o1) = self.f.parse(i)?;
     let (i, o2) = self.g.parse(i)?;
     Ok((i, (o1, o2)))
@@ -624,7 +624,7 @@ impl<F, G> Or<F, G> {
 impl<I: Clone, O, E: crate::error::ParseError<I>, F: Parser<I, O, E>, G: Parser<I, O, E>>
   Parser<I, O, E> for Or<F, G>
 {
-  fn parse(&mut self, i: I) -> IResult<I, O, E> {
+  fn parse_next(&mut self, i: I) -> IResult<I, O, E> {
     match self.f.parse(i.clone()) {
       Err(Err::Error(e1)) => match self.g.parse(i) {
         Err(Err::Error(e2)) => Err(Err::Error(e1.or(e2))),
@@ -777,7 +777,7 @@ where
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
-  fn parse(&mut self, input: I) -> IResult<I, O, E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, O, E> {
     let i = input.clone();
     match (self.f).parse(input) {
       Err(Err::Incomplete(_)) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Complete))),
@@ -886,7 +886,7 @@ where
   O1: Borrow<O2>,
   O2: ?Sized,
 {
-  fn parse(&mut self, input: I) -> IResult<I, O1, E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, O1, E> {
     let i = input.clone();
     let (input, o) = (self.first).parse(input)?;
 
@@ -946,7 +946,7 @@ impl<F, O1, O2> Value<F, O1, O2> {
 impl<I, O1, O2: Clone, E: ParseError<I>, F: Parser<I, O1, E>> Parser<I, O2, E>
   for Value<F, O1, O2>
 {
-  fn parse(&mut self, input: I) -> IResult<I, O2, E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, O2, E> {
     (self.parser)
       .parse(input)
       .map(|(i, _)| (i, self.val.clone()))
@@ -1046,7 +1046,7 @@ where
   E: ParseError<I>,
   F: Parser<I, O, E>,
 {
-  fn parse(&mut self, input: I) -> IResult<I, <I as IntoOutput>::Output, E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, <I as IntoOutput>::Output, E> {
     let i = input.clone();
     match (self.parser).parse(i) {
       Ok((i, _)) => {
@@ -1149,7 +1149,7 @@ where
   E: ParseError<I>,
   F: Parser<I, O, E>,
 {
-  fn parse(&mut self, input: I) -> IResult<I, (O, <I as IntoOutput>::Output), E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, (O, <I as IntoOutput>::Output), E> {
     let i = input.clone();
     match (self.parser).parse(i) {
       Ok((remaining, result)) => {
@@ -1184,7 +1184,7 @@ where
   E: ParseError<I>,
   F: Parser<I, O, E>,
 {
-  fn parse(&mut self, input: I) -> IResult<I, Range<usize>, E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, Range<usize>, E> {
     let start = input.location();
     self.parser.parse(input).map(move |(remaining, _)| {
       let end = remaining.location();
@@ -1215,7 +1215,7 @@ where
   E: ParseError<I>,
   F: Parser<I, O, E>,
 {
-  fn parse(&mut self, input: I) -> IResult<I, (O, Range<usize>), E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, (O, Range<usize>), E> {
     let start = input.location();
     self.parser.parse(input).map(move |(remaining, output)| {
       let end = remaining.location();
@@ -1353,7 +1353,7 @@ impl<F, O1, O2: From<O1>> OutputInto<F, O1, O2> {
 impl<I: Clone, O1, O2: From<O1>, E, F: Parser<I, O1, E>> Parser<I, O2, E>
   for OutputInto<F, O1, O2>
 {
-  fn parse(&mut self, i: I) -> IResult<I, O2, E> {
+  fn parse_next(&mut self, i: I) -> IResult<I, O2, E> {
     match self.f.parse(i) {
       Ok((i, o)) => Ok((i, o.into())),
       Err(err) => Err(err),
@@ -1382,7 +1382,7 @@ impl<F, E1, E2: From<E1>> ErrInto<F, E1, E2> {
 impl<I: Clone, O, E1, E2: crate::error::ParseError<I> + From<E1>, F: Parser<I, O, E1>>
   Parser<I, O, E2> for ErrInto<F, E1, E2>
 {
-  fn parse(&mut self, i: I) -> IResult<I, O, E2> {
+  fn parse_next(&mut self, i: I) -> IResult<I, O, E2> {
     match self.f.parse(i) {
       Ok(ok) => Ok(ok),
       Err(Err::Error(e)) => Err(Err::Error(e.into())),

--- a/src/error.rs
+++ b/src/error.rs
@@ -453,7 +453,7 @@
 //! use winnow::prelude::*;
 //! # use winnow::bytes::tag;
 //! fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-//!     tag("abcd").dbg_err("tag").parse(i)
+//!     tag("abcd").dbg_err("tag").parse_next(i)
 //! }
 //!
 //! let a = &b"efghijkl"[..];
@@ -750,7 +750,7 @@ pub fn context<I: Clone, E: ContextError<I, &'static str>, F, O>(
 where
   F: Parser<I, O, E>,
 {
-  move |i: I| match f.parse(i.clone()) {
+  move |i: I| match f.parse_next(i.clone()) {
     Ok(o) => Ok(o),
     Err(Err::Incomplete(i)) => Err(Err::Incomplete(i)),
     Err(Err::Error(e)) => Err(Err::Error(E::add_context(i, context, e))),
@@ -784,7 +784,7 @@ where
   F: Parser<I, O, E>,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, O, E> {
-    match (self.f).parse(i.clone()) {
+    match (self.f).parse_next(i.clone()) {
       Ok(o) => Ok(o),
       Err(Err::Incomplete(i)) => Err(Err::Incomplete(i)),
       Err(Err::Error(e)) => Err(Err::Error(E::add_context(i, self.context.clone(), e))),
@@ -1089,7 +1089,7 @@ where
   fn parse_next(&mut self, input: I) -> IResult<I, O, E> {
     use crate::input::HexDisplay;
     let i = input.clone();
-    match self.f.parse(i) {
+    match self.f.parse_next(i) {
       Err(e) => {
         let input = input.as_bytes();
         eprintln!("{}: Error({:?}) at:\n{}", self.context, e, input.to_hex(8));

--- a/src/error.rs
+++ b/src/error.rs
@@ -783,7 +783,7 @@ where
   E: ContextError<I, C>,
   F: Parser<I, O, E>,
 {
-  fn parse(&mut self, i: I) -> IResult<I, O, E> {
+  fn parse_next(&mut self, i: I) -> IResult<I, O, E> {
     match (self.f).parse(i.clone()) {
       Ok(o) => Ok(o),
       Err(Err::Incomplete(i)) => Err(Err::Incomplete(i)),
@@ -1086,7 +1086,7 @@ where
   F: Parser<I, O, E>,
   C: std::fmt::Display,
 {
-  fn parse(&mut self, input: I) -> IResult<I, O, E> {
+  fn parse_next(&mut self, input: I) -> IResult<I, O, E> {
     use crate::input::HexDisplay;
     let i = input.clone();
     match self.f.parse(i) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -147,7 +147,7 @@ impl<I> crate::lib::std::ops::Deref for Located<I> {
 /// let data = "Hello";
 /// let state = Cell::new(0);
 /// let input = Input { input: data, state: State(&state) };
-/// let output = word.parse(input).finish().unwrap();
+/// let output = word.parse_next(input).finish().unwrap();
 /// assert_eq!(state.get(), 1);
 /// ```
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1973,7 +1973,7 @@ impl<'a, const LEN: usize> Compare<[u8; LEN]> for &'a [u8] {
 /// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::bytes::take_while1;
 /// fn hex_digit1(input: &str) -> IResult<&str, &str> {
-///     take_while1(('a'..='f', 'A'..='F', '0'..='9')).parse(input)
+///     take_while1(('a'..='f', 'A'..='F', '0'..='9')).parse_next(input)
 /// }
 ///
 /// assert_eq!(hex_digit1("21cZ"), Ok(("Z", "21c")));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,12 @@
 //! }
 //!
 //! fn hex_primary(input: &str) -> IResult<&str, u8> {
-//!   take_while_m_n(2, 2, is_hex_digit).map_res(from_hex).parse(input)
+//!   take_while_m_n(2, 2, is_hex_digit).map_res(from_hex).parse_next(input)
 //! }
 //!
 //! fn hex_color(input: &str) -> IResult<&str, Color> {
 //!   let (input, _) = tag("#")(input)?;
-//!   let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse(input)?;
+//!   let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse_next(input)?;
 //!
 //!   Ok((input, Color { red, green, blue }))
 //! }
@@ -268,15 +268,15 @@
 //! let mut tpl = (be_u16, take(3u8), tag("fg"));
 //!
 //! assert_eq!(
-//!   tpl.parse(Streaming(&b"abcdefgh"[..])),
+//!   tpl.parse_next(Streaming(&b"abcdefgh"[..])),
 //!   Ok((
 //!     Streaming(&b"h"[..]),
 //!     (0x6162u16, &b"cde"[..], &b"fg"[..])
 //!   ))
 //! );
-//! assert_eq!(tpl.parse(Streaming(&b"abcde"[..])), Err(winnow::Err::Incomplete(Needed::new(2))));
+//! assert_eq!(tpl.parse_next(Streaming(&b"abcde"[..])), Err(winnow::Err::Incomplete(Needed::new(2))));
 //! let input = &b"abcdejk"[..];
-//! assert_eq!(tpl.parse(Streaming(input)), Err(winnow::Err::Error((Streaming(&input[5..]), ErrorKind::Tag))));
+//! assert_eq!(tpl.parse_next(Streaming(input)), Err(winnow::Err::Error((Streaming(&input[5..]), ErrorKind::Tag))));
 //! # }
 //! ```
 //!
@@ -501,7 +501,7 @@ pub mod _tutorial;
 /// }
 ///
 /// fn main() {
-///   let result = parse_data.parse("100").finish();
+///   let result = parse_data.parse_next("100").finish();
 ///   assert_eq!(result, Ok(100));
 /// }
 /// ```

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -58,7 +58,7 @@ where
     let mut acc = crate::lib::std::vec::Vec::with_capacity(4);
     loop {
       let len = i.input_len();
-      match f.parse(i.clone()) {
+      match f.parse_next(i.clone()) {
         Err(Err::Error(_)) => return Ok((i, acc)),
         Err(e) => return Err(e),
         Ok((i1, o)) => {
@@ -108,7 +108,7 @@ where
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
-  move |mut i: I| match f.parse(i.clone()) {
+  move |mut i: I| match f.parse_next(i.clone()) {
     Err(Err::Error(err)) => Err(Err::Error(E::append(i, ErrorKind::Many1, err))),
     Err(e) => Err(e),
     Ok((i1, o)) => {
@@ -118,7 +118,7 @@ where
 
       loop {
         let len = i.input_len();
-        match f.parse(i.clone()) {
+        match f.parse_next(i.clone()) {
           Err(Err::Error(_)) => return Ok((i, acc)),
           Err(e) => return Err(e),
           Ok((i1, o)) => {
@@ -172,10 +172,10 @@ where
     let mut res = crate::lib::std::vec::Vec::new();
     loop {
       let len = i.input_len();
-      match g.parse(i.clone()) {
+      match g.parse_next(i.clone()) {
         Ok((i1, o)) => return Ok((i1, (res, o))),
         Err(Err::Error(_)) => {
-          match f.parse(i.clone()) {
+          match f.parse_next(i.clone()) {
             Err(Err::Error(err)) => return Err(Err::Error(E::append(i, ErrorKind::ManyTill, err))),
             Err(e) => return Err(e),
             Ok((i1, o)) => {
@@ -233,7 +233,7 @@ where
   move |mut i: I| {
     let mut res = Vec::new();
 
-    match f.parse(i.clone()) {
+    match f.parse_next(i.clone()) {
       Err(Err::Error(_)) => return Ok((i, res)),
       Err(e) => return Err(e),
       Ok((i1, o)) => {
@@ -244,7 +244,7 @@ where
 
     loop {
       let len = i.input_len();
-      match sep.parse(i.clone()) {
+      match sep.parse_next(i.clone()) {
         Err(Err::Error(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
@@ -253,7 +253,7 @@ where
             return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
           }
 
-          match f.parse(i1.clone()) {
+          match f.parse_next(i1.clone()) {
             Err(Err::Error(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
@@ -307,7 +307,7 @@ where
     let mut res = Vec::new();
 
     // Parse the first element
-    match f.parse(i.clone()) {
+    match f.parse_next(i.clone()) {
       Err(e) => return Err(e),
       Ok((i1, o)) => {
         res.push(o);
@@ -317,7 +317,7 @@ where
 
     loop {
       let len = i.input_len();
-      match sep.parse(i.clone()) {
+      match sep.parse_next(i.clone()) {
         Err(Err::Error(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
@@ -326,7 +326,7 @@ where
             return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
           }
 
-          match f.parse(i1.clone()) {
+          match f.parse_next(i1.clone()) {
             Err(Err::Error(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
@@ -390,7 +390,7 @@ where
     let mut res = crate::lib::std::vec::Vec::with_capacity(min.min(max_initial_capacity));
     for count in 0..max {
       let len = input.input_len();
-      match parse.parse(input.clone()) {
+      match parse.parse_next(input.clone()) {
         Ok((tail, value)) => {
           // infinite loop check: the parser must always consume
           if tail.input_len() == len {
@@ -455,7 +455,7 @@ where
     loop {
       let input_ = input.clone();
       let len = input.input_len();
-      match f.parse(input_) {
+      match f.parse_next(input_) {
         Ok((i, _)) => {
           // infinite loop check: the parser must always consume
           if i.input_len() == len {
@@ -508,7 +508,7 @@ where
 {
   move |i: I| {
     let i_ = i.clone();
-    match f.parse(i_) {
+    match f.parse_next(i_) {
       Err(Err::Error(_)) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1Count))),
       Err(i) => Err(i),
       Ok((i1, _)) => {
@@ -518,7 +518,7 @@ where
         loop {
           let len = input.input_len();
           let input_ = input.clone();
-          match f.parse(input_) {
+          match f.parse_next(input_) {
             Err(Err::Error(_)) => return Ok((input, count)),
             Err(e) => return Err(e),
             Ok((i, _)) => {
@@ -572,7 +572,7 @@ where
 
     for _ in 0..count {
       let input_ = input.clone();
-      match f.parse(input_) {
+      match f.parse_next(input_) {
         Ok((i, o)) => {
           res.push(o);
           input = i;
@@ -625,7 +625,7 @@ where
 
     for elem in buf.iter_mut() {
       let input_ = input.clone();
-      match f.parse(input_) {
+      match f.parse_next(input_) {
         Ok((i, o)) => {
           *elem = o;
           input = i;
@@ -697,7 +697,7 @@ where
     loop {
       let i_ = input.clone();
       let len = input.input_len();
-      match f.parse(i_) {
+      match f.parse_next(i_) {
         Ok((i, o)) => {
           // infinite loop check: the parser must always consume
           if i.input_len() == len {
@@ -769,7 +769,7 @@ where
   move |i: I| {
     let _i = i.clone();
     let init = init();
-    match f.parse(_i) {
+    match f.parse_next(_i) {
       Err(Err::Error(_)) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1))),
       Err(e) => Err(e),
       Ok((i1, o1)) => {
@@ -779,7 +779,7 @@ where
         loop {
           let _input = input.clone();
           let len = input.input_len();
-          match f.parse(_input) {
+          match f.parse_next(_input) {
             Err(Err::Error(_)) => {
               break;
             }
@@ -865,7 +865,7 @@ where
     let mut acc = init();
     for count in 0..max {
       let len = input.input_len();
-      match parse.parse(input.clone()) {
+      match parse.parse_next(input.clone()) {
         Ok((tail, value)) => {
           // infinite loop check: the parser must always consume
           if tail.input_len() == len {
@@ -923,9 +923,9 @@ where
   E: ParseError<I>,
 {
   move |i: I| {
-    let (i, length) = f.parse(i)?;
+    let (i, length) = f.parse_next(i)?;
 
-    crate::bytes::take(length).parse(i)
+    crate::bytes::take(length).parse_next(i)
   }
 }
 
@@ -969,9 +969,9 @@ where
   E: ParseError<I>,
 {
   move |i: I| {
-    let (i, data) = length_data(f.by_ref()).parse(i)?;
+    let (i, data) = length_data(f.by_ref()).parse_next(i)?;
     let data = I::merge_output(i.clone(), data);
-    let (_, o) = g.by_ref().complete().parse(data)?;
+    let (_, o) = g.by_ref().complete().parse_next(data)?;
     Ok((i, o))
   }
 }
@@ -1009,13 +1009,13 @@ where
   E: ParseError<I>,
 {
   move |i: I| {
-    let (i, count) = f.parse(i)?;
+    let (i, count) = f.parse_next(i)?;
     let mut input = i.clone();
     let mut res = Vec::new();
 
     for _ in 0..count.to_usize() {
       let input_ = input.clone();
-      match g.parse(input_) {
+      match g.parse_next(input_) {
         Ok((i, o)) => {
           res.push(o);
           input = i;

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -367,7 +367,7 @@ fn length_count_test() {
     digit
       .map_res(str::from_utf8)
       .map_res(FromStr::from_str)
-      .parse(i)
+      .parse_next(i)
   }
 
   fn cnt(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, Vec<&[u8]>> {
@@ -408,7 +408,7 @@ fn length_data_test() {
     digit
       .map_res(str::from_utf8)
       .map_res(FromStr::from_str)
-      .parse(i)
+      .parse_next(i)
   }
 
   fn take(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -222,7 +222,7 @@ pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u8.map(|x| x as i8).parse(input)
+  be_u8.map(|x| x as i8).parse_next(input)
 }
 
 /// Recognizes a big endian signed 2 bytes integer.
@@ -248,7 +248,7 @@ pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u16.map(|x| x as i16).parse(input)
+  be_u16.map(|x| x as i16).parse_next(input)
 }
 
 /// Recognizes a big endian signed 3 bytes integer.
@@ -283,7 +283,7 @@ where
         x as i32
       }
     })
-    .parse(input)
+    .parse_next(input)
 }
 
 /// Recognizes a big endian signed 4 bytes integer.
@@ -309,7 +309,7 @@ pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u32.map(|x| x as i32).parse(input)
+  be_u32.map(|x| x as i32).parse_next(input)
 }
 
 /// Recognizes a big endian signed 8 bytes integer.
@@ -335,7 +335,7 @@ pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u64.map(|x| x as i64).parse(input)
+  be_u64.map(|x| x as i64).parse_next(input)
 }
 
 /// Recognizes a big endian signed 16 bytes integer.
@@ -361,7 +361,7 @@ pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u128.map(|x| x as i128).parse(input)
+  be_u128.map(|x| x as i128).parse_next(input)
 }
 
 /// Recognizes an unsigned 1 byte integer.
@@ -561,7 +561,7 @@ pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u8.map(|x| x as i8).parse(input)
+  be_u8.map(|x| x as i8).parse_next(input)
 }
 
 /// Recognizes a little endian signed 2 bytes integer.
@@ -587,7 +587,7 @@ pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  le_u16.map(|x| x as i16).parse(input)
+  le_u16.map(|x| x as i16).parse_next(input)
 }
 
 /// Recognizes a little endian signed 3 bytes integer.
@@ -622,7 +622,7 @@ where
         x as i32
       }
     })
-    .parse(input)
+    .parse_next(input)
 }
 
 /// Recognizes a little endian signed 4 bytes integer.
@@ -648,7 +648,7 @@ pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  le_u32.map(|x| x as i32).parse(input)
+  le_u32.map(|x| x as i32).parse_next(input)
 }
 
 /// Recognizes a little endian signed 8 bytes integer.
@@ -674,7 +674,7 @@ pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  le_u64.map(|x| x as i64).parse(input)
+  le_u64.map(|x| x as i64).parse_next(input)
 }
 
 /// Recognizes a little endian signed 16 bytes integer.
@@ -700,7 +700,7 @@ pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  le_u128.map(|x| x as i128).parse(input)
+  le_u128.map(|x| x as i128).parse_next(input)
 }
 
 /// Recognizes an unsigned 1 byte integer
@@ -972,7 +972,7 @@ pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  u8.map(|x| x as i8).parse(i)
+  u8.map(|x| x as i8).parse_next(i)
 }
 
 /// Recognizes a signed 2 byte integer

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -237,7 +237,7 @@ pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u8.map(|x| x as i8).parse(input)
+  be_u8.map(|x| x as i8).parse_next(input)
 }
 
 /// Recognizes a big endian signed 2 bytes integer.
@@ -263,7 +263,7 @@ pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u16.map(|x| x as i16).parse(input)
+  be_u16.map(|x| x as i16).parse_next(input)
 }
 
 /// Recognizes a big endian signed 3 bytes integer.
@@ -298,7 +298,7 @@ where
         x as i32
       }
     })
-    .parse(input)
+    .parse_next(input)
 }
 
 /// Recognizes a big endian signed 4 bytes integer.
@@ -324,7 +324,7 @@ pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u32.map(|x| x as i32).parse(input)
+  be_u32.map(|x| x as i32).parse_next(input)
 }
 
 /// Recognizes a big endian signed 8 bytes integer.
@@ -351,7 +351,7 @@ pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u64.map(|x| x as i64).parse(input)
+  be_u64.map(|x| x as i64).parse_next(input)
 }
 
 /// Recognizes a big endian signed 16 bytes integer.
@@ -377,7 +377,7 @@ pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  be_u128.map(|x| x as i128).parse(input)
+  be_u128.map(|x| x as i128).parse_next(input)
 }
 
 /// Recognizes an unsigned 1 byte integer.
@@ -592,7 +592,7 @@ pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  le_u8.map(|x| x as i8).parse(input)
+  le_u8.map(|x| x as i8).parse_next(input)
 }
 
 /// Recognizes a little endian signed 2 bytes integer.
@@ -621,7 +621,7 @@ pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  le_u16.map(|x| x as i16).parse(input)
+  le_u16.map(|x| x as i16).parse_next(input)
 }
 
 /// Recognizes a little endian signed 3 bytes integer.
@@ -659,7 +659,7 @@ where
         x as i32
       }
     })
-    .parse(input)
+    .parse_next(input)
 }
 
 /// Recognizes a little endian signed 4 bytes integer.
@@ -688,7 +688,7 @@ pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  le_u32.map(|x| x as i32).parse(input)
+  le_u32.map(|x| x as i32).parse_next(input)
 }
 
 /// Recognizes a little endian signed 8 bytes integer.
@@ -717,7 +717,7 @@ pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  le_u64.map(|x| x as i64).parse(input)
+  le_u64.map(|x| x as i64).parse_next(input)
 }
 
 /// Recognizes a little endian signed 16 bytes integer.
@@ -746,7 +746,7 @@ pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  le_u128.map(|x| x as i128).parse(input)
+  le_u128.map(|x| x as i128).parse_next(input)
 }
 
 /// Recognizes an unsigned 1 byte integer
@@ -1039,7 +1039,7 @@ pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
 where
   I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
 {
-  u8.map(|x| x as i8).parse(i)
+  u8.map(|x| x as i8).parse_next(i)
 }
 
 /// Recognizes a signed 2 byte integer

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -324,7 +324,7 @@ where
 ///     Ok((input, output))
 /// }
 ///
-/// let (input, output) = success.parse("Hello").unwrap();
+/// let (input, output) = success.parse_next("Hello").unwrap();
 /// assert_eq!(input, "Hello");  // We didn't consume any input
 /// ```
 ///
@@ -339,7 +339,7 @@ where
 ///     }
 /// }
 ///
-/// let (input, output) = success("World").parse("Hello").unwrap();
+/// let (input, output) = success("World").parse_next("Hello").unwrap();
 /// assert_eq!(input, "Hello");  // We didn't consume any input
 /// assert_eq!(output, "World");
 /// ```
@@ -350,6 +350,7 @@ where
 pub trait Parser<I, O, E> {
   /// A parser takes in input type, and returns a `Result` containing
   /// either the remaining input and the output value, or an error
+  #[deprecated(since = "0.3.0", note = "Replaced with `Parser::parse_next`")]
   fn parse(&mut self, input: I) -> IResult<I, O, E> {
     self.parse_next(input)
   }
@@ -378,8 +379,8 @@ pub trait Parser<I, O, E> {
   ///     mut g: impl Parser<&'i [u8], O, E>
   /// ) -> impl FnMut(&'i [u8]) -> IResult<&'i [u8], O, E> {
   ///   move |i: &'i [u8]| {
-  ///     let (i, data) = length_data(f).parse(i)?;
-  ///     let (_, o) = g.complete().parse(data)?;
+  ///     let (i, data) = length_data(f).parse_next(i)?;
+  ///     let (_, o) = g.complete().parse_next(data)?;
   ///     Ok((i, o))
   ///   }
   /// }
@@ -397,8 +398,8 @@ pub trait Parser<I, O, E> {
   ///     mut g: impl Parser<&'i [u8], O, E>
   /// ) -> impl FnMut(&'i [u8]) -> IResult<&'i [u8], O, E> {
   ///   move |i: &'i [u8]| {
-  ///     let (i, data) = length_data(f.by_ref()).parse(i)?;
-  ///     let (_, o) = g.by_ref().complete().parse(data)?;
+  ///     let (i, data) = length_data(f.by_ref()).parse_next(i)?;
+  ///     let (_, o) = g.by_ref().complete().parse_next(data)?;
   ///     Ok((i, o))
   ///   }
   /// }
@@ -420,8 +421,8 @@ pub trait Parser<I, O, E> {
   ///
   /// let mut parser = alpha1.value(1234);
   ///
-  /// assert_eq!(parser.parse("abcd"), Ok(("", 1234)));
-  /// assert_eq!(parser.parse("123abcd;"), Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
+  /// assert_eq!(parser.parse_next("abcd"), Ok(("", 1234)));
+  /// assert_eq!(parser.parse_next("123abcd;"), Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
   /// # }
   /// ```
   fn value<O2>(self, val: O2) -> Value<Self, O, O2>
@@ -449,7 +450,7 @@ pub trait Parser<I, O, E> {
   ///  let mut parser2 = parser1.output_into();
   ///
   /// // the parser converts the &str output of the child parser into a Vec<u8>
-  /// let bytes: IResult<&str, Vec<u8>> = parser2.parse("abcd");
+  /// let bytes: IResult<&str, Vec<u8>> = parser2.parse_next("abcd");
   /// assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
   /// # }
   /// ```
@@ -472,8 +473,8 @@ pub trait Parser<I, O, E> {
   ///
   /// let mut parser = separated_pair(alpha1, ',', alpha1).recognize();
   ///
-  /// assert_eq!(parser.parse("abcd,efgh"), Ok(("", "abcd,efgh")));
-  /// assert_eq!(parser.parse("abcd;"),Err(Err::Error((";", ErrorKind::OneOf))));
+  /// assert_eq!(parser.parse_next("abcd,efgh"), Ok(("", "abcd,efgh")));
+  /// assert_eq!(parser.parse_next("abcd;"),Err(Err::Error((";", ErrorKind::OneOf))));
   /// # }
   /// ```
   fn recognize(self) -> Recognize<Self, O>
@@ -502,23 +503,23 @@ pub trait Parser<I, O, E> {
   /// use winnow::sequence::separated_pair;
   ///
   /// fn inner_parser(input: &str) -> IResult<&str, bool> {
-  ///     tag("1234").value(true).parse(input)
+  ///     tag("1234").value(true).parse_next(input)
   /// }
   ///
   /// # fn main() {
   ///
   /// let mut consumed_parser = separated_pair(alpha1, ',', alpha1).value(true).with_recognized();
   ///
-  /// assert_eq!(consumed_parser.parse("abcd,efgh1"), Ok(("1", (true, "abcd,efgh"))));
-  /// assert_eq!(consumed_parser.parse("abcd;"),Err(Err::Error((";", ErrorKind::OneOf))));
+  /// assert_eq!(consumed_parser.parse_next("abcd,efgh1"), Ok(("1", (true, "abcd,efgh"))));
+  /// assert_eq!(consumed_parser.parse_next("abcd;"),Err(Err::Error((";", ErrorKind::OneOf))));
   ///
   /// // the second output (representing the consumed input)
   /// // should be the same as that of the `recognize` parser.
   /// let mut recognize_parser = inner_parser.recognize();
   /// let mut consumed_parser = inner_parser.with_recognized().map(|(output, consumed)| consumed);
   ///
-  /// assert_eq!(recognize_parser.parse("1234"), consumed_parser.parse("1234"));
-  /// assert_eq!(recognize_parser.parse("abcd"), consumed_parser.parse("abcd"));
+  /// assert_eq!(recognize_parser.parse_next("1234"), consumed_parser.parse_next("1234"));
+  /// assert_eq!(recognize_parser.parse_next("abcd"), consumed_parser.parse_next("abcd"));
   /// # }
   /// ```
   fn with_recognized(self) -> WithRecognized<Self, O>
@@ -541,8 +542,8 @@ pub trait Parser<I, O, E> {
   ///
   /// let mut parser = separated_pair(alpha1.span(), ',', alpha1.span());
   ///
-  /// assert_eq!(parser.parse(Located::new("abcd,efgh")).finish(), Ok((0..4, 5..9)));
-  /// assert_eq!(parser.parse(Located::new("abcd;")),Err(Err::Error((Located::new("abcd;").slice(4..), ErrorKind::OneOf))));
+  /// assert_eq!(parser.parse_next(Located::new("abcd,efgh")).finish(), Ok((0..4, 5..9)));
+  /// assert_eq!(parser.parse_next(Located::new("abcd;")),Err(Err::Error((Located::new("abcd;").slice(4..), ErrorKind::OneOf))));
   /// ```
   fn span(self) -> Span<Self, O>
   where
@@ -572,23 +573,23 @@ pub trait Parser<I, O, E> {
   /// use winnow::sequence::separated_pair;
   ///
   /// fn inner_parser(input: Located<&str>) -> IResult<Located<&str>, bool> {
-  ///     tag("1234").value(true).parse(input)
+  ///     tag("1234").value(true).parse_next(input)
   /// }
   ///
   /// # fn main() {
   ///
   /// let mut consumed_parser = separated_pair(alpha1.value(1).with_span(), ',', alpha1.value(2).with_span());
   ///
-  /// assert_eq!(consumed_parser.parse(Located::new("abcd,efgh")).finish(), Ok(((1, 0..4), (2, 5..9))));
-  /// assert_eq!(consumed_parser.parse(Located::new("abcd;")),Err(Err::Error((Located::new("abcd;").slice(4..), ErrorKind::OneOf))));
+  /// assert_eq!(consumed_parser.parse_next(Located::new("abcd,efgh")).finish(), Ok(((1, 0..4), (2, 5..9))));
+  /// assert_eq!(consumed_parser.parse_next(Located::new("abcd;")),Err(Err::Error((Located::new("abcd;").slice(4..), ErrorKind::OneOf))));
   ///
   /// // the second output (representing the consumed input)
   /// // should be the same as that of the `span` parser.
   /// let mut recognize_parser = inner_parser.span();
   /// let mut consumed_parser = inner_parser.with_span().map(|(output, consumed)| consumed);
   ///
-  /// assert_eq!(recognize_parser.parse(Located::new("1234")), consumed_parser.parse(Located::new("1234")));
-  /// assert_eq!(recognize_parser.parse(Located::new("abcd")), consumed_parser.parse(Located::new("abcd")));
+  /// assert_eq!(recognize_parser.parse_next(Located::new("1234")), consumed_parser.parse_next(Located::new("1234")));
+  /// assert_eq!(recognize_parser.parse_next(Located::new("abcd")), consumed_parser.parse_next(Located::new("abcd")));
   /// # }
   /// ```
   fn with_span(self) -> WithSpan<Self, O>
@@ -611,10 +612,10 @@ pub trait Parser<I, O, E> {
   /// let mut parser = digit1.map(|s: &str| s.len());
   ///
   /// // the parser will count how many characters were returned by digit1
-  /// assert_eq!(parser.parse("123456"), Ok(("", 6)));
+  /// assert_eq!(parser.parse_next("123456"), Ok(("", 6)));
   ///
   /// // this will fail if digit1 fails
-  /// assert_eq!(parser.parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+  /// assert_eq!(parser.parse_next("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
   /// # }
   /// ```
   fn map<G, O2>(self, g: G) -> Map<Self, G, O>
@@ -637,13 +638,13 @@ pub trait Parser<I, O, E> {
   /// let mut parse = digit1.map_res(|s: &str| s.parse::<u8>());
   ///
   /// // the parser will convert the result of digit1 to a number
-  /// assert_eq!(parse.parse("123"), Ok(("", 123)));
+  /// assert_eq!(parse.parse_next("123"), Ok(("", 123)));
   ///
   /// // this will fail if digit1 fails
-  /// assert_eq!(parse.parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+  /// assert_eq!(parse.parse_next("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
   ///
   /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-  /// assert_eq!(parse.parse("123456"), Err(Err::Error(("123456", ErrorKind::MapRes))));
+  /// assert_eq!(parse.parse_next("123456"), Err(Err::Error(("123456", ErrorKind::MapRes))));
   /// # }
   /// ```
   fn map_res<G, O2, E2>(self, g: G) -> MapRes<Self, G, O>
@@ -666,13 +667,13 @@ pub trait Parser<I, O, E> {
   /// let mut parse = digit1.map_opt(|s: &str| s.parse::<u8>().ok());
   ///
   /// // the parser will convert the result of digit1 to a number
-  /// assert_eq!(parse.parse("123"), Ok(("", 123)));
+  /// assert_eq!(parse.parse_next("123"), Ok(("", 123)));
   ///
   /// // this will fail if digit1 fails
-  /// assert_eq!(parse.parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+  /// assert_eq!(parse.parse_next("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
   ///
   /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-  /// assert_eq!(parse.parse("123456"), Err(Err::Error(("123456", ErrorKind::MapOpt))));
+  /// assert_eq!(parse.parse_next("123456"), Err(Err::Error(("123456", ErrorKind::MapOpt))));
   /// # }
   /// ```
   fn map_opt<G, O2>(self, g: G) -> MapOpt<Self, G, O>
@@ -695,8 +696,8 @@ pub trait Parser<I, O, E> {
   ///
   /// let mut length_data = u8.flat_map(take);
   ///
-  /// assert_eq!(length_data.parse(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
-  /// assert_eq!(length_data.parse(&[4, 0, 1, 2][..]), Err(Err::Error((&[0, 1, 2][..], ErrorKind::Eof))));
+  /// assert_eq!(length_data.parse_next(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
+  /// assert_eq!(length_data.parse_next(&[4, 0, 1, 2][..]), Err(Err::Error((&[0, 1, 2][..], ErrorKind::Eof))));
   /// # }
   /// ```
   fn flat_map<G, H, O2>(self, g: G) -> FlatMap<Self, G, O>
@@ -720,9 +721,9 @@ pub trait Parser<I, O, E> {
   ///
   /// let mut digits = take(5u8).and_then(digit1);
   ///
-  /// assert_eq!(digits.parse("12345"), Ok(("", "12345")));
-  /// assert_eq!(digits.parse("123ab"), Ok(("", "123")));
-  /// assert_eq!(digits.parse("123"), Err(Err::Error(("123", ErrorKind::Eof))));
+  /// assert_eq!(digits.parse_next("12345"), Ok(("", "12345")));
+  /// assert_eq!(digits.parse_next("123ab"), Ok(("", "123")));
+  /// assert_eq!(digits.parse_next("123"), Err(Err::Error(("123", ErrorKind::Eof))));
   /// # }
   /// ```
   fn and_then<G, O2>(self, g: G) -> AndThen<Self, G, O>
@@ -747,9 +748,9 @@ pub trait Parser<I, O, E> {
   ///
   /// let mut parser = alpha1.verify(|s: &str| s.len() == 4);
   ///
-  /// assert_eq!(parser.parse("abcd"), Ok(("", "abcd")));
-  /// assert_eq!(parser.parse("abcde"), Err(Err::Error(("abcde", ErrorKind::Verify))));
-  /// assert_eq!(parser.parse("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
+  /// assert_eq!(parser.parse_next("abcd"), Ok(("", "abcd")));
+  /// assert_eq!(parser.parse_next("abcde"), Err(Err::Error(("abcde", ErrorKind::Verify))));
+  /// assert_eq!(parser.parse_next("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
   /// # }
   /// ```
   fn verify<G, O2: ?Sized>(self, second: G) -> Verify<Self, G, O2>
@@ -784,8 +785,8 @@ pub trait Parser<I, O, E> {
   ///
   /// let mut parser = take(5u8).complete();
   ///
-  /// assert_eq!(parser.parse(Streaming("abcdefg")), Ok((Streaming("fg"), "abcde")));
-  /// assert_eq!(parser.parse(Streaming("abcd")), Err(Err::Error((Streaming("abcd"), ErrorKind::Complete))));
+  /// assert_eq!(parser.parse_next(Streaming("abcdefg")), Ok((Streaming("fg"), "abcde")));
+  /// assert_eq!(parser.parse_next(Streaming("abcd")), Err(Err::Error((Streaming("abcd"), ErrorKind::Complete))));
   /// # }
   /// ```
   fn complete(self) -> Complete<Self>
@@ -815,7 +816,7 @@ pub trait Parser<I, O, E> {
   /// use winnow::{IResult, bytes::tag};
   ///
   /// fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-  ///   tag("abcd").dbg_err("alpha tag").parse(i)
+  ///   tag("abcd").dbg_err("alpha tag").parse_next(i)
   /// }
   ///
   /// let a = &b"efghijkl"[..];
@@ -878,7 +879,7 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::{Err, error::{ErrorKind, Error}};
 /// fn parser(i: &[u8]) -> IResult<&[u8], u8> {
-///     b'a'.parse(i)
+///     b'a'.parse_next(i)
 /// }
 /// assert_eq!(parser(&b"abc"[..]), Ok((&b"bc"[..], b'a')));
 /// assert_eq!(parser(&b" abc"[..]), Err(Err::Error(Error::new(&b" abc"[..], ErrorKind::OneOf))));
@@ -891,7 +892,7 @@ where
   E: ParseError<I>,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, u8, E> {
-    crate::bytes::one_of(*self).parse(i)
+    crate::bytes::one_of(*self).parse_next(i)
   }
 }
 
@@ -903,7 +904,7 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::{Err, error::{ErrorKind, Error}};
 /// fn parser(i: &str) -> IResult<&str, char> {
-///     'a'.parse(i)
+///     'a'.parse_next(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
 /// assert_eq!(parser(" abc"), Err(Err::Error(Error::new(" abc", ErrorKind::OneOf))));
@@ -917,7 +918,7 @@ where
   E: ParseError<I>,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, <I as InputIter>::Item, E> {
-    crate::bytes::one_of(*self).parse(i)
+    crate::bytes::one_of(*self).parse_next(i)
   }
 }
 
@@ -931,7 +932,7 @@ where
 /// # use winnow::bytes::take;
 ///
 /// fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   alt((&"Hello"[..], take(5usize))).parse(s)
+///   alt((&"Hello"[..], take(5usize))).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser(&b"Hello, World!"[..]), Ok((&b", World!"[..], &b"Hello"[..])));
@@ -945,7 +946,7 @@ where
   I: IntoOutput,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {
-    crate::bytes::tag(*self).parse(i)
+    crate::bytes::tag(*self).parse_next(i)
   }
 }
 
@@ -959,7 +960,7 @@ where
 /// # use winnow::bytes::take;
 ///
 /// fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   alt((b"Hello", take(5usize))).parse(s)
+///   alt((b"Hello", take(5usize))).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser(&b"Hello, World!"[..]), Ok((&b", World!"[..], &b"Hello"[..])));
@@ -974,7 +975,7 @@ where
   I: IntoOutput,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {
-    crate::bytes::tag(*self).parse(i)
+    crate::bytes::tag(*self).parse_next(i)
   }
 }
 
@@ -988,7 +989,7 @@ where
 /// # use winnow::bytes::take;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
-///   alt(("Hello", take(5usize))).parse(s)
+///   alt(("Hello", take(5usize))).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
@@ -1002,7 +1003,7 @@ where
   I: IntoOutput,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {
-    crate::bytes::tag(*self).parse(i)
+    crate::bytes::tag(*self).parse_next(i)
   }
 }
 
@@ -1022,7 +1023,7 @@ macro_rules! impl_parser_for_tuple {
       fn parse_next(&mut self, i: I) -> IResult<I, ($($output),+,), E> {
         let ($(ref mut $parser),+,) = *self;
 
-        $(let(i, $output) = $parser.parse(i)?;)+
+        $(let(i, $output) = $parser.parse_next(i)?;)+
 
         Ok((i, ($($output),+,)))
       }
@@ -1073,7 +1074,7 @@ use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 impl<'a, I, O, E> Parser<I, O, E> for Box<dyn Parser<I, O, E> + 'a> {
   fn parse_next(&mut self, input: I) -> IResult<I, O, E> {
-    (**self).parse(input)
+    (**self).parse_next(input)
   }
 }
 
@@ -1115,9 +1116,9 @@ mod tests {
     use crate::{error::ErrorKind, Err};
 
     let mut parser = (alpha1,);
-    assert_eq!(parser.parse("abc123def"), Ok(("123def", ("abc",))));
+    assert_eq!(parser.parse_next("abc123def"), Ok(("123def", ("abc",))));
     assert_eq!(
-      parser.parse("123def"),
+      parser.parse_next("123def"),
       Err(Err::Error(("123def", ErrorKind::Alpha)))
     );
   }
@@ -1126,7 +1127,7 @@ mod tests {
   fn tuple_test() {
     #[allow(clippy::type_complexity)]
     fn tuple_3(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (u16, &[u8], &[u8])> {
-      (be_u16, take(3u8), tag("fg")).parse(i)
+      (be_u16, take(3u8), tag("fg")).parse_next(i)
     }
 
     assert_eq!(
@@ -1153,10 +1154,10 @@ mod tests {
   #[test]
   fn unit_type() {
     fn parser(i: &str) -> IResult<&str, ()> {
-      ().parse(i)
+      ().parse_next(i)
     }
-    assert_eq!(parser.parse("abxsbsh"), Ok(("abxsbsh", ())));
-    assert_eq!(parser.parse("sdfjakdsas"), Ok(("sdfjakdsas", ())));
-    assert_eq!(parser.parse(""), Ok(("", ())));
+    assert_eq!(parser.parse_next("abxsbsh"), Ok(("abxsbsh", ())));
+    assert_eq!(parser.parse_next("sdfjakdsas"), Ok(("sdfjakdsas", ())));
+    assert_eq!(parser.parse_next(""), Ok(("", ())));
   }
 }

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -38,8 +38,8 @@ where
   G: Parser<I, O2, E>,
 {
   move |input: I| {
-    let (input, o1) = first.parse(input)?;
-    second.parse(input).map(|(i, o2)| (i, (o1, o2)))
+    let (input, o1) = first.parse_next(input)?;
+    second.parse_next(input).map(|(i, o2)| (i, (o1, o2)))
   }
 }
 
@@ -72,8 +72,8 @@ where
   G: Parser<I, O2, E>,
 {
   move |input: I| {
-    let (input, _) = first.parse(input)?;
-    second.parse(input)
+    let (input, _) = first.parse_next(input)?;
+    second.parse_next(input)
   }
 }
 
@@ -106,8 +106,8 @@ where
   G: Parser<I, O2, E>,
 {
   move |input: I| {
-    let (input, o1) = first.parse(input)?;
-    second.parse(input).map(|(i, _)| (i, o1))
+    let (input, o1) = first.parse_next(input)?;
+    second.parse_next(input).map(|(i, _)| (i, o1))
   }
 }
 
@@ -144,9 +144,9 @@ where
   H: Parser<I, O3, E>,
 {
   move |input: I| {
-    let (input, o1) = first.parse(input)?;
-    let (input, _) = sep.parse(input)?;
-    second.parse(input).map(|(i, o2)| (i, (o1, o2)))
+    let (input, o1) = first.parse_next(input)?;
+    let (input, _) = sep.parse_next(input)?;
+    second.parse_next(input).map(|(i, o2)| (i, (o1, o2)))
   }
 }
 
@@ -183,9 +183,9 @@ where
   H: Parser<I, O3, E>,
 {
   move |input: I| {
-    let (input, _) = first.parse(input)?;
-    let (input, o2) = second.parse(input)?;
-    third.parse(input).map(|(i, _)| (i, o2))
+    let (input, _) = first.parse_next(input)?;
+    let (input, o2) = second.parse_next(input)?;
+    third.parse_next(input).map(|(i, _)| (i, o2))
   }
 }
 
@@ -203,7 +203,7 @@ impl<Input, Output, Error: ParseError<Input>, F: Parser<Input, Output, Error>>
   Tuple<Input, (Output,), Error> for (F,)
 {
   fn parse(&mut self, input: Input) -> IResult<Input, (Output,), Error> {
-    self.0.parse(input).map(|(i, o)| (i, (o,)))
+    self.0.parse_next(input).map(|(i, o)| (i, (o,)))
   }
 }
 
@@ -239,17 +239,17 @@ macro_rules! tuple_trait_impl(
 
 macro_rules! tuple_trait_inner(
   ($it:tt, $self:expr, $input:expr, (), $head:ident $($id:ident)+) => ({
-    let (i, o) = $self.$it.parse($input.clone())?;
+    let (i, o) = $self.$it.parse_next($input.clone())?;
 
     succ!($it, tuple_trait_inner!($self, i, ( o ), $($id)+))
   });
   ($it:tt, $self:expr, $input:expr, ($($parsed:tt)*), $head:ident $($id:ident)+) => ({
-    let (i, o) = $self.$it.parse($input.clone())?;
+    let (i, o) = $self.$it.parse_next($input.clone())?;
 
     succ!($it, tuple_trait_inner!($self, i, ($($parsed)* , o), $($id)+))
   });
   ($it:tt, $self:expr, $input:expr, ($($parsed:tt)*), $head:ident) => ({
-    let (i, o) = $self.$it.parse($input.clone())?;
+    let (i, o) = $self.$it.parse_next($input.clone())?;
 
     Ok((i, ($($parsed)* , o)))
   });

--- a/src/str.rs
+++ b/src/str.rs
@@ -494,7 +494,7 @@ mod test {
     let b = "ababcd";
 
     fn f(i: &str) -> IResult<&str, &str> {
-      many1(alt((tag("a"), tag("b")))).recognize().parse(i)
+      many1(alt((tag("a"), tag("b")))).recognize().parse_next(i)
     }
 
     assert_eq!(f(a), Ok((&a[6..], a)));

--- a/tests/css.rs
+++ b/tests/css.rs
@@ -19,12 +19,12 @@ fn is_hex_digit(c: char) -> bool {
 fn hex_primary(input: &str) -> IResult<&str, u8> {
   take_while_m_n(2, 2, is_hex_digit)
     .map_res(from_hex)
-    .parse(input)
+    .parse_next(input)
 }
 
 fn hex_color(input: &str) -> IResult<&str, Color> {
   let (input, _) = tag("#")(input)?;
-  let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse(input)?;
+  let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse_next(input)?;
 
   Ok((input, Color { red, green, blue }))
 }

--- a/tests/custom_errors.rs
+++ b/tests/custom_errors.rs
@@ -40,7 +40,9 @@ fn test2(input: Streaming<&str>) -> IResult<Streaming<&str>, &str, CustomError> 
 }
 
 fn test3(input: Streaming<&str>) -> IResult<Streaming<&str>, &str, CustomError> {
-  test1.verify(|s: &str| s.starts_with("abcd")).parse(input)
+  test1
+    .verify(|s: &str| s.starts_with("abcd"))
+    .parse_next(input)
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -15,7 +15,7 @@ fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
   ))
   .recognize();
   let float_str = float_bytes.map_res(str::from_utf8);
-  float_str.map_res(FromStr::from_str).parse(i)
+  float_str.map_res(FromStr::from_str).parse_next(i)
 }
 
 fn float(i: &[u8]) -> IResult<&[u8], f32> {
@@ -26,7 +26,7 @@ fn float(i: &[u8]) -> IResult<&[u8], f32> {
         .unwrap_or(1f32)
         * value
     })
-    .parse(i)
+    .parse_next(i)
 }
 
 #[test]

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -13,15 +13,15 @@ use std::str;
 fn category(i: &[u8]) -> IResult<&[u8], &str> {
   delimited('[', take_while(|c| c != b']'), ']')
     .map_res(str::from_utf8)
-    .parse(i)
+    .parse_next(i)
 }
 
 fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
-  let (i, key) = alphanumeric.map_res(str::from_utf8).parse(i)?;
-  let (i, _) = (opt(space), '=', opt(space)).parse(i)?;
+  let (i, key) = alphanumeric.map_res(str::from_utf8).parse_next(i)?;
+  let (i, _) = (opt(space), '=', opt(space)).parse_next(i)?;
   let (i, val) = take_while(|c| c != b'\n' && c != b';')
     .map_res(str::from_utf8)
-    .parse(i)?;
+    .parse_next(i)?;
   let (i, _) = opt((';', take_while(|c| c != b'\n')))(i)?;
   Ok((i, (key, val)))
 }
@@ -29,7 +29,7 @@ fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
 fn keys_and_values(i: &[u8]) -> IResult<&[u8], HashMap<&str, &str>> {
   many0(terminated(key_value, opt(multispace)))
     .map(|vec| vec.into_iter().collect())
-    .parse(i)
+    .parse_next(i)
 }
 
 fn category_and_keys(i: &[u8]) -> IResult<&[u8], (&str, HashMap<&str, &str>)> {
@@ -45,7 +45,7 @@ fn categories(i: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str>>> {
     many0(terminated(key_value, opt(multispace))).map(|vec: Vec<_>| vec.into_iter().collect()),
   ))
   .map(|vec: Vec<_>| vec.into_iter().collect())
-  .parse(i)
+  .parse_next(i)
 }
 
 #[test]

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -30,7 +30,7 @@ fn category(i: &str) -> IResult<&str, &str> {
 
 fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
   let (i, key) = alphanumeric(i)?;
-  let (i, _) = (opt(space), "=", opt(space)).parse(i)?;
+  let (i, _) = (opt(space), "=", opt(space)).parse_next(i)?;
   let (i, val) = take_till(is_line_ending_or_comment)(i)?;
   let (i, _) = opt(space)(i)?;
   let (i, _) = opt((";", not_line_ending))(i)?;
@@ -51,7 +51,7 @@ fn keys_and_values(input: &str) -> IResult<&str, HashMap<&str, &str>> {
 }
 
 fn category_and_keys(i: &str) -> IResult<&str, (&str, HashMap<&str, &str>)> {
-  (category, keys_and_values).parse(i)
+  (category, keys_and_values).parse_next(i)
 }
 
 #[allow(clippy::type_complexity)]

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -52,7 +52,7 @@ mod parse_int {
           Err(e) => panic!("UH OH! NOT A DIGIT! {:?}", e),
         }
       })
-      .parse(i)?;
+      .parse_next(i)?;
 
     Ok((i, res))
   }
@@ -208,7 +208,7 @@ fn issue_1027_convert_error_panic_nonempty() {
 
   let input = "a";
 
-  let result: IResult<_, _, VerboseError<&str>> = ('a', 'b').parse(input);
+  let result: IResult<_, _, VerboseError<&str>> = ('a', 'b').parse_next(input);
   let err = match result.unwrap_err() {
     Err::Error(e) => e,
     _ => unreachable!(),

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -29,7 +29,7 @@ fn boolean(input: &str) -> IResult<&str, bool> {
 fn u16_hex(input: &str) -> IResult<&str, u16> {
   take(4usize)
     .map_res(|s| u16::from_str_radix(s, 16))
-    .parse(input)
+    .parse_next(input)
 }
 
 fn unicode_escape(input: &str) -> IResult<&str, char> {
@@ -51,7 +51,7 @@ fn unicode_escape(input: &str) -> IResult<&str, char> {
     // Could be probably replaced with .unwrap() or _unchecked due to the verify checks
     std::char::from_u32,
   )
-  .parse(input)
+  .parse_next(input)
 }
 
 fn character(input: &str) -> IResult<&str, char> {
@@ -105,7 +105,7 @@ fn object(input: &str) -> IResult<&str, HashMap<String, JsonValue>> {
     '}',
   )
   .map(|key_values| key_values.into_iter().collect())
-  .parse(input)
+  .parse_next(input)
 }
 
 fn json_value(input: &str) -> IResult<&str, JsonValue> {
@@ -122,7 +122,7 @@ fn json_value(input: &str) -> IResult<&str, JsonValue> {
 }
 
 fn json(input: &str) -> IResult<&str, JsonValue> {
-  ws(json_value).parse(input)
+  ws(json_value).parse_next(input)
 }
 
 #[test]

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -245,7 +245,7 @@ struct MP4BoxHeader {
 }
 
 fn brand_name(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &str> {
-  take(4_usize).map_res(str::from_utf8).parse(input)
+  take(4_usize).map_res(str::from_utf8).parse_next(input)
 }
 
 fn filetype_parser(input: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, FileType<'_>> {

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -15,7 +15,7 @@ use winnow::{Err, Needed};
 // We request a length that would trigger an overflow if computing consumed + requested
 #[allow(clippy::type_complexity)]
 fn parser02(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (&[u8], &[u8])> {
-  (take(1_usize), take(18446744073709551615_usize)).parse(i)
+  (take(1_usize), take(18446744073709551615_usize)).parse_next(i)
 }
 
 #[test]

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -14,7 +14,7 @@ fn atom(_tomb: &mut ()) -> impl for<'a> FnMut(&'a [u8]) -> IResult<&'a [u8], Str
     take_till1(" \t\r\n")
       .map_res(str::from_utf8)
       .map(ToString::to_string)
-      .parse(input)
+      .parse_next(input)
   }
 }
 


### PR DESCRIPTION
`parse_next` better conveys that this is an incremental step, leading
people to make fewer mistakes with the API.

In the future, I'll add a new `parse` that replaces `finish` which is
the other half of this equation.