### PR TITLE
fix: Prefer Into over From in bounds

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1314,13 +1314,19 @@ where
 
 /// Implementation of [`Parser::output_into`]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
-pub struct OutputInto<F, O1, O2: From<O1>> {
+pub struct OutputInto<F, O1, O2>
+where
+  O1: Into<O2>,
+{
   f: F,
   phantom_out1: core::marker::PhantomData<O1>,
   phantom_out2: core::marker::PhantomData<O2>,
 }
 
-impl<F, O1, O2: From<O1>> OutputInto<F, O1, O2> {
+impl<F, O1, O2> OutputInto<F, O1, O2>
+where
+  O1: Into<O2>,
+{
   pub(crate) fn new(f: F) -> Self {
     Self {
       f,
@@ -1330,8 +1336,9 @@ impl<F, O1, O2: From<O1>> OutputInto<F, O1, O2> {
   }
 }
 
-impl<I: Clone, O1, O2: From<O1>, E, F: Parser<I, O1, E>> Parser<I, O2, E>
-  for OutputInto<F, O1, O2>
+impl<I: Clone, O1, O2, E, F: Parser<I, O1, E>> Parser<I, O2, E> for OutputInto<F, O1, O2>
+where
+  O1: Into<O2>,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, O2, E> {
     match self.f.parse_next(i) {
@@ -1343,13 +1350,19 @@ impl<I: Clone, O1, O2: From<O1>, E, F: Parser<I, O1, E>> Parser<I, O2, E>
 
 /// Implementation of [`Parser::err_into`]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
-pub struct ErrInto<F, E1, E2: From<E1>> {
+pub struct ErrInto<F, E1, E2>
+where
+  E1: Into<E2>,
+{
   f: F,
   phantom_err1: core::marker::PhantomData<E1>,
   phantom_err2: core::marker::PhantomData<E2>,
 }
 
-impl<F, E1, E2: From<E1>> ErrInto<F, E1, E2> {
+impl<F, E1, E2> ErrInto<F, E1, E2>
+where
+  E1: Into<E2>,
+{
   pub(crate) fn new(f: F) -> Self {
     Self {
       f,
@@ -1359,8 +1372,10 @@ impl<F, E1, E2: From<E1>> ErrInto<F, E1, E2> {
   }
 }
 
-impl<I: Clone, O, E1, E2: crate::error::ParseError<I> + From<E1>, F: Parser<I, O, E1>>
-  Parser<I, O, E2> for ErrInto<F, E1, E2>
+impl<I: Clone, O, E1, E2: crate::error::ParseError<I>, F: Parser<I, O, E1>> Parser<I, O, E2>
+  for ErrInto<F, E1, E2>
+where
+  E1: Into<E2>,
 {
   fn parse_next(&mut self, i: I) -> IResult<I, O, E2> {
     match self.f.parse_next(i) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -192,7 +192,7 @@ impl<E> Err<E> {
   /// Automatically converts between errors if the underlying type supports it
   pub fn convert<F>(e: Err<F>) -> Self
   where
-    E: From<F>,
+    F: Into<E>,
   {
     e.map(crate::lib::std::convert::Into::into)
   }
@@ -436,9 +436,10 @@ pub trait Parser<I, O, E> {
   /// assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
   /// # }
   /// ```
-  fn output_into<O2: From<O>>(self) -> OutputInto<Self, O, O2>
+  fn output_into<O2>(self) -> OutputInto<Self, O, O2>
   where
     Self: core::marker::Sized,
+    O: Into<O2>,
   {
     OutputInto::new(self)
   }
@@ -779,9 +780,10 @@ pub trait Parser<I, O, E> {
   }
 
   /// Convert the parser's error to another type using [`std::convert::From`]
-  fn err_into<E2: From<E>>(self) -> ErrInto<Self, E, E2>
+  fn err_into<E2>(self) -> ErrInto<Self, E, E2>
   where
     Self: core::marker::Sized,
+    E: Into<E2>,
   {
     ErrInto::new(self)
   }


### PR DESCRIPTION
Unsure how to handle `O: From<u8>` type bounds.

Inspired by rust-bakery/nom#1460

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
