### PR TITLE
length_count: use Vec::with_capacity

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1011,7 +1011,9 @@ where
   move |i: I| {
     let (i, count) = f.parse_next(i)?;
     let mut input = i.clone();
-    let mut res = Vec::new();
+    let max_initial_capacity =
+      MAX_INITIAL_CAPACITY_BYTES / crate::lib::std::mem::size_of::<O>().max(1);
+    let mut res = Vec::with_capacity(count.to_usize().min(max_initial_capacity));
 
     for _ in 0..count.to_usize() {
       let input_ = input.clone();


### PR DESCRIPTION
This change avoids reallocation while filling in the array. In my case this causes a ~20% perf increase.

See rust-bakery/nom#1462

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
