### PR TITLE
fix(input)!: Cleanup to prepare for trait merger

### DIFF
--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -4,7 +4,7 @@
 #![allow(deprecated)]
 
 use crate::error::{ErrorKind, ParseError};
-use crate::input::{InputIter, InputLength, Slice, ToUsize};
+use crate::input::{InputIter, Slice, SliceLen, ToUsize};
 use crate::lib::std::ops::{AddAssign, Div, RangeFrom, Shl, Shr};
 use crate::{Err, IResult};
 
@@ -39,7 +39,7 @@ pub fn take<I, O, C, E: ParseError<(I, usize)>>(
   count: C,
 ) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
   C: ToUsize,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
@@ -52,14 +52,14 @@ pub(crate) fn take_internal<I, O, E: ParseError<(I, usize)>>(
   count: usize,
 ) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
   if count == 0 {
     Ok(((input, bit_offset), 0u8.into()))
   } else {
     let cnt = (count + bit_offset).div(8);
-    if input.input_len() * 8 < count + bit_offset {
+    if input.slice_len() * 8 < count + bit_offset {
       Err(Err::Error(E::from_error_kind(
         (input, bit_offset),
         ErrorKind::Eof,
@@ -104,7 +104,7 @@ pub fn tag<I, O, C, E: ParseError<(I, usize)>>(
   count: C,
 ) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + Clone,
   C: ToUsize,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
@@ -118,7 +118,7 @@ pub(crate) fn tag_internal<I, O, E: ParseError<(I, usize)>>(
   count: usize,
 ) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + Clone,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
   let inp = input.clone();
@@ -151,7 +151,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::bits::bool`")]
 pub fn bool<I, E: ParseError<(I, usize)>>(input: (I, usize)) -> IResult<(I, usize), bool, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   let (res, bit): (_, u32) = take(1usize)(input)?;
   Ok((res, bit != 0))

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -7,7 +7,7 @@ pub mod streaming;
 mod tests;
 
 use crate::error::{ErrorConvert, ErrorKind, ParseError};
-use crate::input::{InputIsStreaming, InputIter, InputLength, Slice, ToUsize};
+use crate::input::{InputIsStreaming, InputIter, Slice, SliceLen, ToUsize};
 use crate::lib::std::ops::{AddAssign, RangeFrom, Shl, Shr};
 use crate::{Err, IResult, Needed, Parser};
 
@@ -139,7 +139,7 @@ pub fn take<I, O, C, E: ParseError<(I, usize)>, const STREAMING: bool>(
   count: C,
 ) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
   C: ToUsize,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
@@ -203,11 +203,8 @@ pub fn tag<I, O, C, E: ParseError<(I, usize)>, const STREAMING: bool>(
   count: C,
 ) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>>
-    + InputIter<Item = u8>
-    + InputLength
-    + InputIsStreaming<STREAMING>
-    + Clone,
+  I:
+    Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING> + Clone,
   C: ToUsize,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
@@ -241,7 +238,7 @@ pub fn bool<I, E: ParseError<(I, usize)>, const STREAMING: bool>(
   input: (I, usize),
 ) -> IResult<(I, usize), bool, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   #![allow(deprecated)]
   if STREAMING {

--- a/src/bits/streaming.rs
+++ b/src/bits/streaming.rs
@@ -4,7 +4,7 @@
 #![allow(deprecated)]
 
 use crate::error::{ErrorKind, ParseError};
-use crate::input::{InputIter, InputLength, Slice, ToUsize};
+use crate::input::{InputIter, Slice, SliceLen, ToUsize};
 use crate::lib::std::ops::{AddAssign, Div, RangeFrom, Shl, Shr};
 use crate::{Err, IResult, Needed};
 
@@ -19,7 +19,7 @@ pub fn take<I, O, C, E: ParseError<(I, usize)>>(
   count: C,
 ) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
   C: ToUsize,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
@@ -32,14 +32,14 @@ pub(crate) fn take_internal<I, O, E: ParseError<(I, usize)>>(
   count: usize,
 ) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
   if count == 0 {
     Ok(((input, bit_offset), 0u8.into()))
   } else {
     let cnt = (count + bit_offset).div(8);
-    if input.input_len() * 8 < count + bit_offset {
+    if input.slice_len() * 8 < count + bit_offset {
       Err(Err::Incomplete(Needed::new(count)))
     } else {
       let mut acc: O = 0_u8.into();
@@ -84,7 +84,7 @@ pub fn tag<I, O, C, E: ParseError<(I, usize)>>(
   count: C,
 ) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + Clone,
   C: ToUsize,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
@@ -98,7 +98,7 @@ pub(crate) fn tag_internal<I, O, E: ParseError<(I, usize)>>(
   count: usize,
 ) -> IResult<(I, usize), O, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + Clone,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + Clone,
   O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
   let inp = input.clone();
@@ -131,7 +131,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::bits::bool`")]
 pub fn bool<I, E: ParseError<(I, usize)>>(input: (I, usize)) -> IResult<(I, usize), bool, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   let (res, bit): (_, u32) = take(1usize)(input)?;
   Ok((res, bit != 0))

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -159,10 +159,8 @@ macro_rules! alt_trait_inner(
 alt_trait!(A B C D E F G H I J K L M N O P Q R S T U);
 
 // Manually implement Alt for (A,), the 1-tuple type
-impl<Input, Output, Error: ParseError<Input>, A: Parser<Input, Output, Error>>
-  Alt<Input, Output, Error> for (A,)
-{
-  fn choice(&mut self, input: Input) -> IResult<Input, Output, Error> {
+impl<I, O, E: ParseError<I>, A: Parser<I, O, E>> Alt<I, O, E> for (A,) {
+  fn choice(&mut self, input: I) -> IResult<I, O, E> {
     self.0.parse_next(input)
   }
 }

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -5,7 +5,7 @@
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  Compare, CompareResult, ContainsToken, FindSubstring, InputIter, InputTake, InputTakeAtOffset,
+  Compare, CompareResult, ContainsToken, FindSlice, InputIter, InputTake, InputTakeAtOffset,
   IntoOutput, Slice, SliceLen, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
@@ -648,7 +648,7 @@ pub fn take_until<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + FindSubstring<T>,
+  Input: InputTake + FindSlice<T>,
   Input: IntoOutput,
   T: SliceLen + Clone,
 {
@@ -660,11 +660,11 @@ pub(crate) fn take_until_internal<T, Input, Error: ParseError<Input>>(
   t: T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + FindSubstring<T>,
+  Input: InputTake + FindSlice<T>,
   Input: IntoOutput,
   T: SliceLen,
 {
-  let res: IResult<_, _, Error> = match i.find_substring(t) {
+  let res: IResult<_, _, Error> = match i.find_slice(t) {
     None => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
     Some(index) => Ok(i.take_split(index)),
   };
@@ -697,7 +697,7 @@ pub fn take_until1<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + FindSubstring<T>,
+  Input: InputTake + FindSlice<T>,
   Input: IntoOutput,
   T: SliceLen + Clone,
 {
@@ -709,11 +709,11 @@ pub(crate) fn take_until1_internal<T, Input, Error: ParseError<Input>>(
   t: T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + FindSubstring<T>,
+  Input: InputTake + FindSlice<T>,
   Input: IntoOutput,
   T: SliceLen,
 {
-  let res: IResult<_, _, Error> = match i.find_substring(t) {
+  let res: IResult<_, _, Error> = match i.find_slice(t) {
     None | Some(0) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
     Some(index) => Ok(i.take_split(index)),
   };

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -17,7 +17,7 @@ pub(crate) fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as InputIter>:
 where
   I: InputIter + InputLength + Slice<RangeFrom<usize>>,
 {
-  let mut it = input.iter_indices();
+  let mut it = input.iter_offsets();
   match it.next() {
     None => Err(Err::Error(E::from_error_kind(input, ErrorKind::Eof))),
     Some((_, c)) => match it.next() {
@@ -145,7 +145,7 @@ where
   <I as InputIter>::Item: Copy,
   T: FindToken<<I as InputIter>::Item>,
 {
-  let mut it = input.iter_indices();
+  let mut it = input.iter_offsets();
   match it.next() {
     Some((_, c)) if list.find_token(c) => match it.next() {
       None => Ok((input.slice(input.input_len()..), c)),
@@ -164,7 +164,7 @@ where
   <I as InputIter>::Item: Copy,
   T: FindToken<<I as InputIter>::Item>,
 {
-  let mut it = input.iter_indices();
+  let mut it = input.iter_offsets();
   match it.next() {
     Some((_, c)) if !list.find_token(c) => match it.next() {
       None => Ok((input.slice(input.input_len()..), c)),
@@ -419,11 +419,11 @@ where
   Input: IntoOutput,
   T: FindToken<<Input as InputIter>::Item>,
 {
-  match input.position(|c| !list.find_token(c)) {
+  match input.offset_for(|c| !list.find_token(c)) {
     Some(idx) => {
       if idx >= m {
         if idx <= n {
-          let res: IResult<_, _, Error> = if let Ok(index) = input.slice_index(idx) {
+          let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(idx) {
             Ok(input.take_split(index)).into_output()
           } else {
             Err(Err::Error(Error::from_error_kind(
@@ -433,7 +433,7 @@ where
           };
           res
         } else {
-          let res: IResult<_, _, Error> = if let Ok(index) = input.slice_index(n) {
+          let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(n) {
             Ok(input.take_split(index)).into_output()
           } else {
             Err(Err::Error(Error::from_error_kind(
@@ -451,7 +451,7 @@ where
     None => {
       let len = input.input_len();
       if len >= n {
-        match input.slice_index(n) {
+        match input.offset_at(n) {
           Ok(index) => Ok(input.take_split(index)).into_output(),
           Err(_needed) => Err(Err::Error(Error::from_error_kind(
             input,
@@ -617,7 +617,7 @@ where
   Input: InputIter + InputTake,
   Input: IntoOutput,
 {
-  match i.slice_index(c) {
+  match i.offset_at(c) {
     Err(_needed) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::Eof))),
     Ok(index) => Ok(i.take_split(index)).into_output(),
   }

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -799,7 +799,7 @@ where
         if i2.input_len() == 0 {
           return Ok((input.slice(input.input_len()..), input)).into_output();
         } else if i2.input_len() == current_len {
-          let index = input.offset(&i2);
+          let index = input.offset_to(&i2);
           return Ok(input.take_split(index)).into_output();
         } else {
           i = i2;
@@ -827,7 +827,7 @@ where
             }
           }
         } else {
-          let index = input.offset(&i);
+          let index = input.offset_to(&i);
           if index == 0 {
             return Err(Err::Error(Error::from_error_kind(
               input,
@@ -949,7 +949,7 @@ where
         } else if i2.input_len() == current_len {
           return Ok((remainder, res));
         } else {
-          index = input.offset(&i2);
+          index = input.offset_to(&i2);
         }
       }
       Err(Err::Error(_)) => {
@@ -970,7 +970,7 @@ where
                 if i2.input_len() == 0 {
                   return Ok((i.slice(i.input_len()..), res));
                 } else {
-                  index = input.offset(&i2);
+                  index = input.offset_to(&i2);
                 }
               }
               Err(e) => return Err(e),

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -6,7 +6,7 @@ use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
   Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake,
-  InputTakeAtPosition, IntoOutput, Slice, ToUsize,
+  InputTakeAtOffset, IntoOutput, Slice, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
 use crate::lib::std::result::Result::Ok;
@@ -202,9 +202,9 @@ pub fn is_not<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| is_not_internal(i, &arr)
 }
@@ -214,12 +214,12 @@ pub(crate) fn is_not_internal<T, Input, Error: ParseError<Input>>(
   arr: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::IsNot;
-  i.split_at_position1_complete(|c| arr.find_token(c), e)
+  i.split_at_offset1_complete(|c| arr.find_token(c), e)
     .into_output()
 }
 
@@ -251,9 +251,9 @@ pub fn is_a<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| is_a_internal(i, &arr)
 }
@@ -263,12 +263,12 @@ pub(crate) fn is_a_internal<T, Input, Error: ParseError<Input>>(
   arr: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::IsA;
-  i.split_at_position1_complete(|c| !arr.find_token(c), e)
+  i.split_at_offset1_complete(|c| !arr.find_token(c), e)
     .into_output()
 }
 
@@ -298,9 +298,9 @@ pub fn take_while<T, Input, Error: ParseError<Input>>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_while_internal(i, &list)
 }
@@ -310,11 +310,11 @@ pub(crate) fn take_while_internal<T, Input, Error: ParseError<Input>>(
   list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
-  i.split_at_position_complete(|c| !list.find_token(c))
+  i.split_at_offset_complete(|c| !list.find_token(c))
     .into_output()
 }
 
@@ -345,9 +345,9 @@ pub fn take_while1<T, Input, Error: ParseError<Input>>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_while1_internal(i, &list)
 }
@@ -357,12 +357,12 @@ pub(crate) fn take_while1_internal<T, Input, Error: ParseError<Input>>(
   list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeWhile1;
-  i.split_at_position1_complete(|c| !list.find_token(c), e)
+  i.split_at_offset1_complete(|c| !list.find_token(c), e)
     .into_output()
 }
 
@@ -495,9 +495,9 @@ pub fn take_till<T, Input, Error: ParseError<Input>>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_till_internal(i, &list)
 }
@@ -507,11 +507,11 @@ pub(crate) fn take_till_internal<T, Input, Error: ParseError<Input>>(
   list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
-  i.split_at_position_complete(|c| list.find_token(c))
+  i.split_at_offset_complete(|c| list.find_token(c))
     .into_output()
 }
 
@@ -544,9 +544,9 @@ pub fn take_till1<T, Input, Error: ParseError<Input>>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_till1_internal(i, &list)
 }
@@ -556,12 +556,12 @@ pub(crate) fn take_till1_internal<T, Input, Error: ParseError<Input>>(
   list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeTill1;
-  i.split_at_position1_complete(|c| list.find_token(c), e)
+  i.split_at_offset1_complete(|c| list.find_token(c), e)
     .into_output()
 }
 
@@ -753,7 +753,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: IntoOutput,
@@ -776,7 +776,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: IntoOutput,
@@ -894,7 +894,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
@@ -920,7 +920,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -5,7 +5,7 @@
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake,
+  Compare, CompareResult, ContainsToken, FindSubstring, InputIter, InputLength, InputTake,
   InputTakeAtOffset, IntoOutput, Slice, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
@@ -143,11 +143,11 @@ pub(crate) fn one_of_internal<I, T, E: ParseError<I>>(
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
   <I as InputIter>::Item: Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   let mut it = input.iter_offsets();
   match it.next() {
-    Some((_, c)) if list.find_token(c) => match it.next() {
+    Some((_, c)) if list.contains_token(c) => match it.next() {
       None => Ok((input.slice(input.input_len()..), c)),
       Some((idx, _)) => Ok((input.slice(idx..), c)),
     },
@@ -162,11 +162,11 @@ pub(crate) fn none_of_internal<I, T, E: ParseError<I>>(
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
   <I as InputIter>::Item: Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   let mut it = input.iter_offsets();
   match it.next() {
-    Some((_, c)) if !list.find_token(c) => match it.next() {
+    Some((_, c)) if !list.contains_token(c) => match it.next() {
       None => Ok((input.slice(input.input_len()..), c)),
       Some((idx, _)) => Ok((input.slice(idx..), c)),
     },
@@ -204,7 +204,7 @@ pub fn is_not<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| is_not_internal(i, &arr)
 }
@@ -216,10 +216,10 @@ pub(crate) fn is_not_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::IsNot;
-  i.split_at_offset1_complete(|c| arr.find_token(c), e)
+  i.split_at_offset1_complete(|c| arr.contains_token(c), e)
     .into_output()
 }
 
@@ -253,7 +253,7 @@ pub fn is_a<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| is_a_internal(i, &arr)
 }
@@ -265,10 +265,10 @@ pub(crate) fn is_a_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::IsA;
-  i.split_at_offset1_complete(|c| !arr.find_token(c), e)
+  i.split_at_offset1_complete(|c| !arr.contains_token(c), e)
     .into_output()
 }
 
@@ -300,7 +300,7 @@ pub fn take_while<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_while_internal(i, &list)
 }
@@ -312,9 +312,9 @@ pub(crate) fn take_while_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
-  i.split_at_offset_complete(|c| !list.find_token(c))
+  i.split_at_offset_complete(|c| !list.contains_token(c))
     .into_output()
 }
 
@@ -347,7 +347,7 @@ pub fn take_while1<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_while1_internal(i, &list)
 }
@@ -359,10 +359,10 @@ pub(crate) fn take_while1_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeWhile1;
-  i.split_at_offset1_complete(|c| !list.find_token(c), e)
+  i.split_at_offset1_complete(|c| !list.contains_token(c), e)
     .into_output()
 }
 
@@ -403,7 +403,7 @@ pub fn take_while_m_n<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTake + InputIter + InputLength + Slice<RangeFrom<usize>>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputIter>::Item>,
+  T: ContainsToken<<Input as InputIter>::Item>,
 {
   move |i: Input| take_while_m_n_internal(i, m, n, &list)
 }
@@ -417,9 +417,9 @@ pub(crate) fn take_while_m_n_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTake + InputIter + InputLength + Slice<RangeFrom<usize>>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputIter>::Item>,
+  T: ContainsToken<<Input as InputIter>::Item>,
 {
-  match input.offset_for(|c| !list.find_token(c)) {
+  match input.offset_for(|c| !list.contains_token(c)) {
     Some(idx) => {
       if idx >= m {
         if idx <= n {
@@ -497,7 +497,7 @@ pub fn take_till<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_till_internal(i, &list)
 }
@@ -509,9 +509,9 @@ pub(crate) fn take_till_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
-  i.split_at_offset_complete(|c| list.find_token(c))
+  i.split_at_offset_complete(|c| list.contains_token(c))
     .into_output()
 }
 
@@ -546,7 +546,7 @@ pub fn take_till1<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_till1_internal(i, &list)
 }
@@ -558,10 +558,10 @@ pub(crate) fn take_till1_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeTill1;
-  i.split_at_offset1_complete(|c| list.find_token(c), e)
+  i.split_at_offset1_complete(|c| list.contains_token(c), e)
     .into_output()
 }
 

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -7,8 +7,8 @@ mod tests;
 
 use crate::error::ParseError;
 use crate::input::{
-  Compare, ContainsToken, FindSubstring, InputIsStreaming, InputIter, InputLength, InputTake,
-  InputTakeAtOffset, IntoOutput, Slice, ToUsize,
+  Compare, ContainsToken, FindSubstring, InputIsStreaming, InputIter, InputTake, InputTakeAtOffset,
+  IntoOutput, Slice, SliceLen, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
 use crate::{IResult, Parser};
@@ -42,7 +42,7 @@ pub fn any<I, E: ParseError<I>, const STREAMING: bool>(
   input: I,
 ) -> IResult<I, <I as InputIter>::Item, E>
 where
-  I: InputIter + InputLength + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
+  I: InputIter + SliceLen + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::any(input)
@@ -95,9 +95,9 @@ pub fn tag<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + Compare<T> + InputIsStreaming<STREAMING>,
+  Input: InputTake + SliceLen + Compare<T> + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: InputLength + Clone,
+  T: SliceLen + Clone,
 {
   move |i: Input| {
     let t = tag.clone();
@@ -151,9 +151,9 @@ pub fn tag_no_case<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + Compare<T> + InputIsStreaming<STREAMING>,
+  Input: InputTake + SliceLen + Compare<T> + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: InputLength + Clone,
+  T: SliceLen + Clone,
 {
   move |i: Input| {
     let t = tag.clone();
@@ -215,7 +215,7 @@ pub fn one_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
   list: T,
 ) -> impl Fn(I) -> IResult<I, <I as InputIter>::Item, Error>
 where
-  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter + SliceLen + InputIsStreaming<STREAMING>,
   <I as InputIter>::Item: Copy,
   T: ContainsToken<<I as InputIter>::Item>,
 {
@@ -257,7 +257,7 @@ pub fn none_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
   list: T,
 ) -> impl Fn(I) -> IResult<I, <I as InputIter>::Item, Error>
 where
-  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter + SliceLen + InputIsStreaming<STREAMING>,
   <I as InputIter>::Item: Copy,
   T: ContainsToken<<I as InputIter>::Item>,
 {
@@ -443,8 +443,7 @@ pub fn take_while_m_n<T, Input, Error: ParseError<Input>, const STREAMING: bool>
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input:
-    InputTake + InputIter + InputLength + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
+  Input: InputTake + InputIter + SliceLen + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
   T: ContainsToken<<Input as InputIter>::Item>,
 {
@@ -639,7 +638,7 @@ pub fn take<C, Input, Error: ParseError<Input>, const STREAMING: bool>(
   count: C,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
+  Input: InputIter + SliceLen + InputTake + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
   C: ToUsize,
 {
@@ -696,9 +695,9 @@ pub fn take_until<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + FindSubstring<T> + InputIsStreaming<STREAMING>,
+  Input: InputTake + SliceLen + FindSubstring<T> + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: InputLength + Clone,
+  T: SliceLen + Clone,
 {
   move |i: Input| {
     if STREAMING {
@@ -755,9 +754,9 @@ pub fn take_until1<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + FindSubstring<T> + InputIsStreaming<STREAMING>,
+  Input: InputTake + SliceLen + FindSubstring<T> + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: InputLength + Clone,
+  T: SliceLen + Clone,
 {
   move |i: Input| {
     if STREAMING {
@@ -811,7 +810,7 @@ pub fn escaped<'a, Input: 'a, Error, F, G, O1, O2, const STREAMING: bool>(
 where
   Input: Clone
     + crate::input::Offset
-    + InputLength
+    + SliceLen
     + InputTake
     + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
@@ -899,7 +898,7 @@ pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output, const S
 where
   Input: Clone
     + crate::input::Offset
-    + InputLength
+    + SliceLen
     + InputTake
     + InputTakeAtOffset
     + Slice<RangeFrom<usize>>

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 
 use crate::error::ParseError;
 use crate::input::{
-  Compare, FindSubstring, FindToken, InputIsStreaming, InputIter, InputLength, InputTake,
+  Compare, ContainsToken, FindSubstring, InputIsStreaming, InputIter, InputLength, InputTake,
   InputTakeAtOffset, IntoOutput, Slice, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
@@ -165,7 +165,7 @@ where
   }
 }
 
-/// Returns a token that matches the [pattern][FindToken]
+/// Returns a token that matches the [pattern][ContainsToken]
 ///
 /// **Note:** [`Parser`] is implemented as a convenience (complete
 /// only) for
@@ -217,7 +217,7 @@ pub fn one_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<STREAMING>,
   <I as InputIter>::Item: Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   move |i: I| {
     if STREAMING {
@@ -228,7 +228,7 @@ where
   }
 }
 
-/// Returns a token that does not match the [pattern][FindToken]
+/// Returns a token that does not match the [pattern][ContainsToken]
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
@@ -259,7 +259,7 @@ pub fn none_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<STREAMING>,
   <I as InputIter>::Item: Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   move |i: I| {
     if STREAMING {
@@ -270,7 +270,7 @@ where
   }
 }
 
-/// Returns the longest input slice (if any) that matches the [pattern][FindToken]
+/// Returns the longest input slice (if any) that matches the [pattern][ContainsToken]
 ///
 /// *Streaming version*: will return a `Err::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
 /// # Example
@@ -311,7 +311,7 @@ pub fn take_while<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
 where
   Input: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
   Input: InputTakeAtOffset,
 {
   move |i: Input| {
@@ -323,7 +323,7 @@ where
   }
 }
 
-/// Returns the longest (at least 1) input slice that matches the [pattern][FindToken]
+/// Returns the longest (at least 1) input slice that matches the [pattern][ContainsToken]
 ///
 /// It will return an `Err(Err::Error(Error::new(_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 ///
@@ -385,7 +385,7 @@ pub fn take_while1<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
 where
   Input: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| {
     if STREAMING {
@@ -396,7 +396,7 @@ where
   }
 }
 
-/// Returns the longest (m <= len <= n) input slice that matches the [pattern][FindToken]
+/// Returns the longest (m <= len <= n) input slice that matches the [pattern][ContainsToken]
 ///
 /// It will return an `Err::Error(Error::new(_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
 /// of range (m <= len <= n).
@@ -446,7 +446,7 @@ where
   Input:
     InputTake + InputIter + InputLength + Slice<RangeFrom<usize>> + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputIter>::Item>,
+  T: ContainsToken<<Input as InputIter>::Item>,
 {
   move |i: Input| {
     if STREAMING {
@@ -457,7 +457,7 @@ where
   }
 }
 
-/// Returns the longest input slice (if any) till a [pattern][FindToken] is met.
+/// Returns the longest input slice (if any) till a [pattern][ContainsToken] is met.
 ///
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
@@ -498,7 +498,7 @@ pub fn take_till<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
 where
   Input: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| {
     if STREAMING {
@@ -509,7 +509,7 @@ where
   }
 }
 
-/// Returns the longest (at least 1) input slice till a [pattern][FindToken] is met.
+/// Returns the longest (at least 1) input slice till a [pattern][ContainsToken] is met.
 ///
 /// It will return `Err(Err::Error(Error::new(_, ErrorKind::TakeTill1)))` if the input is empty or the
 /// predicate matches the first input.
@@ -571,7 +571,7 @@ pub fn take_till1<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
 where
   Input: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| {
     if STREAMING {

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -8,7 +8,7 @@ mod tests;
 use crate::error::ParseError;
 use crate::input::{
   Compare, FindSubstring, FindToken, InputIsStreaming, InputIter, InputLength, InputTake,
-  InputTakeAtPosition, IntoOutput, Slice, ToUsize,
+  InputTakeAtOffset, IntoOutput, Slice, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
 use crate::{IResult, Parser};
@@ -309,10 +309,10 @@ pub fn take_while<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
-  Input: InputTakeAtPosition,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  Input: InputTakeAtOffset,
 {
   move |i: Input| {
     if STREAMING {
@@ -383,9 +383,9 @@ pub fn take_while1<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| {
     if STREAMING {
@@ -496,9 +496,9 @@ pub fn take_till<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| {
     if STREAMING {
@@ -569,9 +569,9 @@ pub fn take_till1<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  Input: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| {
     if STREAMING {
@@ -813,7 +813,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter
     + InputIsStreaming<STREAMING>,
@@ -901,7 +901,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter
     + InputIsStreaming<STREAMING>,

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 
 use crate::error::ParseError;
 use crate::input::{
-  Compare, ContainsToken, FindSubstring, InputIsStreaming, InputIter, InputTake, InputTakeAtOffset,
+  Compare, ContainsToken, FindSlice, InputIsStreaming, InputIter, InputTake, InputTakeAtOffset,
   IntoOutput, Slice, SliceLen, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
@@ -695,7 +695,7 @@ pub fn take_until<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + SliceLen + FindSubstring<T> + InputIsStreaming<STREAMING>,
+  Input: InputTake + SliceLen + FindSlice<T> + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
   T: SliceLen + Clone,
 {
@@ -754,7 +754,7 @@ pub fn take_until1<T, Input, Error: ParseError<Input>, const STREAMING: bool>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + SliceLen + FindSubstring<T> + InputIsStreaming<STREAMING>,
+  Input: InputTake + SliceLen + FindSlice<T> + InputIsStreaming<STREAMING>,
   Input: IntoOutput,
   T: SliceLen + Clone,
 {

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -5,7 +5,7 @@
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  Compare, CompareResult, ContainsToken, FindSubstring, InputIter, InputTake, InputTakeAtOffset,
+  Compare, CompareResult, ContainsToken, FindSlice, InputIter, InputTake, InputTakeAtOffset,
   IntoOutput, Slice, SliceLen, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
@@ -693,7 +693,7 @@ pub fn take_until<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + SliceLen + FindSubstring<T>,
+  Input: InputTake + SliceLen + FindSlice<T>,
   Input: IntoOutput,
   T: Clone,
 {
@@ -705,10 +705,10 @@ pub(crate) fn take_until_internal<T, Input, Error: ParseError<Input>>(
   t: T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + SliceLen + FindSubstring<T>,
+  Input: InputTake + SliceLen + FindSlice<T>,
   Input: IntoOutput,
 {
-  let res: IResult<_, _, Error> = match i.find_substring(t) {
+  let res: IResult<_, _, Error> = match i.find_slice(t) {
     None => Err(Err::Incomplete(Needed::Unknown)),
     Some(index) => Ok(i.take_split(index)),
   };
@@ -747,7 +747,7 @@ pub fn take_until1<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + SliceLen + FindSubstring<T>,
+  Input: InputTake + SliceLen + FindSlice<T>,
   Input: IntoOutput,
   T: Clone,
 {
@@ -759,10 +759,10 @@ pub(crate) fn take_until1_internal<T, Input, Error: ParseError<Input>>(
   t: T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + SliceLen + FindSubstring<T>,
+  Input: InputTake + SliceLen + FindSlice<T>,
   Input: IntoOutput,
 {
-  let res: IResult<_, _, Error> = match i.find_substring(t) {
+  let res: IResult<_, _, Error> = match i.find_slice(t) {
     None => Err(Err::Incomplete(Needed::Unknown)),
     Some(0) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
     Some(index) => Ok(i.take_split(index)),

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -5,7 +5,7 @@
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake,
+  Compare, CompareResult, ContainsToken, FindSubstring, InputIter, InputLength, InputTake,
   InputTakeAtOffset, IntoOutput, Slice, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
@@ -149,11 +149,11 @@ pub(crate) fn one_of_internal<I, T, E: ParseError<I>>(
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
   <I as InputIter>::Item: Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   let mut it = input.iter_offsets();
   match it.next() {
-    Some((_, c)) if list.find_token(c) => match it.next() {
+    Some((_, c)) if list.contains_token(c) => match it.next() {
       None => Ok((input.slice(input.input_len()..), c)),
       Some((idx, _)) => Ok((input.slice(idx..), c)),
     },
@@ -169,11 +169,11 @@ pub(crate) fn none_of_internal<I, T, E: ParseError<I>>(
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
   <I as InputIter>::Item: Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   let mut it = input.iter_offsets();
   match it.next() {
-    Some((_, c)) if !list.find_token(c) => match it.next() {
+    Some((_, c)) if !list.contains_token(c) => match it.next() {
       None => Ok((input.slice(input.input_len()..), c)),
       Some((idx, _)) => Ok((input.slice(idx..), c)),
     },
@@ -215,7 +215,7 @@ pub fn is_not<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| is_not_internal(i, &arr)
 }
@@ -227,10 +227,10 @@ pub(crate) fn is_not_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::IsNot;
-  i.split_at_offset1_streaming(|c| arr.find_token(c), e)
+  i.split_at_offset1_streaming(|c| arr.contains_token(c), e)
     .into_output()
 }
 
@@ -269,7 +269,7 @@ pub fn is_a<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| is_a_internal(i, &arr)
 }
@@ -281,10 +281,10 @@ pub(crate) fn is_a_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::IsA;
-  i.split_at_offset1_streaming(|c| !arr.find_token(c), e)
+  i.split_at_offset1_streaming(|c| !arr.contains_token(c), e)
     .into_output()
 }
 
@@ -322,7 +322,7 @@ pub fn take_while<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_while_internal(i, &list)
 }
@@ -334,9 +334,9 @@ pub(crate) fn take_while_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
-  i.split_at_offset_streaming(|c| !list.find_token(c))
+  i.split_at_offset_streaming(|c| !list.contains_token(c))
     .into_output()
 }
 
@@ -376,7 +376,7 @@ pub fn take_while1<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_while1_internal(i, &list)
 }
@@ -388,10 +388,10 @@ pub(crate) fn take_while1_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeWhile1;
-  i.split_at_offset1_streaming(|c| !list.find_token(c), e)
+  i.split_at_offset1_streaming(|c| !list.contains_token(c), e)
     .into_output()
 }
 
@@ -434,7 +434,7 @@ pub fn take_while_m_n<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTake + InputIter + InputLength,
   Input: IntoOutput,
-  T: FindToken<<Input as InputIter>::Item>,
+  T: ContainsToken<<Input as InputIter>::Item>,
 {
   move |i: Input| take_while_m_n_internal(i, m, n, &list)
 }
@@ -448,11 +448,11 @@ pub(crate) fn take_while_m_n_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTake + InputIter + InputLength,
   Input: IntoOutput,
-  T: FindToken<<Input as InputIter>::Item>,
+  T: ContainsToken<<Input as InputIter>::Item>,
 {
   let input = i;
 
-  match input.offset_for(|c| !list.find_token(c)) {
+  match input.offset_for(|c| !list.contains_token(c)) {
     Some(idx) => {
       if idx >= m {
         if idx <= n {
@@ -535,7 +535,7 @@ pub fn take_till<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_till_internal(i, &list)
 }
@@ -547,9 +547,9 @@ pub(crate) fn take_till_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
-  i.split_at_offset_streaming(|c| list.find_token(c))
+  i.split_at_offset_streaming(|c| list.contains_token(c))
     .into_output()
 }
 
@@ -588,7 +588,7 @@ pub fn take_till1<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_till1_internal(i, &list)
 }
@@ -600,10 +600,10 @@ pub(crate) fn take_till1_internal<T, Input, Error: ParseError<Input>>(
 where
   Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtOffset>::Item>,
+  T: ContainsToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeTill1;
-  i.split_at_offset1_streaming(|c| list.find_token(c), e)
+  i.split_at_offset1_streaming(|c| list.contains_token(c), e)
     .into_output()
 }
 

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -850,7 +850,7 @@ where
         if i2.input_len() == 0 {
           return Err(Err::Incomplete(Needed::Unknown));
         } else if i2.input_len() == current_len {
-          let index = input.offset(&i2);
+          let index = input.offset_to(&i2);
           return Ok(input.take_split(index)).into_output();
         } else {
           i = i2;
@@ -875,7 +875,7 @@ where
             }
           }
         } else {
-          let index = input.offset(&i);
+          let index = input.offset_to(&i);
           return Ok(input.take_split(index)).into_output();
         }
       }
@@ -990,7 +990,7 @@ where
         } else if i2.input_len() == current_len {
           return Ok((remainder, res));
         } else {
-          index = input.offset(&i2);
+          index = input.offset_to(&i2);
         }
       }
       Err(Err::Error(_)) => {
@@ -1008,7 +1008,7 @@ where
                 if i2.input_len() == 0 {
                   return Err(Err::Incomplete(Needed::Unknown));
                 } else {
-                  index = input.offset(&i2);
+                  index = input.offset_to(&i2);
                 }
               }
               Err(e) => return Err(e),

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -5,8 +5,8 @@
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  Compare, CompareResult, ContainsToken, FindSubstring, InputIter, InputLength, InputTake,
-  InputTakeAtOffset, IntoOutput, Slice, ToUsize,
+  Compare, CompareResult, ContainsToken, FindSubstring, InputIter, InputTake, InputTakeAtOffset,
+  IntoOutput, Slice, SliceLen, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
 use crate::lib::std::result::Result::Ok;
@@ -15,13 +15,13 @@ use crate::{Err, IResult, Needed, Parser};
 
 pub(crate) fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as InputIter>::Item, E>
 where
-  I: InputIter + InputLength + Slice<RangeFrom<usize>>,
+  I: InputIter + SliceLen + Slice<RangeFrom<usize>>,
 {
   let mut it = input.iter_offsets();
   match it.next() {
     None => Err(Err::Incomplete(Needed::new(1))),
     Some((_, c)) => match it.next() {
-      None => Ok((input.slice(input.input_len()..), c)),
+      None => Ok((input.slice(input.slice_len()..), c)),
       Some((idx, _)) => Ok((input.slice(idx..), c)),
     },
   }
@@ -55,9 +55,9 @@ pub fn tag<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + Compare<T>,
+  Input: InputTake + SliceLen + Compare<T>,
   Input: IntoOutput,
-  T: InputLength + Clone,
+  T: SliceLen + Clone,
 {
   move |i: Input| tag_internal(i, tag.clone())
 }
@@ -67,15 +67,15 @@ pub(crate) fn tag_internal<T, Input, Error: ParseError<Input>>(
   t: T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + Compare<T>,
+  Input: InputTake + SliceLen + Compare<T>,
   Input: IntoOutput,
-  T: InputLength,
+  T: SliceLen,
 {
-  let tag_len = t.input_len();
+  let tag_len = t.slice_len();
 
   let res: IResult<_, _, Error> = match i.compare(t) {
     CompareResult::Ok => Ok(i.take_split(tag_len)),
-    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
+    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.slice_len()))),
     CompareResult::Error => {
       let e: ErrorKind = ErrorKind::Tag;
       Err(Err::Error(Error::from_error_kind(i, e)))
@@ -113,9 +113,9 @@ pub fn tag_no_case<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + Compare<T>,
+  Input: InputTake + SliceLen + Compare<T>,
   Input: IntoOutput,
-  T: InputLength + Clone,
+  T: SliceLen + Clone,
 {
   move |i: Input| tag_no_case_internal(i, tag.clone())
 }
@@ -125,15 +125,15 @@ pub(crate) fn tag_no_case_internal<T, Input, Error: ParseError<Input>>(
   t: T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + Compare<T>,
+  Input: InputTake + SliceLen + Compare<T>,
   Input: IntoOutput,
-  T: InputLength,
+  T: SliceLen,
 {
-  let tag_len = t.input_len();
+  let tag_len = t.slice_len();
 
   let res: IResult<_, _, Error> = match (i).compare_no_case(t) {
     CompareResult::Ok => Ok(i.take_split(tag_len)),
-    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
+    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.slice_len()))),
     CompareResult::Error => {
       let e: ErrorKind = ErrorKind::Tag;
       Err(Err::Error(Error::from_error_kind(i, e)))
@@ -147,14 +147,14 @@ pub(crate) fn one_of_internal<I, T, E: ParseError<I>>(
   list: &T,
 ) -> IResult<I, <I as InputIter>::Item, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter + SliceLen,
   <I as InputIter>::Item: Copy,
   T: ContainsToken<<I as InputIter>::Item>,
 {
   let mut it = input.iter_offsets();
   match it.next() {
     Some((_, c)) if list.contains_token(c) => match it.next() {
-      None => Ok((input.slice(input.input_len()..), c)),
+      None => Ok((input.slice(input.slice_len()..), c)),
       Some((idx, _)) => Ok((input.slice(idx..), c)),
     },
     Some(_) => Err(Err::Error(E::from_error_kind(input, ErrorKind::OneOf))),
@@ -167,14 +167,14 @@ pub(crate) fn none_of_internal<I, T, E: ParseError<I>>(
   list: &T,
 ) -> IResult<I, <I as InputIter>::Item, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter + SliceLen,
   <I as InputIter>::Item: Copy,
   T: ContainsToken<<I as InputIter>::Item>,
 {
   let mut it = input.iter_offsets();
   match it.next() {
     Some((_, c)) if !list.contains_token(c) => match it.next() {
-      None => Ok((input.slice(input.input_len()..), c)),
+      None => Ok((input.slice(input.slice_len()..), c)),
       Some((idx, _)) => Ok((input.slice(idx..), c)),
     },
     Some(_) => Err(Err::Error(E::from_error_kind(input, ErrorKind::NoneOf))),
@@ -432,7 +432,7 @@ pub fn take_while_m_n<T, Input, Error: ParseError<Input>>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputIter + InputLength,
+  Input: InputTake + InputIter + SliceLen,
   Input: IntoOutput,
   T: ContainsToken<<Input as InputIter>::Item>,
 {
@@ -446,7 +446,7 @@ pub(crate) fn take_while_m_n_internal<T, Input, Error: ParseError<Input>>(
   list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputIter + InputLength,
+  Input: InputTake + InputIter + SliceLen,
   Input: IntoOutput,
   T: ContainsToken<<Input as InputIter>::Item>,
 {
@@ -482,7 +482,7 @@ where
       }
     }
     None => {
-      let len = input.input_len();
+      let len = input.slice_len();
       if len >= n {
         match input.offset_at(n) {
           Ok(index) => Ok(input.take_split(index)).into_output(),
@@ -640,7 +640,7 @@ pub fn take<C, Input, Error: ParseError<Input>>(
   count: C,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputIter + InputTake + InputLength,
+  Input: InputIter + InputTake + SliceLen,
   Input: IntoOutput,
   C: ToUsize,
 {
@@ -653,7 +653,7 @@ pub(crate) fn take_internal<Input, Error: ParseError<Input>>(
   c: usize,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputIter + InputTake + InputLength,
+  Input: InputIter + InputTake + SliceLen,
   Input: IntoOutput,
 {
   match i.offset_at(c) {
@@ -693,7 +693,7 @@ pub fn take_until<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + FindSubstring<T>,
+  Input: InputTake + SliceLen + FindSubstring<T>,
   Input: IntoOutput,
   T: Clone,
 {
@@ -705,7 +705,7 @@ pub(crate) fn take_until_internal<T, Input, Error: ParseError<Input>>(
   t: T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + FindSubstring<T>,
+  Input: InputTake + SliceLen + FindSubstring<T>,
   Input: IntoOutput,
 {
   let res: IResult<_, _, Error> = match i.find_substring(t) {
@@ -747,7 +747,7 @@ pub fn take_until1<T, Input, Error: ParseError<Input>>(
   tag: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + FindSubstring<T>,
+  Input: InputTake + SliceLen + FindSubstring<T>,
   Input: IntoOutput,
   T: Clone,
 {
@@ -759,7 +759,7 @@ pub(crate) fn take_until1_internal<T, Input, Error: ParseError<Input>>(
   t: T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTake + InputLength + FindSubstring<T>,
+  Input: InputTake + SliceLen + FindSubstring<T>,
   Input: IntoOutput,
 {
   let res: IResult<_, _, Error> = match i.find_substring(t) {
@@ -804,7 +804,7 @@ pub fn escaped<Input, Error, F, G, O1, O2>(
 where
   Input: Clone
     + crate::input::Offset
-    + InputLength
+    + SliceLen
     + InputTake
     + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
@@ -827,7 +827,7 @@ pub(crate) fn escaped_internal<Input, Error, F, G, O1, O2>(
 where
   Input: Clone
     + crate::input::Offset
-    + InputLength
+    + SliceLen
     + InputTake
     + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
@@ -842,14 +842,14 @@ where
 
   let mut i = input.clone();
 
-  while i.input_len() > 0 {
-    let current_len = i.input_len();
+  while i.slice_len() > 0 {
+    let current_len = i.slice_len();
 
     match normal.parse_next(i.clone()) {
       Ok((i2, _)) => {
-        if i2.input_len() == 0 {
+        if i2.slice_len() == 0 {
           return Err(Err::Incomplete(Needed::Unknown));
-        } else if i2.input_len() == current_len {
+        } else if i2.slice_len() == current_len {
           let index = input.offset_to(&i2);
           return Ok(input.take_split(index)).into_output();
         } else {
@@ -857,15 +857,15 @@ where
         }
       }
       Err(Err::Error(_)) => {
-        // unwrap() should be safe here since index < $i.input_len()
+        // unwrap() should be safe here since index < $i.slice_len()
         if i.iter_elements().next().unwrap().as_char() == control_char {
           let next = control_char.len_utf8();
-          if next >= i.input_len() {
+          if next >= i.slice_len() {
             return Err(Err::Incomplete(Needed::new(1)));
           } else {
             match escapable.parse_next(i.slice(next..)) {
               Ok((i2, _)) => {
-                if i2.input_len() == 0 {
+                if i2.slice_len() == 0 {
                   return Err(Err::Incomplete(Needed::Unknown));
                 } else {
                   i = i2;
@@ -933,7 +933,7 @@ pub fn escaped_transform<Input, Error, F, G, O1, O2, ExtendItem, Output>(
 where
   Input: Clone
     + crate::input::Offset
-    + InputLength
+    + SliceLen
     + InputTake
     + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
@@ -959,7 +959,7 @@ pub(crate) fn escaped_transform_internal<Input, Error, F, G, O1, O2, ExtendItem,
 where
   Input: Clone
     + crate::input::Offset
-    + InputLength
+    + SliceLen
     + InputTake
     + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
@@ -979,33 +979,33 @@ where
 
   let i = input.clone();
 
-  while index < i.input_len() {
-    let current_len = i.input_len();
+  while index < i.slice_len() {
+    let current_len = i.slice_len();
     let remainder = i.slice(index..);
     match normal.parse_next(remainder.clone()) {
       Ok((i2, o)) => {
         o.extend_into(&mut res);
-        if i2.input_len() == 0 {
+        if i2.slice_len() == 0 {
           return Err(Err::Incomplete(Needed::Unknown));
-        } else if i2.input_len() == current_len {
+        } else if i2.slice_len() == current_len {
           return Ok((remainder, res));
         } else {
           index = input.offset_to(&i2);
         }
       }
       Err(Err::Error(_)) => {
-        // unwrap() should be safe here since index < $i.input_len()
+        // unwrap() should be safe here since index < $i.slice_len()
         if remainder.iter_elements().next().unwrap().as_char() == control_char {
           let next = index + control_char.len_utf8();
-          let input_len = input.input_len();
+          let slice_len = input.slice_len();
 
-          if next >= input_len {
+          if next >= slice_len {
             return Err(Err::Incomplete(Needed::Unknown));
           } else {
             match transform.parse_next(i.slice(next..)) {
               Ok((i2, o)) => {
                 o.extend_into(&mut res);
-                if i2.input_len() == 0 {
+                if i2.slice_len() == 0 {
                   return Err(Err::Incomplete(Needed::Unknown));
                 } else {
                   index = input.offset_to(&i2);

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -6,7 +6,7 @@ use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
   Compare, CompareResult, FindSubstring, FindToken, InputIter, InputLength, InputTake,
-  InputTakeAtPosition, IntoOutput, Slice, ToUsize,
+  InputTakeAtOffset, IntoOutput, Slice, ToUsize,
 };
 use crate::lib::std::ops::RangeFrom;
 use crate::lib::std::result::Result::Ok;
@@ -213,9 +213,9 @@ pub fn is_not<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| is_not_internal(i, &arr)
 }
@@ -225,12 +225,12 @@ pub(crate) fn is_not_internal<T, Input, Error: ParseError<Input>>(
   arr: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::IsNot;
-  i.split_at_position1_streaming(|c| arr.find_token(c), e)
+  i.split_at_offset1_streaming(|c| arr.find_token(c), e)
     .into_output()
 }
 
@@ -267,9 +267,9 @@ pub fn is_a<T, Input, Error: ParseError<Input>>(
   arr: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| is_a_internal(i, &arr)
 }
@@ -279,12 +279,12 @@ pub(crate) fn is_a_internal<T, Input, Error: ParseError<Input>>(
   arr: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::IsA;
-  i.split_at_position1_streaming(|c| !arr.find_token(c), e)
+  i.split_at_offset1_streaming(|c| !arr.find_token(c), e)
     .into_output()
 }
 
@@ -320,9 +320,9 @@ pub fn take_while<T, Input, Error: ParseError<Input>>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_while_internal(i, &list)
 }
@@ -332,11 +332,11 @@ pub(crate) fn take_while_internal<T, Input, Error: ParseError<Input>>(
   list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
-  i.split_at_position_streaming(|c| !list.find_token(c))
+  i.split_at_offset_streaming(|c| !list.find_token(c))
     .into_output()
 }
 
@@ -374,9 +374,9 @@ pub fn take_while1<T, Input, Error: ParseError<Input>>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_while1_internal(i, &list)
 }
@@ -386,12 +386,12 @@ pub(crate) fn take_while1_internal<T, Input, Error: ParseError<Input>>(
   list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeWhile1;
-  i.split_at_position1_streaming(|c| !list.find_token(c), e)
+  i.split_at_offset1_streaming(|c| !list.find_token(c), e)
     .into_output()
 }
 
@@ -533,9 +533,9 @@ pub fn take_till<T, Input, Error: ParseError<Input>>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_till_internal(i, &list)
 }
@@ -545,11 +545,11 @@ pub(crate) fn take_till_internal<T, Input, Error: ParseError<Input>>(
   list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
-  i.split_at_position_streaming(|c| list.find_token(c))
+  i.split_at_offset_streaming(|c| list.find_token(c))
     .into_output()
 }
 
@@ -586,9 +586,9 @@ pub fn take_till1<T, Input, Error: ParseError<Input>>(
   list: T,
 ) -> impl Fn(Input) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   move |i: Input| take_till1_internal(i, &list)
 }
@@ -598,12 +598,12 @@ pub(crate) fn take_till1_internal<T, Input, Error: ParseError<Input>>(
   list: &T,
 ) -> IResult<Input, <Input as IntoOutput>::Output, Error>
 where
-  Input: InputTakeAtPosition,
+  Input: InputTakeAtOffset,
   Input: IntoOutput,
-  T: FindToken<<Input as InputTakeAtPosition>::Item>,
+  T: FindToken<<Input as InputTakeAtOffset>::Item>,
 {
   let e: ErrorKind = ErrorKind::TakeTill1;
-  i.split_at_position1_streaming(|c| list.find_token(c), e)
+  i.split_at_offset1_streaming(|c| list.find_token(c), e)
     .into_output()
 }
 
@@ -806,7 +806,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: IntoOutput,
@@ -829,7 +829,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: IntoOutput,
@@ -935,7 +935,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
@@ -961,7 +961,7 @@ where
     + crate::input::Offset
     + InputLength
     + InputTake
-    + InputTakeAtPosition
+    + InputTakeAtOffset
     + Slice<RangeFrom<usize>>
     + InputIter,
   Input: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -9,7 +9,7 @@ use crate::combinator::opt;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput, Slice,
+  AsChar, ContainsToken, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput, Slice,
 };
 use crate::input::{Compare, CompareResult};
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
@@ -122,7 +122,7 @@ pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, c
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
   <I as InputIter>::Item: AsChar + Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   move |i: I| crate::bytes::complete::one_of_internal(i, &list).map(|(i, c)| (i, c.as_char()))
 }
@@ -146,7 +146,7 @@ pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, 
 where
   I: Slice<RangeFrom<usize>> + InputLength + InputIter,
   <I as InputIter>::Item: AsChar + Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   move |i: I| crate::bytes::complete::none_of_internal(i, &list).map(|(i, c)| (i, c.as_char()))
 }

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -222,7 +222,7 @@ where
   <T as InputIter>::Item: AsChar,
   <T as InputIter>::Item: AsChar,
 {
-  match input.position(|item| {
+  match input.offset_for(|item| {
     let c = item.as_char();
     c == '\r' || c == '\n'
   }) {
@@ -903,7 +903,7 @@ macro_rules! ints {
 
                 let mut value: $t = 0;
                 if sign {
-                    for (pos, c) in i.iter_indices() {
+                    for (pos, c) in i.iter_offsets() {
                         match c.as_char().to_digit(10) {
                             None => {
                                 if pos == 0 {
@@ -919,7 +919,7 @@ macro_rules! ints {
                         }
                     }
                 } else {
-                    for (pos, c) in i.iter_indices() {
+                    for (pos, c) in i.iter_offsets() {
                         match c.as_char().to_digit(10) {
                             None => {
                                 if pos == 0 {
@@ -964,7 +964,7 @@ macro_rules! uints {
                 }
 
                 let mut value: $t = 0;
-                for (pos, c) in i.iter_indices() {
+                for (pos, c) in i.iter_offsets() {
                     match c.as_char().to_digit(10) {
                         None => {
                             if pos == 0 {

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -9,7 +9,7 @@ use crate::combinator::opt;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtPosition, IntoOutput, Slice,
+  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput, Slice,
 };
 use crate::input::{Compare, CompareResult};
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
@@ -392,12 +392,12 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::character::alpha0`")]
 pub fn alpha0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_complete(|item| !item.is_alpha())
+    .split_at_offset_complete(|item| !item.is_alpha())
     .into_output()
 }
 
@@ -423,12 +423,12 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::character::alpha1`")]
 pub fn alpha1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_complete(|item| !item.is_alpha(), ErrorKind::Alpha)
+    .split_at_offset1_complete(|item| !item.is_alpha(), ErrorKind::Alpha)
     .into_output()
 }
 
@@ -455,12 +455,12 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::character::digit0`")]
 pub fn digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_complete(|item| !item.is_dec_digit())
+    .split_at_offset_complete(|item| !item.is_dec_digit())
     .into_output()
 }
 
@@ -504,12 +504,12 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::character::digit1`")]
 pub fn digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_complete(|item| !item.is_dec_digit(), ErrorKind::Digit)
+    .split_at_offset1_complete(|item| !item.is_dec_digit(), ErrorKind::Digit)
     .into_output()
 }
 
@@ -537,12 +537,12 @@ where
 )]
 pub fn hex_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_complete(|item| !item.is_hex_digit())
+    .split_at_offset_complete(|item| !item.is_hex_digit())
     .into_output()
 }
 /// Recognizes one or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -570,12 +570,12 @@ where
 )]
 pub fn hex_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_complete(|item| !item.is_hex_digit(), ErrorKind::HexDigit)
+    .split_at_offset1_complete(|item| !item.is_hex_digit(), ErrorKind::HexDigit)
     .into_output()
 }
 
@@ -604,12 +604,12 @@ where
 )]
 pub fn oct_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_complete(|item| !item.is_oct_digit())
+    .split_at_offset_complete(|item| !item.is_oct_digit())
     .into_output()
 }
 
@@ -638,12 +638,12 @@ where
 )]
 pub fn oct_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_complete(|item| !item.is_oct_digit(), ErrorKind::OctDigit)
+    .split_at_offset1_complete(|item| !item.is_oct_digit(), ErrorKind::OctDigit)
     .into_output()
 }
 
@@ -672,12 +672,12 @@ where
 )]
 pub fn alphanumeric0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_complete(|item| !item.is_alphanum())
+    .split_at_offset_complete(|item| !item.is_alphanum())
     .into_output()
 }
 
@@ -706,12 +706,12 @@ where
 )]
 pub fn alphanumeric1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_complete(|item| !item.is_alphanum(), ErrorKind::AlphaNumeric)
+    .split_at_offset1_complete(|item| !item.is_alphanum(), ErrorKind::AlphaNumeric)
     .into_output()
 }
 
@@ -737,12 +737,12 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::character::space0`")]
 pub fn space0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   input
-    .split_at_position_complete(|item| {
+    .split_at_offset_complete(|item| {
       let c = item.as_char();
       !(c == ' ' || c == '\t')
     })
@@ -771,12 +771,12 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::character::space1`")]
 pub fn space1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   input
-    .split_at_position1_complete(
+    .split_at_offset1_complete(
       |item| {
         let c = item.as_char();
         !(c == ' ' || c == '\t')
@@ -811,12 +811,12 @@ where
 )]
 pub fn multispace0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   input
-    .split_at_position_complete(|item| {
+    .split_at_offset_complete(|item| {
       let c = item.as_char();
       !(c == ' ' || c == '\t' || c == '\r' || c == '\n')
     })
@@ -848,12 +848,12 @@ where
 )]
 pub fn multispace1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   input
-    .split_at_position1_complete(
+    .split_at_offset1_complete(
       |item| {
         let c = item.as_char();
         !(c == ' ' || c == '\t' || c == '\r' || c == '\n')

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -1185,43 +1185,43 @@ mod tests {
 
     match alpha1::<_, Error<_>>(a) {
       Ok((i, _)) => {
-        assert_eq!(a.offset(i) + i.len(), a.len());
+        assert_eq!(a.offset_to(i) + i.len(), a.len());
       }
       _ => panic!("wrong return type in offset test for alpha"),
     }
     match digit1::<_, Error<_>>(b) {
       Ok((i, _)) => {
-        assert_eq!(b.offset(i) + i.len(), b.len());
+        assert_eq!(b.offset_to(i) + i.len(), b.len());
       }
       _ => panic!("wrong return type in offset test for digit"),
     }
     match alphanumeric1::<_, Error<_>>(c) {
       Ok((i, _)) => {
-        assert_eq!(c.offset(i) + i.len(), c.len());
+        assert_eq!(c.offset_to(i) + i.len(), c.len());
       }
       _ => panic!("wrong return type in offset test for alphanumeric"),
     }
     match space1::<_, Error<_>>(d) {
       Ok((i, _)) => {
-        assert_eq!(d.offset(i) + i.len(), d.len());
+        assert_eq!(d.offset_to(i) + i.len(), d.len());
       }
       _ => panic!("wrong return type in offset test for space"),
     }
     match multispace1::<_, Error<_>>(e) {
       Ok((i, _)) => {
-        assert_eq!(e.offset(i) + i.len(), e.len());
+        assert_eq!(e.offset_to(i) + i.len(), e.len());
       }
       _ => panic!("wrong return type in offset test for multispace"),
     }
     match hex_digit1::<_, Error<_>>(f) {
       Ok((i, _)) => {
-        assert_eq!(f.offset(i) + i.len(), f.len());
+        assert_eq!(f.offset_to(i) + i.len(), f.len());
       }
       _ => panic!("wrong return type in offset test for hex_digit"),
     }
     match oct_digit1::<_, Error<_>>(f) {
       Ok((i, _)) => {
-        assert_eq!(f.offset(i) + i.len(), f.len());
+        assert_eq!(f.offset_to(i) + i.len(), f.len());
       }
       _ => panic!("wrong return type in offset test for oct_digit"),
     }

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -9,7 +9,7 @@ use crate::combinator::opt;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  AsChar, ContainsToken, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput, Slice,
+  AsChar, ContainsToken, InputIter, InputTake, InputTakeAtOffset, IntoOutput, Slice, SliceLen,
 };
 use crate::input::{Compare, CompareResult};
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
@@ -120,7 +120,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::bytes::one_of`")]
 pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
 where
-  I: Slice<RangeFrom<usize>> + InputIter + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter + SliceLen,
   <I as InputIter>::Item: AsChar + Copy,
   T: ContainsToken<<I as InputIter>::Item>,
 {
@@ -144,7 +144,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::bytes::none_of`")]
 pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, char, Error>
 where
-  I: Slice<RangeFrom<usize>> + InputLength + InputIter,
+  I: Slice<RangeFrom<usize>> + SliceLen + InputIter,
   <I as InputIter>::Item: AsChar + Copy,
   T: ContainsToken<<I as InputIter>::Item>,
 {
@@ -216,7 +216,7 @@ where
 pub fn not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  T: InputIter + InputLength,
+  T: InputIter + SliceLen,
   T: IntoOutput,
   T: Compare<&'static str>,
   <T as InputIter>::Item: AsChar,
@@ -226,7 +226,7 @@ where
     let c = item.as_char();
     c == '\r' || c == '\n'
   }) {
-    None => Ok((input.slice(input.input_len()..), input)).into_output(),
+    None => Ok((input.slice(input.slice_len()..), input)).into_output(),
     Some(index) => {
       let mut it = input.slice(index..).iter_elements();
       let nth = it.next().unwrap().as_char();
@@ -273,7 +273,7 @@ where
 pub fn line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
   T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  T: InputIter + InputLength,
+  T: InputIter + SliceLen,
   T: IntoOutput,
   T: Compare<&'static str>,
 {
@@ -364,7 +364,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::bytes::any`")]
 pub fn anychar<T, E: ParseError<T>>(input: T) -> IResult<T, char, E>
 where
-  T: InputIter + InputLength + Slice<RangeFrom<usize>>,
+  T: InputIter + SliceLen + Slice<RangeFrom<usize>>,
   <T as InputIter>::Item: AsChar,
 {
   crate::bytes::complete::any(input).map(|(i, c)| (i, c.as_char()))
@@ -890,14 +890,14 @@ macro_rules! ints {
         /// *Complete version*: can parse until the end of input.
         pub fn $t<T, E: ParseError<T>>(input: T) -> IResult<T, $t, E>
             where
-            T: InputIter + Slice<RangeFrom<usize>> + InputLength + InputTake + Clone,
+            T: InputIter + Slice<RangeFrom<usize>> + SliceLen + InputTake + Clone,
             T: IntoOutput,
             <T as InputIter>::Item: AsChar,
             T: for <'a> Compare<&'a[u8]>,
             {
                 let (i, sign) = sign(input.clone())?;
 
-                if i.input_len() == 0 {
+                if i.slice_len() == 0 {
                     return Err(Err::Error(E::from_error_kind(input, ErrorKind::Digit)));
                 }
 
@@ -936,7 +936,7 @@ macro_rules! ints {
                     }
                 }
 
-                Ok((i.slice(i.input_len()..), value))
+                Ok((i.slice(i.slice_len()..), value))
             }
         )+
     }
@@ -953,13 +953,13 @@ macro_rules! uints {
         /// *Complete version*: can parse until the end of input.
         pub fn $t<T, E: ParseError<T>>(input: T) -> IResult<T, $t, E>
             where
-            T: InputIter + Slice<RangeFrom<usize>> + InputLength,
+            T: InputIter + Slice<RangeFrom<usize>> + SliceLen,
             T: IntoOutput,
             <T as InputIter>::Item: AsChar,
             {
                 let i = input;
 
-                if i.input_len() == 0 {
+                if i.slice_len() == 0 {
                     return Err(Err::Error(E::from_error_kind(i, ErrorKind::Digit)));
                 }
 
@@ -980,7 +980,7 @@ macro_rules! uints {
                     }
                 }
 
-                Ok((i.slice(i.input_len()..), value))
+                Ok((i.slice(i.slice_len()..), value))
             }
         )+
     }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -12,7 +12,7 @@ mod tests;
 use crate::error::ParseError;
 use crate::input::Compare;
 use crate::input::{
-  AsBytes, AsChar, InputIsStreaming, InputIter, InputLength, InputTake, InputTakeAtPosition,
+  AsBytes, AsChar, InputIsStreaming, InputIter, InputLength, InputTake, InputTakeAtOffset,
   IntoOutput, Offset, ParseTo, Slice,
 };
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
@@ -277,9 +277,9 @@ pub fn alpha0<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::alpha0(input)
@@ -323,9 +323,9 @@ pub fn alpha1<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::alpha1(input)
@@ -370,9 +370,9 @@ pub fn digit0<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::digit0(input)
@@ -432,9 +432,9 @@ pub fn digit1<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::digit1(input)
@@ -477,9 +477,9 @@ pub fn hex_digit0<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::hex_digit0(input)
@@ -523,9 +523,9 @@ pub fn hex_digit1<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::hex_digit1(input)
@@ -569,9 +569,9 @@ pub fn oct_digit0<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::oct_digit0(input)
@@ -615,9 +615,9 @@ pub fn oct_digit1<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::oct_digit1(input)
@@ -661,9 +661,9 @@ pub fn alphanumeric0<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::alphanumeric0(input)
@@ -707,9 +707,9 @@ pub fn alphanumeric1<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::alphanumeric1(input)
@@ -741,9 +741,9 @@ pub fn space0<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   if STREAMING {
     streaming::space0(input)
@@ -787,9 +787,9 @@ pub fn space1<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   if STREAMING {
     streaming::space1(input)
@@ -833,9 +833,9 @@ pub fn multispace0<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   if STREAMING {
     streaming::multispace0(input)
@@ -879,9 +879,9 @@ pub fn multispace1<T, E: ParseError<T>, const STREAMING: bool>(
   input: T,
 ) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   if STREAMING {
     streaming::multispace1(input)
@@ -996,8 +996,8 @@ where
   <T as IntoOutput>::Output: ParseTo<f32>,
   <T as InputIter>::Item: AsChar + Copy,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPosition,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset,
+  <T as InputTakeAtOffset>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {
@@ -1057,8 +1057,8 @@ where
   <T as IntoOutput>::Output: ParseTo<f64>,
   <T as InputIter>::Item: AsChar + Copy,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPosition,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset,
+  <T as InputTakeAtOffset>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {
@@ -1116,8 +1116,8 @@ where
   T: InputIter + InputLength + InputIsStreaming<STREAMING>,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPosition,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     crate::number::streaming::recognize_float(input)
@@ -1155,8 +1155,8 @@ where
   T: InputIter + InputTake + InputIsStreaming<STREAMING>,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar + Copy,
-  T: InputTakeAtPosition + InputLength,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset + InputLength,
+  <T as InputTakeAtOffset>::Item: AsChar,
   T: for<'a> Compare<&'a [u8]>,
   T: AsBytes,
 {

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -47,14 +47,14 @@ use crate::IResult;
 /// assert_eq!(crlf::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn crlf<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn crlf<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  T: InputIter + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  T: Compare<&'static str>,
+  I: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+  I: InputIter + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  I: Compare<&'static str>,
 {
   if STREAMING {
     streaming::crlf(input)
@@ -97,16 +97,16 @@ where
 /// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rbc")), Err(Err::Error(Error::new(Streaming("a\rbc"), ErrorKind::Tag ))));
 /// ```
 #[inline(always)]
-pub fn not_line_ending<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn not_line_ending<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  T: InputIter + InputLength + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  T: Compare<&'static str>,
-  <T as InputIter>::Item: AsChar,
-  <T as InputIter>::Item: AsChar,
+  I: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+  I: InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  I: Compare<&'static str>,
+  <I as InputIter>::Item: AsChar,
+  <I as InputIter>::Item: AsChar,
 {
   if STREAMING {
     streaming::not_line_ending(input)
@@ -144,14 +144,14 @@ where
 /// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn line_ending<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn line_ending<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  T: InputIter + InputLength + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  T: Compare<&'static str>,
+  I: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+  I: InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  I: Compare<&'static str>,
 {
   if STREAMING {
     streaming::line_ending(input)
@@ -273,13 +273,13 @@ where
 /// assert_eq!(alpha0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha0<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn alpha0<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::alpha0(input)
@@ -319,13 +319,13 @@ where
 /// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha1<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn alpha1<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::alpha1(input)
@@ -366,13 +366,13 @@ where
 /// assert_eq!(digit0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn digit0<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn digit0<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::digit0(input)
@@ -428,13 +428,13 @@ where
 /// assert!(parser("b").is_err());
 /// ```
 #[inline(always)]
-pub fn digit1<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn digit1<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::digit1(input)
@@ -473,13 +473,13 @@ where
 /// assert_eq!(hex_digit0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit0<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn hex_digit0<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::hex_digit0(input)
@@ -519,13 +519,13 @@ where
 /// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit1<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn hex_digit1<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::hex_digit1(input)
@@ -565,13 +565,13 @@ where
 /// assert_eq!(oct_digit0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit0<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn oct_digit0<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::oct_digit0(input)
@@ -611,13 +611,13 @@ where
 /// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit1<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn oct_digit1<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::oct_digit1(input)
@@ -657,13 +657,13 @@ where
 /// assert_eq!(alphanumeric0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric0<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn alphanumeric0<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::alphanumeric0(input)
@@ -703,13 +703,13 @@ where
 /// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric1<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn alphanumeric1<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     streaming::alphanumeric1(input)
@@ -737,13 +737,13 @@ where
 /// assert_eq!(space0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space0<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn space0<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar + Clone,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   if STREAMING {
     streaming::space0(input)
@@ -783,13 +783,13 @@ where
 /// assert_eq!(space1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space1<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn space1<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar + Clone,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   if STREAMING {
     streaming::space1(input)
@@ -829,13 +829,13 @@ where
 /// assert_eq!(multispace0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace0<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn multispace0<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar + Clone,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   if STREAMING {
     streaming::multispace0(input)
@@ -875,13 +875,13 @@ where
 /// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace1<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn multispace1<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: InputTakeAtOffset + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputTakeAtOffset>::Item: AsChar + Clone,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   if STREAMING {
     streaming::multispace1(input)
@@ -900,12 +900,12 @@ macro_rules! ints {
         ///
         /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
         #[inline(always)]
-        pub fn $t<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, $t, E>
+        pub fn $t<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, $t, E>
             where
-            T: InputIter + Slice<RangeFrom<usize>> + InputLength + InputTake + Clone + InputIsStreaming<STREAMING>,
-            T: IntoOutput,
-            <T as InputIter>::Item: AsChar,
-            T: for <'a> Compare<&'a[u8]>,
+            I: InputIter + Slice<RangeFrom<usize>> + InputLength + InputTake + Clone + InputIsStreaming<STREAMING>,
+            I: IntoOutput,
+            <I as InputIter>::Item: AsChar,
+            I: for <'a> Compare<&'a[u8]>,
             {
                 if STREAMING {
                   streaming::$t(input)
@@ -929,11 +929,11 @@ macro_rules! uints {
         ///
         /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
         #[inline(always)]
-        pub fn $t<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, $t, E>
+        pub fn $t<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, $t, E>
             where
-            T: InputIter + Slice<RangeFrom<usize>> + InputLength + InputIsStreaming<STREAMING>,
-            T: IntoOutput,
-            <T as InputIter>::Item: AsChar,
+            I: InputIter + Slice<RangeFrom<usize>> + InputLength + InputIsStreaming<STREAMING>,
+            I: IntoOutput,
+            <I as InputIter>::Item: AsChar,
             {
                 if STREAMING {
                   streaming::$t(input)
@@ -987,19 +987,19 @@ uints! { u8 u16 u32 u64 u128 }
 /// assert_eq!(parser(Streaming("abc")), Err(Err::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
-pub fn f32<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, f32, E>
+pub fn f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f32, E>
 where
-  T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
-  T: Clone + Offset + Compare<&'static str>,
-  T: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as IntoOutput>::Output: ParseTo<f32>,
-  <T as InputIter>::Item: AsChar + Copy,
-  <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtOffset,
-  <T as InputTakeAtOffset>::Item: AsChar,
-  T: AsBytes,
-  T: for<'a> Compare<&'a [u8]>,
+  I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
+  I: Clone + Offset + Compare<&'static str>,
+  I: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as IntoOutput>::Output: ParseTo<f32>,
+  <I as InputIter>::Item: AsChar + Copy,
+  <I as InputIter>::IterElem: Clone,
+  I: InputTakeAtOffset,
+  <I as InputTakeAtOffset>::Item: AsChar,
+  I: AsBytes,
+  I: for<'a> Compare<&'a [u8]>,
 {
   if STREAMING {
     crate::number::streaming::float(input)
@@ -1048,19 +1048,19 @@ where
 /// assert_eq!(parser(Streaming("abc")), Err(Err::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
-pub fn f64<T, E: ParseError<T>, const STREAMING: bool>(input: T) -> IResult<T, f64, E>
+pub fn f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f64, E>
 where
-  T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
-  T: Clone + Offset + Compare<&'static str>,
-  T: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as IntoOutput>::Output: ParseTo<f64>,
-  <T as InputIter>::Item: AsChar + Copy,
-  <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtOffset,
-  <T as InputTakeAtOffset>::Item: AsChar,
-  T: AsBytes,
-  T: for<'a> Compare<&'a [u8]>,
+  I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
+  I: Clone + Offset + Compare<&'static str>,
+  I: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as IntoOutput>::Output: ParseTo<f64>,
+  <I as InputIter>::Item: AsChar + Copy,
+  <I as InputIter>::IterElem: Clone,
+  I: InputTakeAtOffset,
+  <I as InputTakeAtOffset>::Item: AsChar,
+  I: AsBytes,
+  I: for<'a> Compare<&'a [u8]>,
 {
   if STREAMING {
     crate::number::streaming::double(input)
@@ -1107,17 +1107,17 @@ where
 /// assert_eq!(parser(Streaming("abc")), Err(Err::Error(Error::new(Streaming("abc"), ErrorKind::Char))));
 /// ```
 #[inline(always)]
-pub fn recognize_float<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
-) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn recognize_float<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
+) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  T: Clone + Offset,
-  T: InputIter + InputLength + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputIter>::Item: AsChar,
-  T: InputTakeAtOffset,
-  <T as InputTakeAtOffset>::Item: AsChar,
+  I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+  I: Clone + Offset,
+  I: InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputIter>::Item: AsChar,
+  I: InputTakeAtOffset,
+  <I as InputTakeAtOffset>::Item: AsChar,
 {
   if STREAMING {
     crate::number::streaming::recognize_float(input)
@@ -1137,28 +1137,28 @@ where
 ///
 #[inline(always)]
 #[allow(clippy::type_complexity)]
-pub fn recognize_float_parts<T, E: ParseError<T>, const STREAMING: bool>(
-  input: T,
+pub fn recognize_float_parts<I, E: ParseError<I>, const STREAMING: bool>(
+  input: I,
 ) -> IResult<
-  T,
+  I,
   (
     bool,
-    <T as IntoOutput>::Output,
-    <T as IntoOutput>::Output,
+    <I as IntoOutput>::Output,
+    <I as IntoOutput>::Output,
     i32,
   ),
   E,
 >
 where
-  T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
-  T: Clone + Offset,
-  T: InputIter + InputTake + InputIsStreaming<STREAMING>,
-  T: IntoOutput,
-  <T as InputIter>::Item: AsChar + Copy,
-  T: InputTakeAtOffset + InputLength,
-  <T as InputTakeAtOffset>::Item: AsChar,
-  T: for<'a> Compare<&'a [u8]>,
-  T: AsBytes,
+  I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
+  I: Clone + Offset,
+  I: InputIter + InputTake + InputIsStreaming<STREAMING>,
+  I: IntoOutput,
+  <I as InputIter>::Item: AsChar + Copy,
+  I: InputTakeAtOffset + InputLength,
+  <I as InputTakeAtOffset>::Item: AsChar,
+  I: for<'a> Compare<&'a [u8]>,
+  I: AsBytes,
 {
   if STREAMING {
     crate::number::streaming::recognize_float_parts(input)

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -12,8 +12,8 @@ mod tests;
 use crate::error::ParseError;
 use crate::input::Compare;
 use crate::input::{
-  AsBytes, AsChar, InputIsStreaming, InputIter, InputLength, InputTake, InputTakeAtOffset,
-  IntoOutput, Offset, ParseTo, Slice,
+  AsBytes, AsChar, InputIsStreaming, InputIter, InputTake, InputTakeAtOffset, IntoOutput, Offset,
+  ParseTo, Slice, SliceLen,
 };
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
 use crate::IResult;
@@ -102,7 +102,7 @@ pub fn not_line_ending<I, E: ParseError<I>, const STREAMING: bool>(
 ) -> IResult<I, <I as IntoOutput>::Output, E>
 where
   I: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  I: InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: InputIter + SliceLen + InputIsStreaming<STREAMING>,
   I: IntoOutput,
   I: Compare<&'static str>,
   <I as InputIter>::Item: AsChar,
@@ -149,7 +149,7 @@ pub fn line_ending<I, E: ParseError<I>, const STREAMING: bool>(
 ) -> IResult<I, <I as IntoOutput>::Output, E>
 where
   I: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  I: InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: InputIter + SliceLen + InputIsStreaming<STREAMING>,
   I: IntoOutput,
   I: Compare<&'static str>,
 {
@@ -191,7 +191,7 @@ where
 #[inline(always)]
 pub fn newline<I, Error: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, char, Error>
 where
-  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter + SliceLen + InputIsStreaming<STREAMING>,
   <I as InputIter>::Item: AsChar,
 {
   if STREAMING {
@@ -232,7 +232,7 @@ where
 #[inline(always)]
 pub fn tab<I, Error: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, char, Error>
 where
-  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter + SliceLen + InputIsStreaming<STREAMING>,
   <I as InputIter>::Item: AsChar,
 {
   if STREAMING {
@@ -902,7 +902,7 @@ macro_rules! ints {
         #[inline(always)]
         pub fn $t<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, $t, E>
             where
-            I: InputIter + Slice<RangeFrom<usize>> + InputLength + InputTake + Clone + InputIsStreaming<STREAMING>,
+            I: InputIter + Slice<RangeFrom<usize>> + SliceLen + InputTake + Clone + InputIsStreaming<STREAMING>,
             I: IntoOutput,
             <I as InputIter>::Item: AsChar,
             I: for <'a> Compare<&'a[u8]>,
@@ -931,7 +931,7 @@ macro_rules! uints {
         #[inline(always)]
         pub fn $t<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, $t, E>
             where
-            I: InputIter + Slice<RangeFrom<usize>> + InputLength + InputIsStreaming<STREAMING>,
+            I: InputIter + Slice<RangeFrom<usize>> + SliceLen + InputIsStreaming<STREAMING>,
             I: IntoOutput,
             <I as InputIter>::Item: AsChar,
             {
@@ -991,7 +991,7 @@ pub fn f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f
 where
   I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
   I: Clone + Offset + Compare<&'static str>,
-  I: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
+  I: InputIter + SliceLen + InputTake + InputIsStreaming<STREAMING>,
   I: IntoOutput,
   <I as IntoOutput>::Output: ParseTo<f32>,
   <I as InputIter>::Item: AsChar + Copy,
@@ -1052,7 +1052,7 @@ pub fn f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f
 where
   I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
   I: Clone + Offset + Compare<&'static str>,
-  I: InputIter + InputLength + InputTake + InputIsStreaming<STREAMING>,
+  I: InputIter + SliceLen + InputTake + InputIsStreaming<STREAMING>,
   I: IntoOutput,
   <I as IntoOutput>::Output: ParseTo<f64>,
   <I as InputIter>::Item: AsChar + Copy,
@@ -1113,7 +1113,7 @@ pub fn recognize_float<I, E: ParseError<I>, const STREAMING: bool>(
 where
   I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   I: Clone + Offset,
-  I: InputIter + InputLength + InputIsStreaming<STREAMING>,
+  I: InputIter + SliceLen + InputIsStreaming<STREAMING>,
   I: IntoOutput,
   <I as InputIter>::Item: AsChar,
   I: InputTakeAtOffset,
@@ -1155,7 +1155,7 @@ where
   I: InputIter + InputTake + InputIsStreaming<STREAMING>,
   I: IntoOutput,
   <I as InputIter>::Item: AsChar + Copy,
-  I: InputTakeAtOffset + InputLength,
+  I: InputTakeAtOffset + SliceLen,
   <I as InputTakeAtOffset>::Item: AsChar,
   I: for<'a> Compare<&'a [u8]>,
   I: AsBytes,

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -9,7 +9,7 @@ use crate::combinator::opt;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtPosition, IntoOutput, Slice,
+  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput, Slice,
 };
 use crate::input::{Compare, CompareResult};
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
@@ -393,12 +393,12 @@ where
 )]
 pub fn alpha0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_streaming(|item| !item.is_alpha())
+    .split_at_offset_streaming(|item| !item.is_alpha())
     .into_output()
 }
 
@@ -423,12 +423,12 @@ where
 )]
 pub fn alpha1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_streaming(|item| !item.is_alpha(), ErrorKind::Alpha)
+    .split_at_offset1_streaming(|item| !item.is_alpha(), ErrorKind::Alpha)
     .into_output()
 }
 
@@ -453,12 +453,12 @@ where
 )]
 pub fn digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_streaming(|item| !item.is_dec_digit())
+    .split_at_offset_streaming(|item| !item.is_dec_digit())
     .into_output()
 }
 
@@ -483,12 +483,12 @@ where
 )]
 pub fn digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_streaming(|item| !item.is_dec_digit(), ErrorKind::Digit)
+    .split_at_offset1_streaming(|item| !item.is_dec_digit(), ErrorKind::Digit)
     .into_output()
 }
 
@@ -513,12 +513,12 @@ where
 )]
 pub fn hex_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_streaming(|item| !item.is_hex_digit())
+    .split_at_offset_streaming(|item| !item.is_hex_digit())
     .into_output()
 }
 
@@ -543,12 +543,12 @@ where
 )]
 pub fn hex_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_streaming(|item| !item.is_hex_digit(), ErrorKind::HexDigit)
+    .split_at_offset1_streaming(|item| !item.is_hex_digit(), ErrorKind::HexDigit)
     .into_output()
 }
 
@@ -573,12 +573,12 @@ where
 )]
 pub fn oct_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_streaming(|item| !item.is_oct_digit())
+    .split_at_offset_streaming(|item| !item.is_oct_digit())
     .into_output()
 }
 
@@ -603,12 +603,12 @@ where
 )]
 pub fn oct_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_streaming(|item| !item.is_oct_digit(), ErrorKind::OctDigit)
+    .split_at_offset1_streaming(|item| !item.is_oct_digit(), ErrorKind::OctDigit)
     .into_output()
 }
 
@@ -633,12 +633,12 @@ where
 )]
 pub fn alphanumeric0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position_streaming(|item| !item.is_alphanum())
+    .split_at_offset_streaming(|item| !item.is_alphanum())
     .into_output()
 }
 
@@ -663,12 +663,12 @@ where
 )]
 pub fn alphanumeric1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   input
-    .split_at_position1_streaming(|item| !item.is_alphanum(), ErrorKind::AlphaNumeric)
+    .split_at_offset1_streaming(|item| !item.is_alphanum(), ErrorKind::AlphaNumeric)
     .into_output()
 }
 
@@ -693,12 +693,12 @@ where
 )]
 pub fn space0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   input
-    .split_at_position_streaming(|item| {
+    .split_at_offset_streaming(|item| {
       let c = item.as_char();
       !(c == ' ' || c == '\t')
     })
@@ -725,12 +725,12 @@ where
 )]
 pub fn space1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   input
-    .split_at_position1_streaming(
+    .split_at_offset1_streaming(
       |item| {
         let c = item.as_char();
         !(c == ' ' || c == '\t')
@@ -761,12 +761,12 @@ where
 )]
 pub fn multispace0<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   input
-    .split_at_position_streaming(|item| {
+    .split_at_offset_streaming(|item| {
       let c = item.as_char();
       !(c == ' ' || c == '\t' || c == '\r' || c == '\n')
     })
@@ -794,12 +794,12 @@ where
 )]
 pub fn multispace1<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
 where
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar + Clone,
+  <T as InputTakeAtOffset>::Item: AsChar + Clone,
 {
   input
-    .split_at_position1_streaming(
+    .split_at_offset1_streaming(
       |item| {
         let c = item.as_char();
         !(c == ' ' || c == '\t' || c == '\r' || c == '\n')

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -1116,43 +1116,43 @@ mod tests {
 
     match alpha1::<_, Error<_>>(a) {
       Ok((i, _)) => {
-        assert_eq!(a.offset(i) + i.len(), a.len());
+        assert_eq!(a.offset_to(i) + i.len(), a.len());
       }
       _ => panic!("wrong return type in offset test for alpha"),
     }
     match digit1::<_, Error<_>>(b) {
       Ok((i, _)) => {
-        assert_eq!(b.offset(i) + i.len(), b.len());
+        assert_eq!(b.offset_to(i) + i.len(), b.len());
       }
       _ => panic!("wrong return type in offset test for digit"),
     }
     match alphanumeric1::<_, Error<_>>(c) {
       Ok((i, _)) => {
-        assert_eq!(c.offset(i) + i.len(), c.len());
+        assert_eq!(c.offset_to(i) + i.len(), c.len());
       }
       _ => panic!("wrong return type in offset test for alphanumeric"),
     }
     match space1::<_, Error<_>>(d) {
       Ok((i, _)) => {
-        assert_eq!(d.offset(i) + i.len(), d.len());
+        assert_eq!(d.offset_to(i) + i.len(), d.len());
       }
       _ => panic!("wrong return type in offset test for space"),
     }
     match multispace1::<_, Error<_>>(e) {
       Ok((i, _)) => {
-        assert_eq!(e.offset(i) + i.len(), e.len());
+        assert_eq!(e.offset_to(i) + i.len(), e.len());
       }
       _ => panic!("wrong return type in offset test for multispace"),
     }
     match hex_digit1::<_, Error<_>>(f) {
       Ok((i, _)) => {
-        assert_eq!(f.offset(i) + i.len(), f.len());
+        assert_eq!(f.offset_to(i) + i.len(), f.len());
       }
       _ => panic!("wrong return type in offset test for hex_digit"),
     }
     match oct_digit1::<_, Error<_>>(f) {
       Ok((i, _)) => {
-        assert_eq!(f.offset(i) + i.len(), f.len());
+        assert_eq!(f.offset_to(i) + i.len(), f.len());
       }
       _ => panic!("wrong return type in offset test for oct_digit"),
     }

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -9,7 +9,7 @@ use crate::combinator::opt;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  AsChar, FindToken, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput, Slice,
+  AsChar, ContainsToken, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput, Slice,
 };
 use crate::input::{Compare, CompareResult};
 use crate::lib::std::ops::{Range, RangeFrom, RangeTo};
@@ -132,7 +132,7 @@ pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, c
 where
   I: Slice<RangeFrom<usize>> + InputIter + InputLength,
   <I as InputIter>::Item: AsChar + Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   move |i: I| crate::bytes::streaming::one_of_internal(i, &list).map(|(i, c)| (i, c.as_char()))
 }
@@ -159,7 +159,7 @@ pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Fn(I) -> IResult<I, 
 where
   I: Slice<RangeFrom<usize>> + InputLength + InputIter,
   <I as InputIter>::Item: AsChar + Copy,
-  T: FindToken<<I as InputIter>::Item>,
+  T: ContainsToken<<I as InputIter>::Item>,
 {
   move |i: I| crate::bytes::streaming::none_of_internal(i, &list).map(|(i, c)| (i, c.as_char()))
 }

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -229,7 +229,7 @@ where
   <T as InputIter>::Item: AsChar,
   <T as InputIter>::Item: AsChar,
 {
-  match input.position(|item| {
+  match input.offset_for(|item| {
     let c = item.as_char();
     c == '\r' || c == '\n'
   }) {
@@ -849,7 +849,7 @@ macro_rules! ints {
 
                 let mut value: $t = 0;
                 if sign {
-                    for (pos, c) in i.iter_indices() {
+                    for (pos, c) in i.iter_offsets() {
                         match c.as_char().to_digit(10) {
                             None => {
                                 if pos == 0 {
@@ -865,7 +865,7 @@ macro_rules! ints {
                         }
                     }
                 } else {
-                    for (pos, c) in i.iter_indices() {
+                    for (pos, c) in i.iter_offsets() {
                         match c.as_char().to_digit(10) {
                             None => {
                                 if pos == 0 {
@@ -910,7 +910,7 @@ macro_rules! uints {
                 }
 
                 let mut value: $t = 0;
-                for (pos, c) in i.iter_indices() {
+                for (pos, c) in i.iter_offsets() {
                     match c.as_char().to_digit(10) {
                         None => {
                             if pos == 0 {

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -129,43 +129,43 @@ mod complete {
 
     match alpha1::<_, Error<_>, false>(a) {
       Ok((i, _)) => {
-        assert_eq!(a.offset(i) + i.len(), a.len());
+        assert_eq!(a.offset_to(i) + i.len(), a.len());
       }
       _ => panic!("wrong return type in offset test for alpha"),
     }
     match digit1::<_, Error<_>, false>(b) {
       Ok((i, _)) => {
-        assert_eq!(b.offset(i) + i.len(), b.len());
+        assert_eq!(b.offset_to(i) + i.len(), b.len());
       }
       _ => panic!("wrong return type in offset test for digit"),
     }
     match alphanumeric1::<_, Error<_>, false>(c) {
       Ok((i, _)) => {
-        assert_eq!(c.offset(i) + i.len(), c.len());
+        assert_eq!(c.offset_to(i) + i.len(), c.len());
       }
       _ => panic!("wrong return type in offset test for alphanumeric"),
     }
     match space1::<_, Error<_>, false>(d) {
       Ok((i, _)) => {
-        assert_eq!(d.offset(i) + i.len(), d.len());
+        assert_eq!(d.offset_to(i) + i.len(), d.len());
       }
       _ => panic!("wrong return type in offset test for space"),
     }
     match multispace1::<_, Error<_>, false>(e) {
       Ok((i, _)) => {
-        assert_eq!(e.offset(i) + i.len(), e.len());
+        assert_eq!(e.offset_to(i) + i.len(), e.len());
       }
       _ => panic!("wrong return type in offset test for multispace"),
     }
     match hex_digit1::<_, Error<_>, false>(f) {
       Ok((i, _)) => {
-        assert_eq!(f.offset(i) + i.len(), f.len());
+        assert_eq!(f.offset_to(i) + i.len(), f.len());
       }
       _ => panic!("wrong return type in offset test for hex_digit"),
     }
     match oct_digit1::<_, Error<_>, false>(f) {
       Ok((i, _)) => {
-        assert_eq!(f.offset(i) + i.len(), f.len());
+        assert_eq!(f.offset_to(i) + i.len(), f.len());
       }
       _ => panic!("wrong return type in offset test for oct_digit"),
     }
@@ -714,43 +714,43 @@ mod streaming {
 
     match alpha1::<_, Error<_>, true>(Streaming(a)) {
       Ok((Streaming(i), _)) => {
-        assert_eq!(a.offset(i) + i.len(), a.len());
+        assert_eq!(a.offset_to(i) + i.len(), a.len());
       }
       _ => panic!("wrong return type in offset test for alpha"),
     }
     match digit1::<_, Error<_>, true>(Streaming(b)) {
       Ok((Streaming(i), _)) => {
-        assert_eq!(b.offset(i) + i.len(), b.len());
+        assert_eq!(b.offset_to(i) + i.len(), b.len());
       }
       _ => panic!("wrong return type in offset test for digit"),
     }
     match alphanumeric1::<_, Error<_>, true>(Streaming(c)) {
       Ok((Streaming(i), _)) => {
-        assert_eq!(c.offset(i) + i.len(), c.len());
+        assert_eq!(c.offset_to(i) + i.len(), c.len());
       }
       _ => panic!("wrong return type in offset test for alphanumeric"),
     }
     match space1::<_, Error<_>, true>(Streaming(d)) {
       Ok((Streaming(i), _)) => {
-        assert_eq!(d.offset(i) + i.len(), d.len());
+        assert_eq!(d.offset_to(i) + i.len(), d.len());
       }
       _ => panic!("wrong return type in offset test for space"),
     }
     match multispace1::<_, Error<_>, true>(Streaming(e)) {
       Ok((Streaming(i), _)) => {
-        assert_eq!(e.offset(i) + i.len(), e.len());
+        assert_eq!(e.offset_to(i) + i.len(), e.len());
       }
       _ => panic!("wrong return type in offset test for multispace"),
     }
     match hex_digit1::<_, Error<_>, true>(Streaming(f)) {
       Ok((Streaming(i), _)) => {
-        assert_eq!(f.offset(i) + i.len(), f.len());
+        assert_eq!(f.offset_to(i) + i.len(), f.len());
       }
       _ => panic!("wrong return type in offset test for hex_digit"),
     }
     match oct_digit1::<_, Error<_>, true>(Streaming(f)) {
       Ok((Streaming(i), _)) => {
-        assert_eq!(f.offset(i) + i.len(), f.len());
+        assert_eq!(f.offset_to(i) + i.len(), f.len());
       }
       _ => panic!("wrong return type in offset test for oct_digit"),
     }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -180,11 +180,11 @@ mod tests;
 /// assert_eq!(rest::<_,Error<_>>(""), Ok(("", "")));
 /// ```
 #[inline]
-pub fn rest<T, E: ParseError<T>>(input: T) -> IResult<T, <T as IntoOutput>::Output, E>
+pub fn rest<I, E: ParseError<I>>(input: I) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  T: Slice<RangeFrom<usize>>,
-  T: InputLength,
-  T: IntoOutput,
+  I: Slice<RangeFrom<usize>>,
+  I: InputLength,
+  I: IntoOutput,
 {
   Ok((input.slice(input.input_len()..), input)).into_output()
 }
@@ -199,9 +199,9 @@ where
 /// assert_eq!(rest_len::<_,Error<_>>(""), Ok(("", 0)));
 /// ```
 #[inline]
-pub fn rest_len<T, E: ParseError<T>>(input: T) -> IResult<T, usize, E>
+pub fn rest_len<I, E: ParseError<I>>(input: I) -> IResult<I, usize, E>
 where
-  T: InputLength,
+  I: InputLength,
 {
   let len = input.input_len();
   Ok((input, len))

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1015,7 +1015,7 @@ where
     let i = input.clone();
     match parser.parse_next(i) {
       Ok((i, _)) => {
-        let index = input.offset(&i);
+        let index = input.offset_to(&i);
         Ok((i, input.slice(..index))).into_output()
       }
       Err(e) => Err(e),
@@ -1052,7 +1052,7 @@ where
     let i = input.clone();
     match (self.parser).parse_next(i) {
       Ok((i, _)) => {
-        let index = input.offset(&i);
+        let index = input.offset_to(&i);
         Ok((i, input.slice(..index))).into_output()
       }
       Err(e) => Err(e),
@@ -1117,7 +1117,7 @@ where
     let i = input.clone();
     match parser.parse_next(i) {
       Ok((remaining, result)) => {
-        let index = input.offset(&remaining);
+        let index = input.offset_to(&remaining);
         let consumed = input.slice(..index).into_output();
         Ok((remaining, (consumed, result)))
       }
@@ -1155,7 +1155,7 @@ where
     let i = input.clone();
     match (self.parser).parse_next(i) {
       Ok((remaining, result)) => {
-        let index = input.offset(&remaining);
+        let index = input.offset_to(&remaining);
         let consumed = input.slice(..index).into_output();
         Ok((remaining, (result, consumed)))
       }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1452,13 +1452,12 @@ impl<I: Clone, O, E, F> ParserIterator<I, O, E, F> {
   }
 }
 
-impl<'a, Input, Output, Error, F> core::iter::Iterator
-  for &'a mut ParserIterator<Input, Output, Error, F>
+impl<'a, I, O, E, F> core::iter::Iterator for &'a mut ParserIterator<I, O, E, F>
 where
-  F: Parser<Input, Output, Error>,
-  Input: Clone,
+  F: Parser<I, O, E>,
+  I: Clone,
 {
-  type Item = Output;
+  type Item = O;
 
   fn next(&mut self) -> Option<Self::Item> {
     if let State::Running = self.state.take().unwrap() {

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -156,7 +156,7 @@ use crate::lib::std::boxed::Box;
 
 use crate::error::{ErrorKind, FromExternalError, ParseError};
 use crate::input::IntoOutput;
-use crate::input::{AsChar, InputIter, InputLength, InputTakeAtPosition, Location, ParseTo};
+use crate::input::{AsChar, InputIter, InputLength, InputTakeAtOffset, Location, ParseTo};
 use crate::input::{Compare, CompareResult, Offset, Slice};
 use crate::lib::std::borrow::Borrow;
 use crate::lib::std::convert;

--- a/src/error.rs
+++ b/src/error.rs
@@ -775,7 +775,7 @@ pub fn convert_error<I: core::ops::Deref<Target = str>>(
   let mut result = crate::lib::std::string::String::new();
 
   for (i, (substring, kind)) in e.errors.iter().enumerate() {
-    let offset = input.offset(substring);
+    let offset = input.offset_to(substring);
 
     if input.is_empty() {
       match kind {
@@ -805,7 +805,7 @@ pub fn convert_error<I: core::ops::Deref<Target = str>>(
         .trim_end();
 
       // The (1-indexed) column number is the offset of our substring into that line
-      let column_number = line.offset(substring) + 1;
+      let column_number = line.offset_to(substring) + 1;
 
       match kind {
         VerboseErrorKind::Context(s) => write!(

--- a/src/input.rs
+++ b/src/input.rs
@@ -418,49 +418,7 @@ impl<'a, T> InputIsStreaming<false> for &'a [T] {
   }
 }
 
-impl<T, const L: usize> InputIsStreaming<false> for [T; L] {
-  type Complete = Self;
-  type Streaming = Streaming<Self>;
-
-  #[inline(always)]
-  fn into_complete(self) -> Self::Complete {
-    self
-  }
-  #[inline(always)]
-  fn into_streaming(self) -> Self::Streaming {
-    Streaming(self)
-  }
-}
-
-impl<'a, T, const L: usize> InputIsStreaming<false> for &'a [T; L] {
-  type Complete = Self;
-  type Streaming = Streaming<Self>;
-
-  #[inline(always)]
-  fn into_complete(self) -> Self::Complete {
-    self
-  }
-  #[inline(always)]
-  fn into_streaming(self) -> Self::Streaming {
-    Streaming(self)
-  }
-}
-
 impl<'a> InputIsStreaming<false> for &'a str {
-  type Complete = Self;
-  type Streaming = Streaming<Self>;
-
-  #[inline(always)]
-  fn into_complete(self) -> Self::Complete {
-    self
-  }
-  #[inline(always)]
-  fn into_streaming(self) -> Self::Streaming {
-    Streaming(self)
-  }
-}
-
-impl<'a> InputIsStreaming<false> for (&'a [u8], usize) {
   type Complete = Self;
   type Streaming = Streaming<Self>;
 
@@ -548,13 +506,6 @@ impl<'a> InputLength for &'a str {
   #[inline]
   fn input_len(&self) -> usize {
     self.len()
-  }
-}
-
-impl<'a> InputLength for (&'a [u8], usize) {
-  #[inline]
-  fn input_len(&self) -> usize {
-    self.0.len() * 8 - self.1
   }
 }
 
@@ -676,17 +627,10 @@ impl<'a> AsBytes for &'a [u8] {
   }
 }
 
-impl<const LEN: usize> AsBytes for [u8; LEN] {
+impl AsBytes for str {
   #[inline(always)]
   fn as_bytes(&self) -> &[u8] {
-    self
-  }
-}
-
-impl<'a, const LEN: usize> AsBytes for &'a [u8; LEN] {
-  #[inline(always)]
-  fn as_bytes(&self) -> &[u8] {
-    *self
+    self.as_ref()
   }
 }
 
@@ -694,13 +638,6 @@ impl<'a> AsBytes for &'a str {
   #[inline(always)]
   fn as_bytes(&self) -> &[u8] {
     (*self).as_bytes()
-  }
-}
-
-impl AsBytes for str {
-  #[inline(always)]
-  fn as_bytes(&self) -> &[u8] {
-    self.as_ref()
   }
 }
 
@@ -1002,6 +939,7 @@ where
     self.0.offset_at(count)
   }
 }
+
 impl<'a> InputIter for &'a [u8] {
   type Item = u8;
   type IterOffsets = Enumerate<Self::IterElem>;
@@ -1029,31 +967,6 @@ impl<'a> InputIter for &'a [u8] {
     } else {
       Ok(count)
     }
-  }
-}
-
-impl<'a, const LEN: usize> InputIter for &'a [u8; LEN] {
-  type Item = u8;
-  type IterOffsets = Enumerate<Self::IterElem>;
-  type IterElem = Copied<Iter<'a, u8>>;
-
-  fn iter_offsets(&self) -> Self::IterOffsets {
-    (&self[..]).iter_offsets()
-  }
-
-  fn iter_elements(&self) -> Self::IterElem {
-    (&self[..]).iter_elements()
-  }
-
-  fn offset_for<P>(&self, predicate: P) -> Option<usize>
-  where
-    P: Fn(Self::Item) -> bool,
-  {
-    (&self[..]).offset_for(predicate)
-  }
-
-  fn offset_at(&self, count: usize) -> Result<usize, Needed> {
-    (&self[..]).offset_at(count)
   }
 }
 
@@ -1956,16 +1869,6 @@ pub trait FindToken<T> {
   fn find_token(&self, token: T) -> bool;
 }
 
-impl<I, T> FindToken<T> for Streaming<I>
-where
-  I: FindToken<T>,
-{
-  #[inline(always)]
-  fn find_token(&self, token: T) -> bool {
-    self.0.find_token(token)
-  }
-}
-
 impl FindToken<u8> for u8 {
   fn find_token(&self, token: u8) -> bool {
     *self == token
@@ -2439,43 +2342,7 @@ impl<'a, T> IntoOutput for &'a [T] {
   }
 }
 
-impl<const LEN: usize> IntoOutput for [u8; LEN] {
-  type Output = Self;
-  #[inline]
-  fn into_output(self) -> Self::Output {
-    self
-  }
-  #[inline]
-  fn merge_output(self, inner: Self::Output) -> Self {
-    inner
-  }
-}
-
-impl<'a, const LEN: usize> IntoOutput for &'a [u8; LEN] {
-  type Output = Self;
-  #[inline]
-  fn into_output(self) -> Self::Output {
-    self
-  }
-  #[inline]
-  fn merge_output(self, inner: Self::Output) -> Self {
-    inner
-  }
-}
-
 impl<'a> IntoOutput for &'a str {
-  type Output = Self;
-  #[inline]
-  fn into_output(self) -> Self::Output {
-    self
-  }
-  #[inline]
-  fn merge_output(self, inner: Self::Output) -> Self {
-    inner
-  }
-}
-
-impl<'a> IntoOutput for (&'a [u8], usize) {
   type Output = Self;
   #[inline]
   fn into_output(self) -> Self::Output {

--- a/src/input.rs
+++ b/src/input.rs
@@ -2085,7 +2085,7 @@ impl_find_token_for_tuples!(
 
 /// Look for a substring in self
 pub trait FindSubstring<T> {
-  /// Returns the byte position of the substring if it is found
+  /// Returns the offset of the substring if it is found
   fn find_substring(&self, substr: T) -> Option<usize>;
 }
 
@@ -2102,7 +2102,6 @@ impl<'a, 'b> FindSubstring<&'b str> for &'a [u8] {
 }
 
 impl<'a, 'b> FindSubstring<&'b str> for &'a str {
-  //returns byte index
   fn find_substring(&self, substr: &'b str) -> Option<usize> {
     self.find(substr)
   }

--- a/src/input.rs
+++ b/src/input.rs
@@ -37,7 +37,7 @@
 //! | [`Compare`] |Character comparison operations|
 //! | [`ExtendInto`] |Abstracts something which can extend an `Extend`|
 //! | [`FindSubstring`] |Look for a substring in self|
-//! | [`FindToken`] |Look for self in the given input stream|
+//! | [`ContainsToken`] |Look for self in the given input stream|
 //! | [`InputIter`] |Common iteration operations on the input type|
 //! | [`InputLength`] |Calculate the input length|
 //! | [`IntoOutput`] |Adapt a captired `Input` into an appropriate type|
@@ -1864,222 +1864,222 @@ where
 /// assert_eq!(hex_digit1("H2"), Err(Err::Error(Error::new("H2", ErrorKind::TakeWhile1))));
 /// assert_eq!(hex_digit1(""), Err(Err::Error(Error::new("", ErrorKind::TakeWhile1))));
 /// ```
-pub trait FindToken<T> {
+pub trait ContainsToken<T> {
   /// Returns true if self contains the token
-  fn find_token(&self, token: T) -> bool;
+  fn contains_token(&self, token: T) -> bool;
 }
 
-impl FindToken<u8> for u8 {
-  fn find_token(&self, token: u8) -> bool {
+impl ContainsToken<u8> for u8 {
+  fn contains_token(&self, token: u8) -> bool {
     *self == token
   }
 }
 
-impl<'a> FindToken<&'a u8> for u8 {
-  fn find_token(&self, token: &u8) -> bool {
-    self.find_token(*token)
+impl<'a> ContainsToken<&'a u8> for u8 {
+  fn contains_token(&self, token: &u8) -> bool {
+    self.contains_token(*token)
   }
 }
 
-impl FindToken<char> for u8 {
-  fn find_token(&self, token: char) -> bool {
+impl ContainsToken<char> for u8 {
+  fn contains_token(&self, token: char) -> bool {
     self.as_char() == token
   }
 }
 
-impl<'a> FindToken<&'a char> for u8 {
-  fn find_token(&self, token: &char) -> bool {
-    self.find_token(*token)
+impl<'a> ContainsToken<&'a char> for u8 {
+  fn contains_token(&self, token: &char) -> bool {
+    self.contains_token(*token)
   }
 }
 
-impl<C: AsChar> FindToken<C> for char {
-  fn find_token(&self, token: C) -> bool {
+impl<C: AsChar> ContainsToken<C> for char {
+  fn contains_token(&self, token: C) -> bool {
     *self == token.as_char()
   }
 }
 
-impl<C: AsChar, F: Fn(C) -> bool> FindToken<C> for F {
-  fn find_token(&self, token: C) -> bool {
+impl<C: AsChar, F: Fn(C) -> bool> ContainsToken<C> for F {
+  fn contains_token(&self, token: C) -> bool {
     self(token)
   }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for Range<C2> {
-  fn find_token(&self, token: C1) -> bool {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for Range<C2> {
+  fn contains_token(&self, token: C1) -> bool {
     let start = self.start.clone().as_char();
     let end = self.end.clone().as_char();
     (start..end).contains(&token.as_char())
   }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for RangeInclusive<C2> {
-  fn find_token(&self, token: C1) -> bool {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeInclusive<C2> {
+  fn contains_token(&self, token: C1) -> bool {
     let start = self.start().clone().as_char();
     let end = self.end().clone().as_char();
     (start..=end).contains(&token.as_char())
   }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for RangeFrom<C2> {
-  fn find_token(&self, token: C1) -> bool {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeFrom<C2> {
+  fn contains_token(&self, token: C1) -> bool {
     let start = self.start.clone().as_char();
     (start..).contains(&token.as_char())
   }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for RangeTo<C2> {
-  fn find_token(&self, token: C1) -> bool {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeTo<C2> {
+  fn contains_token(&self, token: C1) -> bool {
     let end = self.end.clone().as_char();
     (..end).contains(&token.as_char())
   }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> FindToken<C1> for RangeToInclusive<C2> {
-  fn find_token(&self, token: C1) -> bool {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeToInclusive<C2> {
+  fn contains_token(&self, token: C1) -> bool {
     let end = self.end.clone().as_char();
     (..=end).contains(&token.as_char())
   }
 }
 
-impl<C1: AsChar> FindToken<C1> for RangeFull {
-  fn find_token(&self, _token: C1) -> bool {
+impl<C1: AsChar> ContainsToken<C1> for RangeFull {
+  fn contains_token(&self, _token: C1) -> bool {
     true
   }
 }
 
-impl<'a> FindToken<u8> for &'a [u8] {
-  fn find_token(&self, token: u8) -> bool {
+impl<'a> ContainsToken<u8> for &'a [u8] {
+  fn contains_token(&self, token: u8) -> bool {
     memchr::memchr(token, self).is_some()
   }
 }
 
-impl<'a, 'b> FindToken<&'a u8> for &'b [u8] {
-  fn find_token(&self, token: &u8) -> bool {
-    self.find_token(*token)
+impl<'a, 'b> ContainsToken<&'a u8> for &'b [u8] {
+  fn contains_token(&self, token: &u8) -> bool {
+    self.contains_token(*token)
   }
 }
 
-impl<'a> FindToken<char> for &'a [u8] {
-  fn find_token(&self, token: char) -> bool {
+impl<'a> ContainsToken<char> for &'a [u8] {
+  fn contains_token(&self, token: char) -> bool {
     self.iter().any(|i| i.as_char() == token)
   }
 }
 
-impl<'a, 'b> FindToken<&'a char> for &'b [u8] {
-  fn find_token(&self, token: &char) -> bool {
-    self.find_token(*token)
+impl<'a, 'b> ContainsToken<&'a char> for &'b [u8] {
+  fn contains_token(&self, token: &char) -> bool {
+    self.contains_token(*token)
   }
 }
 
-impl<const LEN: usize> FindToken<u8> for [u8; LEN] {
-  fn find_token(&self, token: u8) -> bool {
+impl<const LEN: usize> ContainsToken<u8> for [u8; LEN] {
+  fn contains_token(&self, token: u8) -> bool {
     memchr::memchr(token, &self[..]).is_some()
   }
 }
 
-impl<'a, const LEN: usize> FindToken<&'a u8> for [u8; LEN] {
-  fn find_token(&self, token: &u8) -> bool {
-    self.find_token(*token)
+impl<'a, const LEN: usize> ContainsToken<&'a u8> for [u8; LEN] {
+  fn contains_token(&self, token: &u8) -> bool {
+    self.contains_token(*token)
   }
 }
 
-impl<const LEN: usize> FindToken<char> for [u8; LEN] {
-  fn find_token(&self, token: char) -> bool {
+impl<const LEN: usize> ContainsToken<char> for [u8; LEN] {
+  fn contains_token(&self, token: char) -> bool {
     self.iter().any(|i| i.as_char() == token)
   }
 }
 
-impl<'a, const LEN: usize> FindToken<&'a char> for [u8; LEN] {
-  fn find_token(&self, token: &char) -> bool {
-    self.find_token(*token)
+impl<'a, const LEN: usize> ContainsToken<&'a char> for [u8; LEN] {
+  fn contains_token(&self, token: &char) -> bool {
+    self.contains_token(*token)
   }
 }
 
-impl<'a> FindToken<u8> for &'a str {
-  fn find_token(&self, token: u8) -> bool {
-    self.as_bytes().find_token(token)
+impl<'a> ContainsToken<u8> for &'a str {
+  fn contains_token(&self, token: u8) -> bool {
+    self.as_bytes().contains_token(token)
   }
 }
 
-impl<'a, 'b> FindToken<&'a u8> for &'b str {
-  fn find_token(&self, token: &u8) -> bool {
-    self.as_bytes().find_token(token)
+impl<'a, 'b> ContainsToken<&'a u8> for &'b str {
+  fn contains_token(&self, token: &u8) -> bool {
+    self.as_bytes().contains_token(token)
   }
 }
 
-impl<'a> FindToken<char> for &'a str {
-  fn find_token(&self, token: char) -> bool {
+impl<'a> ContainsToken<char> for &'a str {
+  fn contains_token(&self, token: char) -> bool {
     self.chars().any(|i| i == token)
   }
 }
 
-impl<'a, 'b> FindToken<&'a char> for &'b str {
-  fn find_token(&self, token: &char) -> bool {
-    self.find_token(*token)
+impl<'a, 'b> ContainsToken<&'a char> for &'b str {
+  fn contains_token(&self, token: &char) -> bool {
+    self.contains_token(*token)
   }
 }
 
-impl<'a> FindToken<u8> for &'a [char] {
-  fn find_token(&self, token: u8) -> bool {
+impl<'a> ContainsToken<u8> for &'a [char] {
+  fn contains_token(&self, token: u8) -> bool {
     self.iter().any(|i| *i == token.as_char())
   }
 }
 
-impl<'a, 'b> FindToken<&'a u8> for &'b [char] {
-  fn find_token(&self, token: &u8) -> bool {
-    self.find_token(*token)
+impl<'a, 'b> ContainsToken<&'a u8> for &'b [char] {
+  fn contains_token(&self, token: &u8) -> bool {
+    self.contains_token(*token)
   }
 }
 
-impl<'a> FindToken<char> for &'a [char] {
-  fn find_token(&self, token: char) -> bool {
+impl<'a> ContainsToken<char> for &'a [char] {
+  fn contains_token(&self, token: char) -> bool {
     self.iter().any(|i| *i == token)
   }
 }
 
-impl<'a, 'b> FindToken<&'a char> for &'b [char] {
-  fn find_token(&self, token: &char) -> bool {
-    self.find_token(*token)
+impl<'a, 'b> ContainsToken<&'a char> for &'b [char] {
+  fn contains_token(&self, token: &char) -> bool {
+    self.contains_token(*token)
   }
 }
 
-impl<T> FindToken<T> for () {
-  fn find_token(&self, _token: T) -> bool {
+impl<T> ContainsToken<T> for () {
+  fn contains_token(&self, _token: T) -> bool {
     false
   }
 }
 
-macro_rules! impl_find_token_for_tuple {
+macro_rules! impl_contains_token_for_tuple {
   ($($haystack:ident),+) => (
     #[allow(non_snake_case)]
-    impl<T, $($haystack),+> FindToken<T> for ($($haystack),+,)
+    impl<T, $($haystack),+> ContainsToken<T> for ($($haystack),+,)
     where
     T: Clone,
-      $($haystack: FindToken<T>),+
+      $($haystack: ContainsToken<T>),+
     {
-      fn find_token(&self, token: T) -> bool {
+      fn contains_token(&self, token: T) -> bool {
         let ($(ref $haystack),+,) = *self;
-        $($haystack.find_token(token.clone()) || )+ false
+        $($haystack.contains_token(token.clone()) || )+ false
       }
     }
   )
 }
 
-macro_rules! impl_find_token_for_tuples {
+macro_rules! impl_contains_token_for_tuples {
     ($haystack1:ident, $($haystack:ident),+) => {
-        impl_find_token_for_tuples!(__impl $haystack1; $($haystack),+);
+        impl_contains_token_for_tuples!(__impl $haystack1; $($haystack),+);
     };
     (__impl $($haystack:ident),+; $haystack1:ident $(,$haystack2:ident)*) => {
-        impl_find_token_for_tuple!($($haystack),+);
-        impl_find_token_for_tuples!(__impl $($haystack),+, $haystack1; $($haystack2),*);
+        impl_contains_token_for_tuple!($($haystack),+);
+        impl_contains_token_for_tuples!(__impl $($haystack),+, $haystack1; $($haystack2),*);
     };
     (__impl $($haystack:ident),+;) => {
-        impl_find_token_for_tuple!($($haystack),+);
+        impl_contains_token_for_tuple!($($haystack),+);
     }
 }
 
-impl_find_token_for_tuples!(
+impl_contains_token_for_tuples!(
   F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15, F16, F17, F18, F19, F20, F21
 );
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1464,24 +1464,10 @@ pub trait AsBytes {
   fn as_bytes(&self) -> &[u8];
 }
 
-impl AsBytes for [u8] {
-  #[inline(always)]
-  fn as_bytes(&self) -> &[u8] {
-    self
-  }
-}
-
 impl<'a> AsBytes for &'a [u8] {
   #[inline(always)]
   fn as_bytes(&self) -> &[u8] {
     self
-  }
-}
-
-impl AsBytes for str {
-  #[inline(always)]
-  fn as_bytes(&self) -> &[u8] {
-    self.as_ref()
   }
 }
 
@@ -1641,11 +1627,11 @@ impl<
 impl<'a, 'b> Compare<&'b str> for &'a [u8] {
   #[inline(always)]
   fn compare(&self, t: &'b str) -> CompareResult {
-    self.compare(AsBytes::as_bytes(t))
+    self.compare(t.as_bytes())
   }
   #[inline(always)]
   fn compare_no_case(&self, t: &'b str) -> CompareResult {
-    self.compare_no_case(AsBytes::as_bytes(t))
+    self.compare_no_case(t.as_bytes())
   }
 }
 
@@ -1754,7 +1740,7 @@ impl<'a, 'b> FindSubstring<&'b [u8]> for &'a [u8] {
 
 impl<'a, 'b> FindSubstring<&'b str> for &'a [u8] {
   fn find_substring(&self, substr: &'b str) -> Option<usize> {
-    self.find_substring(AsBytes::as_bytes(substr))
+    self.find_substring(substr.as_bytes())
   }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -93,7 +93,7 @@ where
   }
 
   fn location(&self) -> usize {
-    self.initial.offset(&self.input)
+    self.initial.offset_to(&self.input)
   }
 }
 
@@ -561,15 +561,15 @@ impl<'a> InputLength for (&'a [u8], usize) {
 /// Useful functions to calculate the offset between slices and show a hexdump of a slice
 pub trait Offset {
   /// Offset between the first byte of self and the first byte of the argument
-  fn offset(&self, second: &Self) -> usize;
+  fn offset_to(&self, second: &Self) -> usize;
 }
 
 impl<I> Offset for Located<I>
 where
   I: Offset,
 {
-  fn offset(&self, other: &Self) -> usize {
-    self.input.offset(&other.input)
+  fn offset_to(&self, other: &Self) -> usize {
+    self.input.offset_to(&other.input)
   }
 }
 
@@ -577,8 +577,8 @@ impl<I, S> Offset for Stateful<I, S>
 where
   I: Offset,
 {
-  fn offset(&self, other: &Self) -> usize {
-    self.input.offset(&other.input)
+  fn offset_to(&self, other: &Self) -> usize {
+    self.input.offset_to(&other.input)
   }
 }
 
@@ -587,13 +587,13 @@ where
   I: Offset,
 {
   #[inline(always)]
-  fn offset(&self, second: &Self) -> usize {
-    self.0.offset(&second.0)
+  fn offset_to(&self, second: &Self) -> usize {
+    self.0.offset_to(&second.0)
   }
 }
 
 impl Offset for [u8] {
-  fn offset(&self, second: &Self) -> usize {
+  fn offset_to(&self, second: &Self) -> usize {
     let fst = self.as_ptr();
     let snd = second.as_ptr();
 
@@ -602,7 +602,7 @@ impl Offset for [u8] {
 }
 
 impl<'a> Offset for &'a [u8] {
-  fn offset(&self, second: &Self) -> usize {
+  fn offset_to(&self, second: &Self) -> usize {
     let fst = self.as_ptr();
     let snd = second.as_ptr();
 
@@ -611,7 +611,7 @@ impl<'a> Offset for &'a [u8] {
 }
 
 impl Offset for str {
-  fn offset(&self, second: &Self) -> usize {
+  fn offset_to(&self, second: &Self) -> usize {
     let fst = self.as_ptr();
     let snd = second.as_ptr();
 
@@ -620,7 +620,7 @@ impl Offset for str {
 }
 
 impl<'a> Offset for &'a str {
-  fn offset(&self, second: &Self) -> usize {
+  fn offset_to(&self, second: &Self) -> usize {
     let fst = self.as_ptr();
     let snd = second.as_ptr();
 
@@ -2796,9 +2796,9 @@ mod tests {
     let b = &a[2..];
     let c = &a[..4];
     let d = &a[3..5];
-    assert_eq!(a.offset(b), 2);
-    assert_eq!(a.offset(c), 0);
-    assert_eq!(a.offset(d), 3);
+    assert_eq!(a.offset_to(b), 2);
+    assert_eq!(a.offset_to(c), 0);
+    assert_eq!(a.offset_to(d), 3);
   }
 
   #[test]
@@ -2807,8 +2807,8 @@ mod tests {
     let b = &a[7..];
     let c = &a[..5];
     let d = &a[5..9];
-    assert_eq!(a.offset(b), 7);
-    assert_eq!(a.offset(c), 0);
-    assert_eq!(a.offset(d), 5);
+    assert_eq!(a.offset_to(b), 7);
+    assert_eq!(a.offset_to(c), 0);
+    assert_eq!(a.offset_to(d), 5);
   }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1734,20 +1734,20 @@ pub trait FindSlice<T> {
   fn find_slice(&self, substr: T) -> Option<usize>;
 }
 
-impl<'a, 'b> FindSlice<&'b [u8]> for &'a [u8] {
-  fn find_slice(&self, substr: &'b [u8]) -> Option<usize> {
+impl<'i, 's> FindSlice<&'s [u8]> for &'i [u8] {
+  fn find_slice(&self, substr: &'s [u8]) -> Option<usize> {
     memchr::memmem::find(self, substr)
   }
 }
 
-impl<'a, 'b> FindSlice<&'b str> for &'a [u8] {
-  fn find_slice(&self, substr: &'b str) -> Option<usize> {
+impl<'i, 's> FindSlice<&'s str> for &'i [u8] {
+  fn find_slice(&self, substr: &'s str) -> Option<usize> {
     self.find_slice(substr.as_bytes())
   }
 }
 
-impl<'a, 'b> FindSlice<&'b str> for &'a str {
-  fn find_slice(&self, substr: &'b str) -> Option<usize> {
+impl<'i, 's> FindSlice<&'s str> for &'i str {
+  fn find_slice(&self, substr: &'s str) -> Option<usize> {
     self.find(substr)
   }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -41,7 +41,7 @@
 //! | [`AsBytes`] |Casts the input type to a byte slice|
 //! | [`Compare`] |Character comparison operations|
 //! | [`ExtendInto`] |Abstracts something which can extend an `Extend`|
-//! | [`FindSubstring`] |Look for a substring in self|
+//! | [`FindSlice`] |Look for a substring in self|
 //! | [`IntoOutput`] |Adapt a captired `Input` into an appropriate type|
 //! | [`Location`] |Calculate location within initial input|
 //! | [`Offset`] |Calculate the offset between slices|
@@ -1728,57 +1728,57 @@ where
   }
 }
 
-/// Look for a substring in self
-pub trait FindSubstring<T> {
-  /// Returns the offset of the substring if it is found
-  fn find_substring(&self, substr: T) -> Option<usize>;
+/// Look for a slice in self
+pub trait FindSlice<T> {
+  /// Returns the offset of the slice if it is found
+  fn find_slice(&self, substr: T) -> Option<usize>;
 }
 
-impl<'a, 'b> FindSubstring<&'b [u8]> for &'a [u8] {
-  fn find_substring(&self, substr: &'b [u8]) -> Option<usize> {
+impl<'a, 'b> FindSlice<&'b [u8]> for &'a [u8] {
+  fn find_slice(&self, substr: &'b [u8]) -> Option<usize> {
     memchr::memmem::find(self, substr)
   }
 }
 
-impl<'a, 'b> FindSubstring<&'b str> for &'a [u8] {
-  fn find_substring(&self, substr: &'b str) -> Option<usize> {
-    self.find_substring(substr.as_bytes())
+impl<'a, 'b> FindSlice<&'b str> for &'a [u8] {
+  fn find_slice(&self, substr: &'b str) -> Option<usize> {
+    self.find_slice(substr.as_bytes())
   }
 }
 
-impl<'a, 'b> FindSubstring<&'b str> for &'a str {
-  fn find_substring(&self, substr: &'b str) -> Option<usize> {
+impl<'a, 'b> FindSlice<&'b str> for &'a str {
+  fn find_slice(&self, substr: &'b str) -> Option<usize> {
     self.find(substr)
   }
 }
 
-impl<I, T> FindSubstring<T> for Located<I>
+impl<I, T> FindSlice<T> for Located<I>
 where
-  I: FindSubstring<T>,
+  I: FindSlice<T>,
 {
   #[inline(always)]
-  fn find_substring(&self, substr: T) -> Option<usize> {
-    self.input.find_substring(substr)
+  fn find_slice(&self, substr: T) -> Option<usize> {
+    self.input.find_slice(substr)
   }
 }
 
-impl<I, S, T> FindSubstring<T> for Stateful<I, S>
+impl<I, S, T> FindSlice<T> for Stateful<I, S>
 where
-  I: FindSubstring<T>,
+  I: FindSlice<T>,
 {
   #[inline(always)]
-  fn find_substring(&self, substr: T) -> Option<usize> {
-    self.input.find_substring(substr)
+  fn find_slice(&self, substr: T) -> Option<usize> {
+    self.input.find_slice(substr)
   }
 }
 
-impl<I, T> FindSubstring<T> for Streaming<I>
+impl<I, T> FindSlice<T> for Streaming<I>
 where
-  I: FindSubstring<T>,
+  I: FindSlice<T>,
 {
   #[inline(always)]
-  fn find_substring(&self, substr: T) -> Option<usize> {
-    self.0.find_substring(substr)
+  fn find_slice(&self, substr: T) -> Option<usize> {
+    self.0.find_slice(substr)
   }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1928,21 +1928,6 @@ pub trait ExtendInto {
 }
 
 #[cfg(feature = "alloc")]
-impl ExtendInto for [u8] {
-  type Item = u8;
-  type Extender = Vec<u8>;
-
-  #[inline]
-  fn new_builder(&self) -> Vec<u8> {
-    Vec::new()
-  }
-  #[inline]
-  fn extend_into(&self, acc: &mut Vec<u8>) {
-    acc.extend(self.iter().cloned());
-  }
-}
-
-#[cfg(feature = "alloc")]
 impl ExtendInto for &[u8] {
   type Item = u8;
   type Extender = Vec<u8>;
@@ -1954,21 +1939,6 @@ impl ExtendInto for &[u8] {
   #[inline]
   fn extend_into(&self, acc: &mut Vec<u8>) {
     acc.extend_from_slice(self);
-  }
-}
-
-#[cfg(feature = "alloc")]
-impl ExtendInto for str {
-  type Item = char;
-  type Extender = String;
-
-  #[inline]
-  fn new_builder(&self) -> String {
-    String::new()
-  }
-  #[inline]
-  fn extend_into(&self, acc: &mut String) {
-    acc.push_str(self);
   }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1394,15 +1394,6 @@ pub trait Offset {
   fn offset_to(&self, second: &Self) -> usize;
 }
 
-impl Offset for [u8] {
-  fn offset_to(&self, second: &Self) -> usize {
-    let fst = self.as_ptr();
-    let snd = second.as_ptr();
-
-    snd as usize - fst as usize
-  }
-}
-
 impl<'a> Offset for &'a [u8] {
   fn offset_to(&self, second: &Self) -> usize {
     let fst = self.as_ptr();
@@ -1412,7 +1403,8 @@ impl<'a> Offset for &'a [u8] {
   }
 }
 
-impl Offset for str {
+/// Convenience implementation to accept `&[u8]` instead of `&&[u8]` as above
+impl Offset for [u8] {
   fn offset_to(&self, second: &Self) -> usize {
     let fst = self.as_ptr();
     let snd = second.as_ptr();
@@ -1422,6 +1414,16 @@ impl Offset for str {
 }
 
 impl<'a> Offset for &'a str {
+  fn offset_to(&self, second: &Self) -> usize {
+    let fst = self.as_ptr();
+    let snd = second.as_ptr();
+
+    snd as usize - fst as usize
+  }
+}
+
+/// Convenience implementation to accept `&str` instead of `&&str` as above
+impl Offset for str {
   fn offset_to(&self, second: &Self) -> usize {
     let fst = self.as_ptr();
     let snd = second.as_ptr();

--- a/src/input.rs
+++ b/src/input.rs
@@ -2114,7 +2114,7 @@ pub trait HexDisplay {
 static CHARS: &[u8] = b"0123456789abcdef";
 
 #[cfg(feature = "std")]
-impl HexDisplay for [u8] {
+impl HexDisplay for &'_ [u8] {
   #[allow(unused_variables)]
   fn to_hex(&self, chunk_size: usize) -> String {
     self.to_hex_from(chunk_size, 0)
@@ -2162,7 +2162,7 @@ impl HexDisplay for [u8] {
 }
 
 #[cfg(feature = "std")]
-impl HexDisplay for str {
+impl HexDisplay for &'_ str {
   #[allow(unused_variables)]
   fn to_hex(&self, chunk_size: usize) -> String {
     self.to_hex_from(chunk_size, 0)

--- a/src/input.rs
+++ b/src/input.rs
@@ -1740,6 +1740,12 @@ impl<'i, 's> FindSlice<&'s [u8]> for &'i [u8] {
   }
 }
 
+impl<'i> FindSlice<u8> for &'i [u8] {
+  fn find_slice(&self, substr: u8) -> Option<usize> {
+    memchr::memchr(substr, self)
+  }
+}
+
 impl<'i, 's> FindSlice<&'s str> for &'i [u8] {
   fn find_slice(&self, substr: &'s str) -> Option<usize> {
     self.find_slice(substr.as_bytes())
@@ -1748,6 +1754,12 @@ impl<'i, 's> FindSlice<&'s str> for &'i [u8] {
 
 impl<'i, 's> FindSlice<&'s str> for &'i str {
   fn find_slice(&self, substr: &'s str) -> Option<usize> {
+    self.find(substr)
+  }
+}
+
+impl<'i> FindSlice<char> for &'i str {
+  fn find_slice(&self, substr: char) -> Option<usize> {
     self.find(substr)
   }
 }

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use crate::error::ErrorKind;
 use crate::error::ParseError;
-use crate::input::{InputIsStreaming, InputIter, InputLength, InputTake, IntoOutput, ToUsize};
+use crate::input::{InputIsStreaming, InputIter, InputTake, IntoOutput, SliceLen, ToUsize};
 #[cfg(feature = "alloc")]
 use crate::lib::std::vec::Vec;
 use crate::{Err, IResult, Parser};
@@ -50,20 +50,20 @@ const MAX_INITIAL_CAPACITY_BYTES: usize = 65536;
 #[cfg(feature = "alloc")]
 pub fn many0<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
   move |mut i: I| {
     let mut acc = crate::lib::std::vec::Vec::with_capacity(4);
     loop {
-      let len = i.input_len();
+      let len = i.slice_len();
       match f.parse_next(i.clone()) {
         Err(Err::Error(_)) => return Ok((i, acc)),
         Err(e) => return Err(e),
         Ok((i1, o)) => {
           // infinite loop check: the parser must always consume
-          if i1.input_len() == len {
+          if i1.slice_len() == len {
             return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many0)));
           }
 
@@ -104,7 +104,7 @@ where
 #[cfg(feature = "alloc")]
 pub fn many1<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
@@ -117,13 +117,13 @@ where
       i = i1;
 
       loop {
-        let len = i.input_len();
+        let len = i.slice_len();
         match f.parse_next(i.clone()) {
           Err(Err::Error(_)) => return Ok((i, acc)),
           Err(e) => return Err(e),
           Ok((i1, o)) => {
             // infinite loop check: the parser must always consume
-            if i1.input_len() == len {
+            if i1.slice_len() == len {
               return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1)));
             }
 
@@ -163,7 +163,7 @@ pub fn many_till<I, O, P, E, F, G>(
   mut g: G,
 ) -> impl FnMut(I) -> IResult<I, (Vec<O>, P), E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   G: Parser<I, P, E>,
   E: ParseError<I>,
@@ -171,7 +171,7 @@ where
   move |mut i: I| {
     let mut res = crate::lib::std::vec::Vec::new();
     loop {
-      let len = i.input_len();
+      let len = i.slice_len();
       match g.parse_next(i.clone()) {
         Ok((i1, o)) => return Ok((i1, (res, o))),
         Err(Err::Error(_)) => {
@@ -180,7 +180,7 @@ where
             Err(e) => return Err(e),
             Ok((i1, o)) => {
               // infinite loop check: the parser must always consume
-              if i1.input_len() == len {
+              if i1.slice_len() == len {
                 return Err(Err::Error(E::from_error_kind(i1, ErrorKind::ManyTill)));
               }
 
@@ -225,7 +225,7 @@ pub fn separated_list0<I, O, O2, E, F, G>(
   mut f: F,
 ) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   G: Parser<I, O2, E>,
   E: ParseError<I>,
@@ -243,13 +243,13 @@ where
     }
 
     loop {
-      let len = i.input_len();
+      let len = i.slice_len();
       match sep.parse_next(i.clone()) {
         Err(Err::Error(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
           // infinite loop check: the parser must always consume
-          if i1.input_len() == len {
+          if i1.slice_len() == len {
             return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
           }
 
@@ -298,7 +298,7 @@ pub fn separated_list1<I, O, O2, E, F, G>(
   mut f: F,
 ) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   G: Parser<I, O2, E>,
   E: ParseError<I>,
@@ -316,13 +316,13 @@ where
     }
 
     loop {
-      let len = i.input_len();
+      let len = i.slice_len();
       match sep.parse_next(i.clone()) {
         Err(Err::Error(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
           // infinite loop check: the parser must always consume
-          if i1.input_len() == len {
+          if i1.slice_len() == len {
             return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
           }
 
@@ -376,7 +376,7 @@ pub fn many_m_n<I, O, E, F>(
   mut parse: F,
 ) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
@@ -389,11 +389,11 @@ where
       MAX_INITIAL_CAPACITY_BYTES / crate::lib::std::mem::size_of::<O>().max(1);
     let mut res = crate::lib::std::vec::Vec::with_capacity(min.min(max_initial_capacity));
     for count in 0..max {
-      let len = input.input_len();
+      let len = input.slice_len();
       match parse.parse_next(input.clone()) {
         Ok((tail, value)) => {
           // infinite loop check: the parser must always consume
-          if tail.input_len() == len {
+          if tail.slice_len() == len {
             return Err(Err::Error(E::from_error_kind(input, ErrorKind::ManyMN)));
           }
 
@@ -444,7 +444,7 @@ where
 /// ```
 pub fn many0_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
@@ -454,11 +454,11 @@ where
 
     loop {
       let input_ = input.clone();
-      let len = input.input_len();
+      let len = input.slice_len();
       match f.parse_next(input_) {
         Ok((i, _)) => {
           // infinite loop check: the parser must always consume
-          if i.input_len() == len {
+          if i.slice_len() == len {
             return Err(Err::Error(E::from_error_kind(input, ErrorKind::Many0Count)));
           }
 
@@ -502,7 +502,7 @@ where
 /// ```
 pub fn many1_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
@@ -516,14 +516,14 @@ where
         let mut input = i1;
 
         loop {
-          let len = input.input_len();
+          let len = input.slice_len();
           let input_ = input.clone();
           match f.parse_next(input_) {
             Err(Err::Error(_)) => return Ok((input, count)),
             Err(e) => return Err(e),
             Ok((i, _)) => {
               // infinite loop check: the parser must always consume
-              if i.input_len() == len {
+              if i.slice_len() == len {
                 return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1Count)));
               }
 
@@ -684,7 +684,7 @@ pub fn fold_many0<I, O, E, F, G, H, R>(
   mut g: G,
 ) -> impl FnMut(I) -> IResult<I, R, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   G: FnMut(R, O) -> R,
   H: FnMut() -> R,
@@ -696,11 +696,11 @@ where
 
     loop {
       let i_ = input.clone();
-      let len = input.input_len();
+      let len = input.slice_len();
       match f.parse_next(i_) {
         Ok((i, o)) => {
           // infinite loop check: the parser must always consume
-          if i.input_len() == len {
+          if i.slice_len() == len {
             return Err(Err::Error(E::from_error_kind(input, ErrorKind::Many0)));
           }
 
@@ -760,7 +760,7 @@ pub fn fold_many1<I, O, E, F, G, H, R>(
   mut g: G,
 ) -> impl FnMut(I) -> IResult<I, R, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   G: FnMut(R, O) -> R,
   H: FnMut() -> R,
@@ -778,7 +778,7 @@ where
 
         loop {
           let _input = input.clone();
-          let len = input.input_len();
+          let len = input.slice_len();
           match f.parse_next(_input) {
             Err(Err::Error(_)) => {
               break;
@@ -786,7 +786,7 @@ where
             Err(e) => return Err(e),
             Ok((i, o)) => {
               // infinite loop check: the parser must always consume
-              if i.input_len() == len {
+              if i.slice_len() == len {
                 return Err(Err::Failure(E::from_error_kind(i, ErrorKind::Many1)));
               }
 
@@ -851,7 +851,7 @@ pub fn fold_many_m_n<I, O, E, F, G, H, R>(
   mut fold: G,
 ) -> impl FnMut(I) -> IResult<I, R, E>
 where
-  I: Clone + InputLength,
+  I: Clone + SliceLen,
   F: Parser<I, O, E>,
   G: FnMut(R, O) -> R,
   H: FnMut() -> R,
@@ -864,11 +864,11 @@ where
 
     let mut acc = init();
     for count in 0..max {
-      let len = input.input_len();
+      let len = input.slice_len();
       match parse.parse_next(input.clone()) {
         Ok((tail, value)) => {
           // infinite loop check: the parser must always consume
-          if tail.input_len() == len {
+          if tail.slice_len() == len {
             return Err(Err::Error(E::from_error_kind(tail, ErrorKind::ManyMN)));
           }
 
@@ -917,7 +917,7 @@ pub fn length_data<I, N, E, F, const STREAMING: bool>(
   mut f: F,
 ) -> impl FnMut(I) -> IResult<I, <I as IntoOutput>::Output, E>
 where
-  I: InputLength + InputTake + InputIter + IntoOutput + InputIsStreaming<STREAMING>,
+  I: SliceLen + InputTake + InputIter + IntoOutput + InputIsStreaming<STREAMING>,
   N: ToUsize,
   F: Parser<I, N, E>,
   E: ParseError<I>,
@@ -961,7 +961,7 @@ pub fn length_value<I, O, N, E, F, G, const STREAMING: bool>(
   mut g: G,
 ) -> impl FnMut(I) -> IResult<I, O, E>
 where
-  I: InputLength + InputTake + InputIter + IntoOutput + InputIsStreaming<STREAMING>,
+  I: SliceLen + InputTake + InputIter + IntoOutput + InputIsStreaming<STREAMING>,
   I: Clone,
   N: ToUsize,
   F: Parser<I, N, E>,

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -530,7 +530,7 @@ where
     Err(Err::Error(make_error(input, ErrorKind::Eof)))
   } else {
     let mut res = Uint::default();
-    for (index, byte) in input.iter_indices().take(bound) {
+    for (index, byte) in input.iter_offsets().take(bound) {
       res = res + (Uint::from(byte) << (8 * index as u8));
     }
 

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -10,7 +10,7 @@ use crate::combinator::{cut, map, opt, recognize};
 use crate::error::ParseError;
 use crate::error::{make_error, ErrorKind};
 use crate::input::{
-  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtPosition, IntoOutput,
+  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput,
   Offset, Slice,
 };
 use crate::lib::std::ops::{Add, Range, RangeFrom, RangeTo, Shl};
@@ -1407,14 +1407,14 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::hex_u32`")]
 pub fn hex_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: InputTakeAtPosition,
+  I: InputTakeAtOffset,
   I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  <I as InputTakeAtPosition>::Item: AsChar,
+  <I as InputTakeAtOffset>::Item: AsChar,
   I: AsBytes,
   I: InputLength,
 {
   let e: ErrorKind = ErrorKind::IsA;
-  let (i, o) = input.split_at_position1_complete(
+  let (i, o) = input.split_at_offset1_complete(
     |c| {
       let c = c.as_char();
       !"0123456789abcdefABCDEF".contains(c)
@@ -1472,8 +1472,8 @@ where
   T: InputIter,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPosition,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   recognize(
     tuple((
@@ -1507,9 +1507,9 @@ where
   T: Clone + Offset,
   T: InputIter + InputTake + Compare<&'static str>,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPosition,
+  T: InputTakeAtOffset,
   T: IntoOutput,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   alt((
     |i: T| {
@@ -1566,8 +1566,8 @@ where
   T: InputIter + InputTake,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar + Copy,
-  T: InputTakeAtPosition + InputLength,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset + InputLength,
+  <T as InputTakeAtOffset>::Item: AsChar,
   T: for<'a> Compare<&'a [u8]>,
   T: AsBytes,
 {
@@ -1679,8 +1679,8 @@ where
   <T as IntoOutput>::Output: ParseTo<f32>,
   <T as InputIter>::Item: AsChar + Copy,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPosition,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset,
+  <T as InputTakeAtOffset>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {
@@ -1723,8 +1723,8 @@ where
   <T as IntoOutput>::Output: ParseTo<f64>,
   <T as InputIter>::Item: AsChar + Copy,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPosition,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset,
+  <T as InputTakeAtOffset>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -10,8 +10,8 @@ use crate::combinator::{cut, map, opt, recognize};
 use crate::error::ParseError;
 use crate::error::{make_error, ErrorKind};
 use crate::input::{
-  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput,
-  Offset, Slice,
+  AsBytes, AsChar, Compare, InputIter, InputTake, InputTakeAtOffset, IntoOutput, Offset, Slice,
+  SliceLen,
 };
 use crate::lib::std::ops::{Add, Range, RangeFrom, RangeTo, Shl};
 use crate::sequence::{pair, tuple};
@@ -38,7 +38,7 @@ use crate::*;
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_u8`")]
 pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 1)
 }
@@ -64,7 +64,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_u16`")]
 pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 2)
 }
@@ -90,7 +90,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_u24`")]
 pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 3)
 }
@@ -116,7 +116,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_u32`")]
 pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 4)
 }
@@ -142,7 +142,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_u64`")]
 pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 8)
 }
@@ -168,7 +168,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_u128`")]
 pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 16)
 }
@@ -176,10 +176,10 @@ where
 #[inline]
 fn be_uint<I, Uint, E: ParseError<I>>(input: I, bound: usize) -> IResult<I, Uint, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
   Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
 {
-  if input.input_len() < bound {
+  if input.slice_len() < bound {
     Err(Err::Error(make_error(input, ErrorKind::Eof)))
   } else {
     let mut res = Uint::default();
@@ -220,7 +220,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_i8`")]
 pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u8.map(|x| x as i8).parse_next(input)
 }
@@ -246,7 +246,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_i16`")]
 pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u16.map(|x| x as i16).parse_next(input)
 }
@@ -272,7 +272,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_i24`")]
 pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   // Same as the unsigned version but we need to sign-extend manually here
   be_u24
@@ -307,7 +307,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_i32`")]
 pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u32.map(|x| x as i32).parse_next(input)
 }
@@ -333,7 +333,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_i64`")]
 pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u64.map(|x| x as i64).parse_next(input)
 }
@@ -359,7 +359,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_i128`")]
 pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u128.map(|x| x as i128).parse_next(input)
 }
@@ -385,7 +385,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_u8`")]
 pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 1)
 }
@@ -411,7 +411,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_u16`")]
 pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 2)
 }
@@ -437,7 +437,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_u24`")]
 pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 3)
 }
@@ -463,7 +463,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_u32`")]
 pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 4)
 }
@@ -489,7 +489,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_u64`")]
 pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 8)
 }
@@ -515,7 +515,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_u128`")]
 pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 16)
 }
@@ -523,10 +523,10 @@ where
 #[inline]
 fn le_uint<I, Uint, E: ParseError<I>>(input: I, bound: usize) -> IResult<I, Uint, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
   Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
 {
-  if input.input_len() < bound {
+  if input.slice_len() < bound {
     Err(Err::Error(make_error(input, ErrorKind::Eof)))
   } else {
     let mut res = Uint::default();
@@ -559,7 +559,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_i8`")]
 pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u8.map(|x| x as i8).parse_next(input)
 }
@@ -585,7 +585,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_i16`")]
 pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_u16.map(|x| x as i16).parse_next(input)
 }
@@ -611,7 +611,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_i24`")]
 pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   // Same as the unsigned version but we need to sign-extend manually here
   le_u24
@@ -646,7 +646,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_i32`")]
 pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_u32.map(|x| x as i32).parse_next(input)
 }
@@ -672,7 +672,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_i64`")]
 pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_u64.map(|x| x as i64).parse_next(input)
 }
@@ -698,7 +698,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_i128`")]
 pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_u128.map(|x| x as i128).parse_next(input)
 }
@@ -725,10 +725,10 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::u8`")]
 pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   let bound: usize = 1;
-  if input.input_len() < bound {
+  if input.slice_len() < bound {
     Err(Err::Error(make_error(input, ErrorKind::Eof)))
   } else {
     let res = input.iter_elements().next().unwrap();
@@ -768,7 +768,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::u16`")]
 pub fn u16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u16,
@@ -810,7 +810,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::u24`")]
 pub fn u24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u24,
@@ -852,7 +852,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::u32`")]
 pub fn u32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u32,
@@ -894,7 +894,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::u64`")]
 pub fn u64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u64,
@@ -936,7 +936,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::u128`")]
 pub fn u128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u128,
@@ -970,7 +970,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::i8`")]
 pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   u8.map(|x| x as i8).parse_next(i)
 }
@@ -1005,7 +1005,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::i16`")]
 pub fn i16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i16,
@@ -1047,7 +1047,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::i24`")]
 pub fn i24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i24,
@@ -1089,7 +1089,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::i32`")]
 pub fn i32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i32,
@@ -1131,7 +1131,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::i64`")]
 pub fn i64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i64,
@@ -1173,7 +1173,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::i128`")]
 pub fn i128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i128,
@@ -1206,7 +1206,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_f32`")]
 pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match be_u32(input) {
     Err(e) => Err(e),
@@ -1235,7 +1235,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::be_f64`")]
 pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match be_u64(input) {
     Err(e) => Err(e),
@@ -1264,7 +1264,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_f32`")]
 pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match le_u32(input) {
     Err(e) => Err(e),
@@ -1293,7 +1293,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::le_f64`")]
 pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match le_u64(input) {
     Err(e) => Err(e),
@@ -1331,7 +1331,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::f32`")]
 pub fn f32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_f32,
@@ -1373,7 +1373,7 @@ where
 #[deprecated(since = "8.0.0", note = "Replaced with `winnow::number::f64`")]
 pub fn f64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_f64,
@@ -1411,7 +1411,7 @@ where
   I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   <I as InputTakeAtOffset>::Item: AsChar,
   I: AsBytes,
-  I: InputLength,
+  I: SliceLen,
 {
   let e: ErrorKind = ErrorKind::IsA;
   let (i, o) = input.split_at_offset1_complete(
@@ -1423,7 +1423,7 @@ where
   )?;
 
   // Do not parse more than 8 characters for a u32
-  let (parsed, remaining) = if o.input_len() <= 8 {
+  let (parsed, remaining) = if o.slice_len() <= 8 {
     (o, i)
   } else {
     (input.slice(..8), input.slice(8..))
@@ -1566,7 +1566,7 @@ where
   T: InputIter + InputTake,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar + Copy,
-  T: InputTakeAtOffset + InputLength,
+  T: InputTakeAtOffset + SliceLen,
   <T as InputTakeAtOffset>::Item: AsChar,
   T: for<'a> Compare<&'a [u8]>,
   T: AsBytes,
@@ -1575,7 +1575,7 @@ where
 
   let (i, zeroes) = match i.as_bytes().iter().position(|c| *c != b'0') {
     Some(index) => i.take_split(index),
-    None => i.take_split(i.input_len()),
+    None => i.take_split(i.slice_len()),
   };
   //let (i, mut integer) = digit0(i)?;
   let (i, mut integer) = match i
@@ -1584,12 +1584,12 @@ where
     .position(|c| !(*c >= b'0' && *c <= b'9'))
   {
     Some(index) => i.take_split(index),
-    None => i.take_split(i.input_len()),
+    None => i.take_split(i.slice_len()),
   };
 
-  if integer.input_len() == 0 && zeroes.input_len() > 0 {
+  if integer.slice_len() == 0 && zeroes.slice_len() > 0 {
     // keep the last zero if integer is empty
-    integer = zeroes.slice(zeroes.input_len() - 1..);
+    integer = zeroes.slice(zeroes.slice_len() - 1..);
   }
 
   let (i, opt_dot) = opt(tag(&b"."[..]))(i)?;
@@ -1613,7 +1613,7 @@ where
       }
     }
 
-    let position = position.unwrap_or_else(|| i.input_len());
+    let position = position.unwrap_or_else(|| i.slice_len());
 
     let index = if zero_count == 0 {
       position
@@ -1626,7 +1626,7 @@ where
     (i.slice(position..), i.slice(..index))
   };
 
-  if integer.input_len() == 0 && fraction.input_len() == 0 {
+  if integer.slice_len() == 0 && fraction.slice_len() == 0 {
     return Err(Err::Error(E::from_error_kind(input, ErrorKind::Float)));
   }
 
@@ -1674,7 +1674,7 @@ pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
   T: Clone + Offset + Compare<&'static str>,
-  T: InputIter + InputLength + InputTake,
+  T: InputIter + SliceLen + InputTake,
   T: IntoOutput,
   <T as IntoOutput>::Output: ParseTo<f32>,
   <T as InputIter>::Item: AsChar + Copy,
@@ -1718,7 +1718,7 @@ pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>> + Slice<Range<usize>>,
   T: Clone + Offset + Compare<&'static str>,
-  T: InputIter + InputLength + InputTake,
+  T: InputIter + SliceLen + InputTake,
   T: IntoOutput,
   <T as IntoOutput>::Output: ParseTo<f64>,
   <T as InputIter>::Item: AsChar + Copy,

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -9,7 +9,7 @@ mod tests;
 
 use crate::error::ParseError;
 use crate::input::{
-  AsBytes, AsChar, InputIsStreaming, InputIter, InputLength, InputTakeAtPosition, Slice,
+  AsBytes, AsChar, InputIsStreaming, InputIter, InputLength, InputTakeAtOffset, Slice,
 };
 use crate::lib::std::ops::{RangeFrom, RangeTo};
 use crate::IResult;
@@ -2183,9 +2183,9 @@ where
 #[inline(always)]
 pub fn hex_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
 where
-  I: InputTakeAtPosition + InputIsStreaming<STREAMING>,
+  I: InputTakeAtOffset + InputIsStreaming<STREAMING>,
   I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  <I as InputTakeAtPosition>::Item: AsChar,
+  <I as InputTakeAtOffset>::Item: AsChar,
   I: AsBytes,
   I: InputLength,
 {

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -9,7 +9,7 @@ mod tests;
 
 use crate::error::ParseError;
 use crate::input::{
-  AsBytes, AsChar, InputIsStreaming, InputIter, InputLength, InputTakeAtOffset, Slice,
+  AsBytes, AsChar, InputIsStreaming, InputIter, InputTakeAtOffset, Slice, SliceLen,
 };
 use crate::lib::std::ops::{RangeFrom, RangeTo};
 use crate::IResult;
@@ -61,7 +61,7 @@ pub enum Endianness {
 #[inline(always)]
 pub fn be_u8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_u8(input)
@@ -106,7 +106,7 @@ where
 #[inline(always)]
 pub fn be_u16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_u16(input)
@@ -151,7 +151,7 @@ where
 #[inline(always)]
 pub fn be_u24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_u24(input)
@@ -196,7 +196,7 @@ where
 #[inline(always)]
 pub fn be_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_u32(input)
@@ -241,7 +241,7 @@ where
 #[inline(always)]
 pub fn be_u64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_u64(input)
@@ -286,7 +286,7 @@ where
 #[inline(always)]
 pub fn be_u128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_u128(input)
@@ -329,7 +329,7 @@ where
 #[inline(always)]
 pub fn be_i8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_i8(input)
@@ -372,7 +372,7 @@ where
 #[inline(always)]
 pub fn be_i16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_i16(input)
@@ -415,7 +415,7 @@ where
 #[inline(always)]
 pub fn be_i24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_i24(input)
@@ -458,7 +458,7 @@ where
 #[inline(always)]
 pub fn be_i32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_i32(input)
@@ -501,7 +501,7 @@ where
 #[inline(always)]
 pub fn be_i64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_i64(input)
@@ -544,7 +544,7 @@ where
 #[inline(always)]
 pub fn be_i128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_i128(input)
@@ -587,7 +587,7 @@ where
 #[inline(always)]
 pub fn le_u8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_u8(input)
@@ -632,7 +632,7 @@ where
 #[inline(always)]
 pub fn le_u16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_u16(input)
@@ -677,7 +677,7 @@ where
 #[inline(always)]
 pub fn le_u24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_u24(input)
@@ -722,7 +722,7 @@ where
 #[inline(always)]
 pub fn le_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_u32(input)
@@ -767,7 +767,7 @@ where
 #[inline(always)]
 pub fn le_u64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_u64(input)
@@ -812,7 +812,7 @@ where
 #[inline(always)]
 pub fn le_u128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_u128(input)
@@ -855,7 +855,7 @@ where
 #[inline(always)]
 pub fn le_i8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_i8(input)
@@ -900,7 +900,7 @@ where
 #[inline(always)]
 pub fn le_i16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_i16(input)
@@ -945,7 +945,7 @@ where
 #[inline(always)]
 pub fn le_i24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_i24(input)
@@ -990,7 +990,7 @@ where
 #[inline(always)]
 pub fn le_i32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_i32(input)
@@ -1035,7 +1035,7 @@ where
 #[inline(always)]
 pub fn le_i64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_i64(input)
@@ -1080,7 +1080,7 @@ where
 #[inline(always)]
 pub fn le_i128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_i128(input)
@@ -1128,7 +1128,7 @@ where
 #[inline(always)]
 pub fn u8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::u8(input)
@@ -1193,7 +1193,7 @@ pub fn u16<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, u16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::u16(endian)
@@ -1258,7 +1258,7 @@ pub fn u24<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::u24(endian)
@@ -1323,7 +1323,7 @@ pub fn u32<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::u32(endian)
@@ -1388,7 +1388,7 @@ pub fn u64<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, u64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::u64(endian)
@@ -1453,7 +1453,7 @@ pub fn u128<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, u128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::u128(endian)
@@ -1501,7 +1501,7 @@ where
 #[inline(always)]
 pub fn i8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::i8(input)
@@ -1566,7 +1566,7 @@ pub fn i16<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, i16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::i16(endian)
@@ -1631,7 +1631,7 @@ pub fn i24<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::i24(endian)
@@ -1696,7 +1696,7 @@ pub fn i32<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::i32(endian)
@@ -1761,7 +1761,7 @@ pub fn i64<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, i64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::i64(endian)
@@ -1826,7 +1826,7 @@ pub fn i128<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, i128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::i128(endian)
@@ -1871,7 +1871,7 @@ where
 #[inline(always)]
 pub fn be_f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_f32(input)
@@ -1916,7 +1916,7 @@ where
 #[inline(always)]
 pub fn be_f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::be_f64(input)
@@ -1961,7 +1961,7 @@ where
 #[inline(always)]
 pub fn le_f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_f32(input)
@@ -2006,7 +2006,7 @@ where
 #[inline(always)]
 pub fn le_f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::le_f64(input)
@@ -2071,7 +2071,7 @@ pub fn f32<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, f32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::f32(endian)
@@ -2136,7 +2136,7 @@ pub fn f64<I, E: ParseError<I>, const STREAMING: bool>(
   endian: crate::number::Endianness,
 ) -> fn(I) -> IResult<I, f64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<STREAMING>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<STREAMING>,
 {
   if STREAMING {
     streaming::f64(endian)
@@ -2187,7 +2187,7 @@ where
   I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   <I as InputTakeAtOffset>::Item: AsChar,
   I: AsBytes,
-  I: InputLength,
+  I: SliceLen,
 {
   if STREAMING {
     streaming::hex_u32(input)

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -9,7 +9,7 @@ use crate::character::streaming::{char, digit1, sign};
 use crate::combinator::{cut, map, opt, recognize};
 use crate::error::{ErrorKind, ParseError};
 use crate::input::{
-  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtPosition, IntoOutput,
+  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput,
   Offset, Slice,
 };
 use crate::lib::std::ops::{Add, RangeFrom, RangeTo, Shl};
@@ -1505,14 +1505,14 @@ where
 )]
 pub fn hex_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: InputTakeAtPosition,
+  I: InputTakeAtOffset,
   I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
-  <I as InputTakeAtPosition>::Item: AsChar,
+  <I as InputTakeAtOffset>::Item: AsChar,
   I: AsBytes,
   I: InputLength,
 {
   let e: ErrorKind = ErrorKind::IsA;
-  let (i, o) = input.split_at_position1_streaming(
+  let (i, o) = input.split_at_offset1_streaming(
     |c| {
       let c = c.as_char();
       !"0123456789abcdefABCDEF".contains(c)
@@ -1569,8 +1569,8 @@ where
   T: InputIter,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPosition + InputLength,
-  <T as InputTakeAtPosition>::Item: AsChar
+  T: InputTakeAtOffset + InputLength,
+  <T as InputTakeAtOffset>::Item: AsChar
 {
   recognize(
     tuple((
@@ -1605,8 +1605,8 @@ where
   T: InputIter + InputTake + InputLength + Compare<&'static str>,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPosition,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset,
+  <T as InputTakeAtOffset>::Item: AsChar,
 {
   alt((
     |i: T| {
@@ -1663,14 +1663,14 @@ where
   T: InputIter,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtPosition + InputTake + InputLength,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset + InputTake + InputLength,
+  <T as InputTakeAtOffset>::Item: AsChar,
   T: for<'a> Compare<&'a [u8]>,
   T: AsBytes,
 {
   let (i, sign) = sign(input.clone())?;
 
-  //let (i, zeroes) = take_while(|c: <T as InputTakeAtPosition>::Item| c.as_char() == '0')(i)?;
+  //let (i, zeroes) = take_while(|c: <T as InputTakeAtOffset>::Item| c.as_char() == '0')(i)?;
   let (i, zeroes) = match i.as_bytes().iter().position(|c| *c != b'0') {
     Some(index) => i.take_split(index),
     None => i.take_split(i.input_len()),
@@ -1783,8 +1783,8 @@ where
   <T as IntoOutput>::Output: crate::input::ParseTo<f32>,
   <T as InputIter>::Item: AsChar,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPosition,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset,
+  <T as InputTakeAtOffset>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {
@@ -1833,8 +1833,8 @@ where
   <T as IntoOutput>::Output: crate::input::ParseTo<f64>,
   <T as InputIter>::Item: AsChar,
   <T as InputIter>::IterElem: Clone,
-  T: InputTakeAtPosition,
-  <T as InputTakeAtPosition>::Item: AsChar,
+  T: InputTakeAtOffset,
+  <T as InputTakeAtOffset>::Item: AsChar,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
 {

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -561,7 +561,7 @@ where
     Err(Err::Incomplete(Needed::new(bound - input.input_len())))
   } else {
     let mut res = Uint::default();
-    for (index, byte) in input.iter_indices().take(bound) {
+    for (index, byte) in input.iter_offsets().take(bound) {
       res = res + (Uint::from(byte) << (8 * index as u8));
     }
 

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -9,8 +9,8 @@ use crate::character::streaming::{char, digit1, sign};
 use crate::combinator::{cut, map, opt, recognize};
 use crate::error::{ErrorKind, ParseError};
 use crate::input::{
-  AsBytes, AsChar, Compare, InputIter, InputLength, InputTake, InputTakeAtOffset, IntoOutput,
-  Offset, Slice,
+  AsBytes, AsChar, Compare, InputIter, InputTake, InputTakeAtOffset, IntoOutput, Offset, Slice,
+  SliceLen,
 };
 use crate::lib::std::ops::{Add, RangeFrom, RangeTo, Shl};
 use crate::sequence::{pair, tuple};
@@ -39,7 +39,7 @@ use crate::*;
 )]
 pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 1)
 }
@@ -68,7 +68,7 @@ where
 )]
 pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 2)
 }
@@ -97,7 +97,7 @@ where
 )]
 pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 3)
 }
@@ -126,7 +126,7 @@ where
 )]
 pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 4)
 }
@@ -155,7 +155,7 @@ where
 )]
 pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 8)
 }
@@ -183,7 +183,7 @@ where
 )]
 pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_uint(input, 16)
 }
@@ -191,11 +191,11 @@ where
 #[inline]
 fn be_uint<I, Uint, E: ParseError<I>>(input: I, bound: usize) -> IResult<I, Uint, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
   Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
 {
-  if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+  if input.slice_len() < bound {
+    Err(Err::Incomplete(Needed::new(bound - input.slice_len())))
   } else {
     let mut res = Uint::default();
 
@@ -235,7 +235,7 @@ where
 )]
 pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u8.map(|x| x as i8).parse_next(input)
 }
@@ -261,7 +261,7 @@ where
 )]
 pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u16.map(|x| x as i16).parse_next(input)
 }
@@ -287,7 +287,7 @@ where
 )]
 pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   // Same as the unsigned version but we need to sign-extend manually here
   be_u24
@@ -322,7 +322,7 @@ where
 )]
 pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u32.map(|x| x as i32).parse_next(input)
 }
@@ -349,7 +349,7 @@ where
 )]
 pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u64.map(|x| x as i64).parse_next(input)
 }
@@ -375,7 +375,7 @@ where
 )]
 pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   be_u128.map(|x| x as i128).parse_next(input)
 }
@@ -401,7 +401,7 @@ where
 )]
 pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 1)
 }
@@ -430,7 +430,7 @@ where
 )]
 pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 2)
 }
@@ -459,7 +459,7 @@ where
 )]
 pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 3)
 }
@@ -488,7 +488,7 @@ where
 )]
 pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 4)
 }
@@ -517,7 +517,7 @@ where
 )]
 pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 8)
 }
@@ -546,7 +546,7 @@ where
 )]
 pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_uint(input, 16)
 }
@@ -554,11 +554,11 @@ where
 #[inline]
 fn le_uint<I, Uint, E: ParseError<I>>(input: I, bound: usize) -> IResult<I, Uint, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
   Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
 {
-  if input.input_len() < bound {
-    Err(Err::Incomplete(Needed::new(bound - input.input_len())))
+  if input.slice_len() < bound {
+    Err(Err::Incomplete(Needed::new(bound - input.slice_len())))
   } else {
     let mut res = Uint::default();
     for (index, byte) in input.iter_offsets().take(bound) {
@@ -590,7 +590,7 @@ where
 )]
 pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_u8.map(|x| x as i8).parse_next(input)
 }
@@ -619,7 +619,7 @@ where
 )]
 pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_u16.map(|x| x as i16).parse_next(input)
 }
@@ -648,7 +648,7 @@ where
 )]
 pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   // Same as the unsigned version but we need to sign-extend manually here
   le_u24
@@ -686,7 +686,7 @@ where
 )]
 pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_u32.map(|x| x as i32).parse_next(input)
 }
@@ -715,7 +715,7 @@ where
 )]
 pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_u64.map(|x| x as i64).parse_next(input)
 }
@@ -744,7 +744,7 @@ where
 )]
 pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   le_u128.map(|x| x as i128).parse_next(input)
 }
@@ -774,10 +774,10 @@ where
 )]
 pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   let bound: usize = 1;
-  if input.input_len() < bound {
+  if input.slice_len() < bound {
     Err(Err::Incomplete(Needed::new(1)))
   } else {
     let res = input.iter_elements().next().unwrap();
@@ -820,7 +820,7 @@ where
 )]
 pub fn u16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u16,
@@ -865,7 +865,7 @@ where
 )]
 pub fn u24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u24,
@@ -910,7 +910,7 @@ where
 )]
 pub fn u32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u32,
@@ -955,7 +955,7 @@ where
 )]
 pub fn u64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u64,
@@ -1000,7 +1000,7 @@ where
 )]
 pub fn u128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, u128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_u128,
@@ -1037,7 +1037,7 @@ where
 )]
 pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   u8.map(|x| x as i8).parse_next(i)
 }
@@ -1075,7 +1075,7 @@ where
 )]
 pub fn i16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i16, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i16,
@@ -1120,7 +1120,7 @@ where
 )]
 pub fn i24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i24,
@@ -1165,7 +1165,7 @@ where
 )]
 pub fn i32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i32,
@@ -1210,7 +1210,7 @@ where
 )]
 pub fn i64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i64,
@@ -1255,7 +1255,7 @@ where
 )]
 pub fn i128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, i128, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_i128,
@@ -1290,7 +1290,7 @@ where
 )]
 pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match be_u32(input) {
     Err(e) => Err(e),
@@ -1321,7 +1321,7 @@ where
 )]
 pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match be_u64(input) {
     Err(e) => Err(e),
@@ -1352,7 +1352,7 @@ where
 )]
 pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match le_u32(input) {
     Err(e) => Err(e),
@@ -1383,7 +1383,7 @@ where
 )]
 pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match le_u64(input) {
     Err(e) => Err(e),
@@ -1424,7 +1424,7 @@ where
 )]
 pub fn f32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f32, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_f32,
@@ -1469,7 +1469,7 @@ where
 )]
 pub fn f64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f64, E>
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen,
 {
   match endian {
     crate::number::Endianness::Big => be_f64,
@@ -1509,7 +1509,7 @@ where
   I: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   <I as InputTakeAtOffset>::Item: AsChar,
   I: AsBytes,
-  I: InputLength,
+  I: SliceLen,
 {
   let e: ErrorKind = ErrorKind::IsA;
   let (i, o) = input.split_at_offset1_streaming(
@@ -1521,7 +1521,7 @@ where
   )?;
 
   // Do not parse more than 8 characters for a u32
-  let (parsed, remaining) = if o.input_len() <= 8 {
+  let (parsed, remaining) = if o.slice_len() <= 8 {
     (o, i)
   } else {
     (input.slice(..8), input.slice(8..))
@@ -1569,7 +1569,7 @@ where
   T: InputIter,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtOffset + InputLength,
+  T: InputTakeAtOffset + SliceLen,
   <T as InputTakeAtOffset>::Item: AsChar
 {
   recognize(
@@ -1602,7 +1602,7 @@ pub fn recognize_float_or_exceptions<T, E: ParseError<T>>(
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   T: Clone + Offset,
-  T: InputIter + InputTake + InputLength + Compare<&'static str>,
+  T: InputIter + InputTake + SliceLen + Compare<&'static str>,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar,
   T: InputTakeAtOffset,
@@ -1663,7 +1663,7 @@ where
   T: InputIter,
   T: IntoOutput,
   <T as InputIter>::Item: AsChar,
-  T: InputTakeAtOffset + InputTake + InputLength,
+  T: InputTakeAtOffset + InputTake + SliceLen,
   <T as InputTakeAtOffset>::Item: AsChar,
   T: for<'a> Compare<&'a [u8]>,
   T: AsBytes,
@@ -1673,7 +1673,7 @@ where
   //let (i, zeroes) = take_while(|c: <T as InputTakeAtOffset>::Item| c.as_char() == '0')(i)?;
   let (i, zeroes) = match i.as_bytes().iter().position(|c| *c != b'0') {
     Some(index) => i.take_split(index),
-    None => i.take_split(i.input_len()),
+    None => i.take_split(i.slice_len()),
   };
 
   //let (i, mut integer) = digit0(i)?;
@@ -1683,12 +1683,12 @@ where
     .position(|c| !(*c >= b'0' && *c <= b'9'))
   {
     Some(index) => i.take_split(index),
-    None => i.take_split(i.input_len()),
+    None => i.take_split(i.slice_len()),
   };
 
-  if integer.input_len() == 0 && zeroes.input_len() > 0 {
+  if integer.slice_len() == 0 && zeroes.slice_len() > 0 {
     // keep the last zero if integer is empty
-    integer = zeroes.slice(zeroes.input_len() - 1..);
+    integer = zeroes.slice(zeroes.slice_len() - 1..);
   }
 
   let (i, opt_dot) = opt(tag(&b"."[..]))(i)?;
@@ -1728,7 +1728,7 @@ where
     (i.slice(position..), i.slice(..index))
   };
 
-  if integer.input_len() == 0 && fraction.input_len() == 0 {
+  if integer.slice_len() == 0 && fraction.slice_len() == 0 {
     return Err(Err::Error(E::from_error_kind(input, ErrorKind::Float)));
   }
 
@@ -1778,7 +1778,7 @@ pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   T: Clone + Offset,
-  T: InputIter + InputLength + InputTake + Compare<&'static str>,
+  T: InputIter + SliceLen + InputTake + Compare<&'static str>,
   T: IntoOutput,
   <T as IntoOutput>::Output: crate::input::ParseTo<f32>,
   <T as InputIter>::Item: AsChar,
@@ -1828,7 +1828,7 @@ pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
 where
   T: Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
   T: Clone + Offset,
-  T: InputIter + InputLength + InputTake + Compare<&'static str>,
+  T: InputIter + SliceLen + InputTake + Compare<&'static str>,
   T: IntoOutput,
   <T as IntoOutput>::Output: crate::input::ParseTo<f64>,
   <T as InputIter>::Item: AsChar,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,7 +55,7 @@ pub trait FinishIResult<I, O, E> {
 
 impl<I, O, E> FinishIResult<I, O, E> for IResult<I, O, E>
 where
-  I: crate::input::InputLength,
+  I: crate::input::SliceLen,
   I: crate::input::IntoOutput,
   // Force users to deal with `Incomplete` when `InputIsStreaming<true>`
   I: InputIsStreaming<false>,
@@ -888,7 +888,7 @@ where
 /// ```
 impl<I, E> Parser<I, u8, E> for u8
 where
-  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + InputLength + InputIsStreaming<false>,
+  I: Slice<RangeFrom<usize>> + InputIter<Item = u8> + SliceLen + InputIsStreaming<false>,
   E: ParseError<I>,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, u8, E> {
@@ -913,7 +913,7 @@ where
 /// ```
 impl<I, E> Parser<I, <I as InputIter>::Item, E> for char
 where
-  I: Slice<RangeFrom<usize>> + InputIter + InputLength + InputIsStreaming<false>,
+  I: Slice<RangeFrom<usize>> + InputIter + SliceLen + InputIsStreaming<false>,
   <I as InputIter>::Item: AsChar + Copy,
   E: ParseError<I>,
 {
@@ -942,7 +942,7 @@ where
 /// ```
 impl<'s, I, E: ParseError<I>> Parser<I, <I as IntoOutput>::Output, E> for &'s [u8]
 where
-  I: InputTake + InputLength + Compare<&'s [u8]> + InputIsStreaming<false>,
+  I: InputTake + SliceLen + Compare<&'s [u8]> + InputIsStreaming<false>,
   I: IntoOutput,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {
@@ -971,7 +971,7 @@ where
 impl<'s, I, E: ParseError<I>, const N: usize> Parser<I, <I as IntoOutput>::Output, E>
   for &'s [u8; N]
 where
-  I: InputTake + InputLength + Compare<&'s [u8; N]> + InputIsStreaming<false>,
+  I: InputTake + SliceLen + Compare<&'s [u8; N]> + InputIsStreaming<false>,
   I: IntoOutput,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {
@@ -999,7 +999,7 @@ where
 /// ```
 impl<'s, I, E: ParseError<I>> Parser<I, <I as IntoOutput>::Output, E> for &'s str
 where
-  I: InputTake + InputLength + Compare<&'s str> + InputIsStreaming<false>,
+  I: InputTake + SliceLen + Compare<&'s str> + InputIsStreaming<false>,
   I: IntoOutput,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, <I as IntoOutput>::Output, E> {

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -199,10 +199,8 @@ pub trait Tuple<I, O, E> {
 }
 
 #[allow(deprecated)]
-impl<Input, Output, Error: ParseError<Input>, F: Parser<Input, Output, Error>>
-  Tuple<Input, (Output,), Error> for (F,)
-{
-  fn parse(&mut self, input: Input) -> IResult<Input, (Output,), Error> {
+impl<I, O, E: ParseError<I>, F: Parser<I, O, E>> Tuple<I, (O,), E> for (F,) {
+  fn parse(&mut self, input: I) -> IResult<I, (O,), E> {
     self.0.parse_next(input).map(|(i, o)| (i, (o,)))
   }
 }


### PR DESCRIPTION
Trying to separate this from the trait merger that mirrors rust-bakery/nom#1612 so its easier to talk about both.

In general
- Clarifies what types are input types
  - This highlighted that `ContainsToken` (formerly `FindTokens`) is actually a token type
  - **There are still some types being treated as input that aren't properly input**
- Clarifies terminology
  - `Offset::offset` has confused me as which value goes where, so using `Offset::offset_to`
  - winnow-rs#93 is an example of the problem with "index", "position", and "offset" being used interchangeably
- Makes generic parameters more consistent