### PR TITLE
fix(comb): Deprecate `all_consuming`

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -775,6 +775,9 @@ where
 
 /// Succeeds if all the input has been consumed by its child parser.
 ///
+/// **WARNING:** Deprecated, replaced [`eof`] or
+/// [`FinishIResult::finish`][crate::FinishIResult::finish]
+///
 /// ```rust
 /// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::all_consuming;
@@ -788,6 +791,10 @@ where
 /// assert_eq!(parser("123abcd;"),Err(Err::Error(Error::new("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
+#[deprecated(
+  since = "8.0.0",
+  note = "Replaced with `eof` or `FinishIResult::finish`"
+)]
 pub fn all_consuming<I, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
   I: Input,

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -165,6 +165,7 @@ fn test_parser_map_parser() {
 
 #[test]
 fn test_all_consuming() {
+  #![allow(deprecated)]
   let input: &[u8] = &[100, 101, 102][..];
   assert_parse!(
     all_consuming(take(2usize))(input),


### PR DESCRIPTION
We have enough ways of doing this, we should consolidate down.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
