### PR TITLE
fix(error)!: Polish the API

### DIFF
--- a/benches/number.rs
+++ b/benches/number.rs
@@ -4,6 +4,7 @@ extern crate criterion;
 use criterion::Criterion;
 
 use winnow::character::{f64, recognize_float};
+use winnow::error::Error;
 use winnow::error::ErrorKind;
 use winnow::input::ParseTo;
 use winnow::number::be_u64;
@@ -28,49 +29,52 @@ fn number(c: &mut Criterion) {
 fn recognize_float_bytes(c: &mut Criterion) {
   println!(
     "recognize_float_bytes result: {:?}",
-    recognize_float::<_, (_, ErrorKind), false>(&b"-1.234E-12"[..])
+    recognize_float::<_, Error<_>, false>(&b"-1.234E-12"[..])
   );
   c.bench_function("recognize float bytes", |b| {
-    b.iter(|| recognize_float::<_, (_, ErrorKind), false>(&b"-1.234E-12"[..]));
+    b.iter(|| recognize_float::<_, Error<_>, false>(&b"-1.234E-12"[..]));
   });
 }
 
 fn recognize_float_str(c: &mut Criterion) {
   println!(
     "recognize_float_str result: {:?}",
-    recognize_float::<_, (_, ErrorKind), false>("-1.234E-12")
+    recognize_float::<_, Error<_>, false>("-1.234E-12")
   );
   c.bench_function("recognize float str", |b| {
-    b.iter(|| recognize_float::<_, (_, ErrorKind), false>("-1.234E-12"));
+    b.iter(|| recognize_float::<_, Error<_>, false>("-1.234E-12"));
   });
 }
 
 fn float_bytes(c: &mut Criterion) {
   println!(
     "float_bytes result: {:?}",
-    f64::<_, (_, ErrorKind), false>(&b"-1.234E-12"[..])
+    f64::<_, Error<_>, false>(&b"-1.234E-12"[..])
   );
   c.bench_function("float bytes", |b| {
-    b.iter(|| f64::<_, (_, ErrorKind), false>(&b"-1.234E-12"[..]));
+    b.iter(|| f64::<_, Error<_>, false>(&b"-1.234E-12"[..]));
   });
 }
 
 fn float_str(c: &mut Criterion) {
   println!(
     "float_str result: {:?}",
-    f64::<_, (_, ErrorKind), false>("-1.234E-12")
+    f64::<_, Error<_>, false>("-1.234E-12")
   );
   c.bench_function("float str", |b| {
-    b.iter(|| f64::<_, (_, ErrorKind), false>("-1.234E-12"));
+    b.iter(|| f64::<_, Error<_>, false>("-1.234E-12"));
   });
 }
 
-fn std_float(input: &[u8]) -> IResult<&[u8], f64, (&[u8], ErrorKind)> {
+fn std_float(input: &[u8]) -> IResult<&[u8], f64, Error<&[u8]>> {
   match recognize_float(input) {
     Err(e) => Err(e),
     Ok((i, s)) => match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(Err::Error((i, ErrorKind::Float))),
+      None => Err(Err::Error(Error {
+        input: i,
+        kind: ErrorKind::Float,
+      })),
     },
   }
 }

--- a/examples/css/parser.rs
+++ b/examples/css/parser.rs
@@ -15,7 +15,7 @@ impl std::str::FromStr for Color {
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     hex_color(s).finish().map_err(|err| winnow::error::Error {
       input: err.input.to_owned(),
-      code: err.code,
+      kind: err.kind,
     })
   }
 }

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -14,8 +14,8 @@ impl<I> ParseError<I> for CustomError<I> {
     CustomError::Nom(input, kind)
   }
 
-  fn append(_: I, _: ErrorKind, other: Self) -> Self {
-    other
+  fn append(self, _: I, _: ErrorKind) -> Self {
+    self
   }
 }
 

--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -30,7 +30,7 @@ use crate::{Err, IResult};
 /// assert_eq!(parser(([0b00010010].as_ref(), 4), 4), Ok((([].as_ref(), 0), 0b00000010)));
 ///
 /// // Tries to consume 12 bits but only 8 are available
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::Err::Error(Error{input: ([0b00010010].as_ref(), 0), code: ErrorKind::Eof })));
+/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::Err::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bits::take`][crate::bits::take]
@@ -183,7 +183,7 @@ mod test {
       result,
       Err(crate::Err::Error(crate::error::Error {
         input: (input, 8),
-        code: ErrorKind::Eof
+        kind: ErrorKind::Eof
       }))
     );
   }
@@ -219,7 +219,7 @@ mod test {
       result,
       Err(crate::Err::Error(crate::error::Error {
         input: (input, 8),
-        code: ErrorKind::Eof
+        kind: ErrorKind::Eof
       }))
     );
   }

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -132,7 +132,7 @@ where
 /// assert_eq!(parser(([0b00010010].as_ref(), 4), 4), Ok((([].as_ref(), 0), 0b00000010)));
 ///
 /// // Tries to consume 12 bits but only 8 are available
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::Err::Error(Error{input: ([0b00010010].as_ref(), 0), code: ErrorKind::Eof })));
+/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::Err::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
 /// ```
 #[inline(always)]
 pub fn take<I, O, C, E: ParseError<(I, usize)>, const STREAMING: bool>(
@@ -184,7 +184,7 @@ where
 ///     parser(0b000000_01, 2, ([0b111111_11].as_ref(), 0)),
 ///     Err(winnow::Err::Error(Error {
 ///         input: ([0b11111111].as_ref(), 0),
-///         code: ErrorKind::TagBits
+///         kind: ErrorKind::TagBits
 ///     }))
 /// );
 ///
@@ -193,7 +193,7 @@ where
 ///     parser(0b11111110, 8, ([0b11111111].as_ref(), 0)),
 ///     Err(winnow::Err::Error(Error {
 ///         input: ([0b11111111].as_ref(), 0),
-///         code: ErrorKind::TagBits
+///         kind: ErrorKind::TagBits
 ///     }))
 /// );
 /// ```

--- a/src/bits/streaming.rs
+++ b/src/bits/streaming.rs
@@ -180,7 +180,7 @@ mod test {
       result,
       Err(crate::Err::Error(crate::error::Error {
         input: (input, offset),
-        code: ErrorKind::TagBits
+        kind: ErrorKind::TagBits
       }))
     );
   }

--- a/src/bits/tests.rs
+++ b/src/bits/tests.rs
@@ -82,7 +82,7 @@ fn test_take_complete_eof() {
     result,
     Err(crate::Err::Error(crate::error::Error {
       input: (input, 8),
-      code: ErrorKind::Eof
+      kind: ErrorKind::Eof
     }))
   );
 }
@@ -136,7 +136,7 @@ fn test_tag_streaming_err() {
     result,
     Err(crate::Err::Error(crate::error::Error {
       input: (input, offset),
-      code: ErrorKind::TagBits
+      kind: ErrorKind::TagBits
     }))
   );
 }
@@ -160,7 +160,7 @@ fn test_bool_eof_complete() {
     result,
     Err(crate::Err::Error(crate::error::Error {
       input: (input, 8),
-      code: ErrorKind::Eof
+      kind: ErrorKind::Eof
     }))
   );
 }

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -152,7 +152,7 @@ macro_rules! alt_trait_inner(
     }
   );
   ($it:tt, $self:expr, $input:expr, $err:expr, $head:ident) => (
-    Err(Err::Error(Error::append($input, ErrorKind::Alt, $err)))
+    Err(Err::Error($err.append($input, ErrorKind::Alt)))
   );
 );
 
@@ -205,7 +205,7 @@ macro_rules! permutation_trait_impl(
           // or errored on the remaining input
           if let Some(err) = err {
             // There are remaining parsers, and all errored on the remaining input
-            return Err(Err::Error(Error::append(input, ErrorKind::Permutation, err)));
+            return Err(Err::Error(err.append(input, ErrorKind::Permutation)));
           }
 
           // All parsers were applied

--- a/src/branch/tests.rs
+++ b/src/branch/tests.rs
@@ -36,10 +36,10 @@ impl<I: Debug> ParseError<I> for ErrorStr {
     ErrorStr(format!("custom error message: ({:?}, {:?})", input, kind))
   }
 
-  fn append(input: I, kind: ErrorKind, other: Self) -> Self {
+  fn append(self, input: I, kind: ErrorKind) -> Self {
     ErrorStr(format!(
       "custom error message: ({:?}, {:?}) - {:?}",
-      input, kind, other
+      input, kind, self
     ))
   }
 }

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -32,10 +32,10 @@ use crate::{IResult, Parser};
 /// ```
 ///
 /// ```
-/// # use winnow::{bytes::any, Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{bytes::any, Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
-/// assert_eq!(any::<_, (_, ErrorKind), true>(Streaming("abc")), Ok((Streaming("bc"),'a')));
-/// assert_eq!(any::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(any::<_, Error<_>, true>(Streaming("abc")), Ok((Streaming("bc"),'a')));
+/// assert_eq!(any::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn any<I, E: ParseError<I>, const STREAMING: bool>(
@@ -56,7 +56,7 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// It will return `Err(Err::Error(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern
 ///
 /// **Note:** [`Parser`] is implemented for strings and byte strings as a convenience (complete
 /// only)
@@ -114,7 +114,7 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument with no regard to case.
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern.
+/// It will return `Err(Err::Error(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern.
 /// # Example
 /// ```rust
 /// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
@@ -182,9 +182,9 @@ where
 /// # use winnow::*;
 /// # use winnow::{Err, error::ErrorKind, error::Error};
 /// # use winnow::bytes::one_of;
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind), false>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>, false>("abc")("b"), Ok(("", 'b')));
+/// assert_eq!(one_of::<_, _, Error<_>, false>("a")("bc"), Err(Err::Error(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>, false>("a")(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
 ///
 /// fn parser_fn(i: &str) -> IResult<&str, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
@@ -199,9 +199,9 @@ where
 /// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::bytes::one_of;
-/// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("abc")(Streaming("b")), Ok((Streaming(""), 'b')));
-/// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("bc")), Err(Err::Error((Streaming("bc"), ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, (_, ErrorKind), true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(one_of::<_, _, Error<_>, true>("abc")(Streaming("b")), Ok((Streaming(""), 'b')));
+/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Streaming("bc")), Err(Err::Error(Error::new(Streaming("bc"), ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 ///
 /// fn parser_fn(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
@@ -237,20 +237,20 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind};
+/// # use winnow::{Err, error::ErrorKind, error::Error};
 /// # use winnow::bytes::none_of;
-/// assert_eq!(none_of::<_, _, (&str, ErrorKind), false>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, (&str, ErrorKind), false>("ab")("a"), Err(Err::Error(("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, (&str, ErrorKind), false>("a")(""), Err(Err::Error(("", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>, false>("abc")("z"), Ok(("", 'z')));
+/// assert_eq!(none_of::<_, _, Error<_>, false>("ab")("a"), Err(Err::Error(Error::new("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>, false>("a")(""), Err(Err::Error(Error::new("", ErrorKind::NoneOf))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::bytes::none_of;
-/// assert_eq!(none_of::<_, _, (_, ErrorKind), true>("abc")(Streaming("z")), Ok((Streaming(""), 'z')));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind), true>("ab")(Streaming("a")), Err(Err::Error((Streaming("a"), ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind), true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(none_of::<_, _, Error<_>, true>("abc")(Streaming("z")), Ok((Streaming(""), 'z')));
+/// assert_eq!(none_of::<_, _, Error<_>, true>("ab")(Streaming("a")), Err(Err::Error(Error::new(Streaming("a"), ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>, true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn none_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
@@ -275,7 +275,7 @@ where
 /// *Streaming version*: will return a `Err::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
 /// use winnow::bytes::take_while;
 /// use winnow::input::AsChar;
 ///
@@ -290,7 +290,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_while;
 /// use winnow::input::AsChar;
@@ -325,7 +325,7 @@ where
 
 /// Returns the longest (at least 1) input slice that matches the [pattern][FindToken]
 ///
-/// It will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
+/// It will return an `Err(Err::Error(Error::new(_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 ///
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
 ///
@@ -398,7 +398,7 @@ where
 
 /// Returns the longest (m <= len <= n) input slice that matches the [pattern][FindToken]
 ///
-/// It will return an `Err::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
+/// It will return an `Err::Error(Error::new(_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
 /// of range (m <= len <= n).
 ///
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
@@ -464,7 +464,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
 /// use winnow::bytes::take_till;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -478,7 +478,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_till;
 ///
@@ -511,7 +511,7 @@ where
 
 /// Returns the longest (at least 1) input slice till a [pattern][FindToken] is met.
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::TakeTill1)))` if the input is empty or the
+/// It will return `Err(Err::Error(Error::new(_, ErrorKind::TakeTill1)))` if the input is empty or the
 /// predicate matches the first input.
 ///
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
@@ -584,7 +584,7 @@ where
 
 /// Returns an input slice containing the first N input elements (Input[..N]).
 ///
-/// *Complete version*: It will return `Err(Err::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument.
+/// *Complete version*: It will return `Err(Err::Error(Error::new(_, ErrorKind::Eof)))` if the input is shorter than the argument.
 ///
 /// *Streaming version*: if the input has less than N elements, `take` will
 /// return a `Err::Incomplete(Needed::new(M))` where M is the number of
@@ -621,7 +621,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take;
 ///
@@ -657,7 +657,7 @@ where
 ///
 /// It doesn't consume the pattern.
 ///
-/// *Complete version*: It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
+/// *Complete version*: It will return `Err(Err::Error(Error::new(_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 ///
 /// *Streaming version*: will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
@@ -678,7 +678,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_until;
 ///
@@ -713,7 +713,7 @@ where
 ///
 /// It doesn't consume the pattern.
 ///
-/// *Complete version*: It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
+/// *Complete version*: It will return `Err(Err::Error(Error::new(_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 ///
 /// *Streaming version*: will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
@@ -775,7 +775,7 @@ where
 /// * The third argument matches the escaped characters
 /// # Example
 /// ```
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::character::digit1;
 /// use winnow::bytes::escaped;
 /// use winnow::bytes::one_of;
@@ -789,7 +789,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::character::digit1;
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::escaped;
@@ -842,7 +842,7 @@ where
 ///
 /// ```
 /// # use winnow::prelude::*;
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use std::str::from_utf8;
 /// use winnow::bytes::{escaped_transform, tag};
 /// use winnow::character::alpha1;
@@ -867,7 +867,7 @@ where
 ///
 /// ```
 /// # use winnow::prelude::*;
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use std::str::from_utf8;
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::{escaped_transform, tag};

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::input::AsChar;
 use crate::input::Streaming;
@@ -132,12 +133,18 @@ fn complete_escaping_str() {
 
 #[test]
 fn test_escaped_error() {
-  fn esc(s: &str) -> IResult<&str, &str, (&str, ErrorKind)> {
+  fn esc(s: &str) -> IResult<&str, &str> {
     use crate::character::digit1;
     escaped(digit1, '\\', one_of("\"n\\"))(s)
   }
 
-  assert_eq!(esc("abcd"), Err(Err::Error(("abcd", ErrorKind::Escaped))));
+  assert_eq!(
+    esc("abcd"),
+    Err(Err::Error(Error {
+      input: "abcd",
+      kind: ErrorKind::Escaped
+    }))
+  );
 }
 
 #[cfg(feature = "alloc")]
@@ -280,14 +287,17 @@ fn complete_escape_transform_str() {
 #[test]
 #[cfg(feature = "alloc")]
 fn test_escaped_transform_error() {
-  fn esc_trans(s: &str) -> IResult<&str, String, (&str, ErrorKind)> {
+  fn esc_trans(s: &str) -> IResult<&str, String> {
     use crate::character::digit1;
     escaped_transform(digit1, '\\', "n")(s)
   }
 
   assert_eq!(
     esc_trans("abcd"),
-    Err(Err::Error(("abcd", ErrorKind::EscapedTransform)))
+    Err(Err::Error(Error {
+      input: "abcd",
+      kind: ErrorKind::EscapedTransform
+    }))
   );
 }
 
@@ -295,7 +305,7 @@ fn test_escaped_transform_error() {
 fn streaming_any_str() {
   use super::any;
   assert_eq!(
-    any::<_, (Streaming<&str>, ErrorKind), true>(Streaming("Ә")),
+    any::<_, Error<Streaming<&str>>, true>(Streaming("Ә")),
     Ok((Streaming(""), 'Ә'))
   );
 }

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -204,8 +204,8 @@ where
 /// assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
 /// assert_eq!(parser("abc"), Ok(("", "abc")));
 /// assert_eq!(parser(""), Ok(("", "")));
-/// assert_eq!(parser("a\rb\nc"), Err(Err::Error(Error { input: "a\rb\nc", code: ErrorKind::Tag })));
-/// assert_eq!(parser("a\rbc"), Err(Err::Error(Error { input: "a\rbc", code: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rb\nc"), Err(Err::Error(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rbc"), Err(Err::Error(Error { input: "a\rbc", kind: ErrorKind::Tag })));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::not_line_ending`][crate::character::not_line_ending]

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -39,12 +39,12 @@ use crate::IResult;
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::crlf;
-/// assert_eq!(crlf::<_, (_, ErrorKind), true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
-/// assert_eq!(crlf::<_, (_, ErrorKind), true>(Streaming("ab\r\nc")), Err(Err::Error((Streaming("ab\r\nc"), ErrorKind::CrLf))));
-/// assert_eq!(crlf::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(crlf::<_, Error<_>, true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
+/// assert_eq!(crlf::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(Err::Error(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(crlf::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn crlf<T, E: ParseError<T>, const STREAMING: bool>(
@@ -90,11 +90,11 @@ where
 /// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::not_line_ending;
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("ab\r\nc")), Ok((Streaming("\r\nc"), "ab")));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("abc")), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("a\rb\nc")), Err(Err::Error((Streaming("a\rb\nc"), ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind), true>(Streaming("a\rbc")), Err(Err::Error((Streaming("a\rbc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("ab\r\nc")), Ok((Streaming("\r\nc"), "ab")));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("abc")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rb\nc")), Err(Err::Error(Error::new(Streaming("a\rb\nc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rbc")), Err(Err::Error(Error::new(Streaming("a\rbc"), ErrorKind::Tag ))));
 /// ```
 #[inline(always)]
 pub fn not_line_ending<T, E: ParseError<T>, const STREAMING: bool>(
@@ -136,12 +136,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::line_ending;
-/// assert_eq!(line_ending::<_, (_, ErrorKind), true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
-/// assert_eq!(line_ending::<_, (_, ErrorKind), true>(Streaming("ab\r\nc")), Err(Err::Error((Streaming("ab\r\nc"), ErrorKind::CrLf))));
-/// assert_eq!(line_ending::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
+/// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(Err::Error(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn line_ending<T, E: ParseError<T>, const STREAMING: bool>(
@@ -181,12 +181,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::newline;
-/// assert_eq!(newline::<_, (_, ErrorKind), true>(Streaming("\nc")), Ok((Streaming("c"), '\n')));
-/// assert_eq!(newline::<_, (_, ErrorKind), true>(Streaming("\r\nc")), Err(Err::Error((Streaming("\r\nc"), ErrorKind::Char))));
-/// assert_eq!(newline::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(newline::<_, Error<_>, true>(Streaming("\nc")), Ok((Streaming("c"), '\n')));
+/// assert_eq!(newline::<_, Error<_>, true>(Streaming("\r\nc")), Err(Err::Error(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(newline::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn newline<I, Error: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, char, Error>
@@ -222,12 +222,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::tab;
-/// assert_eq!(tab::<_, (_, ErrorKind), true>(Streaming("\tc")), Ok((Streaming("c"), '\t')));
-/// assert_eq!(tab::<_, (_, ErrorKind), true>(Streaming("\r\nc")), Err(Err::Error((Streaming("\r\nc"), ErrorKind::Char))));
-/// assert_eq!(tab::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(tab::<_, Error<_>, true>(Streaming("\tc")), Ok((Streaming("c"), '\t')));
+/// assert_eq!(tab::<_, Error<_>, true>(Streaming("\r\nc")), Err(Err::Error(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(tab::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn tab<I, Error: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, char, Error>
@@ -253,7 +253,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::alpha0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alpha0(input)
@@ -265,12 +265,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alpha0;
-/// assert_eq!(alpha0::<_, (_, ErrorKind), true>(Streaming("ab1c")), Ok((Streaming("1c"), "ab")));
-/// assert_eq!(alpha0::<_, (_, ErrorKind), true>(Streaming("1c")), Ok((Streaming("1c"), "")));
-/// assert_eq!(alpha0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha0::<_, Error<_>, true>(Streaming("ab1c")), Ok((Streaming("1c"), "ab")));
+/// assert_eq!(alpha0::<_, Error<_>, true>(Streaming("1c")), Ok((Streaming("1c"), "")));
+/// assert_eq!(alpha0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alpha0<T, E: ParseError<T>, const STREAMING: bool>(
@@ -311,12 +311,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alpha1;
-/// assert_eq!(alpha1::<_, (_, ErrorKind), true>(Streaming("aB1c")), Ok((Streaming("1c"), "aB")));
-/// assert_eq!(alpha1::<_, (_, ErrorKind), true>(Streaming("1c")), Err(Err::Error((Streaming("1c"), ErrorKind::Alpha))));
-/// assert_eq!(alpha1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("aB1c")), Ok((Streaming("1c"), "aB")));
+/// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("1c")), Err(Err::Error(Error::new(Streaming("1c"), ErrorKind::Alpha))));
+/// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alpha1<T, E: ParseError<T>, const STREAMING: bool>(
@@ -345,7 +345,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit0(input)
@@ -358,12 +358,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::digit0;
-/// assert_eq!(digit0::<_, (_, ErrorKind), true>(Streaming("21c")), Ok((Streaming("c"), "21")));
-/// assert_eq!(digit0::<_, (_, ErrorKind), true>(Streaming("a21c")), Ok((Streaming("a21c"), "")));
-/// assert_eq!(digit0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(digit0::<_, Error<_>, true>(Streaming("21c")), Ok((Streaming("c"), "21")));
+/// assert_eq!(digit0::<_, Error<_>, true>(Streaming("a21c")), Ok((Streaming("a21c"), "")));
+/// assert_eq!(digit0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn digit0<T, E: ParseError<T>, const STREAMING: bool>(
@@ -404,12 +404,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::digit1;
-/// assert_eq!(digit1::<_, (_, ErrorKind), true>(Streaming("21c")), Ok((Streaming("c"), "21")));
-/// assert_eq!(digit1::<_, (_, ErrorKind), true>(Streaming("c1")), Err(Err::Error((Streaming("c1"), ErrorKind::Digit))));
-/// assert_eq!(digit1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(digit1::<_, Error<_>, true>(Streaming("21c")), Ok((Streaming("c"), "21")));
+/// assert_eq!(digit1::<_, Error<_>, true>(Streaming("c1")), Err(Err::Error(Error::new(Streaming("c1"), ErrorKind::Digit))));
+/// assert_eq!(digit1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// ## Parsing an integer
@@ -453,7 +453,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::hex_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     hex_digit0(input)
@@ -465,12 +465,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::hex_digit0;
-/// assert_eq!(hex_digit0::<_, (_, ErrorKind), true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
-/// assert_eq!(hex_digit0::<_, (_, ErrorKind), true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
-/// assert_eq!(hex_digit0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit0::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
+/// assert_eq!(hex_digit0::<_, Error<_>, true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
+/// assert_eq!(hex_digit0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn hex_digit0<T, E: ParseError<T>, const STREAMING: bool>(
@@ -511,12 +511,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::hex_digit1;
-/// assert_eq!(hex_digit1::<_, (_, ErrorKind), true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
-/// assert_eq!(hex_digit1::<_, (_, ErrorKind), true>(Streaming("H2")), Err(Err::Error((Streaming("H2"), ErrorKind::HexDigit))));
-/// assert_eq!(hex_digit1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
+/// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("H2")), Err(Err::Error(Error::new(Streaming("H2"), ErrorKind::HexDigit))));
+/// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn hex_digit1<T, E: ParseError<T>, const STREAMING: bool>(
@@ -545,7 +545,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::oct_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     oct_digit0(input)
@@ -557,12 +557,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::oct_digit0;
-/// assert_eq!(oct_digit0::<_, (_, ErrorKind), true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
-/// assert_eq!(oct_digit0::<_, (_, ErrorKind), true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
-/// assert_eq!(oct_digit0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit0::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
+/// assert_eq!(oct_digit0::<_, Error<_>, true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
+/// assert_eq!(oct_digit0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn oct_digit0<T, E: ParseError<T>, const STREAMING: bool>(
@@ -603,12 +603,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::oct_digit1;
-/// assert_eq!(oct_digit1::<_, (_, ErrorKind), true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
-/// assert_eq!(oct_digit1::<_, (_, ErrorKind), true>(Streaming("H2")), Err(Err::Error((Streaming("H2"), ErrorKind::OctDigit))));
-/// assert_eq!(oct_digit1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
+/// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("H2")), Err(Err::Error(Error::new(Streaming("H2"), ErrorKind::OctDigit))));
+/// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn oct_digit1<T, E: ParseError<T>, const STREAMING: bool>(
@@ -637,7 +637,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::alphanumeric0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alphanumeric0(input)
@@ -649,12 +649,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alphanumeric0;
-/// assert_eq!(alphanumeric0::<_, (_, ErrorKind), true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
-/// assert_eq!(alphanumeric0::<_, (_, ErrorKind), true>(Streaming("&Z21c")), Ok((Streaming("&Z21c"), "")));
-/// assert_eq!(alphanumeric0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric0::<_, Error<_>, true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
+/// assert_eq!(alphanumeric0::<_, Error<_>, true>(Streaming("&Z21c")), Ok((Streaming("&Z21c"), "")));
+/// assert_eq!(alphanumeric0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alphanumeric0<T, E: ParseError<T>, const STREAMING: bool>(
@@ -695,12 +695,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alphanumeric1;
-/// assert_eq!(alphanumeric1::<_, (_, ErrorKind), true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
-/// assert_eq!(alphanumeric1::<_, (_, ErrorKind), true>(Streaming("&H2")), Err(Err::Error((Streaming("&H2"), ErrorKind::AlphaNumeric))));
-/// assert_eq!(alphanumeric1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
+/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("&H2")), Err(Err::Error(Error::new(Streaming("&H2"), ErrorKind::AlphaNumeric))));
+/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alphanumeric1<T, E: ParseError<T>, const STREAMING: bool>(
@@ -729,12 +729,12 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::space0;
-/// assert_eq!(space0::<_, (_, ErrorKind), true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
-/// assert_eq!(space0::<_, (_, ErrorKind), true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
-/// assert_eq!(space0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(space0::<_, Error<_>, true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
+/// assert_eq!(space0::<_, Error<_>, true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
+/// assert_eq!(space0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn space0<T, E: ParseError<T>, const STREAMING: bool>(
@@ -775,12 +775,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::space1;
-/// assert_eq!(space1::<_, (_, ErrorKind), true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
-/// assert_eq!(space1::<_, (_, ErrorKind), true>(Streaming("H2")), Err(Err::Error((Streaming("H2"), ErrorKind::Space))));
-/// assert_eq!(space1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(space1::<_, Error<_>, true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
+/// assert_eq!(space1::<_, Error<_>, true>(Streaming("H2")), Err(Err::Error(Error::new(Streaming("H2"), ErrorKind::Space))));
+/// assert_eq!(space1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn space1<T, E: ParseError<T>, const STREAMING: bool>(
@@ -809,7 +809,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::multispace0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     multispace0(input)
@@ -821,12 +821,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::multispace0;
-/// assert_eq!(multispace0::<_, (_, ErrorKind), true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
-/// assert_eq!(multispace0::<_, (_, ErrorKind), true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
-/// assert_eq!(multispace0::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace0::<_, Error<_>, true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
+/// assert_eq!(multispace0::<_, Error<_>, true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
+/// assert_eq!(multispace0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn multispace0<T, E: ParseError<T>, const STREAMING: bool>(
@@ -867,12 +867,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::multispace1;
-/// assert_eq!(multispace1::<_, (_, ErrorKind), true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
-/// assert_eq!(multispace1::<_, (_, ErrorKind), true>(Streaming("H2")), Err(Err::Error((Streaming("H2"), ErrorKind::MultiSpace))));
-/// assert_eq!(multispace1::<_, (_, ErrorKind), true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace1::<_, Error<_>, true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
+/// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("H2")), Err(Err::Error(Error::new(Streaming("H2"), ErrorKind::MultiSpace))));
+/// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn multispace1<T, E: ParseError<T>, const STREAMING: bool>(
@@ -956,7 +956,7 @@ uints! { u8 u16 u32 u64 u128 }
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::character::f32;
 ///
@@ -967,11 +967,11 @@ uints! { u8 u16 u32 u64 u128 }
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::character::f32;
@@ -984,7 +984,7 @@ uints! { u8 u16 u32 u64 u128 }
 /// assert_eq!(parser(Streaming("11e-1")), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123E-02")), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), 123.0)));
-/// assert_eq!(parser(Streaming("abc")), Err(Err::Error((Streaming("abc"), ErrorKind::Float))));
+/// assert_eq!(parser(Streaming("abc")), Err(Err::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
 pub fn f32<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, f32, E>
@@ -1017,7 +1017,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::character::f64;
 ///
@@ -1028,11 +1028,11 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::character::f64;
@@ -1045,7 +1045,7 @@ where
 /// assert_eq!(parser(Streaming("11e-1")), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123E-02")), Err(Err::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), 123.0)));
-/// assert_eq!(parser(Streaming("abc")), Err(Err::Error((Streaming("abc"), ErrorKind::Float))));
+/// assert_eq!(parser(Streaming("abc")), Err(Err::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
 pub fn f64<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, f64, E>
@@ -1078,7 +1078,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::character::recognize_float;
 ///
@@ -1089,11 +1089,11 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
 /// assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Char))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::character::recognize_float;
 ///
@@ -1104,7 +1104,7 @@ where
 /// assert_eq!(parser(Streaming("11e-1;")), Ok((Streaming(";"), "11e-1")));
 /// assert_eq!(parser(Streaming("123E-02;")), Ok((Streaming(";"), "123E-02")));
 /// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), "123")));
-/// assert_eq!(parser(Streaming("abc")), Err(Err::Error((Streaming("abc"), ErrorKind::Char))));
+/// assert_eq!(parser(Streaming("abc")), Err(Err::Error(Error::new(Streaming("abc"), ErrorKind::Char))));
 /// ```
 #[inline(always)]
 pub fn recognize_float<T, E: ParseError<T>, const STREAMING: bool>(

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -82,8 +82,8 @@ where
 /// assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
 /// assert_eq!(parser("abc"), Ok(("", "abc")));
 /// assert_eq!(parser(""), Ok(("", "")));
-/// assert_eq!(parser("a\rb\nc"), Err(Err::Error(Error { input: "a\rb\nc", code: ErrorKind::Tag })));
-/// assert_eq!(parser("a\rbc"), Err(Err::Error(Error { input: "a\rbc", code: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rb\nc"), Err(Err::Error(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rbc"), Err(Err::Error(Error { input: "a\rbc", kind: ErrorKind::Tag })));
 /// ```
 ///
 /// ```

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -116,11 +116,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::character::streaming::one_of;
-/// assert_eq!(one_of::<_, _, (_, ErrorKind)>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, (_, ErrorKind)>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(one_of::<_, _, Error<_>>("abc")("b"), Ok(("", 'b')));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(Err::Error(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -143,11 +143,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::character::streaming::none_of;
-/// assert_eq!(none_of::<_, _, (_, ErrorKind)>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind)>("ab")("a"), Err(Err::Error(("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(none_of::<_, _, Error<_>>("abc")("z"), Ok(("", 'z')));
+/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(Err::Error(Error::new("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("a")(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::none_of`][crate::bytes::none_of] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -170,11 +170,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::crlf;
-/// assert_eq!(crlf::<_, (_, ErrorKind)>("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(crlf::<_, (_, ErrorKind)>("ab\r\nc"), Err(Err::Error(("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(crlf::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(crlf::<_, Error<_>>("\r\nc"), Ok(("c", "\r\n")));
+/// assert_eq!(crlf::<_, Error<_>>("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(crlf::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(2))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::crlf`][crate::character::crlf] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -208,11 +208,11 @@ where
 /// ```
 /// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::streaming::not_line_ending;
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("ab\r\nc"), Ok(("\r\nc", "ab")));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("abc"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("a\rb\nc"), Err(Err::Error(("a\rb\nc", ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("a\rbc"), Err(Err::Error(("a\rbc", ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>("ab\r\nc"), Ok(("\r\nc", "ab")));
+/// assert_eq!(not_line_ending::<_, Error<_>>("abc"), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>(""), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>("a\rb\nc"), Err(Err::Error(Error::new("a\rb\nc", ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>("a\rbc"), Err(Err::Error(Error::new("a\rbc", ErrorKind::Tag ))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::not_line_ending`][crate::character::not_line_ending] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -262,11 +262,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::line_ending;
-/// assert_eq!(line_ending::<_, (_, ErrorKind)>("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(line_ending::<_, (_, ErrorKind)>("ab\r\nc"), Err(Err::Error(("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(line_ending::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(line_ending::<_, Error<_>>("\r\nc"), Ok(("c", "\r\n")));
+/// assert_eq!(line_ending::<_, Error<_>>("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::line_ending`][crate::character::line_ending] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -301,11 +301,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::newline;
-/// assert_eq!(newline::<_, (_, ErrorKind)>("\nc"), Ok(("c", '\n')));
-/// assert_eq!(newline::<_, (_, ErrorKind)>("\r\nc"), Err(Err::Error(("\r\nc", ErrorKind::Char))));
-/// assert_eq!(newline::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(newline::<_, Error<_>>("\nc"), Ok(("c", '\n')));
+/// assert_eq!(newline::<_, Error<_>>("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(newline::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::newline`][crate::character::newline] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -327,11 +327,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::tab;
-/// assert_eq!(tab::<_, (_, ErrorKind)>("\tc"), Ok(("c", '\t')));
-/// assert_eq!(tab::<_, (_, ErrorKind)>("\r\nc"), Err(Err::Error(("\r\nc", ErrorKind::Char))));
-/// assert_eq!(tab::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(tab::<_, Error<_>>("\tc"), Ok(("c", '\t')));
+/// assert_eq!(tab::<_, Error<_>>("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(tab::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::tab`][crate::character::tab] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -354,9 +354,9 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{character::streaming::anychar, Err, error::ErrorKind, IResult, Needed};
-/// assert_eq!(anychar::<_, (_, ErrorKind)>("abc"), Ok(("bc",'a')));
-/// assert_eq!(anychar::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// # use winnow::{character::streaming::anychar, Err, error::ErrorKind, error::Error, IResult, Needed};
+/// assert_eq!(anychar::<_, Error<_>>("abc"), Ok(("bc",'a')));
+/// assert_eq!(anychar::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::any`][crate::bytes::any] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -379,11 +379,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::alpha0;
-/// assert_eq!(alpha0::<_, (_, ErrorKind)>("ab1c"), Ok(("1c", "ab")));
-/// assert_eq!(alpha0::<_, (_, ErrorKind)>("1c"), Ok(("1c", "")));
-/// assert_eq!(alpha0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha0::<_, Error<_>>("ab1c"), Ok(("1c", "ab")));
+/// assert_eq!(alpha0::<_, Error<_>>("1c"), Ok(("1c", "")));
+/// assert_eq!(alpha0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alpha0`][crate::character::alpha0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -409,11 +409,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::alpha1;
-/// assert_eq!(alpha1::<_, (_, ErrorKind)>("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(alpha1::<_, (_, ErrorKind)>("1c"), Err(Err::Error(("1c", ErrorKind::Alpha))));
-/// assert_eq!(alpha1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha1::<_, Error<_>>("aB1c"), Ok(("1c", "aB")));
+/// assert_eq!(alpha1::<_, Error<_>>("1c"), Err(Err::Error(Error::new("1c", ErrorKind::Alpha))));
+/// assert_eq!(alpha1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alpha1`][crate::character::alpha1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -439,11 +439,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::digit0;
-/// assert_eq!(digit0::<_, (_, ErrorKind)>("21c"), Ok(("c", "21")));
-/// assert_eq!(digit0::<_, (_, ErrorKind)>("a21c"), Ok(("a21c", "")));
-/// assert_eq!(digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(digit0::<_, Error<_>>("21c"), Ok(("c", "21")));
+/// assert_eq!(digit0::<_, Error<_>>("a21c"), Ok(("a21c", "")));
+/// assert_eq!(digit0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::digit0`][crate::character::digit0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -469,11 +469,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::digit1;
-/// assert_eq!(digit1::<_, (_, ErrorKind)>("21c"), Ok(("c", "21")));
-/// assert_eq!(digit1::<_, (_, ErrorKind)>("c1"), Err(Err::Error(("c1", ErrorKind::Digit))));
-/// assert_eq!(digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(digit1::<_, Error<_>>("21c"), Ok(("c", "21")));
+/// assert_eq!(digit1::<_, Error<_>>("c1"), Err(Err::Error(Error::new("c1", ErrorKind::Digit))));
+/// assert_eq!(digit1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::digit1`][crate::character::digit1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -499,11 +499,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::hex_digit0;
-/// assert_eq!(hex_digit0::<_, (_, ErrorKind)>("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(hex_digit0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(hex_digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit0::<_, Error<_>>("21cZ"), Ok(("Z", "21c")));
+/// assert_eq!(hex_digit0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(hex_digit0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::hex_digit0`][crate::character::hex_digit0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -529,11 +529,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::hex_digit1;
-/// assert_eq!(hex_digit1::<_, (_, ErrorKind)>("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(hex_digit1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::HexDigit))));
-/// assert_eq!(hex_digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit1::<_, Error<_>>("21cZ"), Ok(("Z", "21c")));
+/// assert_eq!(hex_digit1::<_, Error<_>>("H2"), Err(Err::Error(Error::new("H2", ErrorKind::HexDigit))));
+/// assert_eq!(hex_digit1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::hex_digit1`][crate::character::hex_digit1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -559,11 +559,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::oct_digit0;
-/// assert_eq!(oct_digit0::<_, (_, ErrorKind)>("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(oct_digit0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(oct_digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit0::<_, Error<_>>("21cZ"), Ok(("cZ", "21")));
+/// assert_eq!(oct_digit0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(oct_digit0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::oct_digit0`][crate::character::oct_digit0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -589,11 +589,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::oct_digit1;
-/// assert_eq!(oct_digit1::<_, (_, ErrorKind)>("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(oct_digit1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::OctDigit))));
-/// assert_eq!(oct_digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit1::<_, Error<_>>("21cZ"), Ok(("cZ", "21")));
+/// assert_eq!(oct_digit1::<_, Error<_>>("H2"), Err(Err::Error(Error::new("H2", ErrorKind::OctDigit))));
+/// assert_eq!(oct_digit1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::oct_digit1`][crate::character::oct_digit1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -619,11 +619,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::alphanumeric0;
-/// assert_eq!(alphanumeric0::<_, (_, ErrorKind)>("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(alphanumeric0::<_, (_, ErrorKind)>("&Z21c"), Ok(("&Z21c", "")));
-/// assert_eq!(alphanumeric0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric0::<_, Error<_>>("21cZ%1"), Ok(("%1", "21cZ")));
+/// assert_eq!(alphanumeric0::<_, Error<_>>("&Z21c"), Ok(("&Z21c", "")));
+/// assert_eq!(alphanumeric0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alphanumeric0`][crate::character::alphanumeric0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -649,11 +649,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::alphanumeric1;
-/// assert_eq!(alphanumeric1::<_, (_, ErrorKind)>("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(alphanumeric1::<_, (_, ErrorKind)>("&H2"), Err(Err::Error(("&H2", ErrorKind::AlphaNumeric))));
-/// assert_eq!(alphanumeric1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>("21cZ%1"), Ok(("%1", "21cZ")));
+/// assert_eq!(alphanumeric1::<_, Error<_>>("&H2"), Err(Err::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alphanumeric1`][crate::character::alphanumeric1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -679,11 +679,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::space0;
-/// assert_eq!(space0::<_, (_, ErrorKind)>(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(space0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(space0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(space0::<_, Error<_>>(" \t21c"), Ok(("21c", " \t")));
+/// assert_eq!(space0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(space0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::space0`][crate::character::space0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -711,11 +711,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::space1;
-/// assert_eq!(space1::<_, (_, ErrorKind)>(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(space1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::Space))));
-/// assert_eq!(space1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(space1::<_, Error<_>>(" \t21c"), Ok(("21c", " \t")));
+/// assert_eq!(space1::<_, Error<_>>("H2"), Err(Err::Error(Error::new("H2", ErrorKind::Space))));
+/// assert_eq!(space1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::space1`][crate::character::space1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -747,11 +747,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::multispace0;
-/// assert_eq!(multispace0::<_, (_, ErrorKind)>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(multispace0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(multispace0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace0::<_, Error<_>>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
+/// assert_eq!(multispace0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(multispace0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::multispace0`][crate::character::multispace0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -780,11 +780,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::multispace1;
-/// assert_eq!(multispace1::<_, (_, ErrorKind)>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(multispace1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::MultiSpace))));
-/// assert_eq!(multispace1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace1::<_, Error<_>>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
+/// assert_eq!(multispace1::<_, Error<_>>("H2"), Err(Err::Error(Error::new("H2", ErrorKind::MultiSpace))));
+/// assert_eq!(multispace1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::multispace1`][crate::character::multispace1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -937,6 +937,7 @@ uints! { u8 u16 u32 u64 u128 }
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::error::Error;
   use crate::error::ErrorKind;
   use crate::input::ParseTo;
   use crate::sequence::pair;
@@ -945,7 +946,7 @@ mod tests {
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      let res: $crate::IResult<_, _, Error<_>> = $left;
       assert_eq!(res, $right);
     };
   );
@@ -953,7 +954,7 @@ mod tests {
   #[test]
   fn anychar_str() {
     use super::anychar;
-    assert_eq!(anychar::<_, (&str, ErrorKind)>("Ә"), Ok(("", 'Ә')));
+    assert_eq!(anychar::<_, Error<_>>("Ә"), Ok(("", 'Ә')));
   }
 
   #[test]
@@ -964,63 +965,72 @@ mod tests {
     let d: &[u8] = "azé12".as_bytes();
     let e: &[u8] = b" ";
     let f: &[u8] = b" ;";
-    //assert_eq!(alpha1::<_, (_, ErrorKind)>(a), Err(Err::Incomplete(Needed::new(1))));
+    //assert_eq!(alpha1::<_, Error<_>>(a), Err(Err::Incomplete(Needed::new(1))));
     assert_parse!(alpha1(a), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(alpha1(b), Err(Err::Error((b, ErrorKind::Alpha))));
-    assert_eq!(alpha1::<_, (_, ErrorKind)>(c), Ok((&c[1..], &b"a"[..])));
+    assert_eq!(alpha1(b), Err(Err::Error(Error::new(b, ErrorKind::Alpha))));
+    assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], &b"a"[..])));
+    assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bytes(), &b"az"[..])));
+    assert_eq!(digit1(a), Err(Err::Error(Error::new(a, ErrorKind::Digit))));
     assert_eq!(
-      alpha1::<_, (_, ErrorKind)>(d),
-      Ok(("é12".as_bytes(), &b"az"[..]))
-    );
-    assert_eq!(digit1(a), Err(Err::Error((a, ErrorKind::Digit))));
-    assert_eq!(
-      digit1::<_, (_, ErrorKind)>(b),
+      digit1::<_, Error<_>>(b),
       Err(Err::Incomplete(Needed::new(1)))
     );
-    assert_eq!(digit1(c), Err(Err::Error((c, ErrorKind::Digit))));
-    assert_eq!(digit1(d), Err(Err::Error((d, ErrorKind::Digit))));
+    assert_eq!(digit1(c), Err(Err::Error(Error::new(c, ErrorKind::Digit))));
+    assert_eq!(digit1(d), Err(Err::Error(Error::new(d, ErrorKind::Digit))));
     assert_eq!(
-      hex_digit1::<_, (_, ErrorKind)>(a),
+      hex_digit1::<_, Error<_>>(a),
       Err(Err::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-      hex_digit1::<_, (_, ErrorKind)>(b),
+      hex_digit1::<_, Error<_>>(b),
       Err(Err::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-      hex_digit1::<_, (_, ErrorKind)>(c),
+      hex_digit1::<_, Error<_>>(c),
       Err(Err::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-      hex_digit1::<_, (_, ErrorKind)>(d),
+      hex_digit1::<_, Error<_>>(d),
       Ok(("zé12".as_bytes(), &b"a"[..]))
     );
-    assert_eq!(hex_digit1(e), Err(Err::Error((e, ErrorKind::HexDigit))));
-    assert_eq!(oct_digit1(a), Err(Err::Error((a, ErrorKind::OctDigit))));
     assert_eq!(
-      oct_digit1::<_, (_, ErrorKind)>(b),
+      hex_digit1(e),
+      Err(Err::Error(Error::new(e, ErrorKind::HexDigit)))
+    );
+    assert_eq!(
+      oct_digit1(a),
+      Err(Err::Error(Error::new(a, ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      oct_digit1::<_, Error<_>>(b),
       Err(Err::Incomplete(Needed::new(1)))
     );
-    assert_eq!(oct_digit1(c), Err(Err::Error((c, ErrorKind::OctDigit))));
-    assert_eq!(oct_digit1(d), Err(Err::Error((d, ErrorKind::OctDigit))));
     assert_eq!(
-      alphanumeric1::<_, (_, ErrorKind)>(a),
+      oct_digit1(c),
+      Err(Err::Error(Error::new(c, ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      oct_digit1(d),
+      Err(Err::Error(Error::new(d, ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      alphanumeric1::<_, Error<_>>(a),
       Err(Err::Incomplete(Needed::new(1)))
     );
     //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
     assert_eq!(
-      alphanumeric1::<_, (_, ErrorKind)>(c),
+      alphanumeric1::<_, Error<_>>(c),
       Err(Err::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-      alphanumeric1::<_, (_, ErrorKind)>(d),
+      alphanumeric1::<_, Error<_>>(d),
       Ok(("é12".as_bytes(), &b"az"[..]))
     );
     assert_eq!(
-      space1::<_, (_, ErrorKind)>(e),
+      space1::<_, Error<_>>(e),
       Err(Err::Incomplete(Needed::new(1)))
     );
-    assert_eq!(space1::<_, (_, ErrorKind)>(f), Ok((&b";"[..], &b" "[..])));
+    assert_eq!(space1::<_, Error<_>>(f), Ok((&b";"[..], &b" "[..])));
   }
 
   #[cfg(feature = "alloc")]
@@ -1032,52 +1042,64 @@ mod tests {
     let d = "azé12";
     let e = " ";
     assert_eq!(
-      alpha1::<_, (_, ErrorKind)>(a),
+      alpha1::<_, Error<_>>(a),
       Err(Err::Incomplete(Needed::new(1)))
     );
-    assert_eq!(alpha1(b), Err(Err::Error((b, ErrorKind::Alpha))));
-    assert_eq!(alpha1::<_, (_, ErrorKind)>(c), Ok((&c[1..], "a")));
-    assert_eq!(alpha1::<_, (_, ErrorKind)>(d), Ok(("é12", "az")));
-    assert_eq!(digit1(a), Err(Err::Error((a, ErrorKind::Digit))));
+    assert_eq!(alpha1(b), Err(Err::Error(Error::new(b, ErrorKind::Alpha))));
+    assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], "a")));
+    assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12", "az")));
+    assert_eq!(digit1(a), Err(Err::Error(Error::new(a, ErrorKind::Digit))));
     assert_eq!(
-      digit1::<_, (_, ErrorKind)>(b),
+      digit1::<_, Error<_>>(b),
       Err(Err::Incomplete(Needed::new(1)))
     );
-    assert_eq!(digit1(c), Err(Err::Error((c, ErrorKind::Digit))));
-    assert_eq!(digit1(d), Err(Err::Error((d, ErrorKind::Digit))));
+    assert_eq!(digit1(c), Err(Err::Error(Error::new(c, ErrorKind::Digit))));
+    assert_eq!(digit1(d), Err(Err::Error(Error::new(d, ErrorKind::Digit))));
     assert_eq!(
-      hex_digit1::<_, (_, ErrorKind)>(a),
-      Err(Err::Incomplete(Needed::new(1)))
-    );
-    assert_eq!(
-      hex_digit1::<_, (_, ErrorKind)>(b),
+      hex_digit1::<_, Error<_>>(a),
       Err(Err::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-      hex_digit1::<_, (_, ErrorKind)>(c),
+      hex_digit1::<_, Error<_>>(b),
       Err(Err::Incomplete(Needed::new(1)))
     );
-    assert_eq!(hex_digit1::<_, (_, ErrorKind)>(d), Ok(("zé12", "a")));
-    assert_eq!(hex_digit1(e), Err(Err::Error((e, ErrorKind::HexDigit))));
-    assert_eq!(oct_digit1(a), Err(Err::Error((a, ErrorKind::OctDigit))));
     assert_eq!(
-      oct_digit1::<_, (_, ErrorKind)>(b),
+      hex_digit1::<_, Error<_>>(c),
       Err(Err::Incomplete(Needed::new(1)))
     );
-    assert_eq!(oct_digit1(c), Err(Err::Error((c, ErrorKind::OctDigit))));
-    assert_eq!(oct_digit1(d), Err(Err::Error((d, ErrorKind::OctDigit))));
+    assert_eq!(hex_digit1::<_, Error<_>>(d), Ok(("zé12", "a")));
     assert_eq!(
-      alphanumeric1::<_, (_, ErrorKind)>(a),
+      hex_digit1(e),
+      Err(Err::Error(Error::new(e, ErrorKind::HexDigit)))
+    );
+    assert_eq!(
+      oct_digit1(a),
+      Err(Err::Error(Error::new(a, ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      oct_digit1::<_, Error<_>>(b),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      oct_digit1(c),
+      Err(Err::Error(Error::new(c, ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      oct_digit1(d),
+      Err(Err::Error(Error::new(d, ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      alphanumeric1::<_, Error<_>>(a),
       Err(Err::Incomplete(Needed::new(1)))
     );
     //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
     assert_eq!(
-      alphanumeric1::<_, (_, ErrorKind)>(c),
+      alphanumeric1::<_, Error<_>>(c),
       Err(Err::Incomplete(Needed::new(1)))
     );
-    assert_eq!(alphanumeric1::<_, (_, ErrorKind)>(d), Ok(("é12", "az")));
+    assert_eq!(alphanumeric1::<_, Error<_>>(d), Ok(("é12", "az")));
     assert_eq!(
-      space1::<_, (_, ErrorKind)>(e),
+      space1::<_, Error<_>>(e),
       Err(Err::Incomplete(Needed::new(1)))
     );
   }
@@ -1092,43 +1114,43 @@ mod tests {
     let e = &b" \t\r\n;"[..];
     let f = &b"123abcDEF;"[..];
 
-    match alpha1::<_, (_, ErrorKind)>(a) {
+    match alpha1::<_, Error<_>>(a) {
       Ok((i, _)) => {
         assert_eq!(a.offset(i) + i.len(), a.len());
       }
       _ => panic!("wrong return type in offset test for alpha"),
     }
-    match digit1::<_, (_, ErrorKind)>(b) {
+    match digit1::<_, Error<_>>(b) {
       Ok((i, _)) => {
         assert_eq!(b.offset(i) + i.len(), b.len());
       }
       _ => panic!("wrong return type in offset test for digit"),
     }
-    match alphanumeric1::<_, (_, ErrorKind)>(c) {
+    match alphanumeric1::<_, Error<_>>(c) {
       Ok((i, _)) => {
         assert_eq!(c.offset(i) + i.len(), c.len());
       }
       _ => panic!("wrong return type in offset test for alphanumeric"),
     }
-    match space1::<_, (_, ErrorKind)>(d) {
+    match space1::<_, Error<_>>(d) {
       Ok((i, _)) => {
         assert_eq!(d.offset(i) + i.len(), d.len());
       }
       _ => panic!("wrong return type in offset test for space"),
     }
-    match multispace1::<_, (_, ErrorKind)>(e) {
+    match multispace1::<_, Error<_>>(e) {
       Ok((i, _)) => {
         assert_eq!(e.offset(i) + i.len(), e.len());
       }
       _ => panic!("wrong return type in offset test for multispace"),
     }
-    match hex_digit1::<_, (_, ErrorKind)>(f) {
+    match hex_digit1::<_, Error<_>>(f) {
       Ok((i, _)) => {
         assert_eq!(f.offset(i) + i.len(), f.len());
       }
       _ => panic!("wrong return type in offset test for hex_digit"),
     }
-    match oct_digit1::<_, (_, ErrorKind)>(f) {
+    match oct_digit1::<_, Error<_>>(f) {
       Ok((i, _)) => {
         assert_eq!(f.offset(i) + i.len(), f.len());
       }
@@ -1140,25 +1162,25 @@ mod tests {
   fn is_not_line_ending_bytes() {
     let a: &[u8] = b"ab12cd\nefgh";
     assert_eq!(
-      not_line_ending::<_, (_, ErrorKind)>(a),
+      not_line_ending::<_, Error<_>>(a),
       Ok((&b"\nefgh"[..], &b"ab12cd"[..]))
     );
 
     let b: &[u8] = b"ab12cd\nefgh\nijkl";
     assert_eq!(
-      not_line_ending::<_, (_, ErrorKind)>(b),
+      not_line_ending::<_, Error<_>>(b),
       Ok((&b"\nefgh\nijkl"[..], &b"ab12cd"[..]))
     );
 
     let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
     assert_eq!(
-      not_line_ending::<_, (_, ErrorKind)>(c),
+      not_line_ending::<_, Error<_>>(c),
       Ok((&b"\r\nefgh\nijkl"[..], &b"ab12cd"[..]))
     );
 
     let d: &[u8] = b"ab12cd";
     assert_eq!(
-      not_line_ending::<_, (_, ErrorKind)>(d),
+      not_line_ending::<_, Error<_>>(d),
       Err(Err::Incomplete(Needed::Unknown))
     );
   }
@@ -1183,11 +1205,14 @@ mod tests {
     */
 
     let f = "βèƒôřè\rÂßÇáƒƭèř";
-    assert_eq!(not_line_ending(f), Err(Err::Error((f, ErrorKind::Tag))));
+    assert_eq!(
+      not_line_ending(f),
+      Err(Err::Error(Error::new(f, ErrorKind::Tag)))
+    );
 
     let g2: &str = "ab12cd";
     assert_eq!(
-      not_line_ending::<_, (_, ErrorKind)>(g2),
+      not_line_ending::<_, Error<_>>(g2),
       Err(Err::Incomplete(Needed::Unknown))
     );
   }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -174,9 +174,10 @@ mod tests;
 ///
 /// ```rust
 /// # use winnow::error::ErrorKind;
+/// # use winnow::error::Error;
 /// use winnow::combinator::rest;
-/// assert_eq!(rest::<_,(_, ErrorKind)>("abc"), Ok(("", "abc")));
-/// assert_eq!(rest::<_,(_, ErrorKind)>(""), Ok(("", "")));
+/// assert_eq!(rest::<_,Error<_>>("abc"), Ok(("", "abc")));
+/// assert_eq!(rest::<_,Error<_>>(""), Ok(("", "")));
 /// ```
 #[inline]
 pub fn rest<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
@@ -192,9 +193,10 @@ where
 ///
 /// ```rust
 /// # use winnow::error::ErrorKind;
+/// # use winnow::error::Error;
 /// use winnow::combinator::rest_len;
-/// assert_eq!(rest_len::<_,(_, ErrorKind)>("abc"), Ok(("abc", 3)));
-/// assert_eq!(rest_len::<_,(_, ErrorKind)>(""), Ok(("", 0)));
+/// assert_eq!(rest_len::<_,Error<_>>("abc"), Ok(("abc", 3)));
+/// assert_eq!(rest_len::<_,Error<_>>(""), Ok(("", 0)));
 /// ```
 #[inline]
 pub fn rest_len<T, E: ParseError<T>>(input: T) -> IResult<T, usize, E>
@@ -228,7 +230,7 @@ impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P> {
 /// **WARNING:** Deprecated, replaced with [`Parser::map`]
 ///
 /// ```rust
-/// use winnow::{Err,error::ErrorKind, IResult,Parser};
+/// use winnow::{Err, error::ErrorKind, error::Error, IResult,Parser};
 /// use winnow::character::digit1;
 /// use winnow::combinator::map;
 /// # fn main() {
@@ -239,7 +241,7 @@ impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P> {
 /// assert_eq!(parser.parse_next("123456"), Ok(("", 6)));
 ///
 /// // this will fail if digit1 fails
-/// assert_eq!(parser.parse_next("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+/// assert_eq!(parser.parse_next("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Digit))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::map")]
@@ -286,7 +288,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> for Ma
 /// **WARNING:** Deprecated, replaced with [`Parser::map_res`]
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::character::digit1;
 /// use winnow::combinator::map_res;
 /// # fn main() {
@@ -297,10 +299,10 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> for Ma
 /// assert_eq!(parse("123"), Ok(("", 123)));
 ///
 /// // this will fail if digit1 fails
-/// assert_eq!(parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+/// assert_eq!(parse("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Digit))));
 ///
 /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-/// assert_eq!(parse("123456"), Err(Err::Error(("123456", ErrorKind::MapRes))));
+/// assert_eq!(parse("123456"), Err(Err::Error(Error::new("123456", ErrorKind::MapRes))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::map_res")]
@@ -362,7 +364,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::map_opt`]
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::character::digit1;
 /// use winnow::combinator::map_opt;
 /// # fn main() {
@@ -373,10 +375,10 @@ where
 /// assert_eq!(parse("123"), Ok(("", 123)));
 ///
 /// // this will fail if digit1 fails
-/// assert_eq!(parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+/// assert_eq!(parse("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Digit))));
 ///
 /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-/// assert_eq!(parse("123456"), Err(Err::Error(("123456", ErrorKind::MapOpt))));
+/// assert_eq!(parse("123456"), Err(Err::Error(Error::new("123456", ErrorKind::MapOpt))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::map_res")]
@@ -438,7 +440,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::and_then`]
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::character::digit1;
 /// use winnow::bytes::take;
 /// use winnow::combinator::map_parser;
@@ -448,7 +450,7 @@ where
 ///
 /// assert_eq!(parse("12345"), Ok(("", "12345")));
 /// assert_eq!(parse("123ab"), Ok(("", "123")));
-/// assert_eq!(parse("123"), Err(Err::Error(("123", ErrorKind::Eof))));
+/// assert_eq!(parse("123"), Err(Err::Error(Error::new("123", ErrorKind::Eof))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::and_then")]
@@ -500,7 +502,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, E>
 /// **WARNING:** Deprecated, replaced with [`Parser::flat_map`]
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::bytes::take;
 /// use winnow::number::u8;
 /// use winnow::combinator::flat_map;
@@ -509,7 +511,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, E>
 /// let mut parse = flat_map(u8, take);
 ///
 /// assert_eq!(parse(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
-/// assert_eq!(parse(&[4, 0, 1, 2][..]), Err(Err::Error((&[0, 1, 2][..], ErrorKind::Eof))));
+/// assert_eq!(parse(&[4, 0, 1, 2][..]), Err(Err::Error(Error::new(&[0, 1, 2][..], ErrorKind::Eof))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::flat_map")]
@@ -560,7 +562,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> H, H: Parser<I, O2, E>> Par
 /// To chain an error up, see [`cut`].
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::opt;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -675,7 +677,7 @@ where
 /// Tries to apply its parser without consuming the input.
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::peek;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -683,7 +685,7 @@ where
 /// let mut parser = peek(alpha1);
 ///
 /// assert_eq!(parser("abcd;"), Ok(("abcd;", "abcd")));
-/// assert_eq!(parser("123;"), Err(Err::Error(("123;", ErrorKind::Alpha))));
+/// assert_eq!(parser("123;"), Err(Err::Error(Error::new("123;", ErrorKind::Alpha))));
 /// # }
 /// ```
 pub fn peek<I: Clone, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
@@ -706,12 +708,12 @@ where
 ///
 /// ```
 /// # use std::str;
-/// # use winnow::{Err, error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// # use winnow::combinator::eof;
 ///
 /// # fn main() {
 /// let parser = eof;
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Eof))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Eof))));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// # }
 /// ```
@@ -734,7 +736,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::complete`]
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult, input::Streaming};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, input::Streaming};
 /// use winnow::bytes::take;
 /// use winnow::combinator::complete;
 /// # fn main() {
@@ -742,7 +744,7 @@ where
 /// let mut parser = complete(take(5u8));
 ///
 /// assert_eq!(parser(Streaming("abcdefg")), Ok((Streaming("fg"), "abcde")));
-/// assert_eq!(parser(Streaming("abcd")), Err(Err::Error((Streaming("abcd"), ErrorKind::Complete))));
+/// assert_eq!(parser(Streaming("abcd")), Err(Err::Error(Error::new(Streaming("abcd"), ErrorKind::Complete))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::complete")]
@@ -789,7 +791,7 @@ where
 /// Succeeds if all the input has been consumed by its child parser.
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::all_consuming;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -797,8 +799,8 @@ where
 /// let mut parser = all_consuming(alpha1);
 ///
 /// assert_eq!(parser("abcd"), Ok(("", "abcd")));
-/// assert_eq!(parser("abcd;"),Err(Err::Error((";", ErrorKind::Eof))));
-/// assert_eq!(parser("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
+/// assert_eq!(parser("abcd;"),Err(Err::Error(Error::new(";", ErrorKind::Eof))));
+/// assert_eq!(parser("123abcd;"),Err(Err::Error(Error::new("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
 pub fn all_consuming<I, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
@@ -824,7 +826,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::map`]
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::verify;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -832,8 +834,8 @@ where
 /// let mut parser = verify(alpha1, |s: &str| s.len() == 4);
 ///
 /// assert_eq!(parser("abcd"), Ok(("", "abcd")));
-/// assert_eq!(parser("abcde"), Err(Err::Error(("abcde", ErrorKind::Verify))));
-/// assert_eq!(parser("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
+/// assert_eq!(parser("abcde"), Err(Err::Error(Error::new("abcde", ErrorKind::Verify))));
+/// assert_eq!(parser("123abcd;"),Err(Err::Error(Error::new("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::verify")]
@@ -903,7 +905,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::value`]
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::value;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -911,7 +913,7 @@ where
 /// let mut parser = value(1234, alpha1);
 ///
 /// assert_eq!(parser("abcd"), Ok(("", 1234)));
-/// assert_eq!(parser("123abcd;"), Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
+/// assert_eq!(parser("123abcd;"), Err(Err::Error(Error::new("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::value")]
@@ -956,7 +958,7 @@ impl<I, O1, O2: Clone, E: ParseError<I>, F: Parser<I, O1, E>> Parser<I, O2, E>
 /// Succeeds if the child parser returns an error.
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::not;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -964,7 +966,7 @@ impl<I, O1, O2: Clone, E: ParseError<I>, F: Parser<I, O1, E>> Parser<I, O2, E>
 /// let mut parser = not(alpha1);
 ///
 /// assert_eq!(parser("123"), Ok(("123", ())));
-/// assert_eq!(parser("abcd"), Err(Err::Error(("abcd", ErrorKind::Not))));
+/// assert_eq!(parser("abcd"), Err(Err::Error(Error::new("abcd", ErrorKind::Not))));
 /// # }
 /// ```
 pub fn not<I: Clone, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, (), E>
@@ -986,7 +988,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::recognize`]
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::recognize;
 /// use winnow::character::{alpha1};
 /// use winnow::sequence::separated_pair;
@@ -995,7 +997,7 @@ where
 /// let mut parser = recognize(separated_pair(alpha1, ',', alpha1));
 ///
 /// assert_eq!(parser("abcd,efgh"), Ok(("", "abcd,efgh")));
-/// assert_eq!(parser("abcd;"),Err(Err::Error((";", ErrorKind::OneOf))));
+/// assert_eq!(parser("abcd;"),Err(Err::Error(Error::new(";", ErrorKind::OneOf))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::recognize")]
@@ -1071,7 +1073,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::{consumed, value, recognize, map};
 /// use winnow::character::{alpha1};
 /// use winnow::bytes::tag;
@@ -1086,7 +1088,7 @@ where
 /// let mut consumed_parser = consumed(value(true, separated_pair(alpha1, ',', alpha1)));
 ///
 /// assert_eq!(consumed_parser("abcd,efgh1"), Ok(("1", ("abcd,efgh", true))));
-/// assert_eq!(consumed_parser("abcd;"),Err(Err::Error((";", ErrorKind::OneOf))));
+/// assert_eq!(consumed_parser("abcd;"),Err(Err::Error(Error::new(";", ErrorKind::OneOf))));
 ///
 ///
 /// // the first output (representing the consumed input)
@@ -1236,7 +1238,7 @@ where
 ///
 /// Without `cut`:
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// # use winnow::bytes::one_of;
 /// # use winnow::character::digit1;
 /// # use winnow::combinator::rest;
@@ -1259,7 +1261,7 @@ where
 ///
 /// With `cut`:
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult, error::Error};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// # use winnow::bytes::one_of;
 /// # use winnow::character::digit1;
 /// # use winnow::combinator::rest;
@@ -1500,15 +1502,15 @@ enum State<E> {
 /// specify the default case.
 ///
 /// ```rust
-/// # use winnow::{Err,error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::branch::alt;
 /// use winnow::combinator::{success, value};
 /// # fn main() {
 ///
-/// let mut parser = success::<_,_,(_,ErrorKind)>(10);
+/// let mut parser = success::<_,_,Error<_>>(10);
 /// assert_eq!(parser("xyz"), Ok(("xyz", 10)));
 ///
-/// let mut sign = alt((value(-1, '-'), value(1, '+'), success::<_,_,(_,ErrorKind)>(1)));
+/// let mut sign = alt((value(-1, '-'), value(1, '+'), success::<_,_,Error<_>>(1)));
 /// assert_eq!(sign("+10"), Ok(("10", 1)));
 /// assert_eq!(sign("-10"), Ok(("10", -1)));
 /// assert_eq!(sign("10"), Ok(("10", 1)));
@@ -1521,11 +1523,11 @@ pub fn success<I, O: Clone, E: ParseError<I>>(val: O) -> impl Fn(I) -> IResult<I
 /// A parser which always fails.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, IResult};
+/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::fail;
 ///
 /// let s = "string";
-/// assert_eq!(fail::<_, &str, _>(s), Err(Err::Error((s, ErrorKind::Fail))));
+/// assert_eq!(fail::<_, &str, _>(s), Err(Err::Error(Error::new(s, ErrorKind::Fail))));
 /// ```
 pub fn fail<I, O, E: ParseError<I>>(i: I) -> IResult<I, O, E> {
   Err(Err::Error(E::from_error_kind(i, ErrorKind::Fail)))

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1277,7 +1277,7 @@ where
 ///
 /// assert_eq!(parser("+10 ab"), Ok((" ab", "10")));
 /// assert_eq!(parser("ab"), Ok(("", "ab")));
-/// assert_eq!(parser("+"), Err(Err::Failure(Error { input: "", code: ErrorKind::Digit })));
+/// assert_eq!(parser("+"), Err(Err::Failure(Error { input: "", kind: ErrorKind::Digit })));
 /// # }
 /// ```
 pub fn cut<I, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, O, E>

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -79,7 +79,7 @@ impl<I> ParseError<I> for CustomError {
     CustomError
   }
 
-  fn append(_: I, _: ErrorKind, _: CustomError) -> Self {
+  fn append(self, _: I, _: ErrorKind) -> Self {
     CustomError
   }
 }

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::bytes::tag;
 use crate::bytes::take;
+use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::Streaming;
@@ -12,7 +13,7 @@ use crate::{Err, IResult, Needed};
 
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {
-    let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+    let res: $crate::IResult<_, _, Error<_>> = $left;
     assert_eq!(res, $right);
   };
 );
@@ -87,7 +88,7 @@ impl<I> ParseError<I> for CustomError {
 struct CustomError;
 #[allow(dead_code)]
 fn custom_error(input: &[u8]) -> IResult<&[u8], &[u8], CustomError> {
-  //fix_error!(input, CustomError, alphanumeric)
+  //fix_error!(input, CustomError<_>, alphanumeric)
   crate::character::alphanumeric1(input)
 }
 
@@ -116,7 +117,10 @@ fn test_map_opt() {
   let input: &[u8] = &[50][..];
   assert_parse!(
     map_opt(u8, |u| if u < 20 { Some(u) } else { None })(input),
-    Err(Err::Error((&[50][..], ErrorKind::MapOpt)))
+    Err(Err::Error(Error {
+      input: &[50][..],
+      kind: ErrorKind::MapOpt
+    }))
   );
   assert_parse!(
     map_opt(u8, |u| if u > 20 { Some(u) } else { None })(input),
@@ -130,7 +134,10 @@ fn test_parser_map_opt() {
   assert_parse!(
     u8.map_opt(|u| if u < 20 { Some(u) } else { None })
       .parse_next(input),
-    Err(Err::Error((&[50][..], ErrorKind::MapOpt)))
+    Err(Err::Error(Error {
+      input: &[50][..],
+      kind: ErrorKind::MapOpt
+    }))
   );
   assert_parse!(
     u8.map_opt(|u| if u > 20 { Some(u) } else { None })
@@ -163,7 +170,10 @@ fn test_all_consuming() {
   let input: &[u8] = &[100, 101, 102][..];
   assert_parse!(
     all_consuming(take(2usize))(input),
-    Err(Err::Error((&[102][..], ErrorKind::Eof)))
+    Err(Err::Error(Error {
+      input: &[102][..],
+      kind: ErrorKind::Eof
+    }))
   );
   assert_parse!(
     all_consuming(take(3usize))(input),
@@ -182,7 +192,10 @@ fn test_verify_ref() {
   assert_eq!(parser1(&b"abcd"[..]), Ok((&b"d"[..], &b"abc"[..])));
   assert_eq!(
     parser1(&b"defg"[..]),
-    Err(Err::Error((&b"defg"[..], ErrorKind::Verify)))
+    Err(Err::Error(Error {
+      input: &b"defg"[..],
+      kind: ErrorKind::Verify
+    }))
   );
 
   fn parser2(i: &[u8]) -> IResult<&[u8], u32> {
@@ -202,7 +215,10 @@ fn test_verify_alloc() {
   assert_eq!(parser1(&b"abcd"[..]), Ok((&b"d"[..], b"abc".to_vec())));
   assert_eq!(
     parser1(&b"defg"[..]),
-    Err(Err::Error((&b"defg"[..], ErrorKind::Verify)))
+    Err(Err::Error(Error {
+      input: &b"defg"[..],
+      kind: ErrorKind::Verify
+    }))
   );
 }
 
@@ -367,7 +383,10 @@ fn test_parser_verify_ref() {
   );
   assert_eq!(
     parser1.parse_next(&b"defg"[..]),
-    Err(Err::Error((&b"defg"[..], ErrorKind::Verify)))
+    Err(Err::Error(Error {
+      input: &b"defg"[..],
+      kind: ErrorKind::Verify
+    }))
   );
 
   fn parser2(i: &[u8]) -> IResult<&[u8], u32> {
@@ -391,7 +410,10 @@ fn test_parser_verify_alloc() {
   );
   assert_eq!(
     parser1.parse_next(&b"defg"[..]),
-    Err(Err::Error((&b"defg"[..], ErrorKind::Verify)))
+    Err(Err::Error(Error {
+      input: &b"defg"[..],
+      kind: ErrorKind::Verify
+    }))
   );
 }
 
@@ -400,6 +422,18 @@ fn fail_test() {
   let a = "string";
   let b = "another string";
 
-  assert_eq!(fail::<_, &str, _>(a), Err(Err::Error((a, ErrorKind::Fail))));
-  assert_eq!(fail::<_, &str, _>(b), Err(Err::Error((b, ErrorKind::Fail))));
+  assert_eq!(
+    fail::<_, &str, _>(a),
+    Err(Err::Error(Error {
+      input: a,
+      kind: ErrorKind::Fail
+    }))
+  );
+  assert_eq!(
+    fail::<_, &str, _>(b),
+    Err(Err::Error(Error {
+      input: b,
+      kind: ErrorKind::Fail
+    }))
+  );
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -998,6 +998,10 @@ impl ErrorKind {
 /// and the position in the input
 #[allow(unused_variables)]
 #[macro_export(local_inner_macros)]
+#[cfg_attr(
+  not(test),
+  deprecated(since = "0.3.0", note = "Replaced with `E::from_error_kind`")
+)]
 macro_rules! error_position(
   ($input:expr, $code:expr) => ({
     $crate::error::ParseError::from_error_kind($input, $code)
@@ -1009,6 +1013,10 @@ macro_rules! error_position(
 /// the parsing tree
 #[allow(unused_variables)]
 #[macro_export(local_inner_macros)]
+#[cfg_attr(
+  not(test),
+  deprecated(since = "0.3.0", note = "Replaced with `E::append`")
+)]
 macro_rules! error_node_position(
   ($input:expr, $code:expr, $next:expr) => ({
     $crate::error::ParseError::append($next, $input, $code)

--- a/src/error.rs
+++ b/src/error.rs
@@ -586,38 +586,6 @@ impl<I: fmt::Display> fmt::Display for Error<I> {
 #[cfg(feature = "std")]
 impl<I: fmt::Debug + fmt::Display> std::error::Error for Error<I> {}
 
-// for backward compatibility, keep those trait implementations
-// for the previously used error type
-impl<I> ParseError<I> for (I, ErrorKind) {
-  fn from_error_kind(input: I, kind: ErrorKind) -> Self {
-    (input, kind)
-  }
-
-  fn append(self, _: I, _: ErrorKind) -> Self {
-    self
-  }
-}
-
-impl<I, C> ContextError<I, C> for (I, ErrorKind) {}
-
-impl<I, E> FromExternalError<I, E> for (I, ErrorKind) {
-  fn from_external_error(input: I, kind: ErrorKind, _e: E) -> Self {
-    (input, kind)
-  }
-}
-
-impl<I> ErrorConvert<(I, ErrorKind)> for ((I, usize), ErrorKind) {
-  fn convert(self) -> (I, ErrorKind) {
-    ((self.0).0, self.1)
-  }
-}
-
-impl<I> ErrorConvert<((I, usize), ErrorKind)> for (I, ErrorKind) {
-  fn convert(self) -> ((I, usize), ErrorKind) {
-    ((self.0, 0), self.1)
-  }
-}
-
 impl<I> ParseError<I> for () {
   fn from_error_kind(_: I, _: ErrorKind) -> Self {}
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -498,11 +498,13 @@ pub trait ParseError<I>: Sized {
   }
 }
 
-/// This trait is required by the `context` combinator to add a static string
-/// to an existing error
+/// Used by the [`context`] to add custom data to errors
+///
+/// May be implemented multiple times for different kinds of context.
 pub trait ContextError<I, C>: Sized {
-  /// Creates a new error from an input position, a static string and an existing error.
-  /// This is used mainly in the [context] combinator, to add user friendly information
+  /// Creates a new error from an input position, a data, and an existing error.
+  ///
+  /// This is used mainly in the [`context`] combinator, to add user friendly information
   /// to errors when backtracking through a parse tree
   fn add_context(self, _input: I, _ctx: C) -> Self {
     self

--- a/src/input.rs
+++ b/src/input.rs
@@ -1334,7 +1334,7 @@ where
         initial: input.initial.clone(),
         input: error.input,
       },
-      error.code,
+      error.kind,
     )
   };
   f(&input.input)
@@ -1426,7 +1426,7 @@ where
         input: error.input,
         state: input.state.clone(),
       },
-      error.code,
+      error.kind,
     )
   };
   f(&input.input)
@@ -1511,7 +1511,7 @@ where
   F: FnOnce(&I) -> IResult<I, I>,
 {
   let map_error =
-    |error: crate::error::Error<I>| E::from_error_kind(Streaming(error.input), error.code);
+    |error: crate::error::Error<I>| E::from_error_kind(Streaming(error.input), error.kind);
   f(&input.0)
     .map(|(remaining, output)| (Streaming(remaining), Streaming(output)))
     .map_err(|error| match error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@
 //!
 //! assert_eq!(alt_tags(&b"abcdxxx"[..]), Ok((&b"xxx"[..], &b"abcd"[..])));
 //! assert_eq!(alt_tags(&b"efghxxx"[..]), Ok((&b"xxx"[..], &b"efgh"[..])));
-//! assert_eq!(alt_tags(&b"ijklxxx"[..]), Err(winnow::Err::Error((&b"ijklxxx"[..], winnow::error::ErrorKind::Tag))));
+//! assert_eq!(alt_tags(&b"ijklxxx"[..]), Err(winnow::Err::Error(winnow::error::Error::new(&b"ijklxxx"[..], winnow::error::ErrorKind::Tag))));
 //! ```
 //!
 //! The **`opt`** combinator makes a parser optional. If the child parser returns
@@ -259,7 +259,7 @@
 //! # fn main() {
 //! use winnow::prelude::*;
 //! use winnow::{
-//!     error::ErrorKind, Needed,
+//!     error::ErrorKind, error::Error, Needed,
 //!     number::be_u16,
 //!     bytes::{tag, take},
 //!     input::Streaming,
@@ -276,7 +276,7 @@
 //! );
 //! assert_eq!(tpl.parse_next(Streaming(&b"abcde"[..])), Err(winnow::Err::Incomplete(Needed::new(2))));
 //! let input = &b"abcdejk"[..];
-//! assert_eq!(tpl.parse_next(Streaming(input)), Err(winnow::Err::Error((Streaming(&input[5..]), ErrorKind::Tag))));
+//! assert_eq!(tpl.parse_next(Streaming(input)), Err(winnow::Err::Error(Error::new(Streaming(&input[5..]), ErrorKind::Tag))));
 //! # }
 //! ```
 //!

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -109,7 +109,7 @@ where
   E: ParseError<I>,
 {
   move |mut i: I| match f.parse_next(i.clone()) {
-    Err(Err::Error(err)) => Err(Err::Error(E::append(i, ErrorKind::Many1, err))),
+    Err(Err::Error(err)) => Err(Err::Error(err.append(i, ErrorKind::Many1))),
     Err(e) => Err(e),
     Ok((i1, o)) => {
       let mut acc = crate::lib::std::vec::Vec::with_capacity(4);
@@ -176,7 +176,7 @@ where
         Ok((i1, o)) => return Ok((i1, (res, o))),
         Err(Err::Error(_)) => {
           match f.parse_next(i.clone()) {
-            Err(Err::Error(err)) => return Err(Err::Error(E::append(i, ErrorKind::ManyTill, err))),
+            Err(Err::Error(err)) => return Err(Err::Error(err.append(i, ErrorKind::ManyTill))),
             Err(e) => return Err(e),
             Ok((i1, o)) => {
               // infinite loop check: the parser must always consume
@@ -402,7 +402,7 @@ where
         }
         Err(Err::Error(e)) => {
           if count < min {
-            return Err(Err::Error(E::append(input, ErrorKind::ManyMN, e)));
+            return Err(Err::Error(e.append(input, ErrorKind::ManyMN)));
           } else {
             return Ok((input, res));
           }
@@ -578,7 +578,7 @@ where
           input = i;
         }
         Err(Err::Error(e)) => {
-          return Err(Err::Error(E::append(i, ErrorKind::Count, e)));
+          return Err(Err::Error(e.append(i, ErrorKind::Count)));
         }
         Err(e) => {
           return Err(e);
@@ -631,7 +631,7 @@ where
           input = i;
         }
         Err(Err::Error(e)) => {
-          return Err(Err::Error(E::append(i, ErrorKind::Count, e)));
+          return Err(Err::Error(e.append(i, ErrorKind::Count)));
         }
         Err(e) => {
           return Err(e);
@@ -878,7 +878,7 @@ where
         //FInputXMError: handle failure properly
         Err(Err::Error(err)) => {
           if count < min {
-            return Err(Err::Error(E::append(input, ErrorKind::ManyMN, err)));
+            return Err(Err::Error(err.append(input, ErrorKind::ManyMN)));
           } else {
             break;
           }
@@ -1023,7 +1023,7 @@ where
           input = i;
         }
         Err(Err::Error(e)) => {
-          return Err(Err::Error(E::append(i, ErrorKind::Count, e)));
+          return Err(Err::Error(e.append(i, ErrorKind::Count)));
         }
         Err(e) => {
           return Err(e);

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -355,7 +355,7 @@ impl<I> ParseError<I> for NilError {
   fn from_error_kind(_: I, _: ErrorKind) -> NilError {
     NilError
   }
-  fn append(_: I, _: ErrorKind, _: NilError) -> NilError {
+  fn append(self, _: I, _: ErrorKind) -> NilError {
     NilError
   }
 }

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -21,7 +21,7 @@ use crate::*;
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u8;
 ///
@@ -30,7 +30,7 @@ use crate::*;
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -47,7 +47,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u16;
 ///
@@ -56,7 +56,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -73,7 +73,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u24;
 ///
@@ -82,7 +82,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -99,7 +99,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u32;
 ///
@@ -108,7 +108,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -125,7 +125,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u64;
 ///
@@ -134,7 +134,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -151,7 +151,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u128;
 ///
@@ -160,7 +160,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -203,7 +203,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i8;
 ///
@@ -212,7 +212,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -229,7 +229,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i16;
 ///
@@ -238,7 +238,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -255,7 +255,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i24;
 ///
@@ -264,7 +264,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -290,7 +290,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i32;
 ///
@@ -299,7 +299,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -316,7 +316,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i64;
 ///
@@ -325,7 +325,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -342,7 +342,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i128;
 ///
@@ -351,7 +351,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -368,7 +368,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u8;
 ///
@@ -377,7 +377,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -394,7 +394,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u16;
 ///
@@ -403,7 +403,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -420,7 +420,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u24;
 ///
@@ -429,7 +429,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -446,7 +446,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u32;
 ///
@@ -455,7 +455,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -472,7 +472,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u64;
 ///
@@ -481,7 +481,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -498,7 +498,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u128;
 ///
@@ -507,7 +507,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -542,7 +542,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i8;
 ///
@@ -551,7 +551,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -568,7 +568,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i16;
 ///
@@ -577,7 +577,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -594,7 +594,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i24;
 ///
@@ -603,7 +603,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -629,7 +629,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i32;
 ///
@@ -638,7 +638,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -655,7 +655,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i64;
 ///
@@ -664,7 +664,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -681,7 +681,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i128;
 ///
@@ -690,7 +690,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -708,7 +708,7 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u8;
 ///
@@ -717,7 +717,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -744,7 +744,7 @@ where
 /// *complete version*: returns an error if there is not enough input data
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u16;
 ///
@@ -753,14 +753,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u16 = |s| {
 ///   u16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -786,7 +786,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u24 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u24;
 ///
@@ -795,14 +795,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u24 = |s| {
 ///   u24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -828,7 +828,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u32 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u32;
 ///
@@ -837,14 +837,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u32 = |s| {
 ///   u32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -870,7 +870,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u64 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u64;
 ///
@@ -879,14 +879,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u64 = |s| {
 ///   u64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -912,7 +912,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u128 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u128;
 ///
@@ -921,14 +921,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u128 = |s| {
 ///   u128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -953,7 +953,7 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i8;
 ///
@@ -962,7 +962,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -981,7 +981,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i16 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i16;
 ///
@@ -990,14 +990,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i16 = |s| {
 ///   i16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1023,7 +1023,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i24 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i24;
 ///
@@ -1032,14 +1032,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i24 = |s| {
 ///   i24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1065,7 +1065,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i32 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i32;
 ///
@@ -1074,14 +1074,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i32 = |s| {
 ///   i32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1107,7 +1107,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i64 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i64;
 ///
@@ -1116,14 +1116,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i64 = |s| {
 ///   i64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1149,7 +1149,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i128 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i128;
 ///
@@ -1158,14 +1158,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i128 = |s| {
 ///   i128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1189,7 +1189,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_f32;
 ///
@@ -1198,7 +1198,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1218,7 +1218,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_f64;
 ///
@@ -1227,7 +1227,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1247,7 +1247,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_f32;
 ///
@@ -1256,7 +1256,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1276,7 +1276,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_f64;
 ///
@@ -1285,7 +1285,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1307,7 +1307,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f32 float.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::f32;
 ///
@@ -1316,14 +1316,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f32 = |s| {
 ///   f32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1349,7 +1349,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f64 float.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::f64;
 ///
@@ -1358,14 +1358,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f64 = |s| {
 ///   f64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1389,7 +1389,7 @@ where
 ///
 /// *Complete version*: Will parse until the end of input if it has less than 8 bytes.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::hex_u32;
 ///
@@ -1399,7 +1399,7 @@ where
 ///
 /// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
 /// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 #[inline]
 ///
@@ -1448,7 +1448,7 @@ where
 /// *Complete version*: Can parse until the end of input.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::recognize_float;
 ///
@@ -1459,7 +1459,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
 /// assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Char))));
 /// ```
 #[rustfmt::skip]
 ///
@@ -1654,7 +1654,7 @@ use crate::input::ParseTo;
 ///
 /// *Complete version*: Can parse until the end of input.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::float;
 ///
@@ -1665,7 +1665,7 @@ use crate::input::ParseTo;
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f32`][crate::character::f32]
@@ -1698,7 +1698,7 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::double;
 ///
@@ -1709,7 +1709,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f64`][crate::character::f64]
@@ -1741,13 +1741,14 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::error::Error;
   use crate::error::ErrorKind;
   use crate::Err;
   use proptest::prelude::*;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      let res: $crate::IResult<_, _> = $left;
       assert_eq!(res, $right);
     };
   );
@@ -2095,7 +2096,7 @@ mod tests {
     let remaining_exponent = "-1.234E-";
     assert_parse!(
       recognize_float(remaining_exponent),
-      Err(Err::Failure(("", ErrorKind::Digit)))
+      Err(Err::Failure(Error::new("", ErrorKind::Digit)))
     );
 
     let (_i, nan) = float::<_, ()>("NaN").unwrap();

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -34,7 +34,7 @@ pub enum Endianness {
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u8;
 ///
@@ -43,16 +43,16 @@ pub enum Endianness {
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u8;
 ///
 /// let parser = |s| {
-///   be_u8::<_, (_, ErrorKind), true>(s)
+///   be_u8::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
@@ -79,7 +79,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u16;
 ///
@@ -88,16 +88,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u16;
 ///
 /// let parser = |s| {
-///   be_u16::<_, (_, ErrorKind), true>(s)
+///   be_u16::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001)));
@@ -124,7 +124,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u24;
 ///
@@ -133,16 +133,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u24;
 ///
 /// let parser = |s| {
-///   be_u24::<_, (_, ErrorKind), true>(s)
+///   be_u24::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x000102)));
@@ -169,7 +169,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u32;
 ///
@@ -178,16 +178,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u32;
 ///
 /// let parser = |s| {
-///   be_u32::<_, (_, ErrorKind), true>(s)
+///   be_u32::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203)));
@@ -214,7 +214,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u64;
 ///
@@ -223,16 +223,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u64;
 ///
 /// let parser = |s| {
-///   be_u64::<_, (_, ErrorKind), true>(s)
+///   be_u64::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001020304050607)));
@@ -259,7 +259,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u128;
 ///
@@ -268,16 +268,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u128;
 ///
 /// let parser = |s| {
-///   be_u128::<_, (_, ErrorKind), true>(s)
+///   be_u128::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203040506070809101112131415)));
@@ -304,7 +304,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i8;
 ///
@@ -313,15 +313,15 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i8;
 ///
-/// let parser = be_i8::<_, (_, ErrorKind), true>;
+/// let parser = be_i8::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
@@ -347,7 +347,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i16;
 ///
@@ -356,15 +356,15 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i16;
 ///
-/// let parser = be_i16::<_, (_, ErrorKind), true>;
+/// let parser = be_i16::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001)));
 /// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(2))));
@@ -390,7 +390,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i24;
 ///
@@ -399,15 +399,15 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i24;
 ///
-/// let parser = be_i24::<_, (_, ErrorKind), true>;
+/// let parser = be_i24::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x000102)));
 /// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(3))));
@@ -433,7 +433,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i32;
 ///
@@ -442,15 +442,15 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i32;
 ///
-/// let parser = be_i32::<_, (_, ErrorKind), true>;
+/// let parser = be_i32::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203)));
 /// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(4))));
@@ -476,7 +476,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i64;
 ///
@@ -485,15 +485,15 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i64;
 ///
-/// let parser = be_i64::<_, (_, ErrorKind), true>;
+/// let parser = be_i64::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001020304050607)));
 /// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
@@ -519,7 +519,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i128;
 ///
@@ -528,15 +528,15 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i128;
 ///
-/// let parser = be_i128::<_, (_, ErrorKind), true>;
+/// let parser = be_i128::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203040506070809101112131415)));
 /// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
@@ -562,7 +562,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u8;
 ///
@@ -571,15 +571,15 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u8;
 ///
-/// let parser = le_u8::<_, (_, ErrorKind), true>;
+/// let parser = le_u8::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
@@ -605,7 +605,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u16;
 ///
@@ -614,16 +614,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u16;
 ///
 /// let parser = |s| {
-///   le_u16::<_, (_, ErrorKind), true>(s)
+///   le_u16::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0100)));
@@ -650,7 +650,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u24;
 ///
@@ -659,16 +659,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u24;
 ///
 /// let parser = |s| {
-///   le_u24::<_, (_, ErrorKind), true>(s)
+///   le_u24::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x020100)));
@@ -695,7 +695,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u32;
 ///
@@ -704,16 +704,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u32;
 ///
 /// let parser = |s| {
-///   le_u32::<_, (_, ErrorKind), true>(s)
+///   le_u32::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x03020100)));
@@ -740,7 +740,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u64;
 ///
@@ -749,16 +749,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u64;
 ///
 /// let parser = |s| {
-///   le_u64::<_, (_, ErrorKind), true>(s)
+///   le_u64::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0706050403020100)));
@@ -785,7 +785,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u128;
 ///
@@ -794,16 +794,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u128;
 ///
 /// let parser = |s| {
-///   le_u128::<_, (_, ErrorKind), true>(s)
+///   le_u128::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x15141312111009080706050403020100)));
@@ -830,7 +830,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i8;
 ///
@@ -839,15 +839,15 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i8;
 ///
-/// let parser = le_i8::<_, (_, ErrorKind), true>;
+/// let parser = le_i8::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
@@ -873,7 +873,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i16;
 ///
@@ -882,16 +882,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i16;
 ///
 /// let parser = |s| {
-///   le_i16::<_, (_, ErrorKind), true>(s)
+///   le_i16::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0100)));
@@ -918,7 +918,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i24;
 ///
@@ -927,16 +927,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i24;
 ///
 /// let parser = |s| {
-///   le_i24::<_, (_, ErrorKind), true>(s)
+///   le_i24::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x020100)));
@@ -963,7 +963,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i32;
 ///
@@ -972,16 +972,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i32;
 ///
 /// let parser = |s| {
-///   le_i32::<_, (_, ErrorKind), true>(s)
+///   le_i32::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x03020100)));
@@ -1008,7 +1008,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i64;
 ///
@@ -1017,16 +1017,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i64;
 ///
 /// let parser = |s| {
-///   le_i64::<_, (_, ErrorKind), true>(s)
+///   le_i64::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0706050403020100)));
@@ -1053,7 +1053,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i128;
 ///
@@ -1062,16 +1062,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i128;
 ///
 /// let parser = |s| {
-///   le_i128::<_, (_, ErrorKind), true>(s)
+///   le_i128::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x15141312111009080706050403020100)));
@@ -1100,7 +1100,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u8;
 ///
@@ -1109,17 +1109,17 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u8;
 ///
 /// let parser = |s| {
-///   u8::<_, (_, ErrorKind), true>(s)
+///   u8::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"\x03abcefg"[..]), 0x00)));
@@ -1149,7 +1149,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u16;
 ///
@@ -1158,31 +1158,31 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u16 = |s| {
 ///   u16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u16;
 ///
 /// let be_u16 = |s| {
-///   u16::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   u16::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_u16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
 ///
 /// let le_u16 = |s| {
-///   u16::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   u16::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0300)));
@@ -1214,7 +1214,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u24;
 ///
@@ -1223,31 +1223,31 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u24 = |s| {
 ///   u24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u24;
 ///
 /// let be_u24 = |s| {
-///   u24::<_,(_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   u24::<_,Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_u24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
 ///
 /// let le_u24 = |s| {
-///   u24::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   u24::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x050300)));
@@ -1279,7 +1279,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u32;
 ///
@@ -1288,31 +1288,31 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u32 = |s| {
 ///   u32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u32;
 ///
 /// let be_u32 = |s| {
-///   u32::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   u32::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_u32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
 ///
 /// let le_u32 = |s| {
-///   u32::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   u32::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07050300)));
@@ -1344,7 +1344,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u64;
 ///
@@ -1353,31 +1353,31 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u64 = |s| {
 ///   u64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u64;
 ///
 /// let be_u64 = |s| {
-///   u64::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   u64::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_u64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
 ///
 /// let le_u64 = |s| {
-///   u64::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   u64::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0706050403020100)));
@@ -1409,7 +1409,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u128;
 ///
@@ -1418,31 +1418,31 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u128 = |s| {
 ///   u128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u128;
 ///
 /// let be_u128 = |s| {
-///   u128::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   u128::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_u128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
 ///
 /// let le_u128 = |s| {
-///   u128::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   u128::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
@@ -1473,7 +1473,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i8;
 ///
@@ -1482,17 +1482,17 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i8;
 ///
 /// let parser = |s| {
-///   i8::<_, (_, ErrorKind), true>(s)
+///   i8::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"\x03abcefg"[..]), 0x00)));
@@ -1522,7 +1522,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i16;
 ///
@@ -1531,31 +1531,31 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i16 = |s| {
 ///   i16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i16;
 ///
 /// let be_i16 = |s| {
-///   i16::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   i16::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_i16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
 ///
 /// let le_i16 = |s| {
-///   i16::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   i16::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0300)));
@@ -1587,7 +1587,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i24;
 ///
@@ -1596,31 +1596,31 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i24 = |s| {
 ///   i24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i24;
 ///
 /// let be_i24 = |s| {
-///   i24::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   i24::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_i24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
 ///
 /// let le_i24 = |s| {
-///   i24::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   i24::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x050300)));
@@ -1652,7 +1652,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i32;
 ///
@@ -1661,31 +1661,31 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i32 = |s| {
 ///   i32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i32;
 ///
 /// let be_i32 = |s| {
-///   i32::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   i32::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_i32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
 ///
 /// let le_i32 = |s| {
-///   i32::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   i32::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07050300)));
@@ -1717,7 +1717,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i64;
 ///
@@ -1726,31 +1726,31 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i64 = |s| {
 ///   i64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i64;
 ///
 /// let be_i64 = |s| {
-///   i64::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   i64::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_i64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
 ///
 /// let le_i64 = |s| {
-///   i64::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   i64::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0706050403020100)));
@@ -1782,7 +1782,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i128;
 ///
@@ -1791,31 +1791,31 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i128 = |s| {
 ///   i128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i128;
 ///
 /// let be_i128 = |s| {
-///   i128::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   i128::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_i128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
 ///
 /// let le_i128 = |s| {
-///   i128::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   i128::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
@@ -1844,7 +1844,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_f32;
 ///
@@ -1853,16 +1853,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_f32;
 ///
 /// let parser = |s| {
-///   be_f32::<_, (_, ErrorKind), true>(s)
+///   be_f32::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&[0x40, 0x29, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 2.640625)));
@@ -1889,7 +1889,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_f64;
 ///
@@ -1898,16 +1898,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_f64;
 ///
 /// let parser = |s| {
-///   be_f64::<_, (_, ErrorKind), true>(s)
+///   be_f64::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 12.5)));
@@ -1934,7 +1934,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_f32;
 ///
@@ -1943,16 +1943,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_f32;
 ///
 /// let parser = |s| {
-///   le_f32::<_, (_, ErrorKind), true>(s)
+///   le_f32::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Streaming(&b""[..]), 12.5)));
@@ -1979,7 +1979,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_f64;
 ///
@@ -1988,16 +1988,16 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_f64;
 ///
 /// let parser = |s| {
-///   le_f64::<_, (_, ErrorKind), true>(s)
+///   le_f64::<_, Error<_>, true>(s)
 /// };
 ///
 /// assert_eq!(parser(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Streaming(&b""[..]), 3145728.0)));
@@ -2027,7 +2027,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::f32;
 ///
@@ -2036,31 +2036,31 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f32 = |s| {
 ///   f32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::f32;
 ///
 /// let be_f32 = |s| {
-///   f32::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   f32::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_f32(Streaming(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 12.5)));
 /// assert_eq!(be_f32(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
 ///
 /// let le_f32 = |s| {
-///   f32::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   f32::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(Streaming(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Streaming(&b""[..]), 12.5)));
@@ -2092,7 +2092,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::f64;
 ///
@@ -2101,31 +2101,31 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f64 = |s| {
 ///   f64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::f64;
 ///
 /// let be_f64 = |s| {
-///   f64::<_, (_, ErrorKind), true>(winnow::number::Endianness::Big)(s)
+///   f64::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_f64(Streaming(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 12.5)));
 /// assert_eq!(be_f64(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(5))));
 ///
 /// let le_f64 = |s| {
-///   f64::<_, (_, ErrorKind), true>(winnow::number::Endianness::Little)(s)
+///   f64::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Streaming(&b""[..]), 12.5)));
@@ -2154,7 +2154,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::hex_u32;
 ///
@@ -2164,11 +2164,11 @@ where
 ///
 /// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
 /// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::hex_u32;
 ///
@@ -2178,7 +2178,7 @@ where
 ///
 /// assert_eq!(parser(Streaming(&b"01AE;"[..])), Ok((Streaming(&b";"[..]), 0x01AE)));
 /// assert_eq!(parser(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Streaming(&b"ggg"[..])), Err(Err::Error((Streaming(&b"ggg"[..]), ErrorKind::IsA))));
+/// assert_eq!(parser(Streaming(&b"ggg"[..])), Err(Err::Error(Error::new(Streaming(&b"ggg"[..]), ErrorKind::IsA))));
 /// ```
 #[inline(always)]
 pub fn hex_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -20,11 +20,11 @@ use crate::*;
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u8;
 ///
 /// let parser = |s| {
-///   be_u8::<_, (_, ErrorKind)>(s)
+///   be_u8::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
@@ -49,11 +49,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u16;
 ///
 /// let parser = |s| {
-///   be_u16::<_, (_, ErrorKind)>(s)
+///   be_u16::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
@@ -78,11 +78,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u24;
 ///
 /// let parser = |s| {
-///   be_u24::<_, (_, ErrorKind)>(s)
+///   be_u24::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
@@ -107,11 +107,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u32;
 ///
 /// let parser = |s| {
-///   be_u32::<_, (_, ErrorKind)>(s)
+///   be_u32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
@@ -136,11 +136,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u64;
 ///
 /// let parser = |s| {
-///   be_u64::<_, (_, ErrorKind)>(s)
+///   be_u64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
@@ -164,11 +164,11 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u128;
 ///
 /// let parser = |s| {
-///   be_u128::<_, (_, ErrorKind)>(s)
+///   be_u128::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
@@ -218,10 +218,10 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i8;
 ///
-/// let parser = be_i8::<_, (_, ErrorKind)>;
+/// let parser = be_i8::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
@@ -244,10 +244,10 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i16;
 ///
-/// let parser = be_i16::<_, (_, ErrorKind)>;
+/// let parser = be_i16::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(2))));
@@ -270,10 +270,10 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i24;
 ///
-/// let parser = be_i24::<_, (_, ErrorKind)>;
+/// let parser = be_i24::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(3))));
@@ -305,10 +305,10 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i32;
 ///
-/// let parser = be_i32::<_, (_, ErrorKind)>;
+/// let parser = be_i32::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
@@ -332,10 +332,10 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i64;
 ///
-/// let parser = be_i64::<_, (_, ErrorKind)>;
+/// let parser = be_i64::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
@@ -358,10 +358,10 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i128;
 ///
-/// let parser = be_i128::<_, (_, ErrorKind)>;
+/// let parser = be_i128::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
@@ -384,10 +384,10 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u8;
 ///
-/// let parser = le_u8::<_, (_, ErrorKind)>;
+/// let parser = le_u8::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
@@ -411,11 +411,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u16;
 ///
 /// let parser = |s| {
-///   le_u16::<_, (_, ErrorKind)>(s)
+///   le_u16::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
@@ -440,11 +440,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u24;
 ///
 /// let parser = |s| {
-///   le_u24::<_, (_, ErrorKind)>(s)
+///   le_u24::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
@@ -469,11 +469,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u32;
 ///
 /// let parser = |s| {
-///   le_u32::<_, (_, ErrorKind)>(s)
+///   le_u32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
@@ -498,11 +498,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u64;
 ///
 /// let parser = |s| {
-///   le_u64::<_, (_, ErrorKind)>(s)
+///   le_u64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
@@ -527,11 +527,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u128;
 ///
 /// let parser = |s| {
-///   le_u128::<_, (_, ErrorKind)>(s)
+///   le_u128::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
@@ -573,10 +573,10 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i8;
 ///
-/// let parser = le_i8::<_, (_, ErrorKind)>;
+/// let parser = le_i8::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
 /// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
@@ -600,11 +600,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i16;
 ///
 /// let parser = |s| {
-///   le_i16::<_, (_, ErrorKind)>(s)
+///   le_i16::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
@@ -629,11 +629,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i24;
 ///
 /// let parser = |s| {
-///   le_i24::<_, (_, ErrorKind)>(s)
+///   le_i24::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
@@ -667,11 +667,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i32;
 ///
 /// let parser = |s| {
-///   le_i32::<_, (_, ErrorKind)>(s)
+///   le_i32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
@@ -696,11 +696,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i64;
 ///
 /// let parser = |s| {
-///   le_i64::<_, (_, ErrorKind)>(s)
+///   le_i64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
@@ -725,11 +725,11 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i128;
 ///
 /// let parser = |s| {
-///   le_i128::<_, (_, ErrorKind)>(s)
+///   le_i128::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
@@ -754,12 +754,12 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u8;
 ///
 /// let parser = |s| {
-///   u8::<_, (_, ErrorKind)>(s)
+///   u8::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
@@ -793,19 +793,19 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u16;
 ///
 /// let be_u16 = |s| {
-///   u16::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   u16::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
 ///
 /// let le_u16 = |s| {
-///   u16::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   u16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
@@ -838,19 +838,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u24 integer.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u24;
 ///
 /// let be_u24 = |s| {
-///   u24::<_,(_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   u24::<_,Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
 ///
 /// let le_u24 = |s| {
-///   u24::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   u24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
@@ -883,19 +883,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u32 integer.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u32;
 ///
 /// let be_u32 = |s| {
-///   u32::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   u32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
 ///
 /// let le_u32 = |s| {
-///   u32::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   u32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
@@ -928,19 +928,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u64 integer.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u64;
 ///
 /// let be_u64 = |s| {
-///   u64::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   u64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
 ///
 /// let le_u64 = |s| {
-///   u64::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   u64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
@@ -973,19 +973,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u128 integer.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u128;
 ///
 /// let be_u128 = |s| {
-///   u128::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   u128::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
 ///
 /// let le_u128 = |s| {
-///   u128::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   u128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
@@ -1017,12 +1017,12 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i8;
 ///
 /// let parser = |s| {
-///   i8::<_, (_, ErrorKind)>(s)
+///   i8::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
@@ -1048,19 +1048,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i16 integer.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i16;
 ///
 /// let be_i16 = |s| {
-///   i16::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   i16::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
 ///
 /// let le_i16 = |s| {
-///   i16::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   i16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
@@ -1093,19 +1093,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i24 integer.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i24;
 ///
 /// let be_i24 = |s| {
-///   i24::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   i24::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
 ///
 /// let le_i24 = |s| {
-///   i24::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   i24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
@@ -1138,19 +1138,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i32 integer.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i32;
 ///
 /// let be_i32 = |s| {
-///   i32::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   i32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
 ///
 /// let le_i32 = |s| {
-///   i32::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   i32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
@@ -1183,19 +1183,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i64 integer.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i64;
 ///
 /// let be_i64 = |s| {
-///   i64::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   i64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
 ///
 /// let le_i64 = |s| {
-///   i64::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   i64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
@@ -1228,19 +1228,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i128 integer.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i128;
 ///
 /// let be_i128 = |s| {
-///   i128::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   i128::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
 ///
 /// let le_i128 = |s| {
-///   i128::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   i128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
@@ -1271,11 +1271,11 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_f32;
 ///
 /// let parser = |s| {
-///   be_f32::<_, (_, ErrorKind)>(s)
+///   be_f32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00][..]), Ok((&b""[..], 2.640625)));
@@ -1302,11 +1302,11 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_f64;
 ///
 /// let parser = |s| {
-///   be_f64::<_, (_, ErrorKind)>(s)
+///   be_f64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
@@ -1333,11 +1333,11 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_f32;
 ///
 /// let parser = |s| {
-///   le_f32::<_, (_, ErrorKind)>(s)
+///   le_f32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
@@ -1364,11 +1364,11 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_f64;
 ///
 /// let parser = |s| {
-///   le_f64::<_, (_, ErrorKind)>(s)
+///   le_f64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 3145728.0)));
@@ -1397,19 +1397,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f32 float.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::f32;
 ///
 /// let be_f32 = |s| {
-///   f32::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   f32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
 ///
 /// let le_f32 = |s| {
-///   f32::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   f32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
@@ -1442,19 +1442,19 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f64 float.
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::f64;
 ///
 /// let be_f64 = |s| {
-///   f64::<_, (_, ErrorKind)>(winnow::number::Endianness::Big)(s)
+///   f64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
 ///
 /// let le_f64 = |s| {
-///   f64::<_, (_, ErrorKind)>(winnow::number::Endianness::Little)(s)
+///   f64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
@@ -1485,7 +1485,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::hex_u32;
 ///
 /// let parser = |s| {
@@ -1494,7 +1494,7 @@ where
 ///
 /// assert_eq!(parser(&b"01AE;"[..]), Ok((&b";"[..], 0x01AE)));
 /// assert_eq!(parser(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 #[inline]
 ///
@@ -1546,7 +1546,7 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if it reaches the end of input.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::recognize_float;
 ///
 /// let parser = |s| {
@@ -1556,7 +1556,7 @@ where
 /// assert_eq!(parser("11e-1;"), Ok((";", "11e-1")));
 /// assert_eq!(parser("123E-02;"), Ok((";", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Char))));
 /// ```
 #[rustfmt::skip]
 ///
@@ -1755,7 +1755,7 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::float;
 ///
@@ -1766,7 +1766,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f32`][crate::character::f32] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -1805,7 +1805,7 @@ where
 /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::double;
 ///
@@ -1816,7 +1816,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f64`][crate::character::f64] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -1853,13 +1853,14 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::error::Error;
   use crate::error::ErrorKind;
   use crate::{Err, Needed};
   use proptest::prelude::*;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      let res: $crate::IResult<_, _, Error<_>> = $left;
       assert_eq!(res, $right);
     };
   );

--- a/src/number/tests.rs
+++ b/src/number/tests.rs
@@ -2,12 +2,13 @@ use super::*;
 
 mod complete {
   use super::*;
+  use crate::error::Error;
   use crate::error::ErrorKind;
   use crate::Err;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      let res: $crate::IResult<_, _, Error<_>> = $left;
       assert_eq!(res, $right);
     };
   );
@@ -400,13 +401,14 @@ mod complete {
 
 mod streaming {
   use super::*;
+  use crate::error::Error;
   use crate::error::ErrorKind;
   use crate::input::Streaming;
   use crate::{Err, Needed};
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, (_, ErrorKind)> = $left;
+      let res: $crate::IResult<_, _, Error<_>> = $left;
       assert_eq!(res, $right);
     };
   );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -238,13 +238,13 @@ impl<T> Err<error::Error<T>> {
   {
     match self {
       Err::Incomplete(n) => Err::Incomplete(n),
-      Err::Failure(error::Error { input, code }) => Err::Failure(error::Error {
+      Err::Failure(error::Error { input, kind }) => Err::Failure(error::Error {
         input: f(input),
-        code,
+        kind,
       }),
-      Err::Error(error::Error { input, code }) => Err::Error(error::Error {
+      Err::Error(error::Error { input, kind }) => Err::Error(error::Error {
         input: f(input),
-        code,
+        kind,
       }),
     }
   }
@@ -807,7 +807,7 @@ pub trait Parser<I, O, E> {
   /// Prints a message and the input if the parser fails.
   ///
   /// The message prints the `Error` or `Incomplete`
-  /// and the parser's calling code.
+  /// and the parser's calling kind.
   ///
   /// It also displays the input in hexdump format
   ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -415,14 +415,14 @@ pub trait Parser<I, O, E> {
   /// # Example
   ///
   /// ```rust
-  /// # use winnow::{Err,error::ErrorKind, IResult, Parser};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult, Parser};
   /// use winnow::character::alpha1;
   /// # fn main() {
   ///
   /// let mut parser = alpha1.value(1234);
   ///
   /// assert_eq!(parser.parse_next("abcd"), Ok(("", 1234)));
-  /// assert_eq!(parser.parse_next("123abcd;"), Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
+  /// assert_eq!(parser.parse_next("123abcd;"), Err(Err::Error(Error::new("123abcd;", ErrorKind::Alpha))));
   /// # }
   /// ```
   fn value<O2>(self, val: O2) -> Value<Self, O, O2>
@@ -466,7 +466,7 @@ pub trait Parser<I, O, E> {
   /// # Example
   ///
   /// ```rust
-  /// # use winnow::{Err,error::ErrorKind, IResult, Parser};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult, Parser};
   /// use winnow::character::{alpha1};
   /// use winnow::sequence::separated_pair;
   /// # fn main() {
@@ -474,7 +474,7 @@ pub trait Parser<I, O, E> {
   /// let mut parser = separated_pair(alpha1, ',', alpha1).recognize();
   ///
   /// assert_eq!(parser.parse_next("abcd,efgh"), Ok(("", "abcd,efgh")));
-  /// assert_eq!(parser.parse_next("abcd;"),Err(Err::Error((";", ErrorKind::OneOf))));
+  /// assert_eq!(parser.parse_next("abcd;"),Err(Err::Error(Error::new(";", ErrorKind::OneOf))));
   /// # }
   /// ```
   fn recognize(self) -> Recognize<Self, O>
@@ -497,7 +497,7 @@ pub trait Parser<I, O, E> {
   ///
   /// ```rust
   /// # use winnow::prelude::*;
-  /// # use winnow::{Err,error::ErrorKind, IResult};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult};
   /// use winnow::character::{alpha1};
   /// use winnow::bytes::tag;
   /// use winnow::sequence::separated_pair;
@@ -511,7 +511,7 @@ pub trait Parser<I, O, E> {
   /// let mut consumed_parser = separated_pair(alpha1, ',', alpha1).value(true).with_recognized();
   ///
   /// assert_eq!(consumed_parser.parse_next("abcd,efgh1"), Ok(("1", (true, "abcd,efgh"))));
-  /// assert_eq!(consumed_parser.parse_next("abcd;"),Err(Err::Error((";", ErrorKind::OneOf))));
+  /// assert_eq!(consumed_parser.parse_next("abcd;"),Err(Err::Error(Error::new(";", ErrorKind::OneOf))));
   ///
   /// // the second output (representing the consumed input)
   /// // should be the same as that of the `recognize` parser.
@@ -535,7 +535,7 @@ pub trait Parser<I, O, E> {
   ///
   /// ```rust
   /// # use winnow::prelude::*;
-  /// # use winnow::{Err,error::ErrorKind, IResult, Parser, input::Slice};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult, Parser, input::Slice};
   /// use winnow::input::Located;
   /// use winnow::character::alpha1;
   /// use winnow::sequence::separated_pair;
@@ -543,7 +543,7 @@ pub trait Parser<I, O, E> {
   /// let mut parser = separated_pair(alpha1.span(), ',', alpha1.span());
   ///
   /// assert_eq!(parser.parse_next(Located::new("abcd,efgh")).finish(), Ok((0..4, 5..9)));
-  /// assert_eq!(parser.parse_next(Located::new("abcd;")),Err(Err::Error((Located::new("abcd;").slice(4..), ErrorKind::OneOf))));
+  /// assert_eq!(parser.parse_next(Located::new("abcd;")),Err(Err::Error(Error::new(Located::new("abcd;").slice(4..), ErrorKind::OneOf))));
   /// ```
   fn span(self) -> Span<Self, O>
   where
@@ -566,7 +566,7 @@ pub trait Parser<I, O, E> {
   ///
   /// ```rust
   /// # use winnow::prelude::*;
-  /// # use winnow::{Err,error::ErrorKind, IResult, input::Slice};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult, input::Slice};
   /// use winnow::input::Located;
   /// use winnow::character::alpha1;
   /// use winnow::bytes::tag;
@@ -581,7 +581,7 @@ pub trait Parser<I, O, E> {
   /// let mut consumed_parser = separated_pair(alpha1.value(1).with_span(), ',', alpha1.value(2).with_span());
   ///
   /// assert_eq!(consumed_parser.parse_next(Located::new("abcd,efgh")).finish(), Ok(((1, 0..4), (2, 5..9))));
-  /// assert_eq!(consumed_parser.parse_next(Located::new("abcd;")),Err(Err::Error((Located::new("abcd;").slice(4..), ErrorKind::OneOf))));
+  /// assert_eq!(consumed_parser.parse_next(Located::new("abcd;")),Err(Err::Error(Error::new(Located::new("abcd;").slice(4..), ErrorKind::OneOf))));
   ///
   /// // the second output (representing the consumed input)
   /// // should be the same as that of the `span` parser.
@@ -605,7 +605,7 @@ pub trait Parser<I, O, E> {
   /// # Example
   ///
   /// ```rust
-  /// use winnow::{Err,error::ErrorKind, IResult,Parser};
+  /// use winnow::{Err,error::ErrorKind, error::Error, IResult,Parser};
   /// use winnow::character::digit1;
   /// # fn main() {
   ///
@@ -615,7 +615,7 @@ pub trait Parser<I, O, E> {
   /// assert_eq!(parser.parse_next("123456"), Ok(("", 6)));
   ///
   /// // this will fail if digit1 fails
-  /// assert_eq!(parser.parse_next("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+  /// assert_eq!(parser.parse_next("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Digit))));
   /// # }
   /// ```
   fn map<G, O2>(self, g: G) -> Map<Self, G, O>
@@ -631,7 +631,7 @@ pub trait Parser<I, O, E> {
   /// # Example
   ///
   /// ```rust
-  /// # use winnow::{Err,error::ErrorKind, IResult, Parser};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult, Parser};
   /// use winnow::character::digit1;
   /// # fn main() {
   ///
@@ -641,10 +641,10 @@ pub trait Parser<I, O, E> {
   /// assert_eq!(parse.parse_next("123"), Ok(("", 123)));
   ///
   /// // this will fail if digit1 fails
-  /// assert_eq!(parse.parse_next("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+  /// assert_eq!(parse.parse_next("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Digit))));
   ///
   /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-  /// assert_eq!(parse.parse_next("123456"), Err(Err::Error(("123456", ErrorKind::MapRes))));
+  /// assert_eq!(parse.parse_next("123456"), Err(Err::Error(Error::new("123456", ErrorKind::MapRes))));
   /// # }
   /// ```
   fn map_res<G, O2, E2>(self, g: G) -> MapRes<Self, G, O>
@@ -660,7 +660,7 @@ pub trait Parser<I, O, E> {
   /// # Example
   ///
   /// ```rust
-  /// # use winnow::{Err,error::ErrorKind, IResult, Parser};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult, Parser};
   /// use winnow::character::digit1;
   /// # fn main() {
   ///
@@ -670,10 +670,10 @@ pub trait Parser<I, O, E> {
   /// assert_eq!(parse.parse_next("123"), Ok(("", 123)));
   ///
   /// // this will fail if digit1 fails
-  /// assert_eq!(parse.parse_next("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
+  /// assert_eq!(parse.parse_next("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Digit))));
   ///
   /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-  /// assert_eq!(parse.parse_next("123456"), Err(Err::Error(("123456", ErrorKind::MapOpt))));
+  /// assert_eq!(parse.parse_next("123456"), Err(Err::Error(Error::new("123456", ErrorKind::MapOpt))));
   /// # }
   /// ```
   fn map_opt<G, O2>(self, g: G) -> MapOpt<Self, G, O>
@@ -689,7 +689,7 @@ pub trait Parser<I, O, E> {
   /// # Example
   ///
   /// ```rust
-  /// # use winnow::{Err,error::ErrorKind, IResult, Parser};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult, Parser};
   /// use winnow::bytes::take;
   /// use winnow::number::u8;
   /// # fn main() {
@@ -697,7 +697,7 @@ pub trait Parser<I, O, E> {
   /// let mut length_data = u8.flat_map(take);
   ///
   /// assert_eq!(length_data.parse_next(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
-  /// assert_eq!(length_data.parse_next(&[4, 0, 1, 2][..]), Err(Err::Error((&[0, 1, 2][..], ErrorKind::Eof))));
+  /// assert_eq!(length_data.parse_next(&[4, 0, 1, 2][..]), Err(Err::Error(Error::new(&[0, 1, 2][..], ErrorKind::Eof))));
   /// # }
   /// ```
   fn flat_map<G, H, O2>(self, g: G) -> FlatMap<Self, G, O>
@@ -714,7 +714,7 @@ pub trait Parser<I, O, E> {
   /// # Example
   ///
   /// ```rust
-  /// # use winnow::{Err,error::ErrorKind, IResult, Parser};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult, Parser};
   /// use winnow::character::digit1;
   /// use winnow::bytes::take;
   /// # fn main() {
@@ -723,7 +723,7 @@ pub trait Parser<I, O, E> {
   ///
   /// assert_eq!(digits.parse_next("12345"), Ok(("", "12345")));
   /// assert_eq!(digits.parse_next("123ab"), Ok(("", "123")));
-  /// assert_eq!(digits.parse_next("123"), Err(Err::Error(("123", ErrorKind::Eof))));
+  /// assert_eq!(digits.parse_next("123"), Err(Err::Error(Error::new("123", ErrorKind::Eof))));
   /// # }
   /// ```
   fn and_then<G, O2>(self, g: G) -> AndThen<Self, G, O>
@@ -742,15 +742,15 @@ pub trait Parser<I, O, E> {
   /// # Example
   ///
   /// ```rust
-  /// # use winnow::{Err,error::ErrorKind, IResult, Parser};
+  /// # use winnow::{Err,error::ErrorKind, error::Error, IResult, Parser};
   /// # use winnow::character::alpha1;
   /// # fn main() {
   ///
   /// let mut parser = alpha1.verify(|s: &str| s.len() == 4);
   ///
   /// assert_eq!(parser.parse_next("abcd"), Ok(("", "abcd")));
-  /// assert_eq!(parser.parse_next("abcde"), Err(Err::Error(("abcde", ErrorKind::Verify))));
-  /// assert_eq!(parser.parse_next("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
+  /// assert_eq!(parser.parse_next("abcde"), Err(Err::Error(Error::new("abcde", ErrorKind::Verify))));
+  /// assert_eq!(parser.parse_next("123abcd;"),Err(Err::Error(Error::new("123abcd;", ErrorKind::Alpha))));
   /// # }
   /// ```
   fn verify<G, O2: ?Sized>(self, second: G) -> Verify<Self, G, O2>
@@ -779,14 +779,14 @@ pub trait Parser<I, O, E> {
   /// # Example
   ///
   /// ```rust
-  /// # use winnow::{Err,error::ErrorKind, IResult, input::Streaming, Parser};
+  /// # use winnow::{Err, error::ErrorKind, error::Error, IResult, input::Streaming, Parser};
   /// # use winnow::bytes::take;
   /// # fn main() {
   ///
   /// let mut parser = take(5u8).complete();
   ///
   /// assert_eq!(parser.parse_next(Streaming("abcdefg")), Ok((Streaming("fg"), "abcde")));
-  /// assert_eq!(parser.parse_next(Streaming("abcd")), Err(Err::Error((Streaming("abcd"), ErrorKind::Complete))));
+  /// assert_eq!(parser.parse_next(Streaming("abcd")), Err(Err::Error(Error::new(Streaming("abcd"), ErrorKind::Complete))));
   /// # }
   /// ```
   fn complete(self) -> Complete<Self>
@@ -1082,6 +1082,7 @@ impl<'a, I, O, E> Parser<I, O, E> for Box<dyn Parser<I, O, E> + 'a> {
 mod tests {
   use super::*;
   use crate::bytes::{tag, take};
+  use crate::error::Error;
   use crate::error::ErrorKind;
   use crate::input::Streaming;
   use crate::number::be_u16;
@@ -1119,7 +1120,10 @@ mod tests {
     assert_eq!(parser.parse_next("abc123def"), Ok(("123def", ("abc",))));
     assert_eq!(
       parser.parse_next("123def"),
-      Err(Err::Error(("123def", ErrorKind::Alpha)))
+      Err(Err::Error(Error {
+        input: "123def",
+        kind: ErrorKind::Alpha
+      }))
     );
   }
 

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -16,7 +16,7 @@ use crate::{IResult, Parser};
 /// * `second` The second parser to apply.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::pair;
 /// use winnow::bytes::tag;
@@ -25,8 +25,8 @@ use crate::{IResult, Parser};
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 #[deprecated(since = "8.0.0", note = "`Parser` is directly implemented for tuples")]
 pub fn pair<I, O1, O2, E: ParseError<I>, F, G>(
@@ -51,7 +51,7 @@ where
 /// * `second` The second parser to get object.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::preceded;
 /// use winnow::bytes::tag;
@@ -60,8 +60,8 @@ where
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "efg")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "efg")));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn preceded<I, O1, O2, E: ParseError<I>, F, G>(
   mut first: F,
@@ -85,7 +85,7 @@ where
 /// * `second` The second parser to match an object.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::terminated;
 /// use winnow::bytes::tag;
@@ -94,8 +94,8 @@ where
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "abc")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "abc")));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn terminated<I, O1, O2, E: ParseError<I>, F, G>(
   mut first: F,
@@ -121,7 +121,7 @@ where
 /// * `second` The second parser to apply.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::separated_pair;
 /// use winnow::bytes::tag;
@@ -130,8 +130,8 @@ where
 ///
 /// assert_eq!(parser("abc|efg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abc|efghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn separated_pair<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
   mut first: F,
@@ -160,7 +160,7 @@ where
 /// * `third` The third parser to apply and discard.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed};
+/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::delimited;
 /// use winnow::bytes::tag;
@@ -169,8 +169,8 @@ where
 ///
 /// assert_eq!(parser("(abc)"), Ok(("", "abc")));
 /// assert_eq!(parser("(abc)def"), Ok(("def", "abc")));
-/// assert_eq!(parser(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn delimited<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
   mut first: F,
@@ -274,13 +274,13 @@ impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
 /// **WARNING:** Deprecated, [`Parser`] is directly implemented for tuples
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind};
+/// # use winnow::{Err, error::ErrorKind, error::Error};
 /// use winnow::sequence::tuple;
 /// use winnow::character::{alpha1, digit1};
 /// let mut parser = tuple((alpha1, digit1, alpha1));
 ///
 /// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
-/// assert_eq!(parser("123def"), Err(Err::Error(("123def", ErrorKind::Alpha))));
+/// assert_eq!(parser("123def"), Err(Err::Error(Error::new("123def", ErrorKind::Alpha))));
 /// ```
 #[deprecated(since = "8.0.0", note = "`Parser` is directly implemented for tuples")]
 #[allow(deprecated)]

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -15,7 +15,10 @@ fn single_element_tuples() {
   assert_eq!(parser("abc123def"), Ok(("123def", ("abc",))));
   assert_eq!(
     parser("123def"),
-    Err(Err::Error(("123def", ErrorKind::Alpha)))
+    Err(Err::Error(Error {
+      input: "123def",
+      kind: ErrorKind::Alpha
+    }))
   );
 }
 

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -24,8 +24,8 @@ impl<'a> ParseError<Streaming<&'a str>> for CustomError {
     CustomError(format!("error code was: {:?}", kind))
   }
 
-  fn append(_: Streaming<&'a str>, kind: ErrorKind, other: CustomError) -> Self {
-    CustomError(format!("{:?}\nerror code was: {:?}", other, kind))
+  fn append(self, _: Streaming<&'a str>, kind: ErrorKind) -> Self {
+    CustomError(format!("{:?}\nerror code was: {:?}", self, kind))
   }
 }
 

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -74,8 +74,7 @@ fn usize_length_bytes_issue() {
   use winnow::multi::length_data;
   use winnow::number::be_u16;
   #[allow(clippy::type_complexity)]
-  let _: IResult<Streaming<&[u8]>, &[u8], (Streaming<&[u8]>, ErrorKind)> =
-    length_data(be_u16)(Streaming(b"012346"));
+  let _: IResult<Streaming<&[u8]>, &[u8]> = length_data(be_u16)(Streaming(b"012346"));
 }
 
 #[test]

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -176,10 +176,10 @@ fn issue_848_overflow_incomplete_bits_to_bytes() {
   }
   assert_eq!(
     parser(Streaming(&b""[..])),
-    Err(Err::Failure(winnow::error_position!(
-      Streaming(&b""[..]),
-      ErrorKind::TooLarge
-    )))
+    Err(Err::Failure(winnow::error::Error {
+      input: Streaming(&b""[..]),
+      code: ErrorKind::TooLarge
+    }))
   );
 }
 
@@ -238,7 +238,7 @@ fn issue_1282_findtoken_char() {
 
 #[test]
 fn issue_x_looser_fill_bounds() {
-  use winnow::{bytes::tag, character::digit1, error_position, multi::fill, sequence::terminated};
+  use winnow::{bytes::tag, character::digit1, multi::fill, sequence::terminated};
 
   fn fill_pair(i: &[u8]) -> IResult<&[u8], [&[u8]; 2]> {
     let mut buf = [&[][..], &[][..]];
@@ -256,7 +256,10 @@ fn issue_x_looser_fill_bounds() {
   );
   assert_eq!(
     fill_pair(b"123,,"),
-    Err(Err::Error(error_position!(&b","[..], ErrorKind::Digit)))
+    Err(Err::Error(winnow::error::Error {
+      input: &b","[..],
+      code: ErrorKind::Digit
+    }))
   );
 }
 

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -178,7 +178,7 @@ fn issue_848_overflow_incomplete_bits_to_bytes() {
     parser(Streaming(&b""[..])),
     Err(Err::Failure(winnow::error::Error {
       input: Streaming(&b""[..]),
-      code: ErrorKind::TooLarge
+      kind: ErrorKind::TooLarge
     }))
   );
 }
@@ -258,7 +258,7 @@ fn issue_x_looser_fill_bounds() {
     fill_pair(b"123,,"),
     Err(Err::Error(winnow::error::Error {
       input: &b","[..],
-      code: ErrorKind::Digit
+      kind: ErrorKind::Digit
     }))
   );
 }

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -6,7 +6,7 @@ mod test {
   use winnow::{branch::alt, bytes::tag_no_case, multi::many1};
   use winnow::{
     bytes::{tag, take, take_till, take_till1, take_until, take_while1},
-    error::{self, ErrorKind},
+    error::{self, Error, ErrorKind},
     Err, IResult,
   };
 
@@ -120,7 +120,7 @@ mod test {
 
     const INPUT: &str = "βèƒôřèÂßÇá";
 
-    let res: IResult<_, _, (_, ErrorKind)> = take(13_usize)(Streaming(INPUT));
+    let res: IResult<_, _, Error<_>> = take(13_usize)(Streaming(INPUT));
     match res {
       Err(Err::Incomplete(_)) => (),
       other => panic!(
@@ -138,7 +138,7 @@ mod test {
     const CONSUMED: &str = "βèƒôřè";
     const LEFTOVER: &str = "ÂßÇ∂áƒƭèř";
 
-    let res: IResult<_, _, (_, ErrorKind)> = take_until(FIND)(INPUT);
+    let res: IResult<_, _, Error<_>> = take_until(FIND)(INPUT);
     match res {
       Ok((extra, output)) => {
         assert!(
@@ -170,7 +170,7 @@ mod test {
     const INPUT: &str = "βèƒôřè";
     const FIND: &str = "βèƒôřèÂßÇ";
 
-    let res: IResult<_, _, (_, ErrorKind)> = take_until(FIND)(Streaming(INPUT));
+    let res: IResult<_, _, Error<_>> = take_until(FIND)(Streaming(INPUT));
     match res {
       Err(Err::Incomplete(_)) => (),
       other => panic!(
@@ -188,7 +188,7 @@ mod test {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const FIND: &str = "Ráñδô₥";
 
-    let res: IResult<_, _, (_, ErrorKind)> = take_until(FIND)(Streaming(INPUT));
+    let res: IResult<_, _, Error<_>> = take_until(FIND)(Streaming(INPUT));
     match res {
       Err(Err::Incomplete(_)) => (),
       other => panic!(

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -312,7 +312,7 @@ mod test {
       f(Streaming(d)),
       Err(Err::Error(winnow::error::Error {
         input: Streaming(d),
-        code: ErrorKind::TakeWhile1
+        kind: ErrorKind::TakeWhile1
       }))
     );
   }

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod test {
-  use winnow::error_position;
   use winnow::input::Streaming;
   use winnow::prelude::*;
   #[cfg(feature = "alloc")]
@@ -311,10 +310,10 @@ mod test {
     assert_eq!(f(Streaming(c)), Ok((Streaming("123"), b)));
     assert_eq!(
       f(Streaming(d)),
-      Err(Err::Error(error_position!(
-        Streaming(d),
-        ErrorKind::TakeWhile1
-      )))
+      Err(Err::Error(winnow::error::Error {
+        input: Streaming(d),
+        code: ErrorKind::TakeWhile1
+      }))
     );
   }
 


### PR DESCRIPTION
This removes cruft

BREAKING CHANGE:
- Moved `other: Self` parameters to be `self`
- Rename `Error::code` to `Error::kind`
- Remove `(I, ErrorKind)` support