### PR TITLE
fix(error)!: Clarify role of different error elements

### DIFF
--- a/benches/number.rs
+++ b/benches/number.rs
@@ -71,7 +71,7 @@ fn std_float(input: &[u8]) -> IResult<&[u8], f64, Error<&[u8]>> {
     Err(e) => Err(e),
     Ok((i, s)) => match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(ErrMode::Error(Error {
+      None => Err(ErrMode::Backtrack(Error {
         input: i,
         kind: ErrorKind::Float,
       })),

--- a/benches/number.rs
+++ b/benches/number.rs
@@ -4,12 +4,12 @@ extern crate criterion;
 use criterion::Criterion;
 
 use winnow::character::{f64, recognize_float};
+use winnow::error::ErrMode;
 use winnow::error::Error;
 use winnow::error::ErrorKind;
 use winnow::input::ParseTo;
 use winnow::number::be_u64;
 use winnow::prelude::*;
-use winnow::ErrMode;
 
 type Input<'i> = &'i [u8];
 

--- a/benches/number.rs
+++ b/benches/number.rs
@@ -9,7 +9,7 @@ use winnow::error::ErrorKind;
 use winnow::input::ParseTo;
 use winnow::number::be_u64;
 use winnow::prelude::*;
-use winnow::Err;
+use winnow::ErrMode;
 
 type Input<'i> = &'i [u8];
 
@@ -71,7 +71,7 @@ fn std_float(input: &[u8]) -> IResult<&[u8], f64, Error<&[u8]>> {
     Err(e) => Err(e),
     Ok((i, s)) => match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(Err::Error(Error {
+      None => Err(ErrMode::Error(Error {
         input: i,
         kind: ErrorKind::Float,
       })),

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -20,7 +20,7 @@ impl<I> ParseError<I> for CustomError<I> {
 }
 
 pub fn parse(_input: &str) -> IResult<&str, &str, CustomError<&str>> {
-  Err(ErrMode::Error(CustomError::MyError))
+  Err(ErrMode::Backtrack(CustomError::MyError))
 }
 
 fn main() {}
@@ -35,7 +35,7 @@ mod tests {
   fn it_works() {
     let err = parse("").unwrap_err();
     match err {
-      ErrMode::Error(e) => assert_eq!(e, CustomError::MyError),
+      ErrMode::Backtrack(e) => assert_eq!(e, CustomError::MyError),
       _ => panic!("Unexpected error: {:?}", err),
     }
   }

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -1,6 +1,6 @@
 use winnow::error::ErrorKind;
 use winnow::error::ParseError;
-use winnow::Err::Error;
+use winnow::ErrMode::Error;
 use winnow::IResult;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -29,7 +29,7 @@ fn main() {}
 mod tests {
   use super::parse;
   use super::CustomError;
-  use winnow::Err::Error;
+  use winnow::ErrMode::Error;
 
   #[test]
   fn it_works() {

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -1,6 +1,6 @@
+use winnow::error::ErrMode;
 use winnow::error::ErrorKind;
 use winnow::error::ParseError;
-use winnow::ErrMode::Error;
 use winnow::IResult;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -20,7 +20,7 @@ impl<I> ParseError<I> for CustomError<I> {
 }
 
 pub fn parse(_input: &str) -> IResult<&str, &str, CustomError<&str>> {
-  Err(Error(CustomError::MyError))
+  Err(ErrMode::Error(CustomError::MyError))
 }
 
 fn main() {}
@@ -29,13 +29,13 @@ fn main() {}
 mod tests {
   use super::parse;
   use super::CustomError;
-  use winnow::ErrMode::Error;
+  use winnow::error::ErrMode;
 
   #[test]
   fn it_works() {
     let err = parse("").unwrap_err();
     match err {
-      Error(e) => assert_eq!(e, CustomError::MyError),
+      ErrMode::Error(e) => assert_eq!(e, CustomError::MyError),
       _ => panic!("Unexpected error: {:?}", err),
     }
   }

--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -89,7 +89,7 @@ fn string<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
 ) -> IResult<Input<'i>, String, E> {
   preceded(
     '\"',
-    // `cut` transforms an `ErrMode::Error(e)` in `ErrMode::Failure(e)`, signaling to
+    // `cut` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
     // combinators like  `alt` that they should not try other parsers. We were in the
     // right branch (since we found the `"` character) but encountered an error when
     // parsing the string

--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -89,7 +89,7 @@ fn string<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
 ) -> IResult<Input<'i>, String, E> {
   preceded(
     '\"',
-    // `cut` transforms an `Err::Error(e)` in `Err::Failure(e)`, signaling to
+    // `cut` transforms an `ErrMode::Error(e)` in `ErrMode::Failure(e)`, signaling to
     // combinators like  `alt` that they should not try other parsers. We were in the
     // right branch (since we found the `"` character) but encountered an error when
     // parsing the string

--- a/examples/json/parser_streaming.rs
+++ b/examples/json/parser_streaming.rs
@@ -6,7 +6,7 @@ use winnow::{
   branch::alt,
   bytes::{any, none_of, one_of, tag, take, take_while},
   character::f64,
-  combinator::{cut, rest},
+  combinator::{cut_err, rest},
   error::{ContextError, ParseError},
   input::Streaming,
   multi::{fold_many0, separated_list0},
@@ -90,11 +90,11 @@ fn string<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
 ) -> IResult<Input<'i>, String, E> {
   preceded(
     one_of('\"'),
-    // `cut` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
+    // `cut_err` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
     // combinators like  `alt` that they should not try other parsers. We were in the
     // right branch (since we found the `"` character) but encountered an error when
     // parsing the string
-    cut(terminated(
+    cut_err(terminated(
       fold_many0(character, String::new, |mut string, c| {
         string.push(c);
         string
@@ -169,7 +169,7 @@ fn array<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
 ) -> IResult<Input<'i>, Vec<JsonValue>, E> {
   preceded(
     (one_of('['), ws),
-    cut(terminated(
+    cut_err(terminated(
       separated_list0((ws, one_of(','), ws), json_value),
       (ws, one_of(']')),
     )),
@@ -183,7 +183,7 @@ fn object<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
 ) -> IResult<Input<'i>, HashMap<String, JsonValue>, E> {
   preceded(
     (one_of('{'), ws),
-    cut(terminated(
+    cut_err(terminated(
       separated_list0((ws, one_of(','), ws), key_value)
         .map(|tuple_vec| tuple_vec.into_iter().map(|(k, v)| (k, v)).collect()),
       (ws, one_of('}')),
@@ -196,7 +196,7 @@ fn object<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
 fn key_value<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
   input: Input<'i>,
 ) -> IResult<Input<'i>, (String, JsonValue), E> {
-  separated_pair(string, cut((ws, one_of(':'), ws)), json_value)(input)
+  separated_pair(string, cut_err((ws, one_of(':'), ws)), json_value)(input)
 }
 
 /// Parser combinators are constructed from the bottom up:

--- a/examples/json/parser_streaming.rs
+++ b/examples/json/parser_streaming.rs
@@ -90,7 +90,7 @@ fn string<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
 ) -> IResult<Input<'i>, String, E> {
   preceded(
     one_of('\"'),
-    // `cut` transforms an `ErrMode::Error(e)` in `ErrMode::Failure(e)`, signaling to
+    // `cut` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
     // combinators like  `alt` that they should not try other parsers. We were in the
     // right branch (since we found the `"` character) but encountered an error when
     // parsing the string

--- a/examples/json/parser_streaming.rs
+++ b/examples/json/parser_streaming.rs
@@ -90,7 +90,7 @@ fn string<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
 ) -> IResult<Input<'i>, String, E> {
   preceded(
     one_of('\"'),
-    // `cut` transforms an `Err::Error(e)` in `Err::Failure(e)`, signaling to
+    // `cut` transforms an `ErrMode::Error(e)` in `ErrMode::Failure(e)`, signaling to
     // combinators like  `alt` that they should not try other parsers. We were in the
     // right branch (since we found the `"` character) but encountered an error when
     // parsing the string

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -7,7 +7,7 @@ use winnow::{
   bytes::one_of,
   bytes::{tag, take_while},
   character::{alphanumeric1 as alphanumeric, escaped, f64},
-  combinator::cut,
+  combinator::cut_err,
   error::ParseError,
   multi::separated_list0,
   sequence::{preceded, separated_pair, terminated},
@@ -215,7 +215,7 @@ fn parse_str<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str
 }
 
 fn string(i: &str) -> IResult<&str, &str> {
-  preceded('\"', cut(terminated(parse_str, '\"')))
+  preceded('\"', cut_err(terminated(parse_str, '\"')))
     .context("string")
     .parse_next(i)
 }
@@ -227,7 +227,7 @@ fn boolean(input: &str) -> IResult<&str, bool> {
 fn array(i: &str) -> IResult<&str, ()> {
   preceded(
     '[',
-    cut(terminated(
+    cut_err(terminated(
       separated_list0(preceded(sp, ','), value).map(|_| ()),
       preceded(sp, ']'),
     )),
@@ -237,13 +237,13 @@ fn array(i: &str) -> IResult<&str, ()> {
 }
 
 fn key_value(i: &str) -> IResult<&str, (&str, ())> {
-  separated_pair(preceded(sp, string), cut(preceded(sp, ':')), value)(i)
+  separated_pair(preceded(sp, string), cut_err(preceded(sp, ':')), value)(i)
 }
 
 fn hash(i: &str) -> IResult<&str, ()> {
   preceded(
     '{',
-    cut(terminated(
+    cut_err(terminated(
       separated_list0(preceded(sp, ','), key_value).map(|_| ()),
       preceded(sp, '}'),
     )),

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -352,7 +352,7 @@ fn eval_expression(e: Expr) -> Option<Expr> {
 /// us call eval on a string directly
 fn eval_from_str(src: &str) -> Result<Expr, String> {
   parse_expr(src)
-    .map_err(|e: winnow::ErrMode<VerboseError<&str>>| format!("{:#?}", e))
+    .map_err(|e: winnow::error::ErrMode<VerboseError<&str>>| format!("{:#?}", e))
     .and_then(|(_, exp)| eval_expression(exp).ok_or_else(|| "Eval failed".to_string()))
 }
 

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -352,7 +352,7 @@ fn eval_expression(e: Expr) -> Option<Expr> {
 /// us call eval on a string directly
 fn eval_from_str(src: &str) -> Result<Expr, String> {
   parse_expr(src)
-    .map_err(|e: winnow::Err<VerboseError<&str>>| format!("{:#?}", e))
+    .map_err(|e: winnow::ErrMode<VerboseError<&str>>| format!("{:#?}", e))
     .and_then(|(_, exp)| eval_expression(exp).ok_or_else(|| "Eval failed".to_string()))
 }
 

--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -6,7 +6,7 @@
 use crate::error::{ErrorKind, ParseError};
 use crate::input::{AsBytes, Input, ToUsize};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
-use crate::{Err, IResult};
+use crate::{ErrMode, IResult};
 
 /// Generates a parser taking `count` bits
 ///
@@ -30,7 +30,7 @@ use crate::{Err, IResult};
 /// assert_eq!(parser(([0b00010010].as_ref(), 4), 4), Ok((([].as_ref(), 0), 0b00000010)));
 ///
 /// // Tries to consume 12 bits but only 8 are available
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::Err::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
+/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::ErrMode::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bits::take`][crate::bits::take]
@@ -60,7 +60,7 @@ where
   } else {
     let cnt = (count + bit_offset).div(8);
     if input.input_len() * 8 < count + bit_offset {
-      Err(Err::Error(E::from_error_kind(
+      Err(ErrMode::Error(E::from_error_kind(
         (input, bit_offset),
         ErrorKind::Eof,
       )))
@@ -128,7 +128,7 @@ where
     if *pattern == o {
       Ok((i, o))
     } else {
-      Err(Err::Error(error_position!(inp, ErrorKind::TagBits)))
+      Err(ErrMode::Error(error_position!(inp, ErrorKind::TagBits)))
     }
   })
 }
@@ -182,7 +182,7 @@ mod test {
 
     assert_eq!(
       result,
-      Err(crate::Err::Error(crate::error::Error {
+      Err(crate::ErrMode::Error(crate::error::Error {
         input: (input, 8),
         kind: ErrorKind::Eof
       }))
@@ -218,7 +218,7 @@ mod test {
 
     assert_eq!(
       result,
-      Err(crate::Err::Error(crate::error::Error {
+      Err(crate::ErrMode::Error(crate::error::Error {
         input: (input, 8),
         kind: ErrorKind::Eof
       }))

--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -3,10 +3,10 @@
 
 #![allow(deprecated)]
 
-use crate::error::{ErrorKind, ParseError};
+use crate::error::{ErrMode, ErrorKind, ParseError};
 use crate::input::{AsBytes, Input, ToUsize};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
-use crate::{ErrMode, IResult};
+use crate::IResult;
 
 /// Generates a parser taking `count` bits
 ///
@@ -30,7 +30,7 @@ use crate::{ErrMode, IResult};
 /// assert_eq!(parser(([0b00010010].as_ref(), 4), 4), Ok((([].as_ref(), 0), 0b00000010)));
 ///
 /// // Tries to consume 12 bits but only 8 are available
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::ErrMode::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
+/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::error::ErrMode::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bits::take`][crate::bits::take]
@@ -182,7 +182,7 @@ mod test {
 
     assert_eq!(
       result,
-      Err(crate::ErrMode::Error(crate::error::Error {
+      Err(crate::error::ErrMode::Error(crate::error::Error {
         input: (input, 8),
         kind: ErrorKind::Eof
       }))
@@ -218,7 +218,7 @@ mod test {
 
     assert_eq!(
       result,
-      Err(crate::ErrMode::Error(crate::error::Error {
+      Err(crate::error::ErrMode::Error(crate::error::Error {
         input: (input, 8),
         kind: ErrorKind::Eof
       }))

--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -30,7 +30,7 @@ use crate::IResult;
 /// assert_eq!(parser(([0b00010010].as_ref(), 4), 4), Ok((([].as_ref(), 0), 0b00000010)));
 ///
 /// // Tries to consume 12 bits but only 8 are available
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::error::ErrMode::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
+/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::error::ErrMode::Backtrack(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bits::take`][crate::bits::take]
@@ -60,7 +60,7 @@ where
   } else {
     let cnt = (count + bit_offset).div(8);
     if input.input_len() * 8 < count + bit_offset {
-      Err(ErrMode::Error(E::from_error_kind(
+      Err(ErrMode::Backtrack(E::from_error_kind(
         (input, bit_offset),
         ErrorKind::Eof,
       )))
@@ -128,7 +128,7 @@ where
     if *pattern == o {
       Ok((i, o))
     } else {
-      Err(ErrMode::Error(error_position!(inp, ErrorKind::TagBits)))
+      Err(ErrMode::Backtrack(error_position!(inp, ErrorKind::TagBits)))
     }
   })
 }
@@ -182,7 +182,7 @@ mod test {
 
     assert_eq!(
       result,
-      Err(crate::error::ErrMode::Error(crate::error::Error {
+      Err(crate::error::ErrMode::Backtrack(crate::error::Error {
         input: (input, 8),
         kind: ErrorKind::Eof
       }))
@@ -218,7 +218,7 @@ mod test {
 
     assert_eq!(
       result,
-      Err(crate::error::ErrMode::Error(crate::error::Error {
+      Err(crate::error::ErrMode::Backtrack(crate::error::Error {
         input: (input, 8),
         kind: ErrorKind::Eof
       }))

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -9,7 +9,7 @@ mod tests;
 use crate::error::{ErrorConvert, ErrorKind, ParseError};
 use crate::input::{AsBytes, Input, InputIsStreaming, ToUsize};
 use crate::lib::std::ops::{AddAssign, Shl, Shr};
-use crate::{Err, IResult, Needed, Parser};
+use crate::{ErrMode, IResult, Needed, Parser};
 
 /// Converts a byte-level input to a bit-level input, for consumption by a parser that uses bits.
 ///
@@ -54,9 +54,9 @@ where
       let (input, _) = rest.next_slice(remaining_bytes_index);
       Ok((input, result))
     }
-    Err(Err::Incomplete(n)) => Err(Err::Incomplete(n.map(|u| u.get() / 8 + 1))),
-    Err(Err::Error(e)) => Err(Err::Error(e.convert())),
-    Err(Err::Failure(e)) => Err(Err::Failure(e.convert())),
+    Err(ErrMode::Incomplete(n)) => Err(ErrMode::Incomplete(n.map(|u| u.get() / 8 + 1))),
+    Err(ErrMode::Error(e)) => Err(ErrMode::Error(e.convert())),
+    Err(ErrMode::Failure(e)) => Err(ErrMode::Failure(e.convert())),
   }
 }
 
@@ -100,13 +100,13 @@ where
     let i = (input, offset);
     match parser.parse_next(inner) {
       Ok((rest, res)) => Ok(((rest, 0), res)),
-      Err(Err::Incomplete(Needed::Unknown)) => Err(Err::Incomplete(Needed::Unknown)),
-      Err(Err::Incomplete(Needed::Size(sz))) => Err(match sz.get().checked_mul(8) {
-        Some(v) => Err::Incomplete(Needed::new(v)),
-        None => Err::Failure(E2::from_error_kind(i, ErrorKind::TooLarge)),
+      Err(ErrMode::Incomplete(Needed::Unknown)) => Err(ErrMode::Incomplete(Needed::Unknown)),
+      Err(ErrMode::Incomplete(Needed::Size(sz))) => Err(match sz.get().checked_mul(8) {
+        Some(v) => ErrMode::Incomplete(Needed::new(v)),
+        None => ErrMode::Failure(E2::from_error_kind(i, ErrorKind::TooLarge)),
       }),
-      Err(Err::Error(e)) => Err(Err::Error(e.convert())),
-      Err(Err::Failure(e)) => Err(Err::Failure(e.convert())),
+      Err(ErrMode::Error(e)) => Err(ErrMode::Error(e.convert())),
+      Err(ErrMode::Failure(e)) => Err(ErrMode::Failure(e.convert())),
     }
   }
 }
@@ -133,7 +133,7 @@ where
 /// assert_eq!(parser(([0b00010010].as_ref(), 4), 4), Ok((([].as_ref(), 0), 0b00000010)));
 ///
 /// // Tries to consume 12 bits but only 8 are available
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::Err::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
+/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::ErrMode::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
 /// ```
 #[inline(always)]
 pub fn take<I, O, C, E: ParseError<(I, usize)>, const STREAMING: bool>(
@@ -183,7 +183,7 @@ where
 /// // The lowest 2 bits of 0b11111111 and 0b00000001 are different.
 /// assert_eq!(
 ///     parser(0b000000_01, 2, ([0b111111_11].as_ref(), 0)),
-///     Err(winnow::Err::Error(Error {
+///     Err(winnow::ErrMode::Error(Error {
 ///         input: ([0b11111111].as_ref(), 0),
 ///         kind: ErrorKind::TagBits
 ///     }))
@@ -192,7 +192,7 @@ where
 /// // The lowest 8 bits of 0b11111111 and 0b11111110 are different.
 /// assert_eq!(
 ///     parser(0b11111110, 8, ([0b11111111].as_ref(), 0)),
-///     Err(winnow::Err::Error(Error {
+///     Err(winnow::ErrMode::Error(Error {
 ///         input: ([0b11111111].as_ref(), 0),
 ///         kind: ErrorKind::TagBits
 ///     }))

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -6,10 +6,10 @@ pub mod streaming;
 #[cfg(test)]
 mod tests;
 
-use crate::error::{ErrorConvert, ErrorKind, ParseError};
+use crate::error::{ErrMode, ErrorConvert, ErrorKind, Needed, ParseError};
 use crate::input::{AsBytes, Input, InputIsStreaming, ToUsize};
 use crate::lib::std::ops::{AddAssign, Shl, Shr};
-use crate::{ErrMode, IResult, Needed, Parser};
+use crate::{IResult, Parser};
 
 /// Converts a byte-level input to a bit-level input, for consumption by a parser that uses bits.
 ///
@@ -133,7 +133,7 @@ where
 /// assert_eq!(parser(([0b00010010].as_ref(), 4), 4), Ok((([].as_ref(), 0), 0b00000010)));
 ///
 /// // Tries to consume 12 bits but only 8 are available
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::ErrMode::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
+/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(winnow::error::ErrMode::Error(Error{input: ([0b00010010].as_ref(), 0), kind: ErrorKind::Eof })));
 /// ```
 #[inline(always)]
 pub fn take<I, O, C, E: ParseError<(I, usize)>, const STREAMING: bool>(
@@ -183,7 +183,7 @@ where
 /// // The lowest 2 bits of 0b11111111 and 0b00000001 are different.
 /// assert_eq!(
 ///     parser(0b000000_01, 2, ([0b111111_11].as_ref(), 0)),
-///     Err(winnow::ErrMode::Error(Error {
+///     Err(winnow::error::ErrMode::Error(Error {
 ///         input: ([0b11111111].as_ref(), 0),
 ///         kind: ErrorKind::TagBits
 ///     }))
@@ -192,7 +192,7 @@ where
 /// // The lowest 8 bits of 0b11111111 and 0b11111110 are different.
 /// assert_eq!(
 ///     parser(0b11111110, 8, ([0b11111111].as_ref(), 0)),
-///     Err(winnow::ErrMode::Error(Error {
+///     Err(winnow::error::ErrMode::Error(Error {
 ///         input: ([0b11111111].as_ref(), 0),
 ///         kind: ErrorKind::TagBits
 ///     }))

--- a/src/bits/streaming.rs
+++ b/src/bits/streaming.rs
@@ -6,7 +6,7 @@
 use crate::error::{ErrorKind, ParseError};
 use crate::input::{AsBytes, Input, ToUsize};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
-use crate::{Err, IResult, Needed};
+use crate::{ErrMode, IResult, Needed};
 
 /// Generates a parser taking `count` bits
 ///
@@ -40,7 +40,7 @@ where
   } else {
     let cnt = (count + bit_offset).div(8);
     if input.input_len() * 8 < count + bit_offset {
-      Err(Err::Incomplete(Needed::new(count)))
+      Err(ErrMode::Incomplete(Needed::new(count)))
     } else {
       let mut acc: O = 0_u8.into();
       let mut offset: usize = bit_offset;
@@ -108,7 +108,7 @@ where
     if *pattern == o {
       Ok((i, o))
     } else {
-      Err(Err::Error(error_position!(inp, ErrorKind::TagBits)))
+      Err(ErrMode::Error(error_position!(inp, ErrorKind::TagBits)))
     }
   })
 }
@@ -179,7 +179,7 @@ mod test {
 
     assert_eq!(
       result,
-      Err(crate::Err::Error(crate::error::Error {
+      Err(crate::ErrMode::Error(crate::error::Error {
         input: (input, offset),
         kind: ErrorKind::TagBits
       }))
@@ -201,6 +201,6 @@ mod test {
 
     let result: crate::IResult<(&[u8], usize), bool> = bool((input, 8));
 
-    assert_eq!(result, Err(crate::Err::Incomplete(Needed::new(1))));
+    assert_eq!(result, Err(crate::ErrMode::Incomplete(Needed::new(1))));
   }
 }

--- a/src/bits/streaming.rs
+++ b/src/bits/streaming.rs
@@ -108,7 +108,7 @@ where
     if *pattern == o {
       Ok((i, o))
     } else {
-      Err(ErrMode::Error(error_position!(inp, ErrorKind::TagBits)))
+      Err(ErrMode::Backtrack(error_position!(inp, ErrorKind::TagBits)))
     }
   })
 }
@@ -179,7 +179,7 @@ mod test {
 
     assert_eq!(
       result,
-      Err(crate::error::ErrMode::Error(crate::error::Error {
+      Err(crate::error::ErrMode::Backtrack(crate::error::Error {
         input: (input, offset),
         kind: ErrorKind::TagBits
       }))

--- a/src/bits/streaming.rs
+++ b/src/bits/streaming.rs
@@ -3,10 +3,10 @@
 
 #![allow(deprecated)]
 
-use crate::error::{ErrorKind, ParseError};
+use crate::error::{ErrMode, ErrorKind, Needed, ParseError};
 use crate::input::{AsBytes, Input, ToUsize};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
-use crate::{ErrMode, IResult, Needed};
+use crate::IResult;
 
 /// Generates a parser taking `count` bits
 ///
@@ -179,7 +179,7 @@ mod test {
 
     assert_eq!(
       result,
-      Err(crate::ErrMode::Error(crate::error::Error {
+      Err(crate::error::ErrMode::Error(crate::error::Error {
         input: (input, offset),
         kind: ErrorKind::TagBits
       }))
@@ -201,6 +201,9 @@ mod test {
 
     let result: crate::IResult<(&[u8], usize), bool> = bool((input, 8));
 
-    assert_eq!(result, Err(crate::ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+      result,
+      Err(crate::error::ErrMode::Incomplete(Needed::new(1)))
+    );
   }
 }

--- a/src/bits/tests.rs
+++ b/src/bits/tests.rs
@@ -80,7 +80,7 @@ fn test_take_complete_eof() {
 
   assert_eq!(
     result,
-    Err(crate::error::ErrMode::Error(crate::error::Error {
+    Err(crate::error::ErrMode::Backtrack(crate::error::Error {
       input: (input, 8),
       kind: ErrorKind::Eof
     }))
@@ -134,7 +134,7 @@ fn test_tag_streaming_err() {
 
   assert_eq!(
     result,
-    Err(crate::error::ErrMode::Error(crate::error::Error {
+    Err(crate::error::ErrMode::Backtrack(crate::error::Error {
       input: (input, offset),
       kind: ErrorKind::TagBits
     }))
@@ -158,7 +158,7 @@ fn test_bool_eof_complete() {
 
   assert_eq!(
     result,
-    Err(crate::error::ErrMode::Error(crate::error::Error {
+    Err(crate::error::ErrMode::Backtrack(crate::error::Error {
       input: (input, 8),
       kind: ErrorKind::Eof
     }))

--- a/src/bits/tests.rs
+++ b/src/bits/tests.rs
@@ -80,7 +80,7 @@ fn test_take_complete_eof() {
 
   assert_eq!(
     result,
-    Err(crate::Err::Error(crate::error::Error {
+    Err(crate::ErrMode::Error(crate::error::Error {
       input: (input, 8),
       kind: ErrorKind::Eof
     }))
@@ -134,7 +134,7 @@ fn test_tag_streaming_err() {
 
   assert_eq!(
     result,
-    Err(crate::Err::Error(crate::error::Error {
+    Err(crate::ErrMode::Error(crate::error::Error {
       input: (input, offset),
       kind: ErrorKind::TagBits
     }))
@@ -158,7 +158,7 @@ fn test_bool_eof_complete() {
 
   assert_eq!(
     result,
-    Err(crate::Err::Error(crate::error::Error {
+    Err(crate::ErrMode::Error(crate::error::Error {
       input: (input, 8),
       kind: ErrorKind::Eof
     }))
@@ -180,5 +180,5 @@ fn test_bool_eof_streaming() {
 
   let result: crate::IResult<(Streaming<&[u8]>, usize), bool> = bool((input, 8));
 
-  assert_eq!(result, Err(crate::Err::Incomplete(Needed::new(1))));
+  assert_eq!(result, Err(crate::ErrMode::Incomplete(Needed::new(1))));
 }

--- a/src/bits/tests.rs
+++ b/src/bits/tests.rs
@@ -80,7 +80,7 @@ fn test_take_complete_eof() {
 
   assert_eq!(
     result,
-    Err(crate::ErrMode::Error(crate::error::Error {
+    Err(crate::error::ErrMode::Error(crate::error::Error {
       input: (input, 8),
       kind: ErrorKind::Eof
     }))
@@ -134,7 +134,7 @@ fn test_tag_streaming_err() {
 
   assert_eq!(
     result,
-    Err(crate::ErrMode::Error(crate::error::Error {
+    Err(crate::error::ErrMode::Error(crate::error::Error {
       input: (input, offset),
       kind: ErrorKind::TagBits
     }))
@@ -158,7 +158,7 @@ fn test_bool_eof_complete() {
 
   assert_eq!(
     result,
-    Err(crate::ErrMode::Error(crate::error::Error {
+    Err(crate::error::ErrMode::Error(crate::error::Error {
       input: (input, 8),
       kind: ErrorKind::Eof
     }))
@@ -180,5 +180,8 @@ fn test_bool_eof_streaming() {
 
   let result: crate::IResult<(Streaming<&[u8]>, usize), bool> = bool((input, 8));
 
-  assert_eq!(result, Err(crate::ErrMode::Incomplete(Needed::new(1))));
+  assert_eq!(
+    result,
+    Err(crate::error::ErrMode::Incomplete(Needed::new(1)))
+  );
 }

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -3,9 +3,10 @@
 #[cfg(test)]
 mod tests;
 
+use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
-use crate::{ErrMode, IResult, Parser};
+use crate::{IResult, Parser};
 
 /// Helper trait for the [alt()] combinator.
 ///
@@ -23,7 +24,7 @@ pub trait Alt<I, O, E> {
 ///
 /// ```rust
 /// # use winnow::error_position;
-/// # use winnow::{ErrMode,error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode,error::ErrorKind, error::Needed, IResult};
 /// use winnow::character::{alpha1, digit1};
 /// use winnow::branch::alt;
 /// # fn main() {
@@ -65,7 +66,7 @@ pub trait Permutation<I, O, E> {
 /// tuple of the parser results.
 ///
 /// ```rust
-/// # use winnow::{ErrMode,error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode,error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::character::{alpha1, digit1};
 /// use winnow::branch::permutation;
 /// # fn main() {
@@ -87,7 +88,7 @@ pub trait Permutation<I, O, E> {
 /// The parsers are applied greedily: if there are multiple unapplied parsers
 /// that could parse the next slice of input, the first one is used.
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult};
 /// use winnow::branch::permutation;
 /// use winnow::bytes::any;
 ///

--- a/src/branch/tests.rs
+++ b/src/branch/tests.rs
@@ -1,7 +1,10 @@
 use crate::branch::{alt, permutation};
 use crate::bytes::tag;
+use crate::error::ErrMode;
 use crate::error::ErrorKind;
+use crate::error::Needed;
 use crate::input::Streaming;
+use crate::IResult;
 #[cfg(feature = "alloc")]
 use crate::{
   error::ParseError,
@@ -10,7 +13,6 @@ use crate::{
     string::{String, ToString},
   },
 };
-use crate::{ErrMode, IResult, Needed};
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/branch/tests.rs
+++ b/src/branch/tests.rs
@@ -10,7 +10,7 @@ use crate::{
     string::{String, ToString},
   },
 };
-use crate::{Err, IResult, Needed};
+use crate::{ErrMode, IResult, Needed};
 
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -53,7 +53,7 @@ fn alt_test() {
 
   #[allow(unused_variables)]
   fn dont_work(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-    Err(Err::Error(ErrorStr("abcd".to_string())))
+    Err(ErrMode::Error(ErrorStr("abcd".to_string())))
   }
 
   fn work2(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
@@ -76,7 +76,7 @@ fn alt_test() {
   let a = &b"abcd"[..];
   assert_eq!(
     alt1(a),
-    Err(Err::Error(error_node_position!(
+    Err(ErrMode::Error(error_node_position!(
       a,
       ErrorKind::Alt,
       ErrorStr("abcd".to_string())
@@ -100,18 +100,21 @@ fn alt_incomplete() {
   }
 
   let a = &b""[..];
-  assert_eq!(alt1(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(alt1(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
   let a = &b"b"[..];
-  assert_eq!(alt1(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(alt1(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
   let a = &b"bcd"[..];
   assert_eq!(alt1(Streaming(a)), Ok((Streaming(&b"d"[..]), &b"bc"[..])));
   let a = &b"cde"[..];
   assert_eq!(
     alt1(Streaming(a)),
-    Err(Err::Error(error_position!(Streaming(a), ErrorKind::Tag)))
+    Err(ErrMode::Error(error_position!(
+      Streaming(a),
+      ErrorKind::Tag
+    )))
   );
   let a = &b"de"[..];
-  assert_eq!(alt1(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(alt1(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
   let a = &b"defg"[..];
   assert_eq!(alt1(Streaming(a)), Ok((Streaming(&b"g"[..]), &b"def"[..])));
 }
@@ -135,7 +138,7 @@ fn permutation_test() {
   let d = &b"efgxyzabcdefghi"[..];
   assert_eq!(
     perm(Streaming(d)),
-    Err(Err::Error(error_node_position!(
+    Err(ErrMode::Error(error_node_position!(
       Streaming(&b"efgxyzabcdefghi"[..]),
       ErrorKind::Permutation,
       error_position!(Streaming(&b"xyzabcdefghi"[..]), ErrorKind::Tag)
@@ -143,5 +146,5 @@ fn permutation_test() {
   );
 
   let e = &b"efgabc"[..];
-  assert_eq!(perm(Streaming(e)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(perm(Streaming(e)), Err(ErrMode::Incomplete(Needed::new(1))));
 }

--- a/src/branch/tests.rs
+++ b/src/branch/tests.rs
@@ -55,7 +55,7 @@ fn alt_test() {
 
   #[allow(unused_variables)]
   fn dont_work(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-    Err(ErrMode::Error(ErrorStr("abcd".to_string())))
+    Err(ErrMode::Backtrack(ErrorStr("abcd".to_string())))
   }
 
   fn work2(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
@@ -78,7 +78,7 @@ fn alt_test() {
   let a = &b"abcd"[..];
   assert_eq!(
     alt1(a),
-    Err(ErrMode::Error(error_node_position!(
+    Err(ErrMode::Backtrack(error_node_position!(
       a,
       ErrorKind::Alt,
       ErrorStr("abcd".to_string())
@@ -110,7 +110,7 @@ fn alt_incomplete() {
   let a = &b"cde"[..];
   assert_eq!(
     alt1(Streaming(a)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(a),
       ErrorKind::Tag
     )))
@@ -140,7 +140,7 @@ fn permutation_test() {
   let d = &b"efgxyzabcdefghi"[..];
   assert_eq!(
     perm(Streaming(d)),
-    Err(ErrMode::Error(error_node_position!(
+    Err(ErrMode::Backtrack(error_node_position!(
       Streaming(&b"efgxyzabcdefghi"[..]),
       ErrorKind::Permutation,
       error_position!(Streaming(&b"xyzabcdefghi"[..]), ErrorKind::Tag)

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -2,6 +2,7 @@
 
 #![allow(deprecated)]
 
+use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
@@ -9,7 +10,7 @@ use crate::input::{
   FindSlice, Input, Offset, SliceLen, ToUsize,
 };
 use crate::lib::std::result::Result::Ok;
-use crate::{ErrMode, IResult, Parser};
+use crate::{IResult, Parser};
 
 pub(crate) fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Input>::Token, E>
 where
@@ -28,7 +29,7 @@ where
 /// It will return `Err(ErrMode::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -78,7 +79,7 @@ where
 /// It will return `Err(ErrMode::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::tag_no_case;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -162,7 +163,7 @@ where
 /// It will return a `ErrMode::Error(("", ErrorKind::IsNot))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::is_not;
 ///
 /// fn not_space(s: &str) -> IResult<&str, &str> {
@@ -207,7 +208,7 @@ where
 /// It will return a `Err(ErrMode::Error((_, ErrorKind::IsA)))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::is_a;
 ///
 /// fn hex(s: &str) -> IResult<&str, &str> {
@@ -251,7 +252,7 @@ where
 /// takes the input and returns a bool)*.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::bytes::complete::take_while;
 /// use winnow::input::AsChar;
 ///
@@ -296,7 +297,7 @@ where
 /// It will return an `Err(ErrMode::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::take_while1;
 /// use winnow::input::AsChar;
 ///
@@ -342,7 +343,7 @@ where
 /// of range (m <= len <= n).
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::take_while_m_n;
 /// use winnow::input::AsChar;
 ///
@@ -439,7 +440,7 @@ where
 /// takes the input and returns a bool)*.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::bytes::complete::take_till;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -485,7 +486,7 @@ where
 /// predicate matches the first input.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::take_till1;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -528,7 +529,7 @@ where
 /// It will return `Err(ErrMode::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::take;
 ///
 /// fn take6(s: &str) -> IResult<&str, &str> {
@@ -585,7 +586,7 @@ where
 /// if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::take_until;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -633,7 +634,7 @@ where
 /// if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::complete::take_until1;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -683,7 +684,7 @@ where
 /// * The third argument matches the escaped characters
 /// # Example
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// # use winnow::character::complete::digit1;
 /// use winnow::bytes::complete::escaped;
 /// use winnow::character::complete::one_of;
@@ -796,7 +797,7 @@ where
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// # use std::str::from_utf8;
 /// use winnow::bytes::complete::{escaped_transform, tag};
 /// use winnow::character::complete::alpha1;

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -18,7 +18,7 @@ where
 {
   input
     .next_token()
-    .ok_or_else(|| ErrMode::Error(E::from_error_kind(input, ErrorKind::Eof)))
+    .ok_or_else(|| ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Eof)))
 }
 
 /// Recognizes a pattern
@@ -26,7 +26,7 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument
 ///
-/// It will return `Err(ErrMode::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// It will return `Err(ErrMode::Backtrack((_, ErrorKind::Tag)))` if the input doesn't match the pattern
 /// # Example
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
@@ -37,8 +37,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Backtrack(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::tag`][crate::bytes::tag]
@@ -66,7 +66,7 @@ where
     CompareResult::Ok => Ok(i.next_slice(tag_len)),
     CompareResult::Incomplete | CompareResult::Error => {
       let e: ErrorKind = ErrorKind::Tag;
-      Err(ErrMode::Error(Error::from_error_kind(i, e)))
+      Err(ErrMode::Backtrack(Error::from_error_kind(i, e)))
     }
   }
 }
@@ -76,7 +76,7 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument with no regard to case.
 ///
-/// It will return `Err(ErrMode::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern.
+/// It will return `Err(ErrMode::Backtrack((_, ErrorKind::Tag)))` if the input doesn't match the pattern.
 /// # Example
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
@@ -89,8 +89,8 @@ where
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
 /// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Backtrack(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::tag_no_case`][crate::bytes::tag_no_case]
@@ -119,7 +119,7 @@ where
     CompareResult::Ok => Ok(i.next_slice(tag_len)),
     CompareResult::Incomplete | CompareResult::Error => {
       let e: ErrorKind = ErrorKind::Tag;
-      Err(ErrMode::Error(Error::from_error_kind(i, e)))
+      Err(ErrMode::Backtrack(Error::from_error_kind(i, e)))
     }
   }
 }
@@ -136,7 +136,7 @@ where
   input
     .next_token()
     .filter(|(_, t)| list.contains_token(*t))
-    .ok_or_else(|| ErrMode::Error(E::from_error_kind(input, ErrorKind::OneOf)))
+    .ok_or_else(|| ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::OneOf)))
 }
 
 pub(crate) fn none_of_internal<I, T, E: ParseError<I>>(
@@ -151,7 +151,7 @@ where
   input
     .next_token()
     .filter(|(_, t)| !list.contains_token(*t))
-    .ok_or_else(|| ErrMode::Error(E::from_error_kind(input, ErrorKind::NoneOf)))
+    .ok_or_else(|| ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::NoneOf)))
 }
 
 /// Parse till certain characters are met.
@@ -160,7 +160,7 @@ where
 ///
 /// It doesn't consume the matched character.
 ///
-/// It will return a `ErrMode::Error(("", ErrorKind::IsNot))` if the pattern wasn't met.
+/// It will return a `ErrMode::Backtrack(("", ErrorKind::IsNot))` if the pattern wasn't met.
 /// # Example
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
@@ -173,7 +173,7 @@ where
 /// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
 /// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
 /// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
-/// assert_eq!(not_space(""), Err(ErrMode::Error(Error::new("", ErrorKind::IsNot))));
+/// assert_eq!(not_space(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::IsNot))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_till1`][crate::bytes::take_till1]
@@ -205,7 +205,7 @@ where
 /// The parser will return the longest slice consisting of the characters in provided in the
 /// combinator's argument.
 ///
-/// It will return a `Err(ErrMode::Error((_, ErrorKind::IsA)))` if the pattern wasn't met.
+/// It will return a `Err(ErrMode::Backtrack((_, ErrorKind::IsA)))` if the pattern wasn't met.
 /// # Example
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
@@ -219,7 +219,7 @@ where
 /// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
 /// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
 /// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
-/// assert_eq!(hex(""), Err(ErrMode::Error(Error::new("", ErrorKind::IsA))));
+/// assert_eq!(hex(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::IsA))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while1`][crate::bytes::take_while1`]
@@ -294,7 +294,7 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return an `Err(ErrMode::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
+/// It will return an `Err(ErrMode::Backtrack((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 /// # Example
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
@@ -307,7 +307,7 @@ where
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// assert_eq!(alpha(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while1`][crate::bytes::take_while1]
@@ -339,7 +339,7 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return an `ErrMode::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
+/// It will return an `ErrMode::Backtrack((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
 /// of range (m <= len <= n).
 /// # Example
 /// ```rust
@@ -354,8 +354,8 @@ where
 /// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
 /// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
-/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Backtrack(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while_m_n`][crate::bytes::take_while_m_n]
@@ -392,7 +392,7 @@ where
           let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(idx) {
             Ok(input.next_slice(index))
           } else {
-            Err(ErrMode::Error(Error::from_error_kind(
+            Err(ErrMode::Backtrack(Error::from_error_kind(
               input,
               ErrorKind::TakeWhileMN,
             )))
@@ -402,7 +402,7 @@ where
           let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(n) {
             Ok(input.next_slice(index))
           } else {
-            Err(ErrMode::Error(Error::from_error_kind(
+            Err(ErrMode::Backtrack(Error::from_error_kind(
               input,
               ErrorKind::TakeWhileMN,
             )))
@@ -411,7 +411,7 @@ where
         }
       } else {
         let e = ErrorKind::TakeWhileMN;
-        Err(ErrMode::Error(Error::from_error_kind(input, e)))
+        Err(ErrMode::Backtrack(Error::from_error_kind(input, e)))
       }
     }
     None => {
@@ -419,7 +419,7 @@ where
       if len >= n {
         match input.offset_at(n) {
           Ok(index) => Ok(input.next_slice(index)),
-          Err(_needed) => Err(ErrMode::Error(Error::from_error_kind(
+          Err(_needed) => Err(ErrMode::Backtrack(Error::from_error_kind(
             input,
             ErrorKind::TakeWhileMN,
           ))),
@@ -428,7 +428,7 @@ where
         Ok(input.next_slice(len))
       } else {
         let e = ErrorKind::TakeWhileMN;
-        Err(ErrMode::Error(Error::from_error_kind(input, e)))
+        Err(ErrMode::Backtrack(Error::from_error_kind(input, e)))
       }
     }
   }
@@ -482,7 +482,7 @@ where
 /// The parser will return the longest slice till the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return `Err(ErrMode::Error((_, ErrorKind::TakeTill1)))` if the input is empty or the
+/// It will return `Err(ErrMode::Backtrack((_, ErrorKind::TakeTill1)))` if the input is empty or the
 /// predicate matches the first input.
 /// # Example
 /// ```rust
@@ -494,9 +494,9 @@ where
 /// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Err(ErrMode::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(":empty matched"), Err(ErrMode::Backtrack(Error::new(":empty matched", ErrorKind::TakeTill1))));
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
-/// assert_eq!(till_colon(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::TakeTill1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_till1`][crate::bytes::take_till1]
@@ -526,7 +526,7 @@ where
 
 /// Returns an input slice containing the first N input elements (I[..N]).
 ///
-/// It will return `Err(ErrMode::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument.
+/// It will return `Err(ErrMode::Backtrack((_, ErrorKind::Eof)))` if the input is shorter than the argument.
 /// # Example
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
@@ -538,8 +538,8 @@ where
 ///
 /// assert_eq!(take6("1234567"), Ok(("7", "123456")));
 /// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(ErrMode::Error(Error::new("short", ErrorKind::Eof))));
-/// assert_eq!(take6(""), Err(ErrMode::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(take6("short"), Err(ErrMode::Backtrack(Error::new("short", ErrorKind::Eof))));
+/// assert_eq!(take6(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Eof))));
 /// ```
 ///
 /// The units that are taken will depend on the input type. For example, for a
@@ -576,13 +576,16 @@ where
 {
   match i.offset_at(c) {
     Ok(offset) => Ok(i.next_slice(offset)),
-    Err(_needed) => Err(ErrMode::Error(Error::from_error_kind(i, ErrorKind::Eof))),
+    Err(_needed) => Err(ErrMode::Backtrack(Error::from_error_kind(
+      i,
+      ErrorKind::Eof,
+    ))),
   }
 }
 
 /// Returns the input slice up to the first occurrence of the pattern.
 ///
-/// It doesn't consume the pattern. It will return `Err(ErrMode::Error((_, ErrorKind::TakeUntil)))`
+/// It doesn't consume the pattern. It will return `Err(ErrMode::Backtrack((_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 /// # Example
 /// ```rust
@@ -594,8 +597,8 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Backtrack(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
 ///
@@ -621,7 +624,7 @@ where
 {
   match i.find_slice(t) {
     Some(offset) => Ok(i.next_slice(offset)),
-    None => Err(ErrMode::Error(Error::from_error_kind(
+    None => Err(ErrMode::Backtrack(Error::from_error_kind(
       i,
       ErrorKind::TakeUntil,
     ))),
@@ -630,7 +633,7 @@ where
 
 /// Returns the non empty input slice up to the first occurrence of the pattern.
 ///
-/// It doesn't consume the pattern. It will return `Err(ErrMode::Error((_, ErrorKind::TakeUntil)))`
+/// It doesn't consume the pattern. It will return `Err(ErrMode::Backtrack((_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 /// # Example
 /// ```rust
@@ -642,10 +645,10 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Backtrack(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"), Err(ErrMode::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("eof"), Err(ErrMode::Backtrack(Error::new("eof", ErrorKind::TakeUntil))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_until1`][crate::bytes::take_until1]
@@ -669,7 +672,7 @@ where
   T: SliceLen,
 {
   match i.find_slice(t) {
-    None | Some(0) => Err(ErrMode::Error(Error::from_error_kind(
+    None | Some(0) => Err(ErrMode::Backtrack(Error::from_error_kind(
       i,
       ErrorKind::TakeUntil,
     ))),
@@ -748,11 +751,11 @@ where
           i = i2;
         }
       }
-      Err(ErrMode::Error(_)) => {
+      Err(ErrMode::Backtrack(_)) => {
         if i.next_token().expect("input_len > 0").1.as_char() == control_char {
           let next = control_char.len_utf8();
           if next >= i.input_len() {
-            return Err(ErrMode::Error(Error::from_error_kind(
+            return Err(ErrMode::Backtrack(Error::from_error_kind(
               input,
               ErrorKind::Escaped,
             )));
@@ -771,7 +774,7 @@ where
         } else {
           let offset = input.offset_to(&i);
           if offset == 0 {
-            return Err(ErrMode::Error(Error::from_error_kind(
+            return Err(ErrMode::Backtrack(Error::from_error_kind(
               input,
               ErrorKind::Escaped,
             )));
@@ -882,13 +885,13 @@ where
           offset = input.offset_to(&i2);
         }
       }
-      Err(ErrMode::Error(_)) => {
+      Err(ErrMode::Backtrack(_)) => {
         if remainder.next_token().expect("input_len > 0").1.as_char() == control_char {
           let next = offset + control_char.len_utf8();
           let input_len = input.input_len();
 
           if next >= input_len {
-            return Err(ErrMode::Error(Error::from_error_kind(
+            return Err(ErrMode::Backtrack(Error::from_error_kind(
               remainder,
               ErrorKind::EscapedTransform,
             )));
@@ -907,7 +910,7 @@ where
           }
         } else {
           if offset == 0 {
-            return Err(ErrMode::Error(Error::from_error_kind(
+            return Err(ErrMode::Backtrack(Error::from_error_kind(
               remainder,
               ErrorKind::EscapedTransform,
             )));
@@ -995,14 +998,14 @@ mod tests {
     assert_eq!(esc(&b"ab\\\"12"[..]), Ok((&b"12"[..], &b"ab\\\""[..])));
     assert_eq!(
       esc(&b"AB\\"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"AB\\"[..],
         ErrorKind::Escaped
       )))
     );
     assert_eq!(
       esc(&b"AB\\A"[..]),
-      Err(ErrMode::Error(error_node_position!(
+      Err(ErrMode::Backtrack(error_node_position!(
         &b"AB\\A"[..],
         ErrorKind::Escaped,
         error_position!(&b"A"[..], ErrorKind::OneOf)
@@ -1030,11 +1033,14 @@ mod tests {
     assert_eq!(esc("ab\\\"12"), Ok(("12", "ab\\\"")));
     assert_eq!(
       esc("AB\\"),
-      Err(ErrMode::Error(error_position!("AB\\", ErrorKind::Escaped)))
+      Err(ErrMode::Backtrack(error_position!(
+        "AB\\",
+        ErrorKind::Escaped
+      )))
     );
     assert_eq!(
       esc("AB\\A"),
-      Err(ErrMode::Error(error_node_position!(
+      Err(ErrMode::Backtrack(error_node_position!(
         "AB\\A",
         ErrorKind::Escaped,
         error_position!("A", ErrorKind::OneOf)
@@ -1091,14 +1097,14 @@ mod tests {
     );
     assert_eq!(
       esc(&b"AB\\"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"\\"[..],
         ErrorKind::EscapedTransform
       )))
     );
     assert_eq!(
       esc(&b"AB\\A"[..]),
-      Err(ErrMode::Error(error_node_position!(
+      Err(ErrMode::Backtrack(error_node_position!(
         &b"AB\\A"[..],
         ErrorKind::EscapedTransform,
         error_position!(&b"A"[..], ErrorKind::Tag)
@@ -1150,14 +1156,14 @@ mod tests {
     assert_eq!(esc("ab\\\"12"), Ok(("12", String::from("ab\""))));
     assert_eq!(
       esc("AB\\"),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         "\\",
         ErrorKind::EscapedTransform
       )))
     );
     assert_eq!(
       esc("AB\\A"),
-      Err(ErrMode::Error(error_node_position!(
+      Err(ErrMode::Backtrack(error_node_position!(
         "AB\\A",
         ErrorKind::EscapedTransform,
         error_position!("A", ErrorKind::Tag)

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -9,7 +9,7 @@ use crate::input::{
   FindSlice, Input, Offset, SliceLen, ToUsize,
 };
 use crate::lib::std::result::Result::Ok;
-use crate::{Err, IResult, Parser};
+use crate::{ErrMode, IResult, Parser};
 
 pub(crate) fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Input>::Token, E>
 where
@@ -17,7 +17,7 @@ where
 {
   input
     .next_token()
-    .ok_or_else(|| Err::Error(E::from_error_kind(input, ErrorKind::Eof)))
+    .ok_or_else(|| ErrMode::Error(E::from_error_kind(input, ErrorKind::Eof)))
 }
 
 /// Recognizes a pattern
@@ -25,10 +25,10 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// It will return `Err(ErrMode::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -36,8 +36,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::tag`][crate::bytes::tag]
@@ -65,7 +65,7 @@ where
     CompareResult::Ok => Ok(i.next_slice(tag_len)),
     CompareResult::Incomplete | CompareResult::Error => {
       let e: ErrorKind = ErrorKind::Tag;
-      Err(Err::Error(Error::from_error_kind(i, e)))
+      Err(ErrMode::Error(Error::from_error_kind(i, e)))
     }
   }
 }
@@ -75,10 +75,10 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument with no regard to case.
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern.
+/// It will return `Err(ErrMode::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::tag_no_case;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -88,8 +88,8 @@ where
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
 /// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::tag_no_case`][crate::bytes::tag_no_case]
@@ -118,7 +118,7 @@ where
     CompareResult::Ok => Ok(i.next_slice(tag_len)),
     CompareResult::Incomplete | CompareResult::Error => {
       let e: ErrorKind = ErrorKind::Tag;
-      Err(Err::Error(Error::from_error_kind(i, e)))
+      Err(ErrMode::Error(Error::from_error_kind(i, e)))
     }
   }
 }
@@ -135,7 +135,7 @@ where
   input
     .next_token()
     .filter(|(_, t)| list.contains_token(*t))
-    .ok_or_else(|| Err::Error(E::from_error_kind(input, ErrorKind::OneOf)))
+    .ok_or_else(|| ErrMode::Error(E::from_error_kind(input, ErrorKind::OneOf)))
 }
 
 pub(crate) fn none_of_internal<I, T, E: ParseError<I>>(
@@ -150,7 +150,7 @@ where
   input
     .next_token()
     .filter(|(_, t)| !list.contains_token(*t))
-    .ok_or_else(|| Err::Error(E::from_error_kind(input, ErrorKind::NoneOf)))
+    .ok_or_else(|| ErrMode::Error(E::from_error_kind(input, ErrorKind::NoneOf)))
 }
 
 /// Parse till certain characters are met.
@@ -159,10 +159,10 @@ where
 ///
 /// It doesn't consume the matched character.
 ///
-/// It will return a `Err::Error(("", ErrorKind::IsNot))` if the pattern wasn't met.
+/// It will return a `ErrMode::Error(("", ErrorKind::IsNot))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::is_not;
 ///
 /// fn not_space(s: &str) -> IResult<&str, &str> {
@@ -172,7 +172,7 @@ where
 /// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
 /// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
 /// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
-/// assert_eq!(not_space(""), Err(Err::Error(Error::new("", ErrorKind::IsNot))));
+/// assert_eq!(not_space(""), Err(ErrMode::Error(Error::new("", ErrorKind::IsNot))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_till1`][crate::bytes::take_till1]
@@ -204,10 +204,10 @@ where
 /// The parser will return the longest slice consisting of the characters in provided in the
 /// combinator's argument.
 ///
-/// It will return a `Err(Err::Error((_, ErrorKind::IsA)))` if the pattern wasn't met.
+/// It will return a `Err(ErrMode::Error((_, ErrorKind::IsA)))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::is_a;
 ///
 /// fn hex(s: &str) -> IResult<&str, &str> {
@@ -218,7 +218,7 @@ where
 /// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
 /// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
 /// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
-/// assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::IsA))));
+/// assert_eq!(hex(""), Err(ErrMode::Error(Error::new("", ErrorKind::IsA))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while1`][crate::bytes::take_while1`]
@@ -251,7 +251,7 @@ where
 /// takes the input and returns a bool)*.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::bytes::complete::take_while;
 /// use winnow::input::AsChar;
 ///
@@ -293,10 +293,10 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
+/// It will return an `Err(ErrMode::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::take_while1;
 /// use winnow::input::AsChar;
 ///
@@ -306,7 +306,7 @@ where
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// assert_eq!(alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while1`][crate::bytes::take_while1]
@@ -338,11 +338,11 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return an `Err::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
+/// It will return an `ErrMode::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
 /// of range (m <= len <= n).
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::take_while_m_n;
 /// use winnow::input::AsChar;
 ///
@@ -353,8 +353,8 @@ where
 /// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
 /// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"ed"), Err(Err::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
-/// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while_m_n`][crate::bytes::take_while_m_n]
@@ -391,7 +391,7 @@ where
           let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(idx) {
             Ok(input.next_slice(index))
           } else {
-            Err(Err::Error(Error::from_error_kind(
+            Err(ErrMode::Error(Error::from_error_kind(
               input,
               ErrorKind::TakeWhileMN,
             )))
@@ -401,7 +401,7 @@ where
           let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(n) {
             Ok(input.next_slice(index))
           } else {
-            Err(Err::Error(Error::from_error_kind(
+            Err(ErrMode::Error(Error::from_error_kind(
               input,
               ErrorKind::TakeWhileMN,
             )))
@@ -410,7 +410,7 @@ where
         }
       } else {
         let e = ErrorKind::TakeWhileMN;
-        Err(Err::Error(Error::from_error_kind(input, e)))
+        Err(ErrMode::Error(Error::from_error_kind(input, e)))
       }
     }
     None => {
@@ -418,7 +418,7 @@ where
       if len >= n {
         match input.offset_at(n) {
           Ok(index) => Ok(input.next_slice(index)),
-          Err(_needed) => Err(Err::Error(Error::from_error_kind(
+          Err(_needed) => Err(ErrMode::Error(Error::from_error_kind(
             input,
             ErrorKind::TakeWhileMN,
           ))),
@@ -427,7 +427,7 @@ where
         Ok(input.next_slice(len))
       } else {
         let e = ErrorKind::TakeWhileMN;
-        Err(Err::Error(Error::from_error_kind(input, e)))
+        Err(ErrMode::Error(Error::from_error_kind(input, e)))
       }
     }
   }
@@ -439,7 +439,7 @@ where
 /// takes the input and returns a bool)*.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::bytes::complete::take_till;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -481,11 +481,11 @@ where
 /// The parser will return the longest slice till the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::TakeTill1)))` if the input is empty or the
+/// It will return `Err(ErrMode::Error((_, ErrorKind::TakeTill1)))` if the input is empty or the
 /// predicate matches the first input.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::take_till1;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -493,9 +493,9 @@ where
 /// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Err(Err::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(":empty matched"), Err(ErrMode::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
-/// assert_eq!(till_colon(""), Err(Err::Error(Error::new("", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeTill1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_till1`][crate::bytes::take_till1]
@@ -525,10 +525,10 @@ where
 
 /// Returns an input slice containing the first N input elements (I[..N]).
 ///
-/// It will return `Err(Err::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument.
+/// It will return `Err(ErrMode::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::take;
 ///
 /// fn take6(s: &str) -> IResult<&str, &str> {
@@ -537,8 +537,8 @@ where
 ///
 /// assert_eq!(take6("1234567"), Ok(("7", "123456")));
 /// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(Err::Error(Error::new("short", ErrorKind::Eof))));
-/// assert_eq!(take6(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(take6("short"), Err(ErrMode::Error(Error::new("short", ErrorKind::Eof))));
+/// assert_eq!(take6(""), Err(ErrMode::Error(Error::new("", ErrorKind::Eof))));
 /// ```
 ///
 /// The units that are taken will depend on the input type. For example, for a
@@ -575,17 +575,17 @@ where
 {
   match i.offset_at(c) {
     Ok(offset) => Ok(i.next_slice(offset)),
-    Err(_needed) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::Eof))),
+    Err(_needed) => Err(ErrMode::Error(Error::from_error_kind(i, ErrorKind::Eof))),
   }
 }
 
 /// Returns the input slice up to the first occurrence of the pattern.
 ///
-/// It doesn't consume the pattern. It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
+/// It doesn't consume the pattern. It will return `Err(ErrMode::Error((_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::take_until;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -593,8 +593,8 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
 ///
@@ -620,17 +620,20 @@ where
 {
   match i.find_slice(t) {
     Some(offset) => Ok(i.next_slice(offset)),
-    None => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
+    None => Err(ErrMode::Error(Error::from_error_kind(
+      i,
+      ErrorKind::TakeUntil,
+    ))),
   }
 }
 
 /// Returns the non empty input slice up to the first occurrence of the pattern.
 ///
-/// It doesn't consume the pattern. It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
+/// It doesn't consume the pattern. It will return `Err(ErrMode::Error((_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::complete::take_until1;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -638,10 +641,10 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"), Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("eof"), Err(ErrMode::Error(Error::new("eof", ErrorKind::TakeUntil))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_until1`][crate::bytes::take_until1]
@@ -665,7 +668,10 @@ where
   T: SliceLen,
 {
   match i.find_slice(t) {
-    None | Some(0) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
+    None | Some(0) => Err(ErrMode::Error(Error::from_error_kind(
+      i,
+      ErrorKind::TakeUntil,
+    ))),
     Some(offset) => Ok(i.next_slice(offset)),
   }
 }
@@ -677,7 +683,7 @@ where
 /// * The third argument matches the escaped characters
 /// # Example
 /// ```
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// # use winnow::character::complete::digit1;
 /// use winnow::bytes::complete::escaped;
 /// use winnow::character::complete::one_of;
@@ -741,11 +747,11 @@ where
           i = i2;
         }
       }
-      Err(Err::Error(_)) => {
+      Err(ErrMode::Error(_)) => {
         if i.next_token().expect("input_len > 0").1.as_char() == control_char {
           let next = control_char.len_utf8();
           if next >= i.input_len() {
-            return Err(Err::Error(Error::from_error_kind(
+            return Err(ErrMode::Error(Error::from_error_kind(
               input,
               ErrorKind::Escaped,
             )));
@@ -764,7 +770,7 @@ where
         } else {
           let offset = input.offset_to(&i);
           if offset == 0 {
-            return Err(Err::Error(Error::from_error_kind(
+            return Err(ErrMode::Error(Error::from_error_kind(
               input,
               ErrorKind::Escaped,
             )));
@@ -790,7 +796,7 @@ where
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// # use std::str::from_utf8;
 /// use winnow::bytes::complete::{escaped_transform, tag};
 /// use winnow::character::complete::alpha1;
@@ -875,13 +881,13 @@ where
           offset = input.offset_to(&i2);
         }
       }
-      Err(Err::Error(_)) => {
+      Err(ErrMode::Error(_)) => {
         if remainder.next_token().expect("input_len > 0").1.as_char() == control_char {
           let next = offset + control_char.len_utf8();
           let input_len = input.input_len();
 
           if next >= input_len {
-            return Err(Err::Error(Error::from_error_kind(
+            return Err(ErrMode::Error(Error::from_error_kind(
               remainder,
               ErrorKind::EscapedTransform,
             )));
@@ -900,7 +906,7 @@ where
           }
         } else {
           if offset == 0 {
-            return Err(Err::Error(Error::from_error_kind(
+            return Err(ErrMode::Error(Error::from_error_kind(
               remainder,
               ErrorKind::EscapedTransform,
             )));
@@ -988,14 +994,14 @@ mod tests {
     assert_eq!(esc(&b"ab\\\"12"[..]), Ok((&b"12"[..], &b"ab\\\""[..])));
     assert_eq!(
       esc(&b"AB\\"[..]),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         &b"AB\\"[..],
         ErrorKind::Escaped
       )))
     );
     assert_eq!(
       esc(&b"AB\\A"[..]),
-      Err(Err::Error(error_node_position!(
+      Err(ErrMode::Error(error_node_position!(
         &b"AB\\A"[..],
         ErrorKind::Escaped,
         error_position!(&b"A"[..], ErrorKind::OneOf)
@@ -1023,11 +1029,11 @@ mod tests {
     assert_eq!(esc("ab\\\"12"), Ok(("12", "ab\\\"")));
     assert_eq!(
       esc("AB\\"),
-      Err(Err::Error(error_position!("AB\\", ErrorKind::Escaped)))
+      Err(ErrMode::Error(error_position!("AB\\", ErrorKind::Escaped)))
     );
     assert_eq!(
       esc("AB\\A"),
-      Err(Err::Error(error_node_position!(
+      Err(ErrMode::Error(error_node_position!(
         "AB\\A",
         ErrorKind::Escaped,
         error_position!("A", ErrorKind::OneOf)
@@ -1084,14 +1090,14 @@ mod tests {
     );
     assert_eq!(
       esc(&b"AB\\"[..]),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         &b"\\"[..],
         ErrorKind::EscapedTransform
       )))
     );
     assert_eq!(
       esc(&b"AB\\A"[..]),
-      Err(Err::Error(error_node_position!(
+      Err(ErrMode::Error(error_node_position!(
         &b"AB\\A"[..],
         ErrorKind::EscapedTransform,
         error_position!(&b"A"[..], ErrorKind::Tag)
@@ -1143,14 +1149,14 @@ mod tests {
     assert_eq!(esc("ab\\\"12"), Ok(("12", String::from("ab\""))));
     assert_eq!(
       esc("AB\\"),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         "\\",
         ErrorKind::EscapedTransform
       )))
     );
     assert_eq!(
       esc("AB\\A"),
-      Err(Err::Error(error_node_position!(
+      Err(ErrMode::Error(error_node_position!(
         "AB\\A",
         ErrorKind::EscapedTransform,
         error_position!("A", ErrorKind::Tag)

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -24,7 +24,7 @@ use crate::IResult;
 /// }
 ///
 /// assert_eq!(parser("abc"), Ok(("bc",'a')));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Eof))));
 /// ```
 ///
 /// ```
@@ -53,7 +53,7 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument
 ///
-/// It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// It will return `Err(ErrMode::Backtrack(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern
 ///
 /// **Note:** [`Parser`][crate::Parser] is implemented for strings and byte strings as a convenience (complete
 /// only)
@@ -69,8 +69,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Backtrack(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// ```rust
@@ -83,8 +83,8 @@ where
 /// }
 ///
 /// assert_eq!(parser(Streaming("Hello, World!")), Ok((Streaming(", World!"), "Hello")));
-/// assert_eq!(parser(Streaming("Something")), Err(ErrMode::Error(Error::new(Streaming("Something"), ErrorKind::Tag))));
-/// assert_eq!(parser(Streaming("S")), Err(ErrMode::Error(Error::new(Streaming("S"), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming("Something")), Err(ErrMode::Backtrack(Error::new(Streaming("Something"), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming("S")), Err(ErrMode::Backtrack(Error::new(Streaming("S"), ErrorKind::Tag))));
 /// assert_eq!(parser(Streaming("H")), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
@@ -111,7 +111,7 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument with no regard to case.
 ///
-/// It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern.
+/// It will return `Err(ErrMode::Backtrack(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern.
 /// # Example
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
@@ -124,8 +124,8 @@ where
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
 /// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Backtrack(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// ```rust
@@ -140,7 +140,7 @@ where
 /// assert_eq!(parser(Streaming("Hello, World!")), Ok((Streaming(", World!"), "Hello")));
 /// assert_eq!(parser(Streaming("hello, World!")), Ok((Streaming(", World!"), "hello")));
 /// assert_eq!(parser(Streaming("HeLlO, World!")), Ok((Streaming(", World!"), "HeLlO")));
-/// assert_eq!(parser(Streaming("Something")), Err(ErrMode::Error(Error::new(Streaming("Something"), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming("Something")), Err(ErrMode::Backtrack(Error::new(Streaming("Something"), ErrorKind::Tag))));
 /// assert_eq!(parser(Streaming("")), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
@@ -180,15 +180,15 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::bytes::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>, false>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>, false>("a")("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, Error<_>, false>("a")(""), Err(ErrMode::Error(Error::new("", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>, false>("a")("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>, false>("a")(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::OneOf))));
 ///
 /// fn parser_fn(i: &str) -> IResult<&str, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
 /// }
 /// assert_eq!(parser_fn("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser_fn("cd"), Err(ErrMode::Error(Error::new("cd", ErrorKind::OneOf))));
-/// assert_eq!(parser_fn(""), Err(ErrMode::Error(Error::new("", ErrorKind::OneOf))));
+/// assert_eq!(parser_fn("cd"), Err(ErrMode::Backtrack(Error::new("cd", ErrorKind::OneOf))));
+/// assert_eq!(parser_fn(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::OneOf))));
 /// ```
 ///
 /// ```
@@ -197,14 +197,14 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::bytes::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>, true>("abc")(Streaming("b")), Ok((Streaming(""), 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Streaming("bc")), Err(ErrMode::Error(Error::new(Streaming("bc"), ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Streaming("bc")), Err(ErrMode::Backtrack(Error::new(Streaming("bc"), ErrorKind::OneOf))));
 /// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn parser_fn(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
 /// }
 /// assert_eq!(parser_fn(Streaming("abc")), Ok((Streaming("bc"), 'a')));
-/// assert_eq!(parser_fn(Streaming("cd")), Err(ErrMode::Error(Error::new(Streaming("cd"), ErrorKind::OneOf))));
+/// assert_eq!(parser_fn(Streaming("cd")), Err(ErrMode::Backtrack(Error::new(Streaming("cd"), ErrorKind::OneOf))));
 /// assert_eq!(parser_fn(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -238,8 +238,8 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::bytes::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>, false>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>, false>("ab")("a"), Err(ErrMode::Error(Error::new("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, Error<_>, false>("a")(""), Err(ErrMode::Error(Error::new("", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>, false>("ab")("a"), Err(ErrMode::Backtrack(Error::new("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>, false>("a")(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::NoneOf))));
 /// ```
 ///
 /// ```
@@ -247,7 +247,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::bytes::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>, true>("abc")(Streaming("z")), Ok((Streaming(""), 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>, true>("ab")(Streaming("a")), Err(ErrMode::Error(Error::new(Streaming("a"), ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>, true>("ab")(Streaming("a")), Err(ErrMode::Backtrack(Error::new(Streaming("a"), ErrorKind::NoneOf))));
 /// assert_eq!(none_of::<_, _, Error<_>, true>("a")(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -323,7 +323,7 @@ where
 
 /// Returns the longest (at least 1) input slice that matches the [pattern][ContainsToken]
 ///
-/// It will return an `Err(ErrMode::Error(Error::new(_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
+/// It will return an `Err(ErrMode::Backtrack(Error::new(_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 ///
 /// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
 ///
@@ -339,7 +339,7 @@ where
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// assert_eq!(alpha(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
 ///
 /// fn hex(s: &str) -> IResult<&str, &str> {
 ///   take_while1("1234567890ABCDEF")(s)
@@ -349,7 +349,7 @@ where
 /// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
 /// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
 /// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
-/// assert_eq!(hex(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeWhile1))));
+/// assert_eq!(hex(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::TakeWhile1))));
 /// ```
 ///
 /// ```rust
@@ -364,7 +364,7 @@ where
 ///
 /// assert_eq!(alpha(Streaming(b"latin123")), Ok((Streaming(&b"123"[..]), &b"latin"[..])));
 /// assert_eq!(alpha(Streaming(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(Streaming(b"12345")), Err(ErrMode::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhile1))));
+/// assert_eq!(alpha(Streaming(b"12345")), Err(ErrMode::Backtrack(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhile1))));
 ///
 /// fn hex(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
 ///   take_while1("1234567890ABCDEF")(s)
@@ -396,7 +396,7 @@ where
 
 /// Returns the longest (m <= len <= n) input slice that matches the [pattern][ContainsToken]
 ///
-/// It will return an `ErrMode::Error(Error::new(_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
+/// It will return an `ErrMode::Backtrack(Error::new(_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
 /// of range (m <= len <= n).
 ///
 /// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
@@ -414,8 +414,8 @@ where
 /// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
 /// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
-/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Backtrack(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
 /// ```
 ///
 /// ```rust
@@ -432,7 +432,7 @@ where
 /// assert_eq!(short_alpha(Streaming(b"lengthy")), Ok((Streaming(&b"y"[..]), &b"length"[..])));
 /// assert_eq!(short_alpha(Streaming(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(short_alpha(Streaming(b"ed")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(Streaming(b"12345")), Err(ErrMode::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(Streaming(b"12345")), Err(ErrMode::Backtrack(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhileMN))));
 /// ```
 #[inline(always)]
 pub fn take_while_m_n<T, I, Error: ParseError<I>, const STREAMING: bool>(
@@ -508,7 +508,7 @@ where
 
 /// Returns the longest (at least 1) input slice till a [pattern][ContainsToken] is met.
 ///
-/// It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::TakeTill1)))` if the input is empty or the
+/// It will return `Err(ErrMode::Backtrack(Error::new(_, ErrorKind::TakeTill1)))` if the input is empty or the
 /// predicate matches the first input.
 ///
 /// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` if the match reaches the
@@ -524,9 +524,9 @@ where
 /// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Err(ErrMode::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(":empty matched"), Err(ErrMode::Backtrack(Error::new(":empty matched", ErrorKind::TakeTill1))));
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
-/// assert_eq!(till_colon(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::TakeTill1))));
 ///
 /// fn not_space(s: &str) -> IResult<&str, &str> {
 ///   take_till1(" \t\r\n")(s)
@@ -535,7 +535,7 @@ where
 /// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
 /// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
 /// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
-/// assert_eq!(not_space(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeTill1))));
+/// assert_eq!(not_space(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::TakeTill1))));
 /// ```
 ///
 /// ```rust
@@ -548,7 +548,7 @@ where
 /// }
 ///
 /// assert_eq!(till_colon(Streaming("latin:123")), Ok((Streaming(":123"), "latin")));
-/// assert_eq!(till_colon(Streaming(":empty matched")), Err(ErrMode::Error(Error::new(Streaming(":empty matched"), ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(Streaming(":empty matched")), Err(ErrMode::Backtrack(Error::new(Streaming(":empty matched"), ErrorKind::TakeTill1))));
 /// assert_eq!(till_colon(Streaming("12345")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(till_colon(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
@@ -581,7 +581,7 @@ where
 
 /// Returns an input slice containing the first N input elements (I[..N]).
 ///
-/// *Complete version*: It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::Eof)))` if the input is shorter than the argument.
+/// *Complete version*: It will return `Err(ErrMode::Backtrack(Error::new(_, ErrorKind::Eof)))` if the input is shorter than the argument.
 ///
 /// *Streaming version*: if the input has less than N elements, `take` will
 /// return a `ErrMode::Incomplete(Needed::new(M))` where M is the number of
@@ -601,8 +601,8 @@ where
 ///
 /// assert_eq!(take6("1234567"), Ok(("7", "123456")));
 /// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(ErrMode::Error(Error::new("short", ErrorKind::Eof))));
-/// assert_eq!(take6(""), Err(ErrMode::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(take6("short"), Err(ErrMode::Backtrack(Error::new("short", ErrorKind::Eof))));
+/// assert_eq!(take6(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Eof))));
 /// ```
 ///
 /// The units that are taken will depend on the input type. For example, for a
@@ -654,7 +654,7 @@ where
 ///
 /// It doesn't consume the pattern.
 ///
-/// *Complete version*: It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::TakeUntil)))`
+/// *Complete version*: It will return `Err(ErrMode::Backtrack(Error::new(_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 ///
 /// *Streaming version*: will return a `ErrMode::Incomplete(Needed::new(N))` if the input doesn't
@@ -669,8 +669,8 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Backtrack(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
 ///
@@ -710,7 +710,7 @@ where
 ///
 /// It doesn't consume the pattern.
 ///
-/// *Complete version*: It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::TakeUntil)))`
+/// *Complete version*: It will return `Err(ErrMode::Backtrack(Error::new(_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 ///
 /// *Streaming version*: will return a `ErrMode::Incomplete(Needed::new(N))` if the input doesn't
@@ -726,10 +726,10 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Backtrack(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"), Err(ErrMode::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("eof"), Err(ErrMode::Backtrack(Error::new("eof", ErrorKind::TakeUntil))));
 /// ```
 ///
 /// ```rust
@@ -745,7 +745,7 @@ where
 /// assert_eq!(until_eof(Streaming("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(until_eof(Streaming("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(until_eof(Streaming("1eof2eof")), Ok((Streaming("eof2eof"), "1")));
-/// assert_eq!(until_eof(Streaming("eof")),  Err(ErrMode::Error(Error::new(Streaming("eof"), ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(Streaming("eof")),  Err(ErrMode::Backtrack(Error::new(Streaming("eof"), ErrorKind::TakeUntil))));
 /// ```
 #[inline(always)]
 pub fn take_until1<T, I, Error: ParseError<I>, const STREAMING: bool>(

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -13,25 +13,25 @@ use crate::IResult;
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{bytes::any, Err, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{bytes::any, ErrMode, error::{Error, ErrorKind}, IResult};
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     any(input)
 /// }
 ///
 /// assert_eq!(parser("abc"), Ok(("bc",'a')));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Eof))));
 /// ```
 ///
 /// ```
-/// # use winnow::{bytes::any, Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{bytes::any, ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// assert_eq!(any::<_, Error<_>, true>(Streaming("abc")), Ok((Streaming("bc"),'a')));
-/// assert_eq!(any::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(any::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn any<I, E: ParseError<I>, const STREAMING: bool>(
@@ -53,7 +53,7 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument
 ///
-/// It will return `Err(Err::Error(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern
 ///
 /// **Note:** [`Parser`][crate::Parser] is implemented for strings and byte strings as a convenience (complete
 /// only)
@@ -61,7 +61,7 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed};
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -69,12 +69,12 @@ where
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::tag;
 ///
@@ -83,9 +83,9 @@ where
 /// }
 ///
 /// assert_eq!(parser(Streaming("Hello, World!")), Ok((Streaming(", World!"), "Hello")));
-/// assert_eq!(parser(Streaming("Something")), Err(Err::Error(Error::new(Streaming("Something"), ErrorKind::Tag))));
-/// assert_eq!(parser(Streaming("S")), Err(Err::Error(Error::new(Streaming("S"), ErrorKind::Tag))));
-/// assert_eq!(parser(Streaming("H")), Err(Err::Incomplete(Needed::new(4))));
+/// assert_eq!(parser(Streaming("Something")), Err(ErrMode::Error(Error::new(Streaming("Something"), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming("S")), Err(ErrMode::Error(Error::new(Streaming("S"), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming("H")), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
 pub fn tag<T, I, Error: ParseError<I>, const STREAMING: bool>(
@@ -111,10 +111,10 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument with no regard to case.
 ///
-/// It will return `Err(Err::Error(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern.
+/// It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::tag_no_case;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -124,12 +124,12 @@ where
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
 /// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::tag_no_case;
 ///
@@ -140,8 +140,8 @@ where
 /// assert_eq!(parser(Streaming("Hello, World!")), Ok((Streaming(", World!"), "Hello")));
 /// assert_eq!(parser(Streaming("hello, World!")), Ok((Streaming(", World!"), "hello")));
 /// assert_eq!(parser(Streaming("HeLlO, World!")), Ok((Streaming(", World!"), "HeLlO")));
-/// assert_eq!(parser(Streaming("Something")), Err(Err::Error(Error::new(Streaming("Something"), ErrorKind::Tag))));
-/// assert_eq!(parser(Streaming("")), Err(Err::Incomplete(Needed::new(5))));
+/// assert_eq!(parser(Streaming("Something")), Err(ErrMode::Error(Error::new(Streaming("Something"), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming("")), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
 pub fn tag_no_case<T, I, Error: ParseError<I>, const STREAMING: bool>(
@@ -171,41 +171,41 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
 /// # use winnow::*;
-/// # use winnow::{Err, error::ErrorKind, error::Error};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::bytes::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>, false>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>, false>("a")("bc"), Err(Err::Error(Error::new("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, Error<_>, false>("a")(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>, false>("a")("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>, false>("a")(""), Err(ErrMode::Error(Error::new("", ErrorKind::OneOf))));
 ///
 /// fn parser_fn(i: &str) -> IResult<&str, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
 /// }
 /// assert_eq!(parser_fn("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser_fn("cd"), Err(Err::Error(Error::new("cd", ErrorKind::OneOf))));
-/// assert_eq!(parser_fn(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// assert_eq!(parser_fn("cd"), Err(ErrMode::Error(Error::new("cd", ErrorKind::OneOf))));
+/// assert_eq!(parser_fn(""), Err(ErrMode::Error(Error::new("", ErrorKind::OneOf))));
 /// ```
 ///
 /// ```
 /// # use winnow::*;
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::bytes::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>, true>("abc")(Streaming("b")), Ok((Streaming(""), 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Streaming("bc")), Err(Err::Error(Error::new(Streaming("bc"), ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Streaming("bc")), Err(ErrMode::Error(Error::new(Streaming("bc"), ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn parser_fn(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
 /// }
 /// assert_eq!(parser_fn(Streaming("abc")), Ok((Streaming("bc"), 'a')));
-/// assert_eq!(parser_fn(Streaming("cd")), Err(Err::Error(Error::new(Streaming("cd"), ErrorKind::OneOf))));
-/// assert_eq!(parser_fn(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser_fn(Streaming("cd")), Err(ErrMode::Error(Error::new(Streaming("cd"), ErrorKind::OneOf))));
+/// assert_eq!(parser_fn(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn one_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
@@ -230,25 +230,25 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::bytes::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>, false>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>, false>("ab")("a"), Err(Err::Error(Error::new("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, Error<_>, false>("a")(""), Err(Err::Error(Error::new("", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>, false>("ab")("a"), Err(ErrMode::Error(Error::new("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>, false>("a")(""), Err(ErrMode::Error(Error::new("", ErrorKind::NoneOf))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::bytes::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>, true>("abc")(Streaming("z")), Ok((Streaming(""), 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>, true>("ab")(Streaming("a")), Err(Err::Error(Error::new(Streaming("a"), ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, Error<_>, true>("a")(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(none_of::<_, _, Error<_>, true>("ab")(Streaming("a")), Err(ErrMode::Error(Error::new(Streaming("a"), ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>, true>("a")(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn none_of<I, T, Error: ParseError<I>, const STREAMING: bool>(
@@ -271,10 +271,10 @@ where
 
 /// Returns the longest input slice (if any) that matches the [pattern][ContainsToken]
 ///
-/// *Streaming version*: will return a `Err::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
+/// *Streaming version*: will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
 /// use winnow::bytes::take_while;
 /// use winnow::input::AsChar;
 ///
@@ -289,7 +289,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_while;
 /// use winnow::input::AsChar;
@@ -300,8 +300,8 @@ where
 ///
 /// assert_eq!(alpha(Streaming(b"latin123")), Ok((Streaming(&b"123"[..]), &b"latin"[..])));
 /// assert_eq!(alpha(Streaming(b"12345")), Ok((Streaming(&b"12345"[..]), &b""[..])));
-/// assert_eq!(alpha(Streaming(b"latin")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(Streaming(b"")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(Streaming(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(Streaming(b"")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn take_while<T, I, Error: ParseError<I>, const STREAMING: bool>(
@@ -323,13 +323,13 @@ where
 
 /// Returns the longest (at least 1) input slice that matches the [pattern][ContainsToken]
 ///
-/// It will return an `Err(Err::Error(Error::new(_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
+/// It will return an `Err(ErrMode::Error(Error::new(_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 ///
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::take_while1;
 /// use winnow::input::AsChar;
 ///
@@ -339,7 +339,7 @@ where
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// assert_eq!(alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
 ///
 /// fn hex(s: &str) -> IResult<&str, &str> {
 ///   take_while1("1234567890ABCDEF")(s)
@@ -349,11 +349,11 @@ where
 /// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
 /// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
 /// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
-/// assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::TakeWhile1))));
+/// assert_eq!(hex(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeWhile1))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_while1;
 /// use winnow::input::AsChar;
@@ -363,8 +363,8 @@ where
 /// }
 ///
 /// assert_eq!(alpha(Streaming(b"latin123")), Ok((Streaming(&b"123"[..]), &b"latin"[..])));
-/// assert_eq!(alpha(Streaming(b"latin")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(Streaming(b"12345")), Err(Err::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhile1))));
+/// assert_eq!(alpha(Streaming(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(Streaming(b"12345")), Err(ErrMode::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhile1))));
 ///
 /// fn hex(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
 ///   take_while1("1234567890ABCDEF")(s)
@@ -373,8 +373,8 @@ where
 /// assert_eq!(hex(Streaming("123 and voila")), Ok((Streaming(" and voila"), "123")));
 /// assert_eq!(hex(Streaming("DEADBEEF and others")), Ok((Streaming(" and others"), "DEADBEEF")));
 /// assert_eq!(hex(Streaming("BADBABEsomething")), Ok((Streaming("something"), "BADBABE")));
-/// assert_eq!(hex(Streaming("D15EA5E")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(hex(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex(Streaming("D15EA5E")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn take_while1<T, I, Error: ParseError<I>, const STREAMING: bool>(
@@ -396,14 +396,14 @@ where
 
 /// Returns the longest (m <= len <= n) input slice that matches the [pattern][ContainsToken]
 ///
-/// It will return an `Err::Error(Error::new(_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
+/// It will return an `ErrMode::Error(Error::new(_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
 /// of range (m <= len <= n).
 ///
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::take_while_m_n;
 /// use winnow::input::AsChar;
 ///
@@ -414,12 +414,12 @@ where
 /// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
 /// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"ed"), Err(Err::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
-/// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_while_m_n;
 /// use winnow::input::AsChar;
@@ -430,9 +430,9 @@ where
 ///
 /// assert_eq!(short_alpha(Streaming(b"latin123")), Ok((Streaming(&b"123"[..]), &b"latin"[..])));
 /// assert_eq!(short_alpha(Streaming(b"lengthy")), Ok((Streaming(&b"y"[..]), &b"length"[..])));
-/// assert_eq!(short_alpha(Streaming(b"latin")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(Streaming(b"ed")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(Streaming(b"12345")), Err(Err::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(Streaming(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(Streaming(b"ed")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(Streaming(b"12345")), Err(ErrMode::Error(Error::new(Streaming(&b"12345"[..]), ErrorKind::TakeWhileMN))));
 /// ```
 #[inline(always)]
 pub fn take_while_m_n<T, I, Error: ParseError<I>, const STREAMING: bool>(
@@ -456,12 +456,12 @@ where
 
 /// Returns the longest input slice (if any) till a [pattern][ContainsToken] is met.
 ///
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
 /// use winnow::bytes::take_till;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -475,7 +475,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_till;
 ///
@@ -485,8 +485,8 @@ where
 ///
 /// assert_eq!(till_colon(Streaming("latin:123")), Ok((Streaming(":123"), "latin")));
 /// assert_eq!(till_colon(Streaming(":empty matched")), Ok((Streaming(":empty matched"), ""))); //allowed
-/// assert_eq!(till_colon(Streaming("12345")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Streaming("12345")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn take_till<T, I, Error: ParseError<I>, const STREAMING: bool>(
@@ -508,15 +508,15 @@ where
 
 /// Returns the longest (at least 1) input slice till a [pattern][ContainsToken] is met.
 ///
-/// It will return `Err(Err::Error(Error::new(_, ErrorKind::TakeTill1)))` if the input is empty or the
+/// It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::TakeTill1)))` if the input is empty or the
 /// predicate matches the first input.
 ///
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::take_till1;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -524,9 +524,9 @@ where
 /// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Err(Err::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(":empty matched"), Err(ErrMode::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
 /// assert_eq!(till_colon("12345"), Ok(("", "12345")));
-/// assert_eq!(till_colon(""), Err(Err::Error(Error::new("", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeTill1))));
 ///
 /// fn not_space(s: &str) -> IResult<&str, &str> {
 ///   take_till1(" \t\r\n")(s)
@@ -535,11 +535,11 @@ where
 /// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
 /// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
 /// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
-/// assert_eq!(not_space(""), Err(Err::Error(Error::new("", ErrorKind::TakeTill1))));
+/// assert_eq!(not_space(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeTill1))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_till1;
 ///
@@ -548,9 +548,9 @@ where
 /// }
 ///
 /// assert_eq!(till_colon(Streaming("latin:123")), Ok((Streaming(":123"), "latin")));
-/// assert_eq!(till_colon(Streaming(":empty matched")), Err(Err::Error(Error::new(Streaming(":empty matched"), ErrorKind::TakeTill1))));
-/// assert_eq!(till_colon(Streaming("12345")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Streaming(":empty matched")), Err(ErrMode::Error(Error::new(Streaming(":empty matched"), ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(Streaming("12345")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn not_space(s: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
 ///   take_till1(" \t\r\n")(s)
@@ -558,8 +558,8 @@ where
 ///
 /// assert_eq!(not_space(Streaming("Hello, World!")), Ok((Streaming(" World!"), "Hello,")));
 /// assert_eq!(not_space(Streaming("Sometimes\t")), Ok((Streaming("\t"), "Sometimes")));
-/// assert_eq!(not_space(Streaming("Nospace")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(not_space(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(not_space(Streaming("Nospace")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(not_space(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn take_till1<T, I, Error: ParseError<I>, const STREAMING: bool>(
@@ -581,18 +581,18 @@ where
 
 /// Returns an input slice containing the first N input elements (I[..N]).
 ///
-/// *Complete version*: It will return `Err(Err::Error(Error::new(_, ErrorKind::Eof)))` if the input is shorter than the argument.
+/// *Complete version*: It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::Eof)))` if the input is shorter than the argument.
 ///
 /// *Streaming version*: if the input has less than N elements, `take` will
-/// return a `Err::Incomplete(Needed::new(M))` where M is the number of
+/// return a `ErrMode::Incomplete(Needed::new(M))` where M is the number of
 /// additional bytes the parser would need to succeed.
 /// It is well defined for `&[u8]` as the number of elements is the byte size,
 /// but for types like `&str`, we cannot know how many bytes correspond for
-/// the next few chars, so the result will be `Err::Incomplete(Needed::Unknown)`
+/// the next few chars, so the result will be `ErrMode::Incomplete(Needed::Unknown)`
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::take;
 ///
 /// fn take6(s: &str) -> IResult<&str, &str> {
@@ -601,8 +601,8 @@ where
 ///
 /// assert_eq!(take6("1234567"), Ok(("7", "123456")));
 /// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(Err::Error(Error::new("short", ErrorKind::Eof))));
-/// assert_eq!(take6(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(take6("short"), Err(ErrMode::Error(Error::new("short", ErrorKind::Eof))));
+/// assert_eq!(take6(""), Err(ErrMode::Error(Error::new("", ErrorKind::Eof))));
 /// ```
 ///
 /// The units that are taken will depend on the input type. For example, for a
@@ -618,7 +618,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take;
 ///
@@ -629,7 +629,7 @@ where
 /// assert_eq!(take6(Streaming("1234567")), Ok((Streaming("7"), "123456")));
 /// assert_eq!(take6(Streaming("things")), Ok((Streaming(""), "things")));
 /// // `Unknown` as we don't know the number of bytes that `count` corresponds to
-/// assert_eq!(take6(Streaming("short")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(take6(Streaming("short")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 #[inline(always)]
 pub fn take<C, I, Error: ParseError<I>, const STREAMING: bool>(
@@ -654,14 +654,14 @@ where
 ///
 /// It doesn't consume the pattern.
 ///
-/// *Complete version*: It will return `Err(Err::Error(Error::new(_, ErrorKind::TakeUntil)))`
+/// *Complete version*: It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 ///
-/// *Streaming version*: will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
+/// *Streaming version*: will return a `ErrMode::Incomplete(Needed::new(N))` if the input doesn't
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::take_until;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -669,13 +669,13 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_until;
 ///
@@ -684,8 +684,8 @@ where
 /// }
 ///
 /// assert_eq!(until_eof(Streaming("hello, worldeof")), Ok((Streaming("eof"), "hello, world")));
-/// assert_eq!(until_eof(Streaming("hello, world")), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Streaming("hello, worldeo")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Streaming("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Streaming("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(until_eof(Streaming("1eof2eof")), Ok((Streaming("eof2eof"), "1")));
 /// ```
 #[inline(always)]
@@ -710,15 +710,15 @@ where
 ///
 /// It doesn't consume the pattern.
 ///
-/// *Complete version*: It will return `Err(Err::Error(Error::new(_, ErrorKind::TakeUntil)))`
+/// *Complete version*: It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 ///
-/// *Streaming version*: will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
+/// *Streaming version*: will return a `ErrMode::Incomplete(Needed::new(N))` if the input doesn't
 /// contain the pattern or if the input is smaller than the pattern.
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::take_until1;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -726,14 +726,14 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeUntil))));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"), Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("eof"), Err(ErrMode::Error(Error::new("eof", ErrorKind::TakeUntil))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_until1;
 ///
@@ -742,10 +742,10 @@ where
 /// }
 ///
 /// assert_eq!(until_eof(Streaming("hello, worldeof")), Ok((Streaming("eof"), "hello, world")));
-/// assert_eq!(until_eof(Streaming("hello, world")), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Streaming("hello, worldeo")), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Streaming("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Streaming("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(until_eof(Streaming("1eof2eof")), Ok((Streaming("eof2eof"), "1")));
-/// assert_eq!(until_eof(Streaming("eof")),  Err(Err::Error(Error::new(Streaming("eof"), ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(Streaming("eof")),  Err(ErrMode::Error(Error::new(Streaming("eof"), ErrorKind::TakeUntil))));
 /// ```
 #[inline(always)]
 pub fn take_until1<T, I, Error: ParseError<I>, const STREAMING: bool>(

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -13,12 +13,12 @@ use crate::IResult;
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{bytes::any, ErrMode, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{bytes::any, error::ErrMode, error::{Error, ErrorKind}, IResult};
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     any(input)
 /// }
@@ -28,7 +28,7 @@ use crate::IResult;
 /// ```
 ///
 /// ```
-/// # use winnow::{bytes::any, ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{bytes::any, error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// assert_eq!(any::<_, Error<_>, true>(Streaming("abc")), Ok((Streaming("bc"),'a')));
 /// assert_eq!(any::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -61,7 +61,7 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -74,7 +74,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::tag;
 ///
@@ -114,7 +114,7 @@ where
 /// It will return `Err(ErrMode::Error(Error::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::tag_no_case;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -129,7 +129,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::tag_no_case;
 ///
@@ -171,13 +171,13 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
 /// # use winnow::*;
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::bytes::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>, false>("abc")("b"), Ok(("", 'b')));
 /// assert_eq!(one_of::<_, _, Error<_>, false>("a")("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
@@ -193,7 +193,7 @@ where
 ///
 /// ```
 /// # use winnow::*;
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::bytes::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>, true>("abc")(Streaming("b")), Ok((Streaming(""), 'b')));
@@ -230,12 +230,12 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::bytes::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>, false>("abc")("z"), Ok(("", 'z')));
 /// assert_eq!(none_of::<_, _, Error<_>, false>("ab")("a"), Err(ErrMode::Error(Error::new("a", ErrorKind::NoneOf))));
@@ -243,7 +243,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::bytes::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>, true>("abc")(Streaming("z")), Ok((Streaming(""), 'z')));
@@ -274,7 +274,7 @@ where
 /// *Streaming version*: will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// use winnow::bytes::take_while;
 /// use winnow::input::AsChar;
 ///
@@ -289,7 +289,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_while;
 /// use winnow::input::AsChar;
@@ -329,7 +329,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::take_while1;
 /// use winnow::input::AsChar;
 ///
@@ -353,7 +353,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_while1;
 /// use winnow::input::AsChar;
@@ -403,7 +403,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::take_while_m_n;
 /// use winnow::input::AsChar;
 ///
@@ -419,7 +419,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_while_m_n;
 /// use winnow::input::AsChar;
@@ -461,7 +461,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// use winnow::bytes::take_till;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -475,7 +475,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_till;
 ///
@@ -516,7 +516,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::take_till1;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -539,7 +539,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_till1;
 ///
@@ -592,7 +592,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::take;
 ///
 /// fn take6(s: &str) -> IResult<&str, &str> {
@@ -618,7 +618,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take;
 ///
@@ -661,7 +661,7 @@ where
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::take_until;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -675,7 +675,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_until;
 ///
@@ -718,7 +718,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::take_until1;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -733,7 +733,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::take_until1;
 ///

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -9,7 +9,7 @@ use crate::input::{
   FindSlice, Input, Offset, SliceLen, ToUsize,
 };
 use crate::lib::std::result::Result::Ok;
-use crate::{Err, IResult, Needed, Parser};
+use crate::{ErrMode, IResult, Needed, Parser};
 
 pub(crate) fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Input>::Token, E>
 where
@@ -17,7 +17,7 @@ where
 {
   input
     .next_token()
-    .ok_or_else(|| Err::Incomplete(Needed::new(1)))
+    .ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))
 }
 
 /// Recognizes a pattern.
@@ -26,7 +26,7 @@ where
 /// the input that matches the argument.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::streaming::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -34,9 +34,9 @@ where
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser("S"), Err(Err::Error(Error::new("S", ErrorKind::Tag))));
-/// assert_eq!(parser("H"), Err(Err::Incomplete(Needed::new(4))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser("S"), Err(ErrMode::Error(Error::new("S", ErrorKind::Tag))));
+/// assert_eq!(parser("H"), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::tag`][crate::bytes::tag] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -65,10 +65,10 @@ where
   let tag_len = t.slice_len();
   match i.compare(t) {
     CompareResult::Ok => Ok(i.next_slice(tag_len)),
-    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
+    CompareResult::Incomplete => Err(ErrMode::Incomplete(Needed::new(tag_len - i.input_len()))),
     CompareResult::Error => {
       let e: ErrorKind = ErrorKind::Tag;
-      Err(Err::Error(Error::from_error_kind(i, e)))
+      Err(ErrMode::Error(Error::from_error_kind(i, e)))
     }
   }
 }
@@ -79,7 +79,7 @@ where
 /// the input that matches the argument with no regard to case.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::streaming::tag_no_case;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -89,8 +89,8 @@ where
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
 /// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(5))));
+/// assert_eq!(parser("Something"), Err(ErrMode::Error(Error::new("Something", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::tag_no_case`][crate::bytes::tag_no_case] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -120,10 +120,10 @@ where
 
   match (i).compare_no_case(t) {
     CompareResult::Ok => Ok(i.next_slice(tag_len)),
-    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(tag_len - i.input_len()))),
+    CompareResult::Incomplete => Err(ErrMode::Incomplete(Needed::new(tag_len - i.input_len()))),
     CompareResult::Error => {
       let e: ErrorKind = ErrorKind::Tag;
-      Err(Err::Error(Error::from_error_kind(i, e)))
+      Err(ErrMode::Error(Error::from_error_kind(i, e)))
     }
   }
 }
@@ -139,11 +139,11 @@ where
 {
   let (new_input, token) = input
     .next_token()
-    .ok_or_else(|| Err::Incomplete(Needed::new(1)))?;
+    .ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))?;
   if list.contains_token(token) {
     Ok((new_input, token))
   } else {
-    Err(Err::Error(E::from_error_kind(input, ErrorKind::OneOf)))
+    Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::OneOf)))
   }
 }
 
@@ -158,11 +158,11 @@ where
 {
   let (new_input, token) = input
     .next_token()
-    .ok_or_else(|| Err::Incomplete(Needed::new(1)))?;
+    .ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))?;
   if !list.contains_token(token) {
     Ok((new_input, token))
   } else {
-    Err(Err::Error(E::from_error_kind(input, ErrorKind::NoneOf)))
+    Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::NoneOf)))
   }
 }
 
@@ -172,10 +172,10 @@ where
 ///
 /// It doesn't consume the matched character.
 ///
-/// It will return a `Err::Incomplete(Needed::new(1))` if the pattern wasn't met.
+/// It will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::bytes::streaming::is_not;
 ///
 /// fn not_space(s: &str) -> IResult<&str, &str> {
@@ -184,8 +184,8 @@ where
 ///
 /// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
 /// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
-/// assert_eq!(not_space("Nospace"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(not_space(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(not_space("Nospace"), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(not_space(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_till1`][crate::bytes::take_till1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -221,11 +221,11 @@ where
 /// combinator's argument.
 ///
 /// # Streaming specific
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the pattern wasn't met
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern wasn't met
 /// or if the pattern reaches the end of the input.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::bytes::streaming::is_a;
 ///
 /// fn hex(s: &str) -> IResult<&str, &str> {
@@ -235,8 +235,8 @@ where
 /// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
 /// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
 /// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
-/// assert_eq!(hex("D15EA5E"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(hex(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex("D15EA5E"), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while1`][crate::bytes::take_while1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -272,10 +272,10 @@ where
 /// takes the input and returns a bool)*.
 ///
 /// # Streaming Specific
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::bytes::streaming::take_while;
 /// use winnow::input::AsChar;
 ///
@@ -285,8 +285,8 @@ where
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
-/// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(b""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(b"latin"), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(b""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while`][crate::bytes::take_while] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -320,14 +320,14 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
+/// It will return an `Err(ErrMode::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 ///
 /// # Streaming Specific
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::streaming::take_while1;
 /// use winnow::input::AsChar;
 ///
@@ -336,8 +336,8 @@ where
 /// }
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// assert_eq!(alpha(b"latin"), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while1`][crate::bytes::take_while1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -372,13 +372,13 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 ///
-/// It will return an `Err::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met.
+/// It will return an `ErrMode::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met.
 /// # Streaming Specific
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::streaming::take_while_m_n;
 /// use winnow::input::AsChar;
 ///
@@ -388,9 +388,9 @@ where
 ///
 /// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
-/// assert_eq!(short_alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(b"ed"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(b"latin"), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_while_m_n`][crate::bytes::take_while_m_n] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -429,7 +429,7 @@ where
           let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(idx) {
             Ok(input.next_slice(index))
           } else {
-            Err(Err::Error(Error::from_error_kind(
+            Err(ErrMode::Error(Error::from_error_kind(
               input,
               ErrorKind::TakeWhileMN,
             )))
@@ -439,7 +439,7 @@ where
           let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(n) {
             Ok(input.next_slice(index))
           } else {
-            Err(Err::Error(Error::from_error_kind(
+            Err(ErrMode::Error(Error::from_error_kind(
               input,
               ErrorKind::TakeWhileMN,
             )))
@@ -448,7 +448,7 @@ where
         }
       } else {
         let e = ErrorKind::TakeWhileMN;
-        Err(Err::Error(Error::from_error_kind(input, e)))
+        Err(ErrMode::Error(Error::from_error_kind(input, e)))
       }
     }
     None => {
@@ -456,14 +456,14 @@ where
       if len >= n {
         match input.offset_at(n) {
           Ok(index) => Ok(input.next_slice(index)),
-          Err(_needed) => Err(Err::Error(Error::from_error_kind(
+          Err(_needed) => Err(ErrMode::Error(Error::from_error_kind(
             input,
             ErrorKind::TakeWhileMN,
           ))),
         }
       } else {
         let needed = if m > len { m - len } else { 1 };
-        Err(Err::Incomplete(Needed::new(needed)))
+        Err(ErrMode::Incomplete(Needed::new(needed)))
       }
     }
   }
@@ -475,12 +475,12 @@ where
 /// takes the input and returns a bool)*.
 ///
 /// # Streaming Specific
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::bytes::streaming::take_till;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -489,8 +489,8 @@ where
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
 /// assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
-/// assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon("12345"), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_till`][crate::bytes::take_till] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -526,11 +526,11 @@ where
 /// takes the input and returns a bool)*.
 ///
 /// # Streaming Specific
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::streaming::take_till1;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -538,9 +538,9 @@ where
 /// }
 ///
 /// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Err(Err::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
-/// assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(":empty matched"), Err(ErrMode::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon("12345"), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_till1`][crate::bytes::take_till1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -575,15 +575,15 @@ where
 ///
 /// # Streaming Specific
 /// *Streaming version* if the input has less than N elements, `take` will
-/// return a `Err::Incomplete(Needed::new(M))` where M is the number of
+/// return a `ErrMode::Incomplete(Needed::new(M))` where M is the number of
 /// additional bytes the parser would need to succeed.
 /// It is well defined for `&[u8]` as the number of elements is the byte size,
 /// but for types like `&str`, we cannot know how many bytes correspond for
-/// the next few chars, so the result will be `Err::Incomplete(Needed::Unknown)`
+/// the next few chars, so the result will be `ErrMode::Incomplete(Needed::Unknown)`
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::bytes::streaming::take;
 ///
 /// fn take6(s: &str) -> IResult<&str, &str> {
@@ -592,7 +592,7 @@ where
 ///
 /// assert_eq!(take6("1234567"), Ok(("7", "123456")));
 /// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(take6("short"), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take`][crate::bytes::take] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -620,7 +620,7 @@ where
 {
   match i.offset_at(c) {
     Ok(offset) => Ok(i.next_slice(offset)),
-    Err(i) => Err(Err::Incomplete(i)),
+    Err(i) => Err(ErrMode::Incomplete(i)),
   }
 }
 
@@ -629,11 +629,11 @@ where
 /// It doesn't consume the pattern.
 ///
 /// # Streaming Specific
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(N))` if the input doesn't
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::bytes::streaming::take_until;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -641,8 +641,8 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("hello, worldeo"), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof("hello, worldeo"), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
 ///
@@ -671,7 +671,7 @@ where
 {
   match i.find_slice(t) {
     Some(offset) => Ok(i.next_slice(offset)),
-    None => Err(Err::Incomplete(Needed::Unknown)),
+    None => Err(ErrMode::Incomplete(Needed::Unknown)),
   }
 }
 
@@ -680,11 +680,11 @@ where
 /// It doesn't consume the pattern.
 ///
 /// # Streaming Specific
-/// *Streaming version* will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
+/// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(N))` if the input doesn't
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::bytes::streaming::take_until1;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -692,10 +692,10 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("hello, worldeo"), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof("hello, worldeo"), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"),  Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof("eof"),  Err(ErrMode::Error(Error::new("eof", ErrorKind::TakeUntil))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::take_until1`][crate::bytes::take_until1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -722,8 +722,11 @@ where
   T: SliceLen,
 {
   match i.find_slice(t) {
-    None => Err(Err::Incomplete(Needed::Unknown)),
-    Some(0) => Err(Err::Error(Error::from_error_kind(i, ErrorKind::TakeUntil))),
+    None => Err(ErrMode::Incomplete(Needed::Unknown)),
+    Some(0) => Err(ErrMode::Error(Error::from_error_kind(
+      i,
+      ErrorKind::TakeUntil,
+    ))),
     Some(offset) => Ok(i.next_slice(offset)),
   }
 }
@@ -735,7 +738,7 @@ where
 /// * The third argument matches the escaped characters
 /// # Example
 /// ```
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// # use winnow::character::streaming::digit1;
 /// use winnow::bytes::streaming::escaped;
 /// use winnow::character::streaming::one_of;
@@ -792,7 +795,7 @@ where
     match normal.parse_next(i.clone()) {
       Ok((i2, _)) => {
         if i2.input_len() == 0 {
-          return Err(Err::Incomplete(Needed::Unknown));
+          return Err(ErrMode::Incomplete(Needed::Unknown));
         } else if i2.input_len() == current_len {
           let offset = input.offset_to(&i2);
           return Ok(input.next_slice(offset));
@@ -800,16 +803,16 @@ where
           i = i2;
         }
       }
-      Err(Err::Error(_)) => {
+      Err(ErrMode::Error(_)) => {
         if i.next_token().expect("input_len > 0").1.as_char() == control_char {
           let next = control_char.len_utf8();
           if next >= i.input_len() {
-            return Err(Err::Incomplete(Needed::new(1)));
+            return Err(ErrMode::Incomplete(Needed::new(1)));
           } else {
             match escapable.parse_next(i.next_slice(next).0) {
               Ok((i2, _)) => {
                 if i2.input_len() == 0 {
-                  return Err(Err::Incomplete(Needed::Unknown));
+                  return Err(ErrMode::Incomplete(Needed::Unknown));
                 } else {
                   i = i2;
                 }
@@ -828,7 +831,7 @@ where
     }
   }
 
-  Err(Err::Incomplete(Needed::Unknown))
+  Err(ErrMode::Incomplete(Needed::Unknown))
 }
 
 /// Matches a byte string with escaped characters.
@@ -840,7 +843,7 @@ where
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// # use std::str::from_utf8;
 /// use winnow::bytes::streaming::{escaped_transform, tag};
 /// use winnow::character::streaming::alpha1;
@@ -917,26 +920,26 @@ where
       Ok((i2, o)) => {
         o.extend_into(&mut res);
         if i2.input_len() == 0 {
-          return Err(Err::Incomplete(Needed::Unknown));
+          return Err(ErrMode::Incomplete(Needed::Unknown));
         } else if i2.input_len() == current_len {
           return Ok((remainder, res));
         } else {
           offset = input.offset_to(&i2);
         }
       }
-      Err(Err::Error(_)) => {
+      Err(ErrMode::Error(_)) => {
         if remainder.next_token().expect("input_len > 0").1.as_char() == control_char {
           let next = offset + control_char.len_utf8();
           let input_len = input.input_len();
 
           if next >= input_len {
-            return Err(Err::Incomplete(Needed::Unknown));
+            return Err(ErrMode::Incomplete(Needed::Unknown));
           } else {
             match transform.parse_next(i.next_slice(next).0) {
               Ok((i2, o)) => {
                 o.extend_into(&mut res);
                 if i2.input_len() == 0 {
-                  return Err(Err::Incomplete(Needed::Unknown));
+                  return Err(ErrMode::Incomplete(Needed::Unknown));
                 } else {
                   offset = input.offset_to(&i2);
                 }
@@ -951,7 +954,7 @@ where
       Err(e) => return Err(e),
     }
   }
-  Err(Err::Incomplete(Needed::Unknown))
+  Err(ErrMode::Incomplete(Needed::Unknown))
 }
 
 #[cfg(test)]
@@ -962,7 +965,7 @@ mod tests {
   };
   use crate::error::ErrorKind;
   use crate::input::AsChar;
-  use crate::{Err, IResult, Needed};
+  use crate::{ErrMode, IResult, Needed};
 
   #[test]
   fn is_a() {
@@ -981,7 +984,7 @@ mod tests {
     let c = &b"cdef"[..];
     assert_eq!(
       a_or_b(c),
-      Err(Err::Error(error_position!(c, ErrorKind::IsA)))
+      Err(ErrMode::Error(error_position!(c, ErrorKind::IsA)))
     );
 
     let d = &b"bacdef"[..];
@@ -1005,14 +1008,14 @@ mod tests {
     let c = &b"abab"[..];
     assert_eq!(
       a_or_b(c),
-      Err(Err::Error(error_position!(c, ErrorKind::IsNot)))
+      Err(ErrMode::Error(error_position!(c, ErrorKind::IsNot)))
     );
 
     let d = &b"cdefba"[..];
     assert_eq!(a_or_b(d), Ok((&b"ba"[..], &b"cdef"[..])));
 
     let e = &b"e"[..];
-    assert_eq!(a_or_b(e), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(a_or_b(e), Err(ErrMode::Incomplete(Needed::new(1))));
   }
 
   #[test]
@@ -1021,9 +1024,9 @@ mod tests {
     fn y(i: &[u8]) -> IResult<&[u8], &[u8]> {
       take_until("end")(i)
     }
-    assert_eq!(y(&b"nd"[..]), Err(Err::Incomplete(Needed::Unknown)));
-    assert_eq!(y(&b"123"[..]), Err(Err::Incomplete(Needed::Unknown)));
-    assert_eq!(y(&b"123en"[..]), Err(Err::Incomplete(Needed::Unknown)));
+    assert_eq!(y(&b"nd"[..]), Err(ErrMode::Incomplete(Needed::Unknown)));
+    assert_eq!(y(&b"123"[..]), Err(ErrMode::Incomplete(Needed::Unknown)));
+    assert_eq!(y(&b"123en"[..]), Err(ErrMode::Incomplete(Needed::Unknown)));
   }
 
   #[test]
@@ -1032,7 +1035,7 @@ mod tests {
     fn ys(i: &str) -> IResult<&str, &str> {
       take_until("end")(i)
     }
-    assert_eq!(ys("123en"), Err(Err::Incomplete(Needed::Unknown)));
+    assert_eq!(ys("123en"), Err(ErrMode::Incomplete(Needed::Unknown)));
   }
 
   #[test]
@@ -1104,8 +1107,8 @@ mod tests {
     let c = b"abcd123";
     let d = b"123";
 
-    assert_eq!(f(&a[..]), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(f(&b[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(&a[..]), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(&b[..]), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(f(&c[..]), Ok((&d[..], &b[..])));
     assert_eq!(f(&d[..]), Ok((&d[..], &a[..])));
   }
@@ -1122,12 +1125,15 @@ mod tests {
     let c = b"abcd123";
     let d = b"123";
 
-    assert_eq!(f(&a[..]), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(f(&b[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(&a[..]), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(&b[..]), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(f(&c[..]), Ok((&b"123"[..], &b[..])));
     assert_eq!(
       f(&d[..]),
-      Err(Err::Error(error_position!(&d[..], ErrorKind::TakeWhile1)))
+      Err(ErrMode::Error(error_position!(
+        &d[..],
+        ErrorKind::TakeWhile1
+      )))
     );
   }
 
@@ -1145,14 +1151,17 @@ mod tests {
     let e = b"abcde";
     let f = b"123";
 
-    assert_eq!(x(&a[..]), Err(Err::Incomplete(Needed::new(2))));
-    assert_eq!(x(&b[..]), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(x(&c[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(x(&a[..]), Err(ErrMode::Incomplete(Needed::new(2))));
+    assert_eq!(x(&b[..]), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(x(&c[..]), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(x(&d[..]), Ok((&b"123"[..], &c[..])));
     assert_eq!(x(&e[..]), Ok((&b"e"[..], &b"abcd"[..])));
     assert_eq!(
       x(&f[..]),
-      Err(Err::Error(error_position!(&f[..], ErrorKind::TakeWhileMN)))
+      Err(ErrMode::Error(error_position!(
+        &f[..],
+        ErrorKind::TakeWhileMN
+      )))
     );
   }
 
@@ -1168,10 +1177,10 @@ mod tests {
     let c = b"123abcd";
     let d = b"123";
 
-    assert_eq!(f(&a[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(&a[..]), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(f(&b[..]), Ok((&b"abcd"[..], &b""[..])));
     assert_eq!(f(&c[..]), Ok((&b"abcd"[..], &b"123"[..])));
-    assert_eq!(f(&d[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(&d[..]), Err(ErrMode::Incomplete(Needed::new(1))));
   }
 
   #[test]
@@ -1186,13 +1195,16 @@ mod tests {
     let c = b"123abcd";
     let d = b"123";
 
-    assert_eq!(f(&a[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(&a[..]), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(
       f(&b[..]),
-      Err(Err::Error(error_position!(&b[..], ErrorKind::TakeTill1)))
+      Err(ErrMode::Error(error_position!(
+        &b[..],
+        ErrorKind::TakeTill1
+      )))
     );
     assert_eq!(f(&c[..]), Ok((&b"abcd"[..], &b"123"[..])));
-    assert_eq!(f(&d[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(&d[..]), Err(ErrMode::Incomplete(Needed::new(1))));
   }
 
   #[test]
@@ -1203,8 +1215,8 @@ mod tests {
       take_while(|c| c != '點')(i)
     }
 
-    assert_eq!(f(""), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(f("abcd"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(""), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f("abcd"), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(f("abcd點"), Ok(("點", "abcd")));
     assert_eq!(f("abcd點a"), Ok(("點a", "abcd")));
 
@@ -1212,7 +1224,7 @@ mod tests {
       take_while(|c| c == '點')(i)
     }
 
-    assert_eq!(g(""), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(g(""), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(g("點abcd"), Ok(("abcd", "點")));
     assert_eq!(g("點點點a"), Ok(("a", "點點點")));
   }
@@ -1225,8 +1237,8 @@ mod tests {
       take_till(|c| c == '點')(i)
     }
 
-    assert_eq!(f(""), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(f("abcd"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(""), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f("abcd"), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(f("abcd點"), Ok(("點", "abcd")));
     assert_eq!(f("abcd點a"), Ok(("點a", "abcd")));
 
@@ -1234,7 +1246,7 @@ mod tests {
       take_till(|c| c != '點')(i)
     }
 
-    assert_eq!(g(""), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(g(""), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(g("點abcd"), Ok(("abcd", "點")));
     assert_eq!(g("點點點a"), Ok(("a", "點點點")));
   }
@@ -1247,9 +1259,9 @@ mod tests {
       take(3_usize)(i)
     }
 
-    assert_eq!(f(""), Err(Err::Incomplete(Needed::Unknown)));
-    assert_eq!(f("ab"), Err(Err::Incomplete(Needed::Unknown)));
-    assert_eq!(f("點"), Err(Err::Incomplete(Needed::Unknown)));
+    assert_eq!(f(""), Err(ErrMode::Incomplete(Needed::Unknown)));
+    assert_eq!(f("ab"), Err(ErrMode::Incomplete(Needed::Unknown)));
+    assert_eq!(f("點"), Err(ErrMode::Incomplete(Needed::Unknown)));
     assert_eq!(f("ab點cd"), Ok(("cd", "ab點")));
     assert_eq!(f("a點bcd"), Ok(("cd", "a點b")));
     assert_eq!(f("a點b"), Ok(("", "a點b")));
@@ -1258,7 +1270,7 @@ mod tests {
       take_while(|c| c == '點')(i)
     }
 
-    assert_eq!(g(""), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(g(""), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(g("點abcd"), Ok(("abcd", "點")));
     assert_eq!(g("點點點a"), Ok(("a", "點點點")));
   }
@@ -1317,8 +1329,14 @@ mod tests {
       x(Streaming(b"\x02..")),
       Ok((Streaming(&[][..]), &b".."[..]))
     );
-    assert_eq!(x(Streaming(b"\x02.")), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(x(Streaming(b"\x02")), Err(Err::Incomplete(Needed::new(2))));
+    assert_eq!(
+      x(Streaming(b"\x02.")),
+      Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      x(Streaming(b"\x02")),
+      Err(ErrMode::Incomplete(Needed::new(2)))
+    );
 
     fn y(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
       let (i, _) = tag("magic")(i)?;
@@ -1334,11 +1352,11 @@ mod tests {
     );
     assert_eq!(
       y(Streaming(b"magic\x02.")),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       y(Streaming(b"magic\x02")),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
   }
 
@@ -1353,14 +1371,17 @@ mod tests {
     assert_eq!(test(&b"aBCdefgh"[..]), Ok((&b"efgh"[..], &b"aBCd"[..])));
     assert_eq!(test(&b"abcdefgh"[..]), Ok((&b"efgh"[..], &b"abcd"[..])));
     assert_eq!(test(&b"ABCDefgh"[..]), Ok((&b"efgh"[..], &b"ABCD"[..])));
-    assert_eq!(test(&b"ab"[..]), Err(Err::Incomplete(Needed::new(2))));
+    assert_eq!(test(&b"ab"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
     assert_eq!(
       test(&b"Hello"[..]),
-      Err(Err::Error(error_position!(&b"Hello"[..], ErrorKind::Tag)))
+      Err(ErrMode::Error(error_position!(
+        &b"Hello"[..],
+        ErrorKind::Tag
+      )))
     );
     assert_eq!(
       test(&b"Hel"[..]),
-      Err(Err::Error(error_position!(&b"Hel"[..], ErrorKind::Tag)))
+      Err(ErrMode::Error(error_position!(&b"Hel"[..], ErrorKind::Tag)))
     );
 
     fn test2(i: &str) -> IResult<&str, &str> {
@@ -1369,14 +1390,14 @@ mod tests {
     assert_eq!(test2("aBCdefgh"), Ok(("efgh", "aBCd")));
     assert_eq!(test2("abcdefgh"), Ok(("efgh", "abcd")));
     assert_eq!(test2("ABCDefgh"), Ok(("efgh", "ABCD")));
-    assert_eq!(test2("ab"), Err(Err::Incomplete(Needed::new(2))));
+    assert_eq!(test2("ab"), Err(ErrMode::Incomplete(Needed::new(2))));
     assert_eq!(
       test2("Hello"),
-      Err(Err::Error(error_position!("Hello", ErrorKind::Tag)))
+      Err(ErrMode::Error(error_position!("Hello", ErrorKind::Tag)))
     );
     assert_eq!(
       test2("Hel"),
-      Err(Err::Error(error_position!("Hel", ErrorKind::Tag)))
+      Err(ErrMode::Error(error_position!("Hel", ErrorKind::Tag)))
     );
   }
 

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -2,14 +2,16 @@
 
 #![allow(deprecated)]
 
+use crate::error::ErrMode;
 use crate::error::ErrorKind;
+use crate::error::Needed;
 use crate::error::ParseError;
 use crate::input::{
   split_at_offset1_streaming, split_at_offset_streaming, Compare, CompareResult, ContainsToken,
   FindSlice, Input, Offset, SliceLen, ToUsize,
 };
 use crate::lib::std::result::Result::Ok;
-use crate::{ErrMode, IResult, Needed, Parser};
+use crate::{IResult, Parser};
 
 pub(crate) fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Input>::Token, E>
 where
@@ -26,7 +28,7 @@ where
 /// the input that matches the argument.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::streaming::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -79,7 +81,7 @@ where
 /// the input that matches the argument with no regard to case.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::streaming::tag_no_case;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -175,7 +177,7 @@ where
 /// It will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern wasn't met.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::bytes::streaming::is_not;
 ///
 /// fn not_space(s: &str) -> IResult<&str, &str> {
@@ -225,7 +227,7 @@ where
 /// or if the pattern reaches the end of the input.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::bytes::streaming::is_a;
 ///
 /// fn hex(s: &str) -> IResult<&str, &str> {
@@ -275,7 +277,7 @@ where
 /// *Streaming version* will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::bytes::streaming::take_while;
 /// use winnow::input::AsChar;
 ///
@@ -327,7 +329,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::streaming::take_while1;
 /// use winnow::input::AsChar;
 ///
@@ -378,7 +380,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::streaming::take_while_m_n;
 /// use winnow::input::AsChar;
 ///
@@ -480,7 +482,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::bytes::streaming::take_till;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -530,7 +532,7 @@ where
 /// end of input or if there was not match.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::streaming::take_till1;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -583,7 +585,7 @@ where
 ///
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::bytes::streaming::take;
 ///
 /// fn take6(s: &str) -> IResult<&str, &str> {
@@ -633,7 +635,7 @@ where
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::bytes::streaming::take_until;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -684,7 +686,7 @@ where
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::bytes::streaming::take_until1;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -738,7 +740,7 @@ where
 /// * The third argument matches the escaped characters
 /// # Example
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// # use winnow::character::streaming::digit1;
 /// use winnow::bytes::streaming::escaped;
 /// use winnow::character::streaming::one_of;
@@ -843,7 +845,7 @@ where
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// # use std::str::from_utf8;
 /// use winnow::bytes::streaming::{escaped_transform, tag};
 /// use winnow::character::streaming::alpha1;
@@ -964,8 +966,9 @@ mod tests {
     multispace1 as multispace, oct_digit1 as oct_digit, space1 as space,
   };
   use crate::error::ErrorKind;
+  use crate::error::{ErrMode, Needed};
   use crate::input::AsChar;
-  use crate::{ErrMode, IResult, Needed};
+  use crate::IResult;
 
   #[test]
   fn is_a() {

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -45,7 +45,7 @@ fn streaming_one_of_test() {
   let b = &b"cde"[..];
   assert_eq!(
     f(Streaming(b)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(b),
       ErrorKind::OneOf
     )))
@@ -68,7 +68,7 @@ fn char_byteslice() {
   let a = &b"abcd"[..];
   assert_eq!(
     f(Streaming(a)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(a),
       ErrorKind::OneOf
     )))
@@ -87,7 +87,7 @@ fn char_str() {
   let a = "abcd";
   assert_eq!(
     f(Streaming(a)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(a),
       ErrorKind::OneOf
     )))
@@ -106,7 +106,7 @@ fn streaming_none_of_test() {
   let a = &b"abcd"[..];
   assert_eq!(
     f(Streaming(a)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(a),
       ErrorKind::NoneOf
     )))
@@ -131,7 +131,10 @@ fn streaming_is_a() {
   let c = Streaming(&b"cdef"[..]);
   assert_eq!(
     a_or_b(c),
-    Err(ErrMode::Error(error_position!(c, ErrorKind::TakeWhile1)))
+    Err(ErrMode::Backtrack(error_position!(
+      c,
+      ErrorKind::TakeWhile1
+    )))
   );
 
   let d = Streaming(&b"bacdef"[..]);
@@ -153,7 +156,7 @@ fn streaming_is_not() {
   let c = Streaming(&b"abab"[..]);
   assert_eq!(
     a_or_b(c),
-    Err(ErrMode::Error(error_position!(c, ErrorKind::TakeTill1)))
+    Err(ErrMode::Backtrack(error_position!(c, ErrorKind::TakeTill1)))
   );
 
   let d = Streaming(&b"cdefba"[..]);
@@ -284,7 +287,7 @@ fn streaming_take_while1() {
   assert_eq!(f(Streaming(c)), Ok((Streaming(&b"123"[..]), b)));
   assert_eq!(
     f(Streaming(d)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(d),
       ErrorKind::TakeWhile1
     )))
@@ -310,7 +313,7 @@ fn streaming_take_while_m_n() {
   assert_eq!(x(Streaming(e)), Ok((Streaming(&b"e"[..]), &b"abcd"[..])));
   assert_eq!(
     x(Streaming(f)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(f),
       ErrorKind::TakeWhileMN
     )))
@@ -346,7 +349,7 @@ fn streaming_take_till1() {
   assert_eq!(f(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
   assert_eq!(
     f(Streaming(b)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(b),
       ErrorKind::TakeTill1
     )))
@@ -535,14 +538,14 @@ fn streaming_case_insensitive() {
   );
   assert_eq!(
     test(Streaming(&b"Hello"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"Hello"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     test(Streaming(&b"Hel"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"Hel"[..]),
       ErrorKind::Tag
     )))
@@ -569,14 +572,14 @@ fn streaming_case_insensitive() {
   );
   assert_eq!(
     test2(Streaming("Hello")),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming("Hello"),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     test2(Streaming("Hel")),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming("Hel"),
       ErrorKind::Tag
     )))

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -1,15 +1,15 @@
 use super::*;
 
 use crate::bytes::tag;
+use crate::error::ErrMode;
 use crate::error::Error;
 use crate::error::ErrorKind;
+use crate::error::Needed;
 use crate::input::AsChar;
 use crate::input::Streaming;
 use crate::multi::length_data;
 use crate::sequence::delimited;
-use crate::ErrMode;
 use crate::IResult;
-use crate::Needed;
 use crate::Parser;
 
 #[test]

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -7,7 +7,7 @@ use crate::input::AsChar;
 use crate::input::Streaming;
 use crate::multi::length_data;
 use crate::sequence::delimited;
-use crate::Err;
+use crate::ErrMode;
 use crate::IResult;
 use crate::Needed;
 use crate::Parser;
@@ -45,7 +45,10 @@ fn streaming_one_of_test() {
   let b = &b"cde"[..];
   assert_eq!(
     f(Streaming(b)),
-    Err(Err::Error(error_position!(Streaming(b), ErrorKind::OneOf)))
+    Err(ErrMode::Error(error_position!(
+      Streaming(b),
+      ErrorKind::OneOf
+    )))
   );
 
   fn utf8(i: Streaming<&str>) -> IResult<Streaming<&str>, char> {
@@ -65,7 +68,10 @@ fn char_byteslice() {
   let a = &b"abcd"[..];
   assert_eq!(
     f(Streaming(a)),
-    Err(Err::Error(error_position!(Streaming(a), ErrorKind::OneOf)))
+    Err(ErrMode::Error(error_position!(
+      Streaming(a),
+      ErrorKind::OneOf
+    )))
   );
 
   let b = &b"cde"[..];
@@ -81,7 +87,10 @@ fn char_str() {
   let a = "abcd";
   assert_eq!(
     f(Streaming(a)),
-    Err(Err::Error(error_position!(Streaming(a), ErrorKind::OneOf)))
+    Err(ErrMode::Error(error_position!(
+      Streaming(a),
+      ErrorKind::OneOf
+    )))
   );
 
   let b = "cde";
@@ -97,7 +106,10 @@ fn streaming_none_of_test() {
   let a = &b"abcd"[..];
   assert_eq!(
     f(Streaming(a)),
-    Err(Err::Error(error_position!(Streaming(a), ErrorKind::NoneOf)))
+    Err(ErrMode::Error(error_position!(
+      Streaming(a),
+      ErrorKind::NoneOf
+    )))
   );
 
   let b = &b"cde"[..];
@@ -119,7 +131,7 @@ fn streaming_is_a() {
   let c = Streaming(&b"cdef"[..]);
   assert_eq!(
     a_or_b(c),
-    Err(Err::Error(error_position!(c, ErrorKind::TakeWhile1)))
+    Err(ErrMode::Error(error_position!(c, ErrorKind::TakeWhile1)))
   );
 
   let d = Streaming(&b"bacdef"[..]);
@@ -141,14 +153,14 @@ fn streaming_is_not() {
   let c = Streaming(&b"abab"[..]);
   assert_eq!(
     a_or_b(c),
-    Err(Err::Error(error_position!(c, ErrorKind::TakeTill1)))
+    Err(ErrMode::Error(error_position!(c, ErrorKind::TakeTill1)))
   );
 
   let d = Streaming(&b"cdefba"[..]);
   assert_eq!(a_or_b(d), Ok((Streaming(&b"ba"[..]), &b"cdef"[..])));
 
   let e = Streaming(&b"e"[..]);
-  assert_eq!(a_or_b(e), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(a_or_b(e), Err(ErrMode::Incomplete(Needed::new(1))));
 }
 
 #[test]
@@ -158,15 +170,15 @@ fn streaming_take_until_incomplete() {
   }
   assert_eq!(
     y(Streaming(&b"nd"[..])),
-    Err(Err::Incomplete(Needed::Unknown))
+    Err(ErrMode::Incomplete(Needed::Unknown))
   );
   assert_eq!(
     y(Streaming(&b"123"[..])),
-    Err(Err::Incomplete(Needed::Unknown))
+    Err(ErrMode::Incomplete(Needed::Unknown))
   );
   assert_eq!(
     y(Streaming(&b"123en"[..])),
-    Err(Err::Incomplete(Needed::Unknown))
+    Err(ErrMode::Incomplete(Needed::Unknown))
   );
 }
 
@@ -177,7 +189,7 @@ fn streaming_take_until_incomplete_s() {
   }
   assert_eq!(
     ys(Streaming("123en")),
-    Err(Err::Incomplete(Needed::Unknown))
+    Err(ErrMode::Incomplete(Needed::Unknown))
   );
 }
 
@@ -251,8 +263,8 @@ fn streaming_take_while() {
   let c = &b"abcd123"[..];
   let d = &b"123"[..];
 
-  assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(f(Streaming(b)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(b)), Err(ErrMode::Incomplete(Needed::new(1))));
   assert_eq!(f(Streaming(c)), Ok((Streaming(d), b)));
   assert_eq!(f(Streaming(d)), Ok((Streaming(d), a)));
 }
@@ -267,12 +279,12 @@ fn streaming_take_while1() {
   let c = &b"abcd123"[..];
   let d = &b"123"[..];
 
-  assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(f(Streaming(b)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(b)), Err(ErrMode::Incomplete(Needed::new(1))));
   assert_eq!(f(Streaming(c)), Ok((Streaming(&b"123"[..]), b)));
   assert_eq!(
     f(Streaming(d)),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(d),
       ErrorKind::TakeWhile1
     )))
@@ -291,14 +303,14 @@ fn streaming_take_while_m_n() {
   let e = &b"abcde"[..];
   let f = &b"123"[..];
 
-  assert_eq!(x(Streaming(a)), Err(Err::Incomplete(Needed::new(2))));
-  assert_eq!(x(Streaming(b)), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(x(Streaming(c)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(x(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(2))));
+  assert_eq!(x(Streaming(b)), Err(ErrMode::Incomplete(Needed::new(1))));
+  assert_eq!(x(Streaming(c)), Err(ErrMode::Incomplete(Needed::new(1))));
   assert_eq!(x(Streaming(d)), Ok((Streaming(&b"123"[..]), c)));
   assert_eq!(x(Streaming(e)), Ok((Streaming(&b"e"[..]), &b"abcd"[..])));
   assert_eq!(
     x(Streaming(f)),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(f),
       ErrorKind::TakeWhileMN
     )))
@@ -315,10 +327,10 @@ fn streaming_take_till() {
   let c = &b"123abcd"[..];
   let d = &b"123"[..];
 
-  assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
   assert_eq!(f(Streaming(b)), Ok((Streaming(&b"abcd"[..]), &b""[..])));
   assert_eq!(f(Streaming(c)), Ok((Streaming(&b"abcd"[..]), &b"123"[..])));
-  assert_eq!(f(Streaming(d)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(d)), Err(ErrMode::Incomplete(Needed::new(1))));
 }
 
 #[test]
@@ -331,16 +343,16 @@ fn streaming_take_till1() {
   let c = &b"123abcd"[..];
   let d = &b"123"[..];
 
-  assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
   assert_eq!(
     f(Streaming(b)),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(b),
       ErrorKind::TakeTill1
     )))
   );
   assert_eq!(f(Streaming(c)), Ok((Streaming(&b"abcd"[..]), &b"123"[..])));
-  assert_eq!(f(Streaming(d)), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming(d)), Err(ErrMode::Incomplete(Needed::new(1))));
 }
 
 #[test]
@@ -349,8 +361,11 @@ fn streaming_take_while_utf8() {
     take_while(|c| c != '點')(i)
   }
 
-  assert_eq!(f(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(f(Streaming("abcd")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
+  assert_eq!(
+    f(Streaming("abcd")),
+    Err(ErrMode::Incomplete(Needed::new(1)))
+  );
   assert_eq!(f(Streaming("abcd點")), Ok((Streaming("點"), "abcd")));
   assert_eq!(f(Streaming("abcd點a")), Ok((Streaming("點a"), "abcd")));
 
@@ -358,7 +373,7 @@ fn streaming_take_while_utf8() {
     take_while(|c| c == '點')(i)
   }
 
-  assert_eq!(g(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(g(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
   assert_eq!(g(Streaming("點abcd")), Ok((Streaming("abcd"), "點")));
   assert_eq!(g(Streaming("點點點a")), Ok((Streaming("a"), "點點點")));
 }
@@ -369,8 +384,11 @@ fn streaming_take_till_utf8() {
     take_till(|c| c == '點')(i)
   }
 
-  assert_eq!(f(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(f(Streaming("abcd")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(f(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
+  assert_eq!(
+    f(Streaming("abcd")),
+    Err(ErrMode::Incomplete(Needed::new(1)))
+  );
   assert_eq!(f(Streaming("abcd點")), Ok((Streaming("點"), "abcd")));
   assert_eq!(f(Streaming("abcd點a")), Ok((Streaming("點a"), "abcd")));
 
@@ -378,7 +396,7 @@ fn streaming_take_till_utf8() {
     take_till(|c| c != '點')(i)
   }
 
-  assert_eq!(g(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(g(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
   assert_eq!(g(Streaming("點abcd")), Ok((Streaming("abcd"), "點")));
   assert_eq!(g(Streaming("點點點a")), Ok((Streaming("a"), "點點點")));
 }
@@ -389,9 +407,15 @@ fn streaming_take_utf8() {
     take(3_usize)(i)
   }
 
-  assert_eq!(f(Streaming("")), Err(Err::Incomplete(Needed::Unknown)));
-  assert_eq!(f(Streaming("ab")), Err(Err::Incomplete(Needed::Unknown)));
-  assert_eq!(f(Streaming("點")), Err(Err::Incomplete(Needed::Unknown)));
+  assert_eq!(f(Streaming("")), Err(ErrMode::Incomplete(Needed::Unknown)));
+  assert_eq!(
+    f(Streaming("ab")),
+    Err(ErrMode::Incomplete(Needed::Unknown))
+  );
+  assert_eq!(
+    f(Streaming("點")),
+    Err(ErrMode::Incomplete(Needed::Unknown))
+  );
   assert_eq!(f(Streaming("ab點cd")), Ok((Streaming("cd"), "ab點")));
   assert_eq!(f(Streaming("a點bcd")), Ok((Streaming("cd"), "a點b")));
   assert_eq!(f(Streaming("a點b")), Ok((Streaming(""), "a點b")));
@@ -400,7 +424,7 @@ fn streaming_take_utf8() {
     take_while(|c| c == '點')(i)
   }
 
-  assert_eq!(g(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+  assert_eq!(g(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
   assert_eq!(g(Streaming("點abcd")), Ok((Streaming("abcd"), "點")));
   assert_eq!(g(Streaming("點點點a")), Ok((Streaming("a"), "點點點")));
 }
@@ -456,8 +480,14 @@ fn streaming_length_bytes() {
     x(Streaming(b"\x02..")),
     Ok((Streaming(&[][..]), &b".."[..]))
   );
-  assert_eq!(x(Streaming(b"\x02.")), Err(Err::Incomplete(Needed::new(1))));
-  assert_eq!(x(Streaming(b"\x02")), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(
+    x(Streaming(b"\x02.")),
+    Err(ErrMode::Incomplete(Needed::new(1)))
+  );
+  assert_eq!(
+    x(Streaming(b"\x02")),
+    Err(ErrMode::Incomplete(Needed::new(2)))
+  );
 
   fn y(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
     let (i, _) = tag("magic")(i)?;
@@ -473,11 +503,11 @@ fn streaming_length_bytes() {
   );
   assert_eq!(
     y(Streaming(b"magic\x02.")),
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(ErrMode::Incomplete(Needed::new(1)))
   );
   assert_eq!(
     y(Streaming(b"magic\x02")),
-    Err(Err::Incomplete(Needed::new(2)))
+    Err(ErrMode::Incomplete(Needed::new(2)))
   );
 }
 
@@ -501,18 +531,18 @@ fn streaming_case_insensitive() {
   );
   assert_eq!(
     test(Streaming(&b"ab"[..])),
-    Err(Err::Incomplete(Needed::new(2)))
+    Err(ErrMode::Incomplete(Needed::new(2)))
   );
   assert_eq!(
     test(Streaming(&b"Hello"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"Hello"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     test(Streaming(&b"Hel"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"Hel"[..]),
       ErrorKind::Tag
     )))
@@ -533,17 +563,20 @@ fn streaming_case_insensitive() {
     test2(Streaming("ABCDefgh")),
     Ok((Streaming("efgh"), "ABCD"))
   );
-  assert_eq!(test2(Streaming("ab")), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(
+    test2(Streaming("ab")),
+    Err(ErrMode::Incomplete(Needed::new(2)))
+  );
   assert_eq!(
     test2(Streaming("Hello")),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming("Hello"),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     test2(Streaming("Hel")),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming("Hel"),
       ErrorKind::Tag
     )))

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -5,13 +5,14 @@
 #![allow(deprecated)]
 
 use crate::combinator::opt;
+use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
   split_at_offset1_complete, split_at_offset_complete, AsBytes, AsChar, ContainsToken, Input,
 };
 use crate::input::{Compare, CompareResult};
-use crate::{ErrMode, IResult};
+use crate::IResult;
 
 /// Recognizes one character.
 ///
@@ -19,7 +20,7 @@ use crate::{ErrMode, IResult};
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{ErrorKind, Error}, IResult};
+/// # use winnow::{error::ErrMode, error::{ErrorKind, Error}, IResult};
 /// # use winnow::character::complete::char;
 /// fn parser(i: &str) -> IResult<&str, char> {
 ///     char('a')(i)
@@ -57,7 +58,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{ErrorKind, Error}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{ErrorKind, Error}, error::Needed, IResult};
 /// # use winnow::character::complete::satisfy;
 /// fn parser(i: &str) -> IResult<&str, char> {
 ///     satisfy(|c| c == 'a' || c == 'b')(i)
@@ -99,7 +100,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::character::complete::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>>("abc")("b"), Ok(("", 'b')));
 /// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
@@ -123,7 +124,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::character::complete::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>>("abc")("z"), Ok(("", 'z')));
 /// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(ErrMode::Error(Error::new("a", ErrorKind::NoneOf))));
@@ -147,7 +148,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult};
 /// # use winnow::character::complete::crlf;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     crlf(input)
@@ -182,7 +183,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::not_line_ending;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     not_line_ending(input)
@@ -238,7 +239,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::line_ending;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     line_ending(input)
@@ -279,7 +280,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::newline;
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     newline(input)
@@ -306,7 +307,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::tab;
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     tab(input)
@@ -334,7 +335,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{character::complete::anychar, ErrMode, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{character::complete::anychar, error::ErrMode, error::{Error, ErrorKind}, IResult};
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     anychar(input)
 /// }
@@ -360,7 +361,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, IResult, error::Needed};
 /// # use winnow::character::complete::alpha0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alpha0(input)
@@ -388,7 +389,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::alpha1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alpha1(input)
@@ -416,7 +417,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, IResult, error::Needed};
 /// # use winnow::character::complete::digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit0(input)
@@ -445,7 +446,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit1(input)
@@ -460,7 +461,7 @@ where
 /// You can use `digit1` in combination with [`map_res`] to parse an integer:
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::combinator::map_res;
 /// # use winnow::character::complete::digit1;
 /// fn parser(input: &str) -> IResult<&str, u32> {
@@ -490,7 +491,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, IResult, error::Needed};
 /// # use winnow::character::complete::hex_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     hex_digit0(input)
@@ -521,7 +522,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::hex_digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     hex_digit1(input)
@@ -552,7 +553,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, IResult, error::Needed};
 /// # use winnow::character::complete::oct_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     oct_digit0(input)
@@ -583,7 +584,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::oct_digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     oct_digit1(input)
@@ -614,7 +615,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, IResult, error::Needed};
 /// # use winnow::character::complete::alphanumeric0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alphanumeric0(input)
@@ -645,7 +646,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::alphanumeric1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alphanumeric1(input)
@@ -676,7 +677,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, IResult, error::Needed};
 /// # use winnow::character::complete::space0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     space0(input)
@@ -707,7 +708,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::space1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     space1(input)
@@ -742,7 +743,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, IResult, error::Needed};
 /// # use winnow::character::complete::multispace0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     multispace0(input)
@@ -776,7 +777,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::complete::multispace1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     multispace1(input)
@@ -919,9 +920,9 @@ uints! { u8 u16 u32 u64 u128 }
 mod tests {
   use super::*;
   use crate::branch::alt;
+  use crate::error::ErrMode;
   use crate::error::Error;
   use crate::input::ParseTo;
-  use crate::ErrMode;
   use proptest::prelude::*;
 
   macro_rules! assert_parse(

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -26,9 +26,9 @@ use crate::IResult;
 ///     char('a')(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser(" abc"), Err(ErrMode::Error(Error::new(" abc", ErrorKind::Char))));
-/// assert_eq!(parser("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser(" abc"), Err(ErrMode::Backtrack(Error::new(" abc", ErrorKind::Char))));
+/// assert_eq!(parser("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of]
@@ -49,7 +49,7 @@ where
   i.next_token()
     .map(|(i, t)| (i, t.as_char()))
     .filter(|(_, t)| *t == c)
-    .ok_or_else(|| ErrMode::Error(Error::from_char(i, c)))
+    .ok_or_else(|| ErrMode::Backtrack(Error::from_char(i, c)))
 }
 
 /// Recognizes one character and checks that it satisfies a predicate
@@ -64,8 +64,8 @@ where
 ///     satisfy(|c| c == 'a' || c == 'b')(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("cd"), Err(ErrMode::Error(Error::new("cd", ErrorKind::Satisfy))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Satisfy))));
+/// assert_eq!(parser("cd"), Err(ErrMode::Backtrack(Error::new("cd", ErrorKind::Satisfy))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Satisfy))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of]
@@ -91,7 +91,7 @@ where
   i.next_token()
     .map(|(i, t)| (i, t.as_char()))
     .filter(|(_, t)| cond(*t))
-    .ok_or_else(|| ErrMode::Error(Error::from_error_kind(i, ErrorKind::Satisfy)))
+    .ok_or_else(|| ErrMode::Backtrack(Error::from_error_kind(i, ErrorKind::Satisfy)))
 }
 
 /// Recognizes one of the provided characters.
@@ -103,8 +103,8 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::character::complete::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Error(Error::new("", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::OneOf))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of]
@@ -127,8 +127,8 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::character::complete::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(ErrMode::Error(Error::new("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Error(Error::new("", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(ErrMode::Backtrack(Error::new("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::NoneOf))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::none_of`][crate::bytes::none_of]
@@ -155,8 +155,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::CrLf))));
+/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::CrLf))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::crlf`][crate::character::crlf]
@@ -171,7 +171,7 @@ where
     CompareResult::Ok => Ok(input.next_slice(CRLF.len())),
     CompareResult::Incomplete | CompareResult::Error => {
       let e: ErrorKind = ErrorKind::CrLf;
-      Err(ErrMode::Error(E::from_error_kind(input, e)))
+      Err(ErrMode::Backtrack(E::from_error_kind(input, e)))
     }
   }
 }
@@ -193,8 +193,8 @@ where
 /// assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
 /// assert_eq!(parser("abc"), Ok(("", "abc")));
 /// assert_eq!(parser(""), Ok(("", "")));
-/// assert_eq!(parser("a\rb\nc"), Err(ErrMode::Error(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
-/// assert_eq!(parser("a\rbc"), Err(ErrMode::Error(Error { input: "a\rbc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rb\nc"), Err(ErrMode::Backtrack(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rbc"), Err(ErrMode::Backtrack(Error { input: "a\rbc", kind: ErrorKind::Tag })));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::not_line_ending`][crate::character::not_line_ending]
@@ -224,7 +224,7 @@ where
           CompareResult::Ok => {}
           CompareResult::Incomplete | CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
-            return Err(ErrMode::Error(E::from_error_kind(input, e)));
+            return Err(ErrMode::Backtrack(E::from_error_kind(input, e)));
           }
         }
       }
@@ -246,8 +246,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::CrLf))));
+/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::CrLf))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::line_ending`][crate::character::line_ending]
@@ -264,12 +264,15 @@ where
   const CRLF: &str = "\r\n";
   match input.compare(LF) {
     CompareResult::Ok => Ok(input.next_slice(LF.len())),
-    CompareResult::Incomplete => Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::CrLf))),
+    CompareResult::Incomplete => Err(ErrMode::Backtrack(E::from_error_kind(
+      input,
+      ErrorKind::CrLf,
+    ))),
     CompareResult::Error => match input.compare("\r\n") {
       CompareResult::Ok => Ok(input.next_slice(CRLF.len())),
-      CompareResult::Incomplete | CompareResult::Error => {
-        Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::CrLf)))
-      }
+      CompareResult::Incomplete | CompareResult::Error => Err(ErrMode::Backtrack(
+        E::from_error_kind(input, ErrorKind::CrLf),
+      )),
     },
   }
 }
@@ -287,8 +290,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("\nc"), Ok(("c", '\n')));
-/// assert_eq!(parser("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::newline`][crate::character::newline]
@@ -314,8 +317,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("\tc"), Ok(("c", '\t')));
-/// assert_eq!(parser("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::tab`][crate::character::tab]
@@ -341,7 +344,7 @@ where
 /// }
 ///
 /// assert_eq!(parser("abc"), Ok(("bc",'a')));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Eof))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::any`][crate::bytes::any]
@@ -396,8 +399,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(parser("1c"), Err(ErrMode::Error(Error::new("1c", ErrorKind::Alpha))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Alpha))));
+/// assert_eq!(parser("1c"), Err(ErrMode::Backtrack(Error::new("1c", ErrorKind::Alpha))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Alpha))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alpha1`][crate::character::alpha1]
@@ -453,8 +456,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("21c"), Ok(("c", "21")));
-/// assert_eq!(parser("c1"), Err(ErrMode::Error(Error::new("c1", ErrorKind::Digit))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Digit))));
+/// assert_eq!(parser("c1"), Err(ErrMode::Backtrack(Error::new("c1", ErrorKind::Digit))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Digit))));
 /// ```
 ///
 /// ## Parsing an integer
@@ -529,8 +532,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::HexDigit))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::HexDigit))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::HexDigit))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::HexDigit))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::hex_digit1`][crate::character::hex_digit1]
@@ -591,8 +594,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::OctDigit))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::OctDigit))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::OctDigit))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::OctDigit))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::oct_digit1`][crate::character::oct_digit1]
@@ -653,8 +656,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(parser("&H2"), Err(ErrMode::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::AlphaNumeric))));
+/// assert_eq!(parser("&H2"), Err(ErrMode::Backtrack(Error::new("&H2", ErrorKind::AlphaNumeric))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::AlphaNumeric))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alphanumeric1`][crate::character::alphanumeric1]
@@ -715,8 +718,8 @@ where
 /// }
 ///
 /// assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::Space))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Space))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Space))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Space))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::space1`][crate::character::space1]
@@ -784,8 +787,8 @@ where
 /// }
 ///
 /// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::MultiSpace))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::MultiSpace))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::MultiSpace))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::MultiSpace))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::multispace1`][crate::character::multispace1]
@@ -839,7 +842,7 @@ macro_rules! ints {
                 let (i, sign) = sign(input.clone())?;
 
                 if i.input_len() == 0 {
-                    return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit)));
+                    return Err(ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Digit)));
                 }
 
                 let mut value: $t = 0;
@@ -847,7 +850,7 @@ macro_rules! ints {
                     match c.as_char().to_digit(10) {
                         None => {
                             if offset == 0 {
-                                return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit)));
+                                return Err(ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Digit)));
                             } else {
                                 return Ok((i.next_slice(offset).0, value));
                             }
@@ -859,7 +862,7 @@ macro_rules! ints {
                                v.checked_sub(d as $t)
                             }
                         }) {
-                            None => return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit))),
+                            None => return Err(ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Digit))),
                             Some(v) => value = v,
                         }
                    }
@@ -888,7 +891,7 @@ macro_rules! uints {
                 let i = input;
 
                 if i.input_len() == 0 {
-                    return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit)));
+                    return Err(ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Digit)));
                 }
 
                 let mut value: $t = 0;
@@ -896,13 +899,13 @@ macro_rules! uints {
                     match c.as_char().to_digit(10) {
                         None => {
                             if offset == 0 {
-                                return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit)));
+                                return Err(ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Digit)));
                             } else {
                                 return Ok((i.next_slice(offset).0, value));
                             }
                         },
                         Some(d) => match value.checked_mul(10).and_then(|v| v.checked_add(d as $t)) {
-                            None => return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit))),
+                            None => return Err(ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Digit))),
                             Some(v) => value = v,
                         }
                     }
@@ -945,7 +948,7 @@ mod tests {
     assert_parse!(alpha1(a), Ok((empty, a)));
     assert_eq!(
       alpha1(b),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: b,
         kind: ErrorKind::Alpha
       }))
@@ -954,7 +957,7 @@ mod tests {
     assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bytes(), &b"az"[..])));
     assert_eq!(
       digit1(a),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: a,
         kind: ErrorKind::Digit
       }))
@@ -962,14 +965,14 @@ mod tests {
     assert_eq!(digit1::<_, Error<_>>(b), Ok((empty, b)));
     assert_eq!(
       digit1(c),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: c,
         kind: ErrorKind::Digit
       }))
     );
     assert_eq!(
       digit1(d),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: d,
         kind: ErrorKind::Digit
       }))
@@ -983,14 +986,14 @@ mod tests {
     );
     assert_eq!(
       hex_digit1(e),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: e,
         kind: ErrorKind::HexDigit
       }))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: a,
         kind: ErrorKind::OctDigit
       }))
@@ -998,14 +1001,14 @@ mod tests {
     assert_eq!(oct_digit1::<_, Error<_>>(b), Ok((empty, b)));
     assert_eq!(
       oct_digit1(c),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: c,
         kind: ErrorKind::OctDigit
       }))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: d,
         kind: ErrorKind::OctDigit
       }))
@@ -1033,7 +1036,7 @@ mod tests {
     assert_eq!(alpha1::<_, Error<_>>(a), Ok((empty, a)));
     assert_eq!(
       alpha1(b),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: b,
         kind: ErrorKind::Alpha
       }))
@@ -1042,7 +1045,7 @@ mod tests {
     assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12", "az")));
     assert_eq!(
       digit1(a),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: a,
         kind: ErrorKind::Digit
       }))
@@ -1050,14 +1053,14 @@ mod tests {
     assert_eq!(digit1::<_, Error<_>>(b), Ok((empty, b)));
     assert_eq!(
       digit1(c),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: c,
         kind: ErrorKind::Digit
       }))
     );
     assert_eq!(
       digit1(d),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: d,
         kind: ErrorKind::Digit
       }))
@@ -1068,14 +1071,14 @@ mod tests {
     assert_eq!(hex_digit1::<_, Error<_>>(d), Ok(("zé12", "a")));
     assert_eq!(
       hex_digit1(e),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: e,
         kind: ErrorKind::HexDigit
       }))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: a,
         kind: ErrorKind::OctDigit
       }))
@@ -1083,14 +1086,14 @@ mod tests {
     assert_eq!(oct_digit1::<_, Error<_>>(b), Ok((empty, b)));
     assert_eq!(
       oct_digit1(c),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: c,
         kind: ErrorKind::OctDigit
       }))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: d,
         kind: ErrorKind::OctDigit
       }))
@@ -1202,7 +1205,7 @@ mod tests {
     let f = "βèƒôřè\rÂßÇáƒƭèř";
     assert_eq!(
       not_line_ending(f),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: f,
         kind: ErrorKind::Tag
       }))
@@ -1220,13 +1223,13 @@ mod tests {
     let i = &b"g"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(error_position!(i, ErrorKind::HexDigit)))
     );
 
     let i = &b"G"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(error_position!(i, ErrorKind::HexDigit)))
     );
 
     assert!(AsChar::is_hex_digit(b'0'));
@@ -1251,7 +1254,7 @@ mod tests {
     let i = &b"8"[..];
     assert_parse!(
       oct_digit1(i),
-      Err(ErrMode::Error(error_position!(i, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(error_position!(i, ErrorKind::OctDigit)))
     );
 
     assert!(AsChar::is_oct_digit(b'0'));
@@ -1307,11 +1310,14 @@ mod tests {
     assert_parse!(crlf(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_parse!(
       crlf(&b"\r"[..]),
-      Err(ErrMode::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!(
+        &b"\r"[..],
+        ErrorKind::CrLf
+      )))
     );
     assert_parse!(
       crlf(&b"\ra"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"\ra"[..],
         ErrorKind::CrLf
       )))
@@ -1320,11 +1326,11 @@ mod tests {
     assert_parse!(crlf("\r\na"), Ok(("a", "\r\n")));
     assert_parse!(
       crlf("\r"),
-      Err(ErrMode::Error(error_position!("\r", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\r", ErrorKind::CrLf)))
     );
     assert_parse!(
       crlf("\ra"),
-      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -1334,11 +1340,14 @@ mod tests {
     assert_parse!(line_ending(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_parse!(
       line_ending(&b"\r"[..]),
-      Err(ErrMode::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!(
+        &b"\r"[..],
+        ErrorKind::CrLf
+      )))
     );
     assert_parse!(
       line_ending(&b"\ra"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"\ra"[..],
         ErrorKind::CrLf
       )))
@@ -1348,11 +1357,11 @@ mod tests {
     assert_parse!(line_ending("\r\na"), Ok(("a", "\r\n")));
     assert_parse!(
       line_ending("\r"),
-      Err(ErrMode::Error(error_position!("\r", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\r", ErrorKind::CrLf)))
     );
     assert_parse!(
       line_ending("\ra"),
-      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -1368,7 +1377,7 @@ mod tests {
     let (i, s) = match digit1::<_, crate::error::Error<_>>(i) {
       Ok((i, s)) => (i, s),
       Err(_) => {
-        return Err(ErrMode::Error(crate::error::Error::from_error_kind(
+        return Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
           input,
           ErrorKind::Digit,
         )))
@@ -1383,7 +1392,7 @@ mod tests {
           Ok((i, -n))
         }
       }
-      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -1394,7 +1403,7 @@ mod tests {
     let (i, s) = digit1(i)?;
     match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -11,7 +11,7 @@ use crate::input::{
   split_at_offset1_complete, split_at_offset_complete, AsBytes, AsChar, ContainsToken, Input,
 };
 use crate::input::{Compare, CompareResult};
-use crate::{Err, IResult};
+use crate::{ErrMode, IResult};
 
 /// Recognizes one character.
 ///
@@ -19,15 +19,15 @@ use crate::{Err, IResult};
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{ErrorKind, Error}, IResult};
+/// # use winnow::{ErrMode, error::{ErrorKind, Error}, IResult};
 /// # use winnow::character::complete::char;
 /// fn parser(i: &str) -> IResult<&str, char> {
 ///     char('a')(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser(" abc"), Err(Err::Error(Error::new(" abc", ErrorKind::Char))));
-/// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser(" abc"), Err(ErrMode::Error(Error::new(" abc", ErrorKind::Char))));
+/// assert_eq!(parser("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of]
@@ -48,7 +48,7 @@ where
   i.next_token()
     .map(|(i, t)| (i, t.as_char()))
     .filter(|(_, t)| *t == c)
-    .ok_or_else(|| Err::Error(Error::from_char(i, c)))
+    .ok_or_else(|| ErrMode::Error(Error::from_char(i, c)))
 }
 
 /// Recognizes one character and checks that it satisfies a predicate
@@ -57,14 +57,14 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{ErrorKind, Error}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{ErrorKind, Error}, Needed, IResult};
 /// # use winnow::character::complete::satisfy;
 /// fn parser(i: &str) -> IResult<&str, char> {
 ///     satisfy(|c| c == 'a' || c == 'b')(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::Satisfy))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Satisfy))));
+/// assert_eq!(parser("cd"), Err(ErrMode::Error(Error::new("cd", ErrorKind::Satisfy))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Satisfy))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of]
@@ -90,7 +90,7 @@ where
   i.next_token()
     .map(|(i, t)| (i, t.as_char()))
     .filter(|(_, t)| cond(*t))
-    .ok_or_else(|| Err::Error(Error::from_error_kind(i, ErrorKind::Satisfy)))
+    .ok_or_else(|| ErrMode::Error(Error::from_error_kind(i, ErrorKind::Satisfy)))
 }
 
 /// Recognizes one of the provided characters.
@@ -99,11 +99,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::character::complete::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(Err::Error(Error::new("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, Error<_>>("a")(""), Err(Err::Error(Error::new("", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Error(Error::new("", ErrorKind::OneOf))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of]
@@ -123,11 +123,11 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::character::complete::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(Err::Error(Error::new("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, Error<_>>("a")(""), Err(Err::Error(Error::new("", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(ErrMode::Error(Error::new("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Error(Error::new("", ErrorKind::NoneOf))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::none_of`][crate::bytes::none_of]
@@ -147,15 +147,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult};
 /// # use winnow::character::complete::crlf;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     crlf(input)
 /// }
 ///
 /// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::CrLf))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::crlf`][crate::character::crlf]
@@ -170,7 +170,7 @@ where
     CompareResult::Ok => Ok(input.next_slice(CRLF.len())),
     CompareResult::Incomplete | CompareResult::Error => {
       let e: ErrorKind = ErrorKind::CrLf;
-      Err(Err::Error(E::from_error_kind(input, e)))
+      Err(ErrMode::Error(E::from_error_kind(input, e)))
     }
   }
 }
@@ -182,7 +182,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::not_line_ending;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     not_line_ending(input)
@@ -192,8 +192,8 @@ where
 /// assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
 /// assert_eq!(parser("abc"), Ok(("", "abc")));
 /// assert_eq!(parser(""), Ok(("", "")));
-/// assert_eq!(parser("a\rb\nc"), Err(Err::Error(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
-/// assert_eq!(parser("a\rbc"), Err(Err::Error(Error { input: "a\rbc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rb\nc"), Err(ErrMode::Error(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rbc"), Err(ErrMode::Error(Error { input: "a\rbc", kind: ErrorKind::Tag })));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::not_line_ending`][crate::character::not_line_ending]
@@ -223,7 +223,7 @@ where
           CompareResult::Ok => {}
           CompareResult::Incomplete | CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
-            return Err(Err::Error(E::from_error_kind(input, e)));
+            return Err(ErrMode::Error(E::from_error_kind(input, e)));
           }
         }
       }
@@ -238,15 +238,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::line_ending;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     line_ending(input)
 /// }
 ///
 /// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::CrLf))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::line_ending`][crate::character::line_ending]
@@ -263,11 +263,11 @@ where
   const CRLF: &str = "\r\n";
   match input.compare(LF) {
     CompareResult::Ok => Ok(input.next_slice(LF.len())),
-    CompareResult::Incomplete => Err(Err::Error(E::from_error_kind(input, ErrorKind::CrLf))),
+    CompareResult::Incomplete => Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::CrLf))),
     CompareResult::Error => match input.compare("\r\n") {
       CompareResult::Ok => Ok(input.next_slice(CRLF.len())),
       CompareResult::Incomplete | CompareResult::Error => {
-        Err(Err::Error(E::from_error_kind(input, ErrorKind::CrLf)))
+        Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::CrLf)))
       }
     },
   }
@@ -279,15 +279,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::newline;
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     newline(input)
 /// }
 ///
 /// assert_eq!(parser("\nc"), Ok(("c", '\n')));
-/// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::newline`][crate::character::newline]
@@ -306,15 +306,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::tab;
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     tab(input)
 /// }
 ///
 /// assert_eq!(parser("\tc"), Ok(("c", '\t')));
-/// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::tab`][crate::character::tab]
@@ -334,13 +334,13 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{character::complete::anychar, Err, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{character::complete::anychar, ErrMode, error::{Error, ErrorKind}, IResult};
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     anychar(input)
 /// }
 ///
 /// assert_eq!(parser("abc"), Ok(("bc",'a')));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Eof))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::any`][crate::bytes::any]
@@ -360,7 +360,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
 /// # use winnow::character::complete::alpha0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alpha0(input)
@@ -388,15 +388,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::alpha1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alpha1(input)
 /// }
 ///
 /// assert_eq!(parser("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(parser("1c"), Err(Err::Error(Error::new("1c", ErrorKind::Alpha))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Alpha))));
+/// assert_eq!(parser("1c"), Err(ErrMode::Error(Error::new("1c", ErrorKind::Alpha))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Alpha))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alpha1`][crate::character::alpha1]
@@ -416,7 +416,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
 /// # use winnow::character::complete::digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit0(input)
@@ -445,22 +445,22 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit1(input)
 /// }
 ///
 /// assert_eq!(parser("21c"), Ok(("c", "21")));
-/// assert_eq!(parser("c1"), Err(Err::Error(Error::new("c1", ErrorKind::Digit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Digit))));
+/// assert_eq!(parser("c1"), Err(ErrMode::Error(Error::new("c1", ErrorKind::Digit))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Digit))));
 /// ```
 ///
 /// ## Parsing an integer
 /// You can use `digit1` in combination with [`map_res`] to parse an integer:
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::combinator::map_res;
 /// # use winnow::character::complete::digit1;
 /// fn parser(input: &str) -> IResult<&str, u32> {
@@ -490,7 +490,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
 /// # use winnow::character::complete::hex_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     hex_digit0(input)
@@ -521,15 +521,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::hex_digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     hex_digit1(input)
 /// }
 ///
 /// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::HexDigit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::HexDigit))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::HexDigit))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::HexDigit))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::hex_digit1`][crate::character::hex_digit1]
@@ -552,7 +552,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
 /// # use winnow::character::complete::oct_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     oct_digit0(input)
@@ -583,15 +583,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::oct_digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     oct_digit1(input)
 /// }
 ///
 /// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::OctDigit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OctDigit))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::OctDigit))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::OctDigit))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::oct_digit1`][crate::character::oct_digit1]
@@ -614,7 +614,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
 /// # use winnow::character::complete::alphanumeric0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alphanumeric0(input)
@@ -645,15 +645,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::alphanumeric1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alphanumeric1(input)
 /// }
 ///
 /// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(parser("&H2"), Err(Err::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::AlphaNumeric))));
+/// assert_eq!(parser("&H2"), Err(ErrMode::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::AlphaNumeric))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alphanumeric1`][crate::character::alphanumeric1]
@@ -676,7 +676,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
 /// # use winnow::character::complete::space0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     space0(input)
@@ -707,15 +707,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::space1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     space1(input)
 /// }
 ///
 /// assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::Space))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Space))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::Space))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Space))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::space1`][crate::character::space1]
@@ -742,7 +742,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, IResult, Needed};
 /// # use winnow::character::complete::multispace0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     multispace0(input)
@@ -776,15 +776,15 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::complete::multispace1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     multispace1(input)
 /// }
 ///
 /// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::MultiSpace))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::MultiSpace))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::MultiSpace))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::MultiSpace))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::multispace1`][crate::character::multispace1]
@@ -838,7 +838,7 @@ macro_rules! ints {
                 let (i, sign) = sign(input.clone())?;
 
                 if i.input_len() == 0 {
-                    return Err(Err::Error(E::from_error_kind(input, ErrorKind::Digit)));
+                    return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit)));
                 }
 
                 let mut value: $t = 0;
@@ -846,7 +846,7 @@ macro_rules! ints {
                     match c.as_char().to_digit(10) {
                         None => {
                             if offset == 0 {
-                                return Err(Err::Error(E::from_error_kind(input, ErrorKind::Digit)));
+                                return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit)));
                             } else {
                                 return Ok((i.next_slice(offset).0, value));
                             }
@@ -858,7 +858,7 @@ macro_rules! ints {
                                v.checked_sub(d as $t)
                             }
                         }) {
-                            None => return Err(Err::Error(E::from_error_kind(input, ErrorKind::Digit))),
+                            None => return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit))),
                             Some(v) => value = v,
                         }
                    }
@@ -887,7 +887,7 @@ macro_rules! uints {
                 let i = input;
 
                 if i.input_len() == 0 {
-                    return Err(Err::Error(E::from_error_kind(i, ErrorKind::Digit)));
+                    return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit)));
                 }
 
                 let mut value: $t = 0;
@@ -895,13 +895,13 @@ macro_rules! uints {
                     match c.as_char().to_digit(10) {
                         None => {
                             if offset == 0 {
-                                return Err(Err::Error(E::from_error_kind(i, ErrorKind::Digit)));
+                                return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit)));
                             } else {
                                 return Ok((i.next_slice(offset).0, value));
                             }
                         },
                         Some(d) => match value.checked_mul(10).and_then(|v| v.checked_add(d as $t)) {
-                            None => return Err(Err::Error(E::from_error_kind(i, ErrorKind::Digit))),
+                            None => return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit))),
                             Some(v) => value = v,
                         }
                     }
@@ -921,7 +921,7 @@ mod tests {
   use crate::branch::alt;
   use crate::error::Error;
   use crate::input::ParseTo;
-  use crate::Err;
+  use crate::ErrMode;
   use proptest::prelude::*;
 
   macro_rules! assert_parse(
@@ -940,11 +940,11 @@ mod tests {
     let d: &[u8] = "azé12".as_bytes();
     let e: &[u8] = b" ";
     let f: &[u8] = b" ;";
-    //assert_eq!(alpha1::<_, Error<_>>(a), Err(Err::Incomplete(Needed::Size(1))));
+    //assert_eq!(alpha1::<_, Error<_>>(a), Err(ErrMode::Incomplete(Needed::Size(1))));
     assert_parse!(alpha1(a), Ok((empty, a)));
     assert_eq!(
       alpha1(b),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: b,
         kind: ErrorKind::Alpha
       }))
@@ -953,7 +953,7 @@ mod tests {
     assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bytes(), &b"az"[..])));
     assert_eq!(
       digit1(a),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: a,
         kind: ErrorKind::Digit
       }))
@@ -961,14 +961,14 @@ mod tests {
     assert_eq!(digit1::<_, Error<_>>(b), Ok((empty, b)));
     assert_eq!(
       digit1(c),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: c,
         kind: ErrorKind::Digit
       }))
     );
     assert_eq!(
       digit1(d),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: d,
         kind: ErrorKind::Digit
       }))
@@ -982,14 +982,14 @@ mod tests {
     );
     assert_eq!(
       hex_digit1(e),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: e,
         kind: ErrorKind::HexDigit
       }))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: a,
         kind: ErrorKind::OctDigit
       }))
@@ -997,14 +997,14 @@ mod tests {
     assert_eq!(oct_digit1::<_, Error<_>>(b), Ok((empty, b)));
     assert_eq!(
       oct_digit1(c),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: c,
         kind: ErrorKind::OctDigit
       }))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: d,
         kind: ErrorKind::OctDigit
       }))
@@ -1032,7 +1032,7 @@ mod tests {
     assert_eq!(alpha1::<_, Error<_>>(a), Ok((empty, a)));
     assert_eq!(
       alpha1(b),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: b,
         kind: ErrorKind::Alpha
       }))
@@ -1041,7 +1041,7 @@ mod tests {
     assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12", "az")));
     assert_eq!(
       digit1(a),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: a,
         kind: ErrorKind::Digit
       }))
@@ -1049,14 +1049,14 @@ mod tests {
     assert_eq!(digit1::<_, Error<_>>(b), Ok((empty, b)));
     assert_eq!(
       digit1(c),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: c,
         kind: ErrorKind::Digit
       }))
     );
     assert_eq!(
       digit1(d),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: d,
         kind: ErrorKind::Digit
       }))
@@ -1067,14 +1067,14 @@ mod tests {
     assert_eq!(hex_digit1::<_, Error<_>>(d), Ok(("zé12", "a")));
     assert_eq!(
       hex_digit1(e),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: e,
         kind: ErrorKind::HexDigit
       }))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: a,
         kind: ErrorKind::OctDigit
       }))
@@ -1082,14 +1082,14 @@ mod tests {
     assert_eq!(oct_digit1::<_, Error<_>>(b), Ok((empty, b)));
     assert_eq!(
       oct_digit1(c),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: c,
         kind: ErrorKind::OctDigit
       }))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: d,
         kind: ErrorKind::OctDigit
       }))
@@ -1201,7 +1201,7 @@ mod tests {
     let f = "βèƒôřè\rÂßÇáƒƭèř";
     assert_eq!(
       not_line_ending(f),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: f,
         kind: ErrorKind::Tag
       }))
@@ -1219,13 +1219,13 @@ mod tests {
     let i = &b"g"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
     );
 
     let i = &b"G"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
     );
 
     assert!(AsChar::is_hex_digit(b'0'));
@@ -1250,7 +1250,7 @@ mod tests {
     let i = &b"8"[..];
     assert_parse!(
       oct_digit1(i),
-      Err(Err::Error(error_position!(i, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(error_position!(i, ErrorKind::OctDigit)))
     );
 
     assert!(AsChar::is_oct_digit(b'0'));
@@ -1306,21 +1306,24 @@ mod tests {
     assert_parse!(crlf(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_parse!(
       crlf(&b"\r"[..]),
-      Err(Err::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
     );
     assert_parse!(
       crlf(&b"\ra"[..]),
-      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(
+        &b"\ra"[..],
+        ErrorKind::CrLf
+      )))
     );
 
     assert_parse!(crlf("\r\na"), Ok(("a", "\r\n")));
     assert_parse!(
       crlf("\r"),
-      Err(Err::Error(error_position!("\r", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\r", ErrorKind::CrLf)))
     );
     assert_parse!(
       crlf("\ra"),
-      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -1330,22 +1333,25 @@ mod tests {
     assert_parse!(line_ending(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_parse!(
       line_ending(&b"\r"[..]),
-      Err(Err::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
     );
     assert_parse!(
       line_ending(&b"\ra"[..]),
-      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(
+        &b"\ra"[..],
+        ErrorKind::CrLf
+      )))
     );
 
     assert_parse!(line_ending("\na"), Ok(("a", "\n")));
     assert_parse!(line_ending("\r\na"), Ok(("a", "\r\n")));
     assert_parse!(
       line_ending("\r"),
-      Err(Err::Error(error_position!("\r", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\r", ErrorKind::CrLf)))
     );
     assert_parse!(
       line_ending("\ra"),
-      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -1361,7 +1367,7 @@ mod tests {
     let (i, s) = match digit1::<_, crate::error::Error<_>>(i) {
       Ok((i, s)) => (i, s),
       Err(_) => {
-        return Err(Err::Error(crate::error::Error::from_error_kind(
+        return Err(ErrMode::Error(crate::error::Error::from_error_kind(
           input,
           ErrorKind::Digit,
         )))
@@ -1376,7 +1382,7 @@ mod tests {
           Ok((i, -n))
         }
       }
-      None => Err(Err::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -1387,7 +1393,7 @@ mod tests {
     let (i, s) = digit1(i)?;
     match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(Err::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -19,12 +19,12 @@ use crate::Parser;
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult};
 /// # use winnow::character::crlf;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     crlf(input)
@@ -36,7 +36,7 @@ use crate::Parser;
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::crlf;
 /// assert_eq!(crlf::<_, Error<_>, true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
@@ -63,12 +63,12 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::not_line_ending;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     not_line_ending(input)
@@ -83,7 +83,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::not_line_ending;
 /// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("ab\r\nc")), Ok((Streaming("\r\nc"), "ab")));
@@ -113,12 +113,12 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::line_ending;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     line_ending(input)
@@ -130,7 +130,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::line_ending;
 /// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
@@ -157,12 +157,12 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::newline;
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     newline(input)
@@ -174,7 +174,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::newline;
 /// assert_eq!(newline::<_, Error<_>, true>(Streaming("\nc")), Ok((Streaming("c"), '\n')));
@@ -199,12 +199,12 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::tab;
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     tab(input)
@@ -216,7 +216,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::tab;
 /// assert_eq!(tab::<_, Error<_>, true>(Streaming("\tc")), Ok((Streaming("c"), '\t')));
@@ -242,13 +242,13 @@ where
 /// *Complete version*: Will return the whole input if no terminating token is found (a non
 /// alphabetic character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphabetic character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::alpha0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alpha0(input)
@@ -260,7 +260,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alpha0;
 /// assert_eq!(alpha0::<_, Error<_>, true>(Streaming("ab1c")), Ok((Streaming("1c"), "ab")));
@@ -288,13 +288,13 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found  (a non alphabetic character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphabetic character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::alpha1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alpha1(input)
@@ -306,7 +306,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alpha1;
 /// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("aB1c")), Ok((Streaming("1c"), "aB")));
@@ -334,13 +334,13 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit0(input)
@@ -353,7 +353,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::digit0;
 /// assert_eq!(digit0::<_, Error<_>, true>(Streaming("21c")), Ok((Streaming("c"), "21")));
@@ -381,13 +381,13 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit1(input)
@@ -399,7 +399,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::digit1;
 /// assert_eq!(digit1::<_, Error<_>, true>(Streaming("21c")), Ok((Streaming("c"), "21")));
@@ -412,7 +412,7 @@ where
 /// You can use `digit1` in combination with [`Parser::map_res`][crate::Parser::map_res] to parse an integer:
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed, Parser};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed, Parser};
 /// # use winnow::character::digit1;
 /// fn parser(input: &str) -> IResult<&str, u32> {
 ///   digit1.map_res(str::parse).parse_next(input)
@@ -442,13 +442,13 @@ where
 ///
 /// *Complete version*: Will return the whole input if no terminating token is found (a non hexadecimal digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non hexadecimal digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::hex_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     hex_digit0(input)
@@ -460,7 +460,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::hex_digit0;
 /// assert_eq!(hex_digit0::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
@@ -488,13 +488,13 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non hexadecimal digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non hexadecimal digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::hex_digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     hex_digit1(input)
@@ -506,7 +506,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::hex_digit1;
 /// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
@@ -534,13 +534,13 @@ where
 /// *Complete version*: Will return the whole input if no terminating token is found (a non octal
 /// digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non octal digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::oct_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     oct_digit0(input)
@@ -552,7 +552,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::oct_digit0;
 /// assert_eq!(oct_digit0::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
@@ -580,13 +580,13 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non octal digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non octal digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::oct_digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     oct_digit1(input)
@@ -598,7 +598,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::oct_digit1;
 /// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
@@ -626,13 +626,13 @@ where
 /// *Complete version*: Will return the whole input if no terminating token is found (a non
 /// alphanumerical character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphanumerical character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::alphanumeric0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alphanumeric0(input)
@@ -644,7 +644,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alphanumeric0;
 /// assert_eq!(alphanumeric0::<_, Error<_>, true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
@@ -672,13 +672,13 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non alphanumerical character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphanumerical character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::alphanumeric1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alphanumeric1(input)
@@ -690,7 +690,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alphanumeric1;
 /// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
@@ -718,13 +718,13 @@ where
 /// *Complete version*: Will return the whole input if no terminating token is found (a non space
 /// character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::space0;
 /// assert_eq!(space0::<_, Error<_>, true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
@@ -752,13 +752,13 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non space character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::space1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     space1(input)
@@ -770,7 +770,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::space1;
 /// assert_eq!(space1::<_, Error<_>, true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
@@ -798,13 +798,13 @@ where
 /// *Complete version*: will return the whole input if no terminating token is found (a non space
 /// character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::multispace0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     multispace0(input)
@@ -816,7 +816,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::multispace0;
 /// assert_eq!(multispace0::<_, Error<_>, true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
@@ -844,13 +844,13 @@ where
 /// *Complete version*: will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non space character).
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::multispace1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     multispace1(input)
@@ -862,7 +862,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::multispace1;
 /// assert_eq!(multispace1::<_, Error<_>, true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
@@ -893,7 +893,7 @@ macro_rules! ints {
         ///
         /// *Complete version*: can parse until the end of input.
         ///
-        /// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+        /// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
         #[inline(always)]
         pub fn $t<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, $t, E>
             where
@@ -921,7 +921,7 @@ macro_rules! uints {
         ///
         /// *Complete version*: can parse until the end of input.
         ///
-        /// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+        /// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
         #[inline(always)]
         pub fn $t<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, $t, E>
             where
@@ -945,13 +945,13 @@ uints! { u8 u16 u32 u64 u128 }
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::character::f32;
 ///
 /// let parser = |s| {
@@ -965,8 +965,8 @@ uints! { u8 u16 u32 u64 u128 }
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::character::f32;
 ///
@@ -1002,13 +1002,13 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::character::f64;
 ///
 /// let parser = |s| {
@@ -1022,8 +1022,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::character::f64;
 ///
@@ -1059,13 +1059,13 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::character::recognize_float;
 ///
 /// let parser = |s| {
@@ -1079,7 +1079,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::character::recognize_float;
 ///
@@ -1118,7 +1118,7 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 #[inline(always)]
 #[allow(clippy::type_complexity)]
@@ -1145,7 +1145,7 @@ where
 /// * The third argument matches the escaped characters
 /// # Example
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::character::digit1;
 /// use winnow::character::escaped;
 /// use winnow::bytes::one_of;
@@ -1159,7 +1159,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::character::digit1;
 /// # use winnow::input::Streaming;
 /// use winnow::character::escaped;
@@ -1205,7 +1205,7 @@ where
 ///
 /// ```
 /// # use winnow::prelude::*;
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use std::str::from_utf8;
 /// use winnow::bytes::tag;
 /// use winnow::character::escaped_transform;
@@ -1231,7 +1231,7 @@ where
 ///
 /// ```
 /// # use winnow::prelude::*;
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use std::str::from_utf8;
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::tag;

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -31,8 +31,8 @@ use crate::Parser;
 /// }
 ///
 /// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::CrLf))));
+/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::CrLf))));
 /// ```
 ///
 /// ```
@@ -40,7 +40,7 @@ use crate::Parser;
 /// # use winnow::input::Streaming;
 /// # use winnow::character::crlf;
 /// assert_eq!(crlf::<_, Error<_>, true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
-/// assert_eq!(crlf::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(ErrMode::Error(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(crlf::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
 /// assert_eq!(crlf::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
@@ -78,8 +78,8 @@ where
 /// assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
 /// assert_eq!(parser("abc"), Ok(("", "abc")));
 /// assert_eq!(parser(""), Ok(("", "")));
-/// assert_eq!(parser("a\rb\nc"), Err(ErrMode::Error(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
-/// assert_eq!(parser("a\rbc"), Err(ErrMode::Error(Error { input: "a\rbc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rb\nc"), Err(ErrMode::Backtrack(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rbc"), Err(ErrMode::Backtrack(Error { input: "a\rbc", kind: ErrorKind::Tag })));
 /// ```
 ///
 /// ```
@@ -89,8 +89,8 @@ where
 /// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("ab\r\nc")), Ok((Streaming("\r\nc"), "ab")));
 /// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rb\nc")), Err(ErrMode::Error(Error::new(Streaming("a\rb\nc"), ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rbc")), Err(ErrMode::Error(Error::new(Streaming("a\rbc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rb\nc")), Err(ErrMode::Backtrack(Error::new(Streaming("a\rb\nc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rbc")), Err(ErrMode::Backtrack(Error::new(Streaming("a\rbc"), ErrorKind::Tag ))));
 /// ```
 #[inline(always)]
 pub fn not_line_ending<I, E: ParseError<I>, const STREAMING: bool>(
@@ -125,8 +125,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::CrLf))));
+/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::CrLf))));
 /// ```
 ///
 /// ```
@@ -134,7 +134,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::line_ending;
 /// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
-/// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(ErrMode::Error(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
 /// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -169,8 +169,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("\nc"), Ok(("c", '\n')));
-/// assert_eq!(parser("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// ```
@@ -178,7 +178,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::newline;
 /// assert_eq!(newline::<_, Error<_>, true>(Streaming("\nc")), Ok((Streaming("c"), '\n')));
-/// assert_eq!(newline::<_, Error<_>, true>(Streaming("\r\nc")), Err(ErrMode::Error(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(newline::<_, Error<_>, true>(Streaming("\r\nc")), Err(ErrMode::Backtrack(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
 /// assert_eq!(newline::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -211,8 +211,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("\tc"), Ok(("c", '\t')));
-/// assert_eq!(parser("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// ```
@@ -220,7 +220,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::tab;
 /// assert_eq!(tab::<_, Error<_>, true>(Streaming("\tc")), Ok((Streaming("c"), '\t')));
-/// assert_eq!(tab::<_, Error<_>, true>(Streaming("\r\nc")), Err(ErrMode::Error(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(tab::<_, Error<_>, true>(Streaming("\r\nc")), Err(ErrMode::Backtrack(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
 /// assert_eq!(tab::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -301,8 +301,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(parser("1c"), Err(ErrMode::Error(Error::new("1c", ErrorKind::Alpha))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Alpha))));
+/// assert_eq!(parser("1c"), Err(ErrMode::Backtrack(Error::new("1c", ErrorKind::Alpha))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Alpha))));
 /// ```
 ///
 /// ```
@@ -310,7 +310,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alpha1;
 /// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("aB1c")), Ok((Streaming("1c"), "aB")));
-/// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("1c")), Err(ErrMode::Error(Error::new(Streaming("1c"), ErrorKind::Alpha))));
+/// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("1c")), Err(ErrMode::Backtrack(Error::new(Streaming("1c"), ErrorKind::Alpha))));
 /// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -394,8 +394,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("21c"), Ok(("c", "21")));
-/// assert_eq!(parser("c1"), Err(ErrMode::Error(Error::new("c1", ErrorKind::Digit))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Digit))));
+/// assert_eq!(parser("c1"), Err(ErrMode::Backtrack(Error::new("c1", ErrorKind::Digit))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Digit))));
 /// ```
 ///
 /// ```
@@ -403,7 +403,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::digit1;
 /// assert_eq!(digit1::<_, Error<_>, true>(Streaming("21c")), Ok((Streaming("c"), "21")));
-/// assert_eq!(digit1::<_, Error<_>, true>(Streaming("c1")), Err(ErrMode::Error(Error::new(Streaming("c1"), ErrorKind::Digit))));
+/// assert_eq!(digit1::<_, Error<_>, true>(Streaming("c1")), Err(ErrMode::Backtrack(Error::new(Streaming("c1"), ErrorKind::Digit))));
 /// assert_eq!(digit1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -501,8 +501,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::HexDigit))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::HexDigit))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::HexDigit))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::HexDigit))));
 /// ```
 ///
 /// ```
@@ -510,7 +510,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::hex_digit1;
 /// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
-/// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Error(Error::new(Streaming("H2"), ErrorKind::HexDigit))));
+/// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Backtrack(Error::new(Streaming("H2"), ErrorKind::HexDigit))));
 /// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -593,8 +593,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::OctDigit))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::OctDigit))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::OctDigit))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::OctDigit))));
 /// ```
 ///
 /// ```
@@ -602,7 +602,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::oct_digit1;
 /// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
-/// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Error(Error::new(Streaming("H2"), ErrorKind::OctDigit))));
+/// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Backtrack(Error::new(Streaming("H2"), ErrorKind::OctDigit))));
 /// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -685,8 +685,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(parser("&H2"), Err(ErrMode::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::AlphaNumeric))));
+/// assert_eq!(parser("&H2"), Err(ErrMode::Backtrack(Error::new("&H2", ErrorKind::AlphaNumeric))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::AlphaNumeric))));
 /// ```
 ///
 /// ```
@@ -694,7 +694,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alphanumeric1;
 /// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
-/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("&H2")), Err(ErrMode::Error(Error::new(Streaming("&H2"), ErrorKind::AlphaNumeric))));
+/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("&H2")), Err(ErrMode::Backtrack(Error::new(Streaming("&H2"), ErrorKind::AlphaNumeric))));
 /// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -765,8 +765,8 @@ where
 /// }
 ///
 /// assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::Space))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Space))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Space))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Space))));
 /// ```
 ///
 /// ```
@@ -774,7 +774,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::space1;
 /// assert_eq!(space1::<_, Error<_>, true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
-/// assert_eq!(space1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Error(Error::new(Streaming("H2"), ErrorKind::Space))));
+/// assert_eq!(space1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Backtrack(Error::new(Streaming("H2"), ErrorKind::Space))));
 /// assert_eq!(space1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -857,8 +857,8 @@ where
 /// }
 ///
 /// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::MultiSpace))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::MultiSpace))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::MultiSpace))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::MultiSpace))));
 /// ```
 ///
 /// ```
@@ -866,7 +866,7 @@ where
 /// # use winnow::input::Streaming;
 /// # use winnow::character::multispace1;
 /// assert_eq!(multispace1::<_, Error<_>, true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
-/// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Error(Error::new(Streaming("H2"), ErrorKind::MultiSpace))));
+/// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Backtrack(Error::new(Streaming("H2"), ErrorKind::MultiSpace))));
 /// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -961,7 +961,7 @@ uints! { u8 u16 u32 u64 u128 }
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// ```rust
@@ -978,7 +978,7 @@ uints! { u8 u16 u32 u64 u128 }
 /// assert_eq!(parser(Streaming("11e-1")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123E-02")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), 123.0)));
-/// assert_eq!(parser(Streaming("abc")), Err(ErrMode::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
+/// assert_eq!(parser(Streaming("abc")), Err(ErrMode::Backtrack(Error::new(Streaming("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
 pub fn f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f32, E>
@@ -1018,7 +1018,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// ```rust
@@ -1035,7 +1035,7 @@ where
 /// assert_eq!(parser(Streaming("11e-1")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123E-02")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), 123.0)));
-/// assert_eq!(parser(Streaming("abc")), Err(ErrMode::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
+/// assert_eq!(parser(Streaming("abc")), Err(ErrMode::Backtrack(Error::new(Streaming("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
 pub fn f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f64, E>
@@ -1075,7 +1075,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
 /// assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Char))));
 /// ```
 ///
 /// ```rust
@@ -1090,7 +1090,7 @@ where
 /// assert_eq!(parser(Streaming("11e-1;")), Ok((Streaming(";"), "11e-1")));
 /// assert_eq!(parser(Streaming("123E-02;")), Ok((Streaming(";"), "123E-02")));
 /// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), "123")));
-/// assert_eq!(parser(Streaming("abc")), Err(ErrMode::Error(Error::new(Streaming("abc"), ErrorKind::Char))));
+/// assert_eq!(parser(Streaming("abc")), Err(ErrMode::Backtrack(Error::new(Streaming("abc"), ErrorKind::Char))));
 /// ```
 #[inline(always)]
 pub fn recognize_float<I, E: ParseError<I>, const STREAMING: bool>(

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -19,29 +19,29 @@ use crate::Parser;
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult};
 /// # use winnow::character::crlf;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     crlf(input)
 /// }
 ///
 /// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::CrLf))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::crlf;
 /// assert_eq!(crlf::<_, Error<_>, true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
-/// assert_eq!(crlf::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(Err::Error(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
-/// assert_eq!(crlf::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(crlf::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(ErrMode::Error(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(crlf::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn crlf<I, E: ParseError<I>, const STREAMING: bool>(
@@ -63,12 +63,12 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::not_line_ending;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     not_line_ending(input)
@@ -78,19 +78,19 @@ where
 /// assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
 /// assert_eq!(parser("abc"), Ok(("", "abc")));
 /// assert_eq!(parser(""), Ok(("", "")));
-/// assert_eq!(parser("a\rb\nc"), Err(Err::Error(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
-/// assert_eq!(parser("a\rbc"), Err(Err::Error(Error { input: "a\rbc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rb\nc"), Err(ErrMode::Error(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser("a\rbc"), Err(ErrMode::Error(Error { input: "a\rbc", kind: ErrorKind::Tag })));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::not_line_ending;
 /// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("ab\r\nc")), Ok((Streaming("\r\nc"), "ab")));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("abc")), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rb\nc")), Err(Err::Error(Error::new(Streaming("a\rb\nc"), ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rbc")), Err(Err::Error(Error::new(Streaming("a\rbc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rb\nc")), Err(ErrMode::Error(Error::new(Streaming("a\rb\nc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>, true>(Streaming("a\rbc")), Err(ErrMode::Error(Error::new(Streaming("a\rbc"), ErrorKind::Tag ))));
 /// ```
 #[inline(always)]
 pub fn not_line_ending<I, E: ParseError<I>, const STREAMING: bool>(
@@ -113,29 +113,29 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::line_ending;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     line_ending(input)
 /// }
 ///
 /// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::CrLf))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::line_ending;
 /// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("\r\nc")), Ok((Streaming("c"), "\r\n")));
-/// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(Err::Error(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
-/// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("ab\r\nc")), Err(ErrMode::Error(Error::new(Streaming("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn line_ending<I, E: ParseError<I>, const STREAMING: bool>(
@@ -157,29 +157,29 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::newline;
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     newline(input)
 /// }
 ///
 /// assert_eq!(parser("\nc"), Ok(("c", '\n')));
-/// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::newline;
 /// assert_eq!(newline::<_, Error<_>, true>(Streaming("\nc")), Ok((Streaming("c"), '\n')));
-/// assert_eq!(newline::<_, Error<_>, true>(Streaming("\r\nc")), Err(Err::Error(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
-/// assert_eq!(newline::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(newline::<_, Error<_>, true>(Streaming("\r\nc")), Err(ErrMode::Error(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(newline::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn newline<I, Error: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, char, Error>
@@ -199,29 +199,29 @@ where
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::tab;
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     tab(input)
 /// }
 ///
 /// assert_eq!(parser("\tc"), Ok(("c", '\t')));
-/// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// assert_eq!(parser("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Char))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::tab;
 /// assert_eq!(tab::<_, Error<_>, true>(Streaming("\tc")), Ok((Streaming("c"), '\t')));
-/// assert_eq!(tab::<_, Error<_>, true>(Streaming("\r\nc")), Err(Err::Error(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
-/// assert_eq!(tab::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(tab::<_, Error<_>, true>(Streaming("\r\nc")), Err(ErrMode::Error(Error::new(Streaming("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(tab::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn tab<I, Error: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, char, Error>
@@ -242,13 +242,13 @@ where
 /// *Complete version*: Will return the whole input if no terminating token is found (a non
 /// alphabetic character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphabetic character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::alpha0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alpha0(input)
@@ -260,12 +260,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alpha0;
 /// assert_eq!(alpha0::<_, Error<_>, true>(Streaming("ab1c")), Ok((Streaming("1c"), "ab")));
 /// assert_eq!(alpha0::<_, Error<_>, true>(Streaming("1c")), Ok((Streaming("1c"), "")));
-/// assert_eq!(alpha0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha0::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alpha0<I, E: ParseError<I>, const STREAMING: bool>(
@@ -288,30 +288,30 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found  (a non alphabetic character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphabetic character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::alpha1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alpha1(input)
 /// }
 ///
 /// assert_eq!(parser("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(parser("1c"), Err(Err::Error(Error::new("1c", ErrorKind::Alpha))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Alpha))));
+/// assert_eq!(parser("1c"), Err(ErrMode::Error(Error::new("1c", ErrorKind::Alpha))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Alpha))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alpha1;
 /// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("aB1c")), Ok((Streaming("1c"), "aB")));
-/// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("1c")), Err(Err::Error(Error::new(Streaming("1c"), ErrorKind::Alpha))));
-/// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("1c")), Err(ErrMode::Error(Error::new(Streaming("1c"), ErrorKind::Alpha))));
+/// assert_eq!(alpha1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alpha1<I, E: ParseError<I>, const STREAMING: bool>(
@@ -334,13 +334,13 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit0(input)
@@ -353,12 +353,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::digit0;
 /// assert_eq!(digit0::<_, Error<_>, true>(Streaming("21c")), Ok((Streaming("c"), "21")));
 /// assert_eq!(digit0::<_, Error<_>, true>(Streaming("a21c")), Ok((Streaming("a21c"), "")));
-/// assert_eq!(digit0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(digit0::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn digit0<I, E: ParseError<I>, const STREAMING: bool>(
@@ -381,30 +381,30 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     digit1(input)
 /// }
 ///
 /// assert_eq!(parser("21c"), Ok(("c", "21")));
-/// assert_eq!(parser("c1"), Err(Err::Error(Error::new("c1", ErrorKind::Digit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Digit))));
+/// assert_eq!(parser("c1"), Err(ErrMode::Error(Error::new("c1", ErrorKind::Digit))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Digit))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::digit1;
 /// assert_eq!(digit1::<_, Error<_>, true>(Streaming("21c")), Ok((Streaming("c"), "21")));
-/// assert_eq!(digit1::<_, Error<_>, true>(Streaming("c1")), Err(Err::Error(Error::new(Streaming("c1"), ErrorKind::Digit))));
-/// assert_eq!(digit1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(digit1::<_, Error<_>, true>(Streaming("c1")), Err(ErrMode::Error(Error::new(Streaming("c1"), ErrorKind::Digit))));
+/// assert_eq!(digit1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// ## Parsing an integer
@@ -412,7 +412,7 @@ where
 /// You can use `digit1` in combination with [`Parser::map_res`][crate::Parser::map_res] to parse an integer:
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed, Parser};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed, Parser};
 /// # use winnow::character::digit1;
 /// fn parser(input: &str) -> IResult<&str, u32> {
 ///   digit1.map_res(str::parse).parse_next(input)
@@ -442,13 +442,13 @@ where
 ///
 /// *Complete version*: Will return the whole input if no terminating token is found (a non hexadecimal digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non hexadecimal digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::hex_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     hex_digit0(input)
@@ -460,12 +460,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::hex_digit0;
 /// assert_eq!(hex_digit0::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
 /// assert_eq!(hex_digit0::<_, Error<_>, true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
-/// assert_eq!(hex_digit0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit0::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn hex_digit0<I, E: ParseError<I>, const STREAMING: bool>(
@@ -488,30 +488,30 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non hexadecimal digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non hexadecimal digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::hex_digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     hex_digit1(input)
 /// }
 ///
 /// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::HexDigit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::HexDigit))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::HexDigit))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::HexDigit))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::hex_digit1;
 /// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("Z"), "21c")));
-/// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("H2")), Err(Err::Error(Error::new(Streaming("H2"), ErrorKind::HexDigit))));
-/// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Error(Error::new(Streaming("H2"), ErrorKind::HexDigit))));
+/// assert_eq!(hex_digit1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn hex_digit1<I, E: ParseError<I>, const STREAMING: bool>(
@@ -534,13 +534,13 @@ where
 /// *Complete version*: Will return the whole input if no terminating token is found (a non octal
 /// digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non octal digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::oct_digit0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     oct_digit0(input)
@@ -552,12 +552,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::oct_digit0;
 /// assert_eq!(oct_digit0::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
 /// assert_eq!(oct_digit0::<_, Error<_>, true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
-/// assert_eq!(oct_digit0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit0::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn oct_digit0<I, E: ParseError<I>, const STREAMING: bool>(
@@ -580,30 +580,30 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non octal digit character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non octal digit character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::oct_digit1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     oct_digit1(input)
 /// }
 ///
 /// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::OctDigit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OctDigit))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::OctDigit))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::OctDigit))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::oct_digit1;
 /// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("21cZ")), Ok((Streaming("cZ"), "21")));
-/// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("H2")), Err(Err::Error(Error::new(Streaming("H2"), ErrorKind::OctDigit))));
-/// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Error(Error::new(Streaming("H2"), ErrorKind::OctDigit))));
+/// assert_eq!(oct_digit1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn oct_digit1<I, E: ParseError<I>, const STREAMING: bool>(
@@ -626,13 +626,13 @@ where
 /// *Complete version*: Will return the whole input if no terminating token is found (a non
 /// alphanumerical character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphanumerical character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::alphanumeric0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alphanumeric0(input)
@@ -644,12 +644,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alphanumeric0;
 /// assert_eq!(alphanumeric0::<_, Error<_>, true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
 /// assert_eq!(alphanumeric0::<_, Error<_>, true>(Streaming("&Z21c")), Ok((Streaming("&Z21c"), "")));
-/// assert_eq!(alphanumeric0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric0::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alphanumeric0<I, E: ParseError<I>, const STREAMING: bool>(
@@ -672,30 +672,30 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non alphanumerical character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphanumerical character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::alphanumeric1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     alphanumeric1(input)
 /// }
 ///
 /// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(parser("&H2"), Err(Err::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::AlphaNumeric))));
+/// assert_eq!(parser("&H2"), Err(ErrMode::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::AlphaNumeric))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::alphanumeric1;
 /// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("21cZ%1")), Ok((Streaming("%1"), "21cZ")));
-/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("&H2")), Err(Err::Error(Error::new(Streaming("&H2"), ErrorKind::AlphaNumeric))));
-/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("&H2")), Err(ErrMode::Error(Error::new(Streaming("&H2"), ErrorKind::AlphaNumeric))));
+/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alphanumeric1<I, E: ParseError<I>, const STREAMING: bool>(
@@ -718,18 +718,18 @@ where
 /// *Complete version*: Will return the whole input if no terminating token is found (a non space
 /// character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::space0;
 /// assert_eq!(space0::<_, Error<_>, true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
 /// assert_eq!(space0::<_, Error<_>, true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
-/// assert_eq!(space0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(space0::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn space0<I, E: ParseError<I>, const STREAMING: bool>(
@@ -752,30 +752,30 @@ where
 /// *Complete version*: Will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non space character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::space1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     space1(input)
 /// }
 ///
 /// assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::Space))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Space))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::Space))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Space))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::space1;
 /// assert_eq!(space1::<_, Error<_>, true>(Streaming(" \t21c")), Ok((Streaming("21c"), " \t")));
-/// assert_eq!(space1::<_, Error<_>, true>(Streaming("H2")), Err(Err::Error(Error::new(Streaming("H2"), ErrorKind::Space))));
-/// assert_eq!(space1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(space1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Error(Error::new(Streaming("H2"), ErrorKind::Space))));
+/// assert_eq!(space1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn space1<I, E: ParseError<I>, const STREAMING: bool>(
@@ -798,13 +798,13 @@ where
 /// *Complete version*: will return the whole input if no terminating token is found (a non space
 /// character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::multispace0;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     multispace0(input)
@@ -816,12 +816,12 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::multispace0;
 /// assert_eq!(multispace0::<_, Error<_>, true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
 /// assert_eq!(multispace0::<_, Error<_>, true>(Streaming("Z21c")), Ok((Streaming("Z21c"), "")));
-/// assert_eq!(multispace0::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace0::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn multispace0<I, E: ParseError<I>, const STREAMING: bool>(
@@ -844,30 +844,30 @@ where
 /// *Complete version*: will return an error if there's not enough input data,
 /// or the whole input if no terminating token is found (a non space character).
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 ///
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::multispace1;
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///     multispace1(input)
 /// }
 ///
 /// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::MultiSpace))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::MultiSpace))));
+/// assert_eq!(parser("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::MultiSpace))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::MultiSpace))));
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::input::Streaming;
 /// # use winnow::character::multispace1;
 /// assert_eq!(multispace1::<_, Error<_>, true>(Streaming(" \t\n\r21c")), Ok((Streaming("21c"), " \t\n\r")));
-/// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("H2")), Err(Err::Error(Error::new(Streaming("H2"), ErrorKind::MultiSpace))));
-/// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("H2")), Err(ErrMode::Error(Error::new(Streaming("H2"), ErrorKind::MultiSpace))));
+/// assert_eq!(multispace1::<_, Error<_>, true>(Streaming("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn multispace1<I, E: ParseError<I>, const STREAMING: bool>(
@@ -893,7 +893,7 @@ macro_rules! ints {
         ///
         /// *Complete version*: can parse until the end of input.
         ///
-        /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+        /// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
         #[inline(always)]
         pub fn $t<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, $t, E>
             where
@@ -921,7 +921,7 @@ macro_rules! uints {
         ///
         /// *Complete version*: can parse until the end of input.
         ///
-        /// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+        /// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
         #[inline(always)]
         pub fn $t<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, $t, E>
             where
@@ -945,12 +945,12 @@ uints! { u8 u16 u32 u64 u128 }
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::character::f32;
 ///
@@ -961,11 +961,11 @@ uints! { u8 u16 u32 u64 u128 }
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::character::f32;
@@ -975,10 +975,10 @@ uints! { u8 u16 u32 u64 u128 }
 /// };
 ///
 /// assert_eq!(parser(Streaming("11e-1 ")), Ok((Streaming(" "), 1.1)));
-/// assert_eq!(parser(Streaming("11e-1")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Streaming("123E-02")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming("11e-1")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming("123E-02")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), 123.0)));
-/// assert_eq!(parser(Streaming("abc")), Err(Err::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
+/// assert_eq!(parser(Streaming("abc")), Err(ErrMode::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
 pub fn f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f32, E>
@@ -1002,12 +1002,12 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::character::f64;
 ///
@@ -1018,11 +1018,11 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::character::f64;
@@ -1032,10 +1032,10 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming("11e-1 ")), Ok((Streaming(" "), 1.1)));
-/// assert_eq!(parser(Streaming("11e-1")), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Streaming("123E-02")), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming("11e-1")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming("123E-02")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), 123.0)));
-/// assert_eq!(parser(Streaming("abc")), Err(Err::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
+/// assert_eq!(parser(Streaming("abc")), Err(ErrMode::Error(Error::new(Streaming("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
 pub fn f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f64, E>
@@ -1059,12 +1059,12 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::character::recognize_float;
 ///
@@ -1075,11 +1075,11 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
 /// assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Char))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::character::recognize_float;
 ///
@@ -1090,7 +1090,7 @@ where
 /// assert_eq!(parser(Streaming("11e-1;")), Ok((Streaming(";"), "11e-1")));
 /// assert_eq!(parser(Streaming("123E-02;")), Ok((Streaming(";"), "123E-02")));
 /// assert_eq!(parser(Streaming("123K-01")), Ok((Streaming("K-01"), "123")));
-/// assert_eq!(parser(Streaming("abc")), Err(Err::Error(Error::new(Streaming("abc"), ErrorKind::Char))));
+/// assert_eq!(parser(Streaming("abc")), Err(ErrMode::Error(Error::new(Streaming("abc"), ErrorKind::Char))));
 /// ```
 #[inline(always)]
 pub fn recognize_float<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1118,7 +1118,7 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 #[inline(always)]
 #[allow(clippy::type_complexity)]
@@ -1145,7 +1145,7 @@ where
 /// * The third argument matches the escaped characters
 /// # Example
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::character::digit1;
 /// use winnow::character::escaped;
 /// use winnow::bytes::one_of;
@@ -1159,7 +1159,7 @@ where
 /// ```
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed, IResult};
 /// # use winnow::character::digit1;
 /// # use winnow::input::Streaming;
 /// use winnow::character::escaped;
@@ -1205,7 +1205,7 @@ where
 ///
 /// ```
 /// # use winnow::prelude::*;
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use std::str::from_utf8;
 /// use winnow::bytes::tag;
 /// use winnow::character::escaped_transform;
@@ -1231,7 +1231,7 @@ where
 ///
 /// ```
 /// # use winnow::prelude::*;
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use std::str::from_utf8;
 /// # use winnow::input::Streaming;
 /// use winnow::bytes::tag;

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -5,21 +5,23 @@
 #![allow(deprecated)]
 
 use crate::combinator::opt;
+use crate::error::ErrMode;
 use crate::error::ErrorKind;
+use crate::error::Needed;
 use crate::error::ParseError;
 use crate::input::{
   split_at_offset1_streaming, split_at_offset_streaming, AsBytes, AsChar, ContainsToken, Input,
 };
 use crate::input::{Compare, CompareResult};
-use crate::{ErrMode, IResult, Needed};
+use crate::IResult;
 
 /// Recognizes one character.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{ErrorKind, Error}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{ErrorKind, Error}, error::Needed, IResult};
 /// # use winnow::character::streaming::char;
 /// fn parser(i: &str) -> IResult<&str, char> {
 ///     char('a')(i)
@@ -60,11 +62,11 @@ where
 
 /// Recognizes one character and checks that it satisfies a predicate
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{ErrorKind, Error}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{ErrorKind, Error}, error::Needed, IResult};
 /// # use winnow::character::streaming::satisfy;
 /// fn parser(i: &str) -> IResult<&str, char> {
 ///     satisfy(|c| c == 'a' || c == 'b')(i)
@@ -113,11 +115,11 @@ where
 
 /// Recognizes one of the provided characters.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::character::streaming::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>>("abc")("b"), Ok(("", 'b')));
 /// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
@@ -140,11 +142,11 @@ where
 
 /// Recognizes a character that is not in the provided characters.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::character::streaming::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>>("abc")("z"), Ok(("", 'z')));
 /// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(ErrMode::Error(Error::new("a", ErrorKind::NoneOf))));
@@ -167,11 +169,11 @@ where
 
 /// Recognizes the string "\r\n".
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::crlf;
 /// assert_eq!(crlf::<_, Error<_>>("\r\nc"), Ok(("c", "\r\n")));
 /// assert_eq!(crlf::<_, Error<_>>("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
@@ -201,11 +203,11 @@ where
 
 /// Recognizes a string of any char except '\r\n' or '\n'.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::character::streaming::not_line_ending;
 /// assert_eq!(not_line_ending::<_, Error<_>>("ab\r\nc"), Ok(("\r\nc", "ab")));
 /// assert_eq!(not_line_ending::<_, Error<_>>("abc"), Err(ErrMode::Incomplete(Needed::Unknown)));
@@ -255,11 +257,11 @@ where
 
 /// Recognizes an end of line (both '\n' and '\r\n').
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::line_ending;
 /// assert_eq!(line_ending::<_, Error<_>>("\r\nc"), Ok(("c", "\r\n")));
 /// assert_eq!(line_ending::<_, Error<_>>("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
@@ -291,11 +293,11 @@ where
 
 /// Matches a newline character '\\n'.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::newline;
 /// assert_eq!(newline::<_, Error<_>>("\nc"), Ok(("c", '\n')));
 /// assert_eq!(newline::<_, Error<_>>("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
@@ -317,11 +319,11 @@ where
 
 /// Matches a tab character '\t'.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::tab;
 /// assert_eq!(tab::<_, Error<_>>("\tc"), Ok(("c", '\t')));
 /// assert_eq!(tab::<_, Error<_>>("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
@@ -344,11 +346,11 @@ where
 /// Matches one byte as a character. Note that the input type will
 /// accept a `str`, but not a `&[u8]`, unlike many other nom parsers.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{character::streaming::anychar, ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{character::streaming::anychar, error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// assert_eq!(anychar::<_, Error<_>>("abc"), Ok(("bc",'a')));
 /// assert_eq!(anychar::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
@@ -368,12 +370,12 @@ where
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphabetic character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::alpha0;
 /// assert_eq!(alpha0::<_, Error<_>>("ab1c"), Ok(("1c", "ab")));
 /// assert_eq!(alpha0::<_, Error<_>>("1c"), Ok(("1c", "")));
@@ -395,12 +397,12 @@ where
 
 /// Recognizes one or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphabetic character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::alpha1;
 /// assert_eq!(alpha1::<_, Error<_>>("aB1c"), Ok(("1c", "aB")));
 /// assert_eq!(alpha1::<_, Error<_>>("1c"), Err(ErrMode::Error(Error::new("1c", ErrorKind::Alpha))));
@@ -422,12 +424,12 @@ where
 
 /// Recognizes zero or more ASCII numerical characters: 0-9
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::digit0;
 /// assert_eq!(digit0::<_, Error<_>>("21c"), Ok(("c", "21")));
 /// assert_eq!(digit0::<_, Error<_>>("a21c"), Ok(("a21c", "")));
@@ -449,12 +451,12 @@ where
 
 /// Recognizes one or more ASCII numerical characters: 0-9
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::digit1;
 /// assert_eq!(digit1::<_, Error<_>>("21c"), Ok(("c", "21")));
 /// assert_eq!(digit1::<_, Error<_>>("c1"), Err(ErrMode::Error(Error::new("c1", ErrorKind::Digit))));
@@ -476,12 +478,12 @@ where
 
 /// Recognizes zero or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non hexadecimal digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::hex_digit0;
 /// assert_eq!(hex_digit0::<_, Error<_>>("21cZ"), Ok(("Z", "21c")));
 /// assert_eq!(hex_digit0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
@@ -503,12 +505,12 @@ where
 
 /// Recognizes one or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non hexadecimal digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::hex_digit1;
 /// assert_eq!(hex_digit1::<_, Error<_>>("21cZ"), Ok(("Z", "21c")));
 /// assert_eq!(hex_digit1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::HexDigit))));
@@ -530,12 +532,12 @@ where
 
 /// Recognizes zero or more octal characters: 0-7
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non octal digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::oct_digit0;
 /// assert_eq!(oct_digit0::<_, Error<_>>("21cZ"), Ok(("cZ", "21")));
 /// assert_eq!(oct_digit0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
@@ -557,12 +559,12 @@ where
 
 /// Recognizes one or more octal characters: 0-7
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non octal digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::oct_digit1;
 /// assert_eq!(oct_digit1::<_, Error<_>>("21cZ"), Ok(("cZ", "21")));
 /// assert_eq!(oct_digit1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::OctDigit))));
@@ -584,12 +586,12 @@ where
 
 /// Recognizes zero or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphanumerical character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::alphanumeric0;
 /// assert_eq!(alphanumeric0::<_, Error<_>>("21cZ%1"), Ok(("%1", "21cZ")));
 /// assert_eq!(alphanumeric0::<_, Error<_>>("&Z21c"), Ok(("&Z21c", "")));
@@ -611,12 +613,12 @@ where
 
 /// Recognizes one or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphanumerical character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::alphanumeric1;
 /// assert_eq!(alphanumeric1::<_, Error<_>>("21cZ%1"), Ok(("%1", "21cZ")));
 /// assert_eq!(alphanumeric1::<_, Error<_>>("&H2"), Err(ErrMode::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
@@ -638,12 +640,12 @@ where
 
 /// Recognizes zero or more spaces and tabs.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::space0;
 /// assert_eq!(space0::<_, Error<_>>(" \t21c"), Ok(("21c", " \t")));
 /// assert_eq!(space0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
@@ -667,12 +669,12 @@ where
 }
 /// Recognizes one or more spaces and tabs.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::space1;
 /// assert_eq!(space1::<_, Error<_>>(" \t21c"), Ok(("21c", " \t")));
 /// assert_eq!(space1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::Space))));
@@ -701,12 +703,12 @@ where
 
 /// Recognizes zero or more spaces, tabs, carriage returns and line feeds.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::multispace0;
 /// assert_eq!(multispace0::<_, Error<_>>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
 /// assert_eq!(multispace0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
@@ -731,12 +733,12 @@ where
 
 /// Recognizes one or more spaces, tabs, carriage returns and line feeds.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::multispace1;
 /// assert_eq!(multispace1::<_, Error<_>>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
 /// assert_eq!(multispace1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::MultiSpace))));
@@ -877,9 +879,10 @@ mod tests {
   use crate::branch::alt;
   use crate::error::Error;
   use crate::error::ErrorKind;
+  use crate::error::{ErrMode, Needed};
   use crate::input::ParseTo;
   use crate::sequence::pair;
-  use crate::{ErrMode, IResult, Needed};
+  use crate::IResult;
   use proptest::prelude::*;
 
   macro_rules! assert_parse(

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -27,7 +27,7 @@ use crate::IResult;
 ///     char('a')(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::Char))));
+/// assert_eq!(parser("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::Char))));
 /// assert_eq!(parser(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -56,7 +56,7 @@ where
   if c == token {
     Ok((input, token))
   } else {
-    Err(ErrMode::Error(Error::from_char(i, c)))
+    Err(ErrMode::Backtrack(Error::from_char(i, c)))
   }
 }
 
@@ -72,7 +72,7 @@ where
 ///     satisfy(|c| c == 'a' || c == 'b')(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("cd"), Err(ErrMode::Error(Error::new("cd", ErrorKind::Satisfy))));
+/// assert_eq!(parser("cd"), Err(ErrMode::Backtrack(Error::new("cd", ErrorKind::Satisfy))));
 /// assert_eq!(parser(""), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 ///
@@ -106,7 +106,7 @@ where
   if cond(token) {
     Ok((input, token))
   } else {
-    Err(ErrMode::Error(Error::from_error_kind(
+    Err(ErrMode::Backtrack(Error::from_error_kind(
       i,
       ErrorKind::Satisfy,
     )))
@@ -122,7 +122,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::character::streaming::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::OneOf))));
 /// assert_eq!(one_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -149,7 +149,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::character::streaming::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(ErrMode::Error(Error::new("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(ErrMode::Backtrack(Error::new("a", ErrorKind::NoneOf))));
 /// assert_eq!(none_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -176,7 +176,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::crlf;
 /// assert_eq!(crlf::<_, Error<_>>("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(crlf::<_, Error<_>>("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(crlf::<_, Error<_>>("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::CrLf))));
 /// assert_eq!(crlf::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 ///
@@ -196,7 +196,7 @@ where
     CompareResult::Incomplete => Err(ErrMode::Incomplete(Needed::new(CRLF.len()))),
     CompareResult::Error => {
       let e: ErrorKind = ErrorKind::CrLf;
-      Err(ErrMode::Error(E::from_error_kind(input, e)))
+      Err(ErrMode::Backtrack(E::from_error_kind(input, e)))
     }
   }
 }
@@ -212,8 +212,8 @@ where
 /// assert_eq!(not_line_ending::<_, Error<_>>("ab\r\nc"), Ok(("\r\nc", "ab")));
 /// assert_eq!(not_line_ending::<_, Error<_>>("abc"), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(not_line_ending::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>>("a\rb\nc"), Err(ErrMode::Error(Error::new("a\rb\nc", ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, Error<_>>("a\rbc"), Err(ErrMode::Error(Error::new("a\rbc", ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>("a\rb\nc"), Err(ErrMode::Backtrack(Error::new("a\rb\nc", ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>("a\rbc"), Err(ErrMode::Backtrack(Error::new("a\rbc", ErrorKind::Tag ))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::not_line_ending`][crate::character::not_line_ending] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -246,7 +246,7 @@ where
           }
           CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
-            return Err(ErrMode::Error(E::from_error_kind(input, e)));
+            return Err(ErrMode::Backtrack(E::from_error_kind(input, e)));
           }
         }
       }
@@ -264,7 +264,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::line_ending;
 /// assert_eq!(line_ending::<_, Error<_>>("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(line_ending::<_, Error<_>>("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, Error<_>>("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::CrLf))));
 /// assert_eq!(line_ending::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -286,7 +286,10 @@ where
     CompareResult::Error => match input.compare("\r\n") {
       CompareResult::Ok => Ok(input.next_slice(CRLF.len())),
       CompareResult::Incomplete => Err(ErrMode::Incomplete(Needed::new(2))),
-      CompareResult::Error => Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::CrLf))),
+      CompareResult::Error => Err(ErrMode::Backtrack(E::from_error_kind(
+        input,
+        ErrorKind::CrLf,
+      ))),
     },
   }
 }
@@ -300,7 +303,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::newline;
 /// assert_eq!(newline::<_, Error<_>>("\nc"), Ok(("c", '\n')));
-/// assert_eq!(newline::<_, Error<_>>("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(newline::<_, Error<_>>("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Char))));
 /// assert_eq!(newline::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -326,7 +329,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::tab;
 /// assert_eq!(tab::<_, Error<_>>("\tc"), Ok(("c", '\t')));
-/// assert_eq!(tab::<_, Error<_>>("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(tab::<_, Error<_>>("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Char))));
 /// assert_eq!(tab::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -405,7 +408,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::alpha1;
 /// assert_eq!(alpha1::<_, Error<_>>("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(alpha1::<_, Error<_>>("1c"), Err(ErrMode::Error(Error::new("1c", ErrorKind::Alpha))));
+/// assert_eq!(alpha1::<_, Error<_>>("1c"), Err(ErrMode::Backtrack(Error::new("1c", ErrorKind::Alpha))));
 /// assert_eq!(alpha1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -459,7 +462,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::digit1;
 /// assert_eq!(digit1::<_, Error<_>>("21c"), Ok(("c", "21")));
-/// assert_eq!(digit1::<_, Error<_>>("c1"), Err(ErrMode::Error(Error::new("c1", ErrorKind::Digit))));
+/// assert_eq!(digit1::<_, Error<_>>("c1"), Err(ErrMode::Backtrack(Error::new("c1", ErrorKind::Digit))));
 /// assert_eq!(digit1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -513,7 +516,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::hex_digit1;
 /// assert_eq!(hex_digit1::<_, Error<_>>("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(hex_digit1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::HexDigit))));
+/// assert_eq!(hex_digit1::<_, Error<_>>("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::HexDigit))));
 /// assert_eq!(hex_digit1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -567,7 +570,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::oct_digit1;
 /// assert_eq!(oct_digit1::<_, Error<_>>("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(oct_digit1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::OctDigit))));
+/// assert_eq!(oct_digit1::<_, Error<_>>("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::OctDigit))));
 /// assert_eq!(oct_digit1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -621,7 +624,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::alphanumeric1;
 /// assert_eq!(alphanumeric1::<_, Error<_>>("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(alphanumeric1::<_, Error<_>>("&H2"), Err(ErrMode::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>("&H2"), Err(ErrMode::Backtrack(Error::new("&H2", ErrorKind::AlphaNumeric))));
 /// assert_eq!(alphanumeric1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -677,7 +680,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::space1;
 /// assert_eq!(space1::<_, Error<_>>(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(space1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::Space))));
+/// assert_eq!(space1::<_, Error<_>>("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Space))));
 /// assert_eq!(space1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -741,7 +744,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::character::streaming::multispace1;
 /// assert_eq!(multispace1::<_, Error<_>>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(multispace1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::MultiSpace))));
+/// assert_eq!(multispace1::<_, Error<_>>("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::MultiSpace))));
 /// assert_eq!(multispace1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -804,7 +807,7 @@ macro_rules! ints {
                     match c.as_char().to_digit(10) {
                         None => {
                             if offset == 0 {
-                                return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit)));
+                                return Err(ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Digit)));
                             } else {
                                 return Ok((i.next_slice(offset).0, value));
                             }
@@ -816,7 +819,7 @@ macro_rules! ints {
                                v.checked_sub(d as $t)
                             }
                         }) {
-                            None => return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit))),
+                            None => return Err(ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Digit))),
                             Some(v) => value = v,
                         }
                    }
@@ -853,13 +856,13 @@ macro_rules! uints {
                     match c.as_char().to_digit(10) {
                         None => {
                             if offset == 0 {
-                                return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit)));
+                                return Err(ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Digit)));
                             } else {
                                 return Ok((i.next_slice(offset).0, value));
                             }
                         },
                         Some(d) => match value.checked_mul(10).and_then(|v| v.checked_add(d as $t)) {
-                            None => return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit))),
+                            None => return Err(ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Digit))),
                             Some(v) => value = v,
                         }
                     }
@@ -910,13 +913,13 @@ mod tests {
     assert_parse!(alpha1(a), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(
       alpha1(b),
-      Err(ErrMode::Error(Error::new(b, ErrorKind::Alpha)))
+      Err(ErrMode::Backtrack(Error::new(b, ErrorKind::Alpha)))
     );
     assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], &b"a"[..])));
     assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bytes(), &b"az"[..])));
     assert_eq!(
       digit1(a),
-      Err(ErrMode::Error(Error::new(a, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Digit)))
     );
     assert_eq!(
       digit1::<_, Error<_>>(b),
@@ -924,11 +927,11 @@ mod tests {
     );
     assert_eq!(
       digit1(c),
-      Err(ErrMode::Error(Error::new(c, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Digit)))
     );
     assert_eq!(
       digit1(d),
-      Err(ErrMode::Error(Error::new(d, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Digit)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>>(a),
@@ -948,11 +951,11 @@ mod tests {
     );
     assert_eq!(
       hex_digit1(e),
-      Err(ErrMode::Error(Error::new(e, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(Error::new(e, ErrorKind::HexDigit)))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(ErrMode::Error(Error::new(a, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(a, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1::<_, Error<_>>(b),
@@ -960,11 +963,11 @@ mod tests {
     );
     assert_eq!(
       oct_digit1(c),
-      Err(ErrMode::Error(Error::new(c, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(c, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(ErrMode::Error(Error::new(d, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(d, ErrorKind::OctDigit)))
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>>(a),
@@ -1000,13 +1003,13 @@ mod tests {
     );
     assert_eq!(
       alpha1(b),
-      Err(ErrMode::Error(Error::new(b, ErrorKind::Alpha)))
+      Err(ErrMode::Backtrack(Error::new(b, ErrorKind::Alpha)))
     );
     assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], "a")));
     assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12", "az")));
     assert_eq!(
       digit1(a),
-      Err(ErrMode::Error(Error::new(a, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Digit)))
     );
     assert_eq!(
       digit1::<_, Error<_>>(b),
@@ -1014,11 +1017,11 @@ mod tests {
     );
     assert_eq!(
       digit1(c),
-      Err(ErrMode::Error(Error::new(c, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Digit)))
     );
     assert_eq!(
       digit1(d),
-      Err(ErrMode::Error(Error::new(d, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Digit)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>>(a),
@@ -1035,11 +1038,11 @@ mod tests {
     assert_eq!(hex_digit1::<_, Error<_>>(d), Ok(("zé12", "a")));
     assert_eq!(
       hex_digit1(e),
-      Err(ErrMode::Error(Error::new(e, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(Error::new(e, ErrorKind::HexDigit)))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(ErrMode::Error(Error::new(a, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(a, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1::<_, Error<_>>(b),
@@ -1047,11 +1050,11 @@ mod tests {
     );
     assert_eq!(
       oct_digit1(c),
-      Err(ErrMode::Error(Error::new(c, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(c, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(ErrMode::Error(Error::new(d, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(d, ErrorKind::OctDigit)))
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>>(a),
@@ -1172,7 +1175,7 @@ mod tests {
     let f = "βèƒôřè\rÂßÇáƒƭèř";
     assert_eq!(
       not_line_ending(f),
-      Err(ErrMode::Error(Error::new(f, ErrorKind::Tag)))
+      Err(ErrMode::Backtrack(Error::new(f, ErrorKind::Tag)))
     );
 
     let g2: &str = "ab12cd";
@@ -1190,13 +1193,13 @@ mod tests {
     let i = &b"g"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(error_position!(i, ErrorKind::HexDigit)))
     );
 
     let i = &b"G"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(error_position!(i, ErrorKind::HexDigit)))
     );
 
     assert!(AsChar::is_hex_digit(b'0'));
@@ -1221,7 +1224,7 @@ mod tests {
     let i = &b"8"[..];
     assert_parse!(
       oct_digit1(i),
-      Err(ErrMode::Error(error_position!(i, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(error_position!(i, ErrorKind::OctDigit)))
     );
 
     assert!(AsChar::is_oct_digit(b'0'));
@@ -1276,7 +1279,7 @@ mod tests {
     assert_parse!(crlf(&b"\r"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
     assert_parse!(
       crlf(&b"\ra"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"\ra"[..],
         ErrorKind::CrLf
       )))
@@ -1286,7 +1289,7 @@ mod tests {
     assert_parse!(crlf("\r"), Err(ErrMode::Incomplete(Needed::new(2))));
     assert_parse!(
       crlf("\ra"),
-      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -1300,7 +1303,7 @@ mod tests {
     );
     assert_parse!(
       line_ending(&b"\ra"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"\ra"[..],
         ErrorKind::CrLf
       )))
@@ -1311,7 +1314,7 @@ mod tests {
     assert_parse!(line_ending("\r"), Err(ErrMode::Incomplete(Needed::new(2))));
     assert_parse!(
       line_ending("\ra"),
-      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -1328,7 +1331,7 @@ mod tests {
       Ok((i, s)) => (i, s),
       Err(ErrMode::Incomplete(i)) => return Err(ErrMode::Incomplete(i)),
       Err(_) => {
-        return Err(ErrMode::Error(crate::error::Error::from_error_kind(
+        return Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
           input,
           ErrorKind::Digit,
         )))
@@ -1342,7 +1345,7 @@ mod tests {
           Ok((i, -n))
         }
       }
-      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -1353,7 +1356,7 @@ mod tests {
     let (i, s) = digit1(i)?;
     match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -1372,7 +1375,7 @@ mod tests {
     let b = &b"cde"[..];
     assert_eq!(
       f(b),
-      Err(ErrMode::Error(error_position!(b, ErrorKind::OneOf)))
+      Err(ErrMode::Backtrack(error_position!(b, ErrorKind::OneOf)))
     );
 
     fn utf8(i: &str) -> IResult<&str, char> {
@@ -1392,7 +1395,7 @@ mod tests {
     let a = &b"abcd"[..];
     assert_eq!(
       f(a),
-      Err(ErrMode::Error(error_position!(a, ErrorKind::NoneOf)))
+      Err(ErrMode::Backtrack(error_position!(a, ErrorKind::NoneOf)))
     );
 
     let b = &b"cde"[..];
@@ -1408,7 +1411,7 @@ mod tests {
     let a = &b"abcd"[..];
     assert_eq!(
       f(a),
-      Err(ErrMode::Error(error_position!(a, ErrorKind::Char)))
+      Err(ErrMode::Backtrack(error_position!(a, ErrorKind::Char)))
     );
 
     let b = &b"cde"[..];
@@ -1424,7 +1427,7 @@ mod tests {
     let a = "abcd";
     assert_eq!(
       f(a),
-      Err(ErrMode::Error(error_position!(a, ErrorKind::Char)))
+      Err(ErrMode::Backtrack(error_position!(a, ErrorKind::Char)))
     );
 
     let b = "cde";

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -11,22 +11,22 @@ use crate::input::{
   split_at_offset1_streaming, split_at_offset_streaming, AsBytes, AsChar, ContainsToken, Input,
 };
 use crate::input::{Compare, CompareResult};
-use crate::{Err, IResult, Needed};
+use crate::{ErrMode, IResult, Needed};
 
 /// Recognizes one character.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{ErrorKind, Error}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{ErrorKind, Error}, Needed, IResult};
 /// # use winnow::character::streaming::char;
 /// fn parser(i: &str) -> IResult<&str, char> {
 ///     char('a')(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::Char))));
+/// assert_eq!(parser(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -50,28 +50,28 @@ where
   let (input, token) = i
     .next_token()
     .map(|(i, t)| (i, t.as_char()))
-    .ok_or_else(|| Err::Incomplete(Needed::new(1)))?;
+    .ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))?;
   if c == token {
     Ok((input, token))
   } else {
-    Err(Err::Error(Error::from_char(i, c)))
+    Err(ErrMode::Error(Error::from_char(i, c)))
   }
 }
 
 /// Recognizes one character and checks that it satisfies a predicate
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{ErrorKind, Error}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{ErrorKind, Error}, Needed, IResult};
 /// # use winnow::character::streaming::satisfy;
 /// fn parser(i: &str) -> IResult<&str, char> {
 ///     satisfy(|c| c == 'a' || c == 'b')(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::Satisfy))));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::Unknown)));
+/// assert_eq!(parser("cd"), Err(ErrMode::Error(Error::new("cd", ErrorKind::Satisfy))));
+/// assert_eq!(parser(""), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -100,25 +100,28 @@ where
   let (input, token) = i
     .next_token()
     .map(|(i, t)| (i, t.as_char()))
-    .ok_or(Err::Incomplete(Needed::Unknown))?;
+    .ok_or(ErrMode::Incomplete(Needed::Unknown))?;
   if cond(token) {
     Ok((input, token))
   } else {
-    Err(Err::Error(Error::from_error_kind(i, ErrorKind::Satisfy)))
+    Err(ErrMode::Error(Error::from_error_kind(
+      i,
+      ErrorKind::Satisfy,
+    )))
   }
 }
 
 /// Recognizes one of the provided characters.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::character::streaming::one_of;
 /// assert_eq!(one_of::<_, _, Error<_>>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(Err::Error(Error::new("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, Error<_>>("a")(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::one_of`][crate::bytes::one_of] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -137,15 +140,15 @@ where
 
 /// Recognizes a character that is not in the provided characters.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::character::streaming::none_of;
 /// assert_eq!(none_of::<_, _, Error<_>>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(Err::Error(Error::new("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, Error<_>>("a")(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(ErrMode::Error(Error::new("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::none_of`][crate::bytes::none_of] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -164,15 +167,15 @@ where
 
 /// Recognizes the string "\r\n".
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::crlf;
 /// assert_eq!(crlf::<_, Error<_>>("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(crlf::<_, Error<_>>("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(crlf::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(crlf::<_, Error<_>>("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(crlf::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::crlf`][crate::character::crlf] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -188,27 +191,27 @@ where
   const CRLF: &str = "\r\n";
   match input.compare(CRLF) {
     CompareResult::Ok => Ok(input.next_slice(CRLF.len())),
-    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(CRLF.len()))),
+    CompareResult::Incomplete => Err(ErrMode::Incomplete(Needed::new(CRLF.len()))),
     CompareResult::Error => {
       let e: ErrorKind = ErrorKind::CrLf;
-      Err(Err::Error(E::from_error_kind(input, e)))
+      Err(ErrMode::Error(E::from_error_kind(input, e)))
     }
   }
 }
 
 /// Recognizes a string of any char except '\r\n' or '\n'.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult, Needed};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult, Needed};
 /// # use winnow::character::streaming::not_line_ending;
 /// assert_eq!(not_line_ending::<_, Error<_>>("ab\r\nc"), Ok(("\r\nc", "ab")));
-/// assert_eq!(not_line_ending::<_, Error<_>>("abc"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>>(""), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>>("a\rb\nc"), Err(Err::Error(Error::new("a\rb\nc", ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, Error<_>>("a\rbc"), Err(Err::Error(Error::new("a\rbc", ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>("abc"), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>("a\rb\nc"), Err(ErrMode::Error(Error::new("a\rb\nc", ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>("a\rbc"), Err(ErrMode::Error(Error::new("a\rbc", ErrorKind::Tag ))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::not_line_ending`][crate::character::not_line_ending] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -226,7 +229,7 @@ where
     let c = item.as_char();
     c == '\r' || c == '\n'
   }) {
-    None => Err(Err::Incomplete(Needed::Unknown)),
+    None => Err(ErrMode::Incomplete(Needed::Unknown)),
     Some(offset) => {
       let (new_input, res) = input.next_slice(offset);
       let bytes = new_input.as_bytes();
@@ -237,11 +240,11 @@ where
           //FIXME: calculate the right index
           CompareResult::Ok => {}
           CompareResult::Incomplete => {
-            return Err(Err::Incomplete(Needed::Unknown));
+            return Err(ErrMode::Incomplete(Needed::Unknown));
           }
           CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
-            return Err(Err::Error(E::from_error_kind(input, e)));
+            return Err(ErrMode::Error(E::from_error_kind(input, e)));
           }
         }
       }
@@ -252,15 +255,15 @@ where
 
 /// Recognizes an end of line (both '\n' and '\r\n').
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::line_ending;
 /// assert_eq!(line_ending::<_, Error<_>>("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(line_ending::<_, Error<_>>("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(line_ending::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(line_ending::<_, Error<_>>("ab\r\nc"), Err(ErrMode::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::line_ending`][crate::character::line_ending] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -277,26 +280,26 @@ where
   const CRLF: &str = "\r\n";
   match input.compare(LF) {
     CompareResult::Ok => Ok(input.next_slice(LF.len())),
-    CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(1))),
+    CompareResult::Incomplete => Err(ErrMode::Incomplete(Needed::new(1))),
     CompareResult::Error => match input.compare("\r\n") {
       CompareResult::Ok => Ok(input.next_slice(CRLF.len())),
-      CompareResult::Incomplete => Err(Err::Incomplete(Needed::new(2))),
-      CompareResult::Error => Err(Err::Error(E::from_error_kind(input, ErrorKind::CrLf))),
+      CompareResult::Incomplete => Err(ErrMode::Incomplete(Needed::new(2))),
+      CompareResult::Error => Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::CrLf))),
     },
   }
 }
 
 /// Matches a newline character '\\n'.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::newline;
 /// assert_eq!(newline::<_, Error<_>>("\nc"), Ok(("c", '\n')));
-/// assert_eq!(newline::<_, Error<_>>("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(newline::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(newline::<_, Error<_>>("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(newline::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::newline`][crate::character::newline] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -314,15 +317,15 @@ where
 
 /// Matches a tab character '\t'.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::tab;
 /// assert_eq!(tab::<_, Error<_>>("\tc"), Ok(("c", '\t')));
-/// assert_eq!(tab::<_, Error<_>>("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(tab::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(tab::<_, Error<_>>("\r\nc"), Err(ErrMode::Error(Error::new("\r\nc", ErrorKind::Char))));
+/// assert_eq!(tab::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::tab`][crate::character::tab] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -341,13 +344,13 @@ where
 /// Matches one byte as a character. Note that the input type will
 /// accept a `str`, but not a `&[u8]`, unlike many other nom parsers.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
 /// ```
-/// # use winnow::{character::streaming::anychar, Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{character::streaming::anychar, ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// assert_eq!(anychar::<_, Error<_>>("abc"), Ok(("bc",'a')));
-/// assert_eq!(anychar::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(anychar::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::bytes::any`][crate::bytes::any] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -365,16 +368,16 @@ where
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphabetic character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::alpha0;
 /// assert_eq!(alpha0::<_, Error<_>>("ab1c"), Ok(("1c", "ab")));
 /// assert_eq!(alpha0::<_, Error<_>>("1c"), Ok(("1c", "")));
-/// assert_eq!(alpha0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha0::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alpha0`][crate::character::alpha0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -392,16 +395,16 @@ where
 
 /// Recognizes one or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphabetic character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::alpha1;
 /// assert_eq!(alpha1::<_, Error<_>>("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(alpha1::<_, Error<_>>("1c"), Err(Err::Error(Error::new("1c", ErrorKind::Alpha))));
-/// assert_eq!(alpha1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha1::<_, Error<_>>("1c"), Err(ErrMode::Error(Error::new("1c", ErrorKind::Alpha))));
+/// assert_eq!(alpha1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alpha1`][crate::character::alpha1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -419,16 +422,16 @@ where
 
 /// Recognizes zero or more ASCII numerical characters: 0-9
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::digit0;
 /// assert_eq!(digit0::<_, Error<_>>("21c"), Ok(("c", "21")));
 /// assert_eq!(digit0::<_, Error<_>>("a21c"), Ok(("a21c", "")));
-/// assert_eq!(digit0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(digit0::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::digit0`][crate::character::digit0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -446,16 +449,16 @@ where
 
 /// Recognizes one or more ASCII numerical characters: 0-9
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::digit1;
 /// assert_eq!(digit1::<_, Error<_>>("21c"), Ok(("c", "21")));
-/// assert_eq!(digit1::<_, Error<_>>("c1"), Err(Err::Error(Error::new("c1", ErrorKind::Digit))));
-/// assert_eq!(digit1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(digit1::<_, Error<_>>("c1"), Err(ErrMode::Error(Error::new("c1", ErrorKind::Digit))));
+/// assert_eq!(digit1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::digit1`][crate::character::digit1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -473,16 +476,16 @@ where
 
 /// Recognizes zero or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non hexadecimal digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::hex_digit0;
 /// assert_eq!(hex_digit0::<_, Error<_>>("21cZ"), Ok(("Z", "21c")));
 /// assert_eq!(hex_digit0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(hex_digit0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit0::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::hex_digit0`][crate::character::hex_digit0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -500,16 +503,16 @@ where
 
 /// Recognizes one or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non hexadecimal digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::hex_digit1;
 /// assert_eq!(hex_digit1::<_, Error<_>>("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(hex_digit1::<_, Error<_>>("H2"), Err(Err::Error(Error::new("H2", ErrorKind::HexDigit))));
-/// assert_eq!(hex_digit1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::HexDigit))));
+/// assert_eq!(hex_digit1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::hex_digit1`][crate::character::hex_digit1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -527,16 +530,16 @@ where
 
 /// Recognizes zero or more octal characters: 0-7
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non octal digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::oct_digit0;
 /// assert_eq!(oct_digit0::<_, Error<_>>("21cZ"), Ok(("cZ", "21")));
 /// assert_eq!(oct_digit0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(oct_digit0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit0::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::oct_digit0`][crate::character::oct_digit0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -554,16 +557,16 @@ where
 
 /// Recognizes one or more octal characters: 0-7
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non octal digit character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::oct_digit1;
 /// assert_eq!(oct_digit1::<_, Error<_>>("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(oct_digit1::<_, Error<_>>("H2"), Err(Err::Error(Error::new("H2", ErrorKind::OctDigit))));
-/// assert_eq!(oct_digit1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::OctDigit))));
+/// assert_eq!(oct_digit1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::oct_digit1`][crate::character::oct_digit1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -581,16 +584,16 @@ where
 
 /// Recognizes zero or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphanumerical character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::alphanumeric0;
 /// assert_eq!(alphanumeric0::<_, Error<_>>("21cZ%1"), Ok(("%1", "21cZ")));
 /// assert_eq!(alphanumeric0::<_, Error<_>>("&Z21c"), Ok(("&Z21c", "")));
-/// assert_eq!(alphanumeric0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric0::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alphanumeric0`][crate::character::alphanumeric0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -608,16 +611,16 @@ where
 
 /// Recognizes one or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non alphanumerical character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::alphanumeric1;
 /// assert_eq!(alphanumeric1::<_, Error<_>>("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(alphanumeric1::<_, Error<_>>("&H2"), Err(Err::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
-/// assert_eq!(alphanumeric1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>("&H2"), Err(ErrMode::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::alphanumeric1`][crate::character::alphanumeric1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -635,16 +638,16 @@ where
 
 /// Recognizes zero or more spaces and tabs.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::space0;
 /// assert_eq!(space0::<_, Error<_>>(" \t21c"), Ok(("21c", " \t")));
 /// assert_eq!(space0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(space0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(space0::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::space0`][crate::character::space0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -664,16 +667,16 @@ where
 }
 /// Recognizes one or more spaces and tabs.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::space1;
 /// assert_eq!(space1::<_, Error<_>>(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(space1::<_, Error<_>>("H2"), Err(Err::Error(Error::new("H2", ErrorKind::Space))));
-/// assert_eq!(space1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(space1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::Space))));
+/// assert_eq!(space1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::space1`][crate::character::space1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -698,16 +701,16 @@ where
 
 /// Recognizes zero or more spaces, tabs, carriage returns and line feeds.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::multispace0;
 /// assert_eq!(multispace0::<_, Error<_>>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
 /// assert_eq!(multispace0::<_, Error<_>>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(multispace0::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace0::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::multispace0`][crate::character::multispace0] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -728,16 +731,16 @@ where
 
 /// Recognizes one or more spaces, tabs, carriage returns and line feeds.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there's not enough input data,
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
 /// ```
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, Needed};
 /// # use winnow::character::streaming::multispace1;
 /// assert_eq!(multispace1::<_, Error<_>>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(multispace1::<_, Error<_>>("H2"), Err(Err::Error(Error::new("H2", ErrorKind::MultiSpace))));
-/// assert_eq!(multispace1::<_, Error<_>>(""), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace1::<_, Error<_>>("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::MultiSpace))));
+/// assert_eq!(multispace1::<_, Error<_>>(""), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::multispace1`][crate::character::multispace1] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -791,7 +794,7 @@ macro_rules! ints {
               let (i, sign) = sign(input.clone())?;
 
                 if i.input_len() == 0 {
-                    return Err(Err::Incomplete(Needed::new(1)));
+                    return Err(ErrMode::Incomplete(Needed::new(1)));
                 }
 
                 let mut value: $t = 0;
@@ -799,7 +802,7 @@ macro_rules! ints {
                     match c.as_char().to_digit(10) {
                         None => {
                             if offset == 0 {
-                                return Err(Err::Error(E::from_error_kind(input, ErrorKind::Digit)));
+                                return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit)));
                             } else {
                                 return Ok((i.next_slice(offset).0, value));
                             }
@@ -811,13 +814,13 @@ macro_rules! ints {
                                v.checked_sub(d as $t)
                             }
                         }) {
-                            None => return Err(Err::Error(E::from_error_kind(input, ErrorKind::Digit))),
+                            None => return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Digit))),
                             Some(v) => value = v,
                         }
                    }
                 }
 
-                Err(Err::Incomplete(Needed::new(1)))
+                Err(ErrMode::Incomplete(Needed::new(1)))
             }
         )+
     }
@@ -840,7 +843,7 @@ macro_rules! uints {
                 let i = input;
 
                 if i.input_len() == 0 {
-                    return Err(Err::Incomplete(Needed::new(1)));
+                    return Err(ErrMode::Incomplete(Needed::new(1)));
                 }
 
                 let mut value: $t = 0;
@@ -848,19 +851,19 @@ macro_rules! uints {
                     match c.as_char().to_digit(10) {
                         None => {
                             if offset == 0 {
-                                return Err(Err::Error(E::from_error_kind(i, ErrorKind::Digit)));
+                                return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit)));
                             } else {
                                 return Ok((i.next_slice(offset).0, value));
                             }
                         },
                         Some(d) => match value.checked_mul(10).and_then(|v| v.checked_add(d as $t)) {
-                            None => return Err(Err::Error(E::from_error_kind(i, ErrorKind::Digit))),
+                            None => return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Digit))),
                             Some(v) => value = v,
                         }
                     }
                 }
 
-                Err(Err::Incomplete(Needed::new(1)))
+                Err(ErrMode::Incomplete(Needed::new(1)))
             }
         )+
     }
@@ -876,7 +879,7 @@ mod tests {
   use crate::error::ErrorKind;
   use crate::input::ParseTo;
   use crate::sequence::pair;
-  use crate::{Err, IResult, Needed};
+  use crate::{ErrMode, IResult, Needed};
   use proptest::prelude::*;
 
   macro_rules! assert_parse(
@@ -900,29 +903,41 @@ mod tests {
     let d: &[u8] = "azé12".as_bytes();
     let e: &[u8] = b" ";
     let f: &[u8] = b" ;";
-    //assert_eq!(alpha1::<_, Error<_>>(a), Err(Err::Incomplete(Needed::new(1))));
-    assert_parse!(alpha1(a), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(alpha1(b), Err(Err::Error(Error::new(b, ErrorKind::Alpha))));
+    //assert_eq!(alpha1::<_, Error<_>>(a), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_parse!(alpha1(a), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+      alpha1(b),
+      Err(ErrMode::Error(Error::new(b, ErrorKind::Alpha)))
+    );
     assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], &b"a"[..])));
     assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bytes(), &b"az"[..])));
-    assert_eq!(digit1(a), Err(Err::Error(Error::new(a, ErrorKind::Digit))));
+    assert_eq!(
+      digit1(a),
+      Err(ErrMode::Error(Error::new(a, ErrorKind::Digit)))
+    );
     assert_eq!(
       digit1::<_, Error<_>>(b),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(digit1(c), Err(Err::Error(Error::new(c, ErrorKind::Digit))));
-    assert_eq!(digit1(d), Err(Err::Error(Error::new(d, ErrorKind::Digit))));
+    assert_eq!(
+      digit1(c),
+      Err(ErrMode::Error(Error::new(c, ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1(d),
+      Err(ErrMode::Error(Error::new(d, ErrorKind::Digit)))
+    );
     assert_eq!(
       hex_digit1::<_, Error<_>>(a),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>>(b),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>>(c),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>>(d),
@@ -930,32 +945,32 @@ mod tests {
     );
     assert_eq!(
       hex_digit1(e),
-      Err(Err::Error(Error::new(e, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(Error::new(e, ErrorKind::HexDigit)))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(Err::Error(Error::new(a, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(a, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1::<_, Error<_>>(b),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       oct_digit1(c),
-      Err(Err::Error(Error::new(c, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(c, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(Err::Error(Error::new(d, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(d, ErrorKind::OctDigit)))
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>>(a),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
     assert_eq!(
       alphanumeric1::<_, Error<_>>(c),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>>(d),
@@ -963,7 +978,7 @@ mod tests {
     );
     assert_eq!(
       space1::<_, Error<_>>(e),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(space1::<_, Error<_>>(f), Ok((&b";"[..], &b" "[..])));
   }
@@ -978,64 +993,76 @@ mod tests {
     let e = " ";
     assert_eq!(
       alpha1::<_, Error<_>>(a),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(alpha1(b), Err(Err::Error(Error::new(b, ErrorKind::Alpha))));
+    assert_eq!(
+      alpha1(b),
+      Err(ErrMode::Error(Error::new(b, ErrorKind::Alpha)))
+    );
     assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], "a")));
     assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12", "az")));
-    assert_eq!(digit1(a), Err(Err::Error(Error::new(a, ErrorKind::Digit))));
+    assert_eq!(
+      digit1(a),
+      Err(ErrMode::Error(Error::new(a, ErrorKind::Digit)))
+    );
     assert_eq!(
       digit1::<_, Error<_>>(b),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(digit1(c), Err(Err::Error(Error::new(c, ErrorKind::Digit))));
-    assert_eq!(digit1(d), Err(Err::Error(Error::new(d, ErrorKind::Digit))));
+    assert_eq!(
+      digit1(c),
+      Err(ErrMode::Error(Error::new(c, ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1(d),
+      Err(ErrMode::Error(Error::new(d, ErrorKind::Digit)))
+    );
     assert_eq!(
       hex_digit1::<_, Error<_>>(a),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>>(b),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>>(c),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(hex_digit1::<_, Error<_>>(d), Ok(("zé12", "a")));
     assert_eq!(
       hex_digit1(e),
-      Err(Err::Error(Error::new(e, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(Error::new(e, ErrorKind::HexDigit)))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(Err::Error(Error::new(a, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(a, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1::<_, Error<_>>(b),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       oct_digit1(c),
-      Err(Err::Error(Error::new(c, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(c, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(Err::Error(Error::new(d, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(d, ErrorKind::OctDigit)))
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>>(a),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
     assert_eq!(
       alphanumeric1::<_, Error<_>>(c),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(alphanumeric1::<_, Error<_>>(d), Ok(("é12", "az")));
     assert_eq!(
       space1::<_, Error<_>>(e),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1116,7 +1143,7 @@ mod tests {
     let d: &[u8] = b"ab12cd";
     assert_eq!(
       not_line_ending::<_, Error<_>>(d),
-      Err(Err::Incomplete(Needed::Unknown))
+      Err(ErrMode::Incomplete(Needed::Unknown))
     );
   }
 
@@ -1142,13 +1169,13 @@ mod tests {
     let f = "βèƒôřè\rÂßÇáƒƭèř";
     assert_eq!(
       not_line_ending(f),
-      Err(Err::Error(Error::new(f, ErrorKind::Tag)))
+      Err(ErrMode::Error(Error::new(f, ErrorKind::Tag)))
     );
 
     let g2: &str = "ab12cd";
     assert_eq!(
       not_line_ending::<_, Error<_>>(g2),
-      Err(Err::Incomplete(Needed::Unknown))
+      Err(ErrMode::Incomplete(Needed::Unknown))
     );
   }
 
@@ -1160,13 +1187,13 @@ mod tests {
     let i = &b"g"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
     );
 
     let i = &b"G"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
     );
 
     assert!(AsChar::is_hex_digit(b'0'));
@@ -1191,7 +1218,7 @@ mod tests {
     let i = &b"8"[..];
     assert_parse!(
       oct_digit1(i),
-      Err(Err::Error(error_position!(i, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(error_position!(i, ErrorKind::OctDigit)))
     );
 
     assert!(AsChar::is_oct_digit(b'0'));
@@ -1243,17 +1270,20 @@ mod tests {
   #[test]
   fn cr_lf() {
     assert_parse!(crlf(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
-    assert_parse!(crlf(&b"\r"[..]), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(crlf(&b"\r"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
     assert_parse!(
       crlf(&b"\ra"[..]),
-      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(
+        &b"\ra"[..],
+        ErrorKind::CrLf
+      )))
     );
 
     assert_parse!(crlf("\r\na"), Ok(("a", "\r\n")));
-    assert_parse!(crlf("\r"), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(crlf("\r"), Err(ErrMode::Incomplete(Needed::new(2))));
     assert_parse!(
       crlf("\ra"),
-      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -1263,19 +1293,22 @@ mod tests {
     assert_parse!(line_ending(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_parse!(
       line_ending(&b"\r"[..]),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       line_ending(&b"\ra"[..]),
-      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(
+        &b"\ra"[..],
+        ErrorKind::CrLf
+      )))
     );
 
     assert_parse!(line_ending("\na"), Ok(("a", "\n")));
     assert_parse!(line_ending("\r\na"), Ok(("a", "\r\n")));
-    assert_parse!(line_ending("\r"), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(line_ending("\r"), Err(ErrMode::Incomplete(Needed::new(2))));
     assert_parse!(
       line_ending("\ra"),
-      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -1290,9 +1323,9 @@ mod tests {
 
     let (i, s) = match digit1::<_, crate::error::Error<_>>(i) {
       Ok((i, s)) => (i, s),
-      Err(Err::Incomplete(i)) => return Err(Err::Incomplete(i)),
+      Err(ErrMode::Incomplete(i)) => return Err(ErrMode::Incomplete(i)),
       Err(_) => {
-        return Err(Err::Error(crate::error::Error::from_error_kind(
+        return Err(ErrMode::Error(crate::error::Error::from_error_kind(
           input,
           ErrorKind::Digit,
         )))
@@ -1306,7 +1339,7 @@ mod tests {
           Ok((i, -n))
         }
       }
-      None => Err(Err::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -1317,7 +1350,7 @@ mod tests {
     let (i, s) = digit1(i)?;
     match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(Err::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -1334,7 +1367,10 @@ mod tests {
     assert_eq!(f(a), Ok((&b"bcd"[..], 'a')));
 
     let b = &b"cde"[..];
-    assert_eq!(f(b), Err(Err::Error(error_position!(b, ErrorKind::OneOf))));
+    assert_eq!(
+      f(b),
+      Err(ErrMode::Error(error_position!(b, ErrorKind::OneOf)))
+    );
 
     fn utf8(i: &str) -> IResult<&str, char> {
       one_of("+\u{FF0B}")(i)
@@ -1351,7 +1387,10 @@ mod tests {
     }
 
     let a = &b"abcd"[..];
-    assert_eq!(f(a), Err(Err::Error(error_position!(a, ErrorKind::NoneOf))));
+    assert_eq!(
+      f(a),
+      Err(ErrMode::Error(error_position!(a, ErrorKind::NoneOf)))
+    );
 
     let b = &b"cde"[..];
     assert_eq!(f(b), Ok((&b"de"[..], 'c')));
@@ -1364,7 +1403,10 @@ mod tests {
     }
 
     let a = &b"abcd"[..];
-    assert_eq!(f(a), Err(Err::Error(error_position!(a, ErrorKind::Char))));
+    assert_eq!(
+      f(a),
+      Err(ErrMode::Error(error_position!(a, ErrorKind::Char)))
+    );
 
     let b = &b"cde"[..];
     assert_eq!(f(b), Ok((&b"de"[..], 'c')));
@@ -1377,7 +1419,10 @@ mod tests {
     }
 
     let a = "abcd";
-    assert_eq!(f(a), Err(Err::Error(error_position!(a, ErrorKind::Char))));
+    assert_eq!(
+      f(a),
+      Err(ErrMode::Error(error_position!(a, ErrorKind::Char)))
+    );
 
     let b = "cde";
     assert_eq!(f(b), Ok(("de", 'c')));

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -10,7 +10,7 @@ mod complete {
   use crate::error::Error;
   use crate::error::ErrorKind;
   use crate::input::ParseTo;
-  use crate::Err;
+  use crate::ErrMode;
   use crate::Parser;
   #[cfg(feature = "alloc")]
   use crate::{lib::std::string::String, lib::std::vec::Vec};
@@ -32,18 +32,30 @@ mod complete {
     let d: &[u8] = "azé12".as_bytes();
     let e: &[u8] = b" ";
     let f: &[u8] = b" ;";
-    //assert_eq!(alpha1::<_, Error>(a), Err(Err::Incomplete(Needed::Size(1))));
+    //assert_eq!(alpha1::<_, Error>(a), Err(ErrMode::Incomplete(Needed::Size(1))));
     assert_parse!(alpha1(a), Ok((empty, a)));
-    assert_eq!(alpha1(b), Err(Err::Error(Error::new(b, ErrorKind::Alpha))));
+    assert_eq!(
+      alpha1(b),
+      Err(ErrMode::Error(Error::new(b, ErrorKind::Alpha)))
+    );
     assert_eq!(alpha1::<_, Error<_>, false>(c), Ok((&c[1..], &b"a"[..])));
     assert_eq!(
       alpha1::<_, Error<_>, false>(d),
       Ok(("é12".as_bytes(), &b"az"[..]))
     );
-    assert_eq!(digit1(a), Err(Err::Error(Error::new(a, ErrorKind::Digit))));
+    assert_eq!(
+      digit1(a),
+      Err(ErrMode::Error(Error::new(a, ErrorKind::Digit)))
+    );
     assert_eq!(digit1::<_, Error<_>, false>(b), Ok((empty, b)));
-    assert_eq!(digit1(c), Err(Err::Error(Error::new(c, ErrorKind::Digit))));
-    assert_eq!(digit1(d), Err(Err::Error(Error::new(d, ErrorKind::Digit))));
+    assert_eq!(
+      digit1(c),
+      Err(ErrMode::Error(Error::new(c, ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1(d),
+      Err(ErrMode::Error(Error::new(d, ErrorKind::Digit)))
+    );
     assert_eq!(hex_digit1::<_, Error<_>, false>(a), Ok((empty, a)));
     assert_eq!(hex_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
     assert_eq!(hex_digit1::<_, Error<_>, false>(c), Ok((empty, c)));
@@ -53,20 +65,20 @@ mod complete {
     );
     assert_eq!(
       hex_digit1(e),
-      Err(Err::Error(Error::new(e, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(Error::new(e, ErrorKind::HexDigit)))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(Err::Error(Error::new(a, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(a, ErrorKind::OctDigit)))
     );
     assert_eq!(oct_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
     assert_eq!(
       oct_digit1(c),
-      Err(Err::Error(Error::new(c, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(c, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(Err::Error(Error::new(d, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(d, ErrorKind::OctDigit)))
     );
     assert_eq!(alphanumeric1::<_, Error<_>, false>(a), Ok((empty, a)));
     //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
@@ -89,33 +101,45 @@ mod complete {
     let d = "azé12";
     let e = " ";
     assert_eq!(alpha1::<_, Error<_>, false>(a), Ok((empty, a)));
-    assert_eq!(alpha1(b), Err(Err::Error(Error::new(b, ErrorKind::Alpha))));
+    assert_eq!(
+      alpha1(b),
+      Err(ErrMode::Error(Error::new(b, ErrorKind::Alpha)))
+    );
     assert_eq!(alpha1::<_, Error<_>, false>(c), Ok((&c[1..], "a")));
     assert_eq!(alpha1::<_, Error<_>, false>(d), Ok(("é12", "az")));
-    assert_eq!(digit1(a), Err(Err::Error(Error::new(a, ErrorKind::Digit))));
+    assert_eq!(
+      digit1(a),
+      Err(ErrMode::Error(Error::new(a, ErrorKind::Digit)))
+    );
     assert_eq!(digit1::<_, Error<_>, false>(b), Ok((empty, b)));
-    assert_eq!(digit1(c), Err(Err::Error(Error::new(c, ErrorKind::Digit))));
-    assert_eq!(digit1(d), Err(Err::Error(Error::new(d, ErrorKind::Digit))));
+    assert_eq!(
+      digit1(c),
+      Err(ErrMode::Error(Error::new(c, ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1(d),
+      Err(ErrMode::Error(Error::new(d, ErrorKind::Digit)))
+    );
     assert_eq!(hex_digit1::<_, Error<_>, false>(a), Ok((empty, a)));
     assert_eq!(hex_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
     assert_eq!(hex_digit1::<_, Error<_>, false>(c), Ok((empty, c)));
     assert_eq!(hex_digit1::<_, Error<_>, false>(d), Ok(("zé12", "a")));
     assert_eq!(
       hex_digit1(e),
-      Err(Err::Error(Error::new(e, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(Error::new(e, ErrorKind::HexDigit)))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(Err::Error(Error::new(a, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(a, ErrorKind::OctDigit)))
     );
     assert_eq!(oct_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
     assert_eq!(
       oct_digit1(c),
-      Err(Err::Error(Error::new(c, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(c, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(Err::Error(Error::new(d, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(d, ErrorKind::OctDigit)))
     );
     assert_eq!(alphanumeric1::<_, Error<_>, false>(a), Ok((empty, a)));
     //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
@@ -207,7 +231,7 @@ mod complete {
     let f = "βèƒôřè\rÂßÇáƒƭèř";
     assert_eq!(
       not_line_ending(f),
-      Err(Err::Error(Error::new(f, ErrorKind::Tag)))
+      Err(ErrMode::Error(Error::new(f, ErrorKind::Tag)))
     );
 
     let g2: &str = "ab12cd";
@@ -222,13 +246,13 @@ mod complete {
     let i = &b"g"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
     );
 
     let i = &b"G"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(Err::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
     );
 
     assert!(AsChar::is_hex_digit(b'0'));
@@ -253,7 +277,7 @@ mod complete {
     let i = &b"8"[..];
     assert_parse!(
       oct_digit1(i),
-      Err(Err::Error(error_position!(i, ErrorKind::OctDigit)))
+      Err(ErrMode::Error(error_position!(i, ErrorKind::OctDigit)))
     );
 
     assert!(AsChar::is_oct_digit(b'0'));
@@ -309,21 +333,24 @@ mod complete {
     assert_parse!(crlf(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_parse!(
       crlf(&b"\r"[..]),
-      Err(Err::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
     );
     assert_parse!(
       crlf(&b"\ra"[..]),
-      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(
+        &b"\ra"[..],
+        ErrorKind::CrLf
+      )))
     );
 
     assert_parse!(crlf("\r\na"), Ok(("a", "\r\n")));
     assert_parse!(
       crlf("\r"),
-      Err(Err::Error(error_position!("\r", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\r", ErrorKind::CrLf)))
     );
     assert_parse!(
       crlf("\ra"),
-      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -333,22 +360,25 @@ mod complete {
     assert_parse!(line_ending(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_parse!(
       line_ending(&b"\r"[..]),
-      Err(Err::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
     );
     assert_parse!(
       line_ending(&b"\ra"[..]),
-      Err(Err::Error(error_position!(&b"\ra"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!(
+        &b"\ra"[..],
+        ErrorKind::CrLf
+      )))
     );
 
     assert_parse!(line_ending("\na"), Ok(("a", "\n")));
     assert_parse!(line_ending("\r\na"), Ok(("a", "\r\n")));
     assert_parse!(
       line_ending("\r"),
-      Err(Err::Error(error_position!("\r", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\r", ErrorKind::CrLf)))
     );
     assert_parse!(
       line_ending("\ra"),
-      Err(Err::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -364,7 +394,7 @@ mod complete {
     let (i, s) = match digit1::<_, crate::error::Error<_>, false>(i) {
       Ok((i, s)) => (i, s),
       Err(_) => {
-        return Err(Err::Error(crate::error::Error::from_error_kind(
+        return Err(ErrMode::Error(crate::error::Error::from_error_kind(
           input,
           ErrorKind::Digit,
         )))
@@ -379,7 +409,7 @@ mod complete {
           Ok((i, -n))
         }
       }
-      None => Err(Err::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -390,7 +420,7 @@ mod complete {
     let (i, s) = digit1(i)?;
     match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(Err::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -455,7 +485,7 @@ mod complete {
     let remaining_exponent = "-1.234E-";
     assert_parse!(
       recognize_float(remaining_exponent),
-      Err(Err::Failure(Error {
+      Err(ErrMode::Failure(Error {
         input: "",
         kind: ErrorKind::Digit
       }))
@@ -477,11 +507,11 @@ mod complete {
       Err(e) => Err(e),
       Ok((i, s)) => {
         if s.is_empty() {
-          return Err(Err::Error(()));
+          return Err(ErrMode::Error(()));
         }
         match s.parse_to() {
           Some(n) => Ok((i, n)),
-          None => Err(Err::Error(())),
+          None => Err(ErrMode::Error(())),
         }
       }
     }
@@ -547,14 +577,14 @@ mod complete {
     assert_eq!(esc(&b"ab\\\"12"[..]), Ok((&b"12"[..], &b"ab\\\""[..])));
     assert_eq!(
       esc(&b"AB\\"[..]),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         &b"AB\\"[..],
         ErrorKind::Escaped
       )))
     );
     assert_eq!(
       esc(&b"AB\\A"[..]),
-      Err(Err::Error(error_node_position!(
+      Err(ErrMode::Error(error_node_position!(
         &b"AB\\A"[..],
         ErrorKind::Escaped,
         error_position!(&b"A"[..], ErrorKind::OneOf)
@@ -583,11 +613,11 @@ mod complete {
     assert_eq!(esc("ab\\\"12"), Ok(("12", "ab\\\"")));
     assert_eq!(
       esc("AB\\"),
-      Err(Err::Error(error_position!("AB\\", ErrorKind::Escaped)))
+      Err(ErrMode::Error(error_position!("AB\\", ErrorKind::Escaped)))
     );
     assert_eq!(
       esc("AB\\A"),
-      Err(Err::Error(error_node_position!(
+      Err(ErrMode::Error(error_node_position!(
         "AB\\A",
         ErrorKind::Escaped,
         error_position!("A", ErrorKind::OneOf)
@@ -614,7 +644,7 @@ mod complete {
 
     assert_eq!(
       esc("abcd"),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: "abcd",
         kind: ErrorKind::Escaped
       }))
@@ -661,14 +691,14 @@ mod complete {
     );
     assert_eq!(
       esc(&b"AB\\"[..]),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         &b"\\"[..],
         ErrorKind::EscapedTransform
       )))
     );
     assert_eq!(
       esc(&b"AB\\A"[..]),
-      Err(Err::Error(error_node_position!(
+      Err(ErrMode::Error(error_node_position!(
         &b"AB\\A"[..],
         ErrorKind::EscapedTransform,
         error_position!(&b"A"[..], ErrorKind::Tag)
@@ -721,14 +751,14 @@ mod complete {
     assert_eq!(esc("ab\\\"12"), Ok(("12", String::from("ab\""))));
     assert_eq!(
       esc("AB\\"),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         "\\",
         ErrorKind::EscapedTransform
       )))
     );
     assert_eq!(
       esc("AB\\A"),
-      Err(Err::Error(error_node_position!(
+      Err(ErrMode::Error(error_node_position!(
         "AB\\A",
         ErrorKind::EscapedTransform,
         error_position!("A", ErrorKind::Tag)
@@ -768,7 +798,7 @@ mod complete {
 
     assert_eq!(
       esc_trans("abcd"),
-      Err(Err::Error(Error {
+      Err(ErrMode::Error(Error {
         input: "abcd",
         kind: ErrorKind::EscapedTransform
       }))
@@ -784,7 +814,7 @@ mod streaming {
   use crate::input::ParseTo;
   use crate::input::Streaming;
   use crate::sequence::pair;
-  use crate::{Err, IResult, Needed};
+  use crate::{ErrMode, IResult, Needed};
   use proptest::prelude::*;
 
   macro_rules! assert_parse(
@@ -802,11 +832,14 @@ mod streaming {
     let d: &[u8] = "azé12".as_bytes();
     let e: &[u8] = b" ";
     let f: &[u8] = b" ;";
-    //assert_eq!(alpha1::<_, Error<_>, true>(a), Err(Err::Incomplete(Needed::new(1))));
-    assert_parse!(alpha1(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
+    //assert_eq!(alpha1::<_, Error<_>, true>(a), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_parse!(
+      alpha1(Streaming(a)),
+      Err(ErrMode::Incomplete(Needed::new(1)))
+    );
     assert_eq!(
       alpha1(Streaming(b)),
-      Err(Err::Error(Error::new(Streaming(b), ErrorKind::Alpha)))
+      Err(ErrMode::Error(Error::new(Streaming(b), ErrorKind::Alpha)))
     );
     assert_eq!(
       alpha1::<_, Error<_>, true>(Streaming(c)),
@@ -818,31 +851,31 @@ mod streaming {
     );
     assert_eq!(
       digit1(Streaming(a)),
-      Err(Err::Error(Error::new(Streaming(a), ErrorKind::Digit)))
+      Err(ErrMode::Error(Error::new(Streaming(a), ErrorKind::Digit)))
     );
     assert_eq!(
       digit1::<_, Error<_>, true>(Streaming(b)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       digit1(Streaming(c)),
-      Err(Err::Error(Error::new(Streaming(c), ErrorKind::Digit)))
+      Err(ErrMode::Error(Error::new(Streaming(c), ErrorKind::Digit)))
     );
     assert_eq!(
       digit1(Streaming(d)),
-      Err(Err::Error(Error::new(Streaming(d), ErrorKind::Digit)))
+      Err(ErrMode::Error(Error::new(Streaming(d), ErrorKind::Digit)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(a)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(b)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(c)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(d)),
@@ -850,32 +883,44 @@ mod streaming {
     );
     assert_eq!(
       hex_digit1(Streaming(e)),
-      Err(Err::Error(Error::new(Streaming(e), ErrorKind::HexDigit)))
+      Err(ErrMode::Error(Error::new(
+        Streaming(e),
+        ErrorKind::HexDigit
+      )))
     );
     assert_eq!(
       oct_digit1(Streaming(a)),
-      Err(Err::Error(Error::new(Streaming(a), ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(
+        Streaming(a),
+        ErrorKind::OctDigit
+      )))
     );
     assert_eq!(
       oct_digit1::<_, Error<_>, true>(Streaming(b)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       oct_digit1(Streaming(c)),
-      Err(Err::Error(Error::new(Streaming(c), ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(
+        Streaming(c),
+        ErrorKind::OctDigit
+      )))
     );
     assert_eq!(
       oct_digit1(Streaming(d)),
-      Err(Err::Error(Error::new(Streaming(d), ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(
+        Streaming(d),
+        ErrorKind::OctDigit
+      )))
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>, true>(Streaming(a)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
     assert_eq!(
       alphanumeric1::<_, Error<_>, true>(Streaming(c)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>, true>(Streaming(d)),
@@ -883,7 +928,7 @@ mod streaming {
     );
     assert_eq!(
       space1::<_, Error<_>, true>(Streaming(e)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       space1::<_, Error<_>, true>(Streaming(f)),
@@ -901,11 +946,11 @@ mod streaming {
     let e = " ";
     assert_eq!(
       alpha1::<_, Error<_>, true>(Streaming(a)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       alpha1(Streaming(b)),
-      Err(Err::Error(Error::new(Streaming(b), ErrorKind::Alpha)))
+      Err(ErrMode::Error(Error::new(Streaming(b), ErrorKind::Alpha)))
     );
     assert_eq!(
       alpha1::<_, Error<_>, true>(Streaming(c)),
@@ -917,31 +962,31 @@ mod streaming {
     );
     assert_eq!(
       digit1(Streaming(a)),
-      Err(Err::Error(Error::new(Streaming(a), ErrorKind::Digit)))
+      Err(ErrMode::Error(Error::new(Streaming(a), ErrorKind::Digit)))
     );
     assert_eq!(
       digit1::<_, Error<_>, true>(Streaming(b)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       digit1(Streaming(c)),
-      Err(Err::Error(Error::new(Streaming(c), ErrorKind::Digit)))
+      Err(ErrMode::Error(Error::new(Streaming(c), ErrorKind::Digit)))
     );
     assert_eq!(
       digit1(Streaming(d)),
-      Err(Err::Error(Error::new(Streaming(d), ErrorKind::Digit)))
+      Err(ErrMode::Error(Error::new(Streaming(d), ErrorKind::Digit)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(a)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(b)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(c)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(d)),
@@ -949,32 +994,44 @@ mod streaming {
     );
     assert_eq!(
       hex_digit1(Streaming(e)),
-      Err(Err::Error(Error::new(Streaming(e), ErrorKind::HexDigit)))
+      Err(ErrMode::Error(Error::new(
+        Streaming(e),
+        ErrorKind::HexDigit
+      )))
     );
     assert_eq!(
       oct_digit1(Streaming(a)),
-      Err(Err::Error(Error::new(Streaming(a), ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(
+        Streaming(a),
+        ErrorKind::OctDigit
+      )))
     );
     assert_eq!(
       oct_digit1::<_, Error<_>, true>(Streaming(b)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       oct_digit1(Streaming(c)),
-      Err(Err::Error(Error::new(Streaming(c), ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(
+        Streaming(c),
+        ErrorKind::OctDigit
+      )))
     );
     assert_eq!(
       oct_digit1(Streaming(d)),
-      Err(Err::Error(Error::new(Streaming(d), ErrorKind::OctDigit)))
+      Err(ErrMode::Error(Error::new(
+        Streaming(d),
+        ErrorKind::OctDigit
+      )))
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>, true>(Streaming(a)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
     assert_eq!(
       alphanumeric1::<_, Error<_>, true>(Streaming(c)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>, true>(Streaming(d)),
@@ -982,7 +1039,7 @@ mod streaming {
     );
     assert_eq!(
       space1::<_, Error<_>, true>(Streaming(e)),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1063,7 +1120,7 @@ mod streaming {
     let d: &[u8] = b"ab12cd";
     assert_eq!(
       not_line_ending::<_, Error<_>, true>(Streaming(d)),
-      Err(Err::Incomplete(Needed::Unknown))
+      Err(ErrMode::Incomplete(Needed::Unknown))
     );
   }
 
@@ -1072,13 +1129,13 @@ mod streaming {
     let f = "βèƒôřè\rÂßÇáƒƭèř";
     assert_eq!(
       not_line_ending(Streaming(f)),
-      Err(Err::Error(Error::new(Streaming(f), ErrorKind::Tag)))
+      Err(ErrMode::Error(Error::new(Streaming(f), ErrorKind::Tag)))
     );
 
     let g2: &str = "ab12cd";
     assert_eq!(
       not_line_ending::<_, Error<_>, true>(Streaming(g2)),
-      Err(Err::Incomplete(Needed::Unknown))
+      Err(ErrMode::Incomplete(Needed::Unknown))
     );
   }
 
@@ -1093,7 +1150,7 @@ mod streaming {
     let i = &b"g"[..];
     assert_parse!(
       hex_digit1(Streaming(i)),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         Streaming(i),
         ErrorKind::HexDigit
       )))
@@ -1102,7 +1159,7 @@ mod streaming {
     let i = &b"G"[..];
     assert_parse!(
       hex_digit1(Streaming(i)),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         Streaming(i),
         ErrorKind::HexDigit
       )))
@@ -1133,7 +1190,7 @@ mod streaming {
     let i = &b"8"[..];
     assert_parse!(
       oct_digit1(Streaming(i)),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         Streaming(i),
         ErrorKind::OctDigit
       )))
@@ -1198,21 +1255,24 @@ mod streaming {
     );
     assert_parse!(
       crlf(Streaming(&b"\r"[..])),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       crlf(Streaming(&b"\ra"[..])),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         Streaming(&b"\ra"[..]),
         ErrorKind::CrLf
       )))
     );
 
     assert_parse!(crlf(Streaming("\r\na")), Ok((Streaming("a"), "\r\n")));
-    assert_parse!(crlf(Streaming("\r")), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(
+      crlf(Streaming("\r")),
+      Err(ErrMode::Incomplete(Needed::new(2)))
+    );
     assert_parse!(
       crlf(Streaming("\ra")),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         Streaming("\ra"),
         ErrorKind::CrLf
       )))
@@ -1231,11 +1291,11 @@ mod streaming {
     );
     assert_parse!(
       line_ending(Streaming(&b"\r"[..])),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       line_ending(Streaming(&b"\ra"[..])),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         Streaming(&b"\ra"[..]),
         ErrorKind::CrLf
       )))
@@ -1248,11 +1308,11 @@ mod streaming {
     );
     assert_parse!(
       line_ending(Streaming("\r")),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       line_ending(Streaming("\ra")),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         Streaming("\ra"),
         ErrorKind::CrLf
       )))
@@ -1272,9 +1332,9 @@ mod streaming {
 
     let (i, s) = match digit1::<_, crate::error::Error<_>, true>(i) {
       Ok((i, s)) => (i, s),
-      Err(Err::Incomplete(i)) => return Err(Err::Incomplete(i)),
+      Err(ErrMode::Incomplete(i)) => return Err(ErrMode::Incomplete(i)),
       Err(_) => {
-        return Err(Err::Error(crate::error::Error::from_error_kind(
+        return Err(ErrMode::Error(crate::error::Error::from_error_kind(
           input,
           ErrorKind::Digit,
         )))
@@ -1288,7 +1348,7 @@ mod streaming {
           Ok((i, -n))
         }
       }
-      None => Err(Err::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -1299,7 +1359,7 @@ mod streaming {
     let (i, s) = digit1(i)?;
     match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(Err::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -7,10 +7,10 @@ mod complete {
   use crate::bytes::one_of;
   use crate::bytes::tag;
   use crate::combinator::opt;
+  use crate::error::ErrMode;
   use crate::error::Error;
   use crate::error::ErrorKind;
   use crate::input::ParseTo;
-  use crate::ErrMode;
   use crate::Parser;
   #[cfg(feature = "alloc")]
   use crate::{lib::std::string::String, lib::std::vec::Vec};
@@ -811,10 +811,11 @@ mod streaming {
   use crate::combinator::opt;
   use crate::error::Error;
   use crate::error::ErrorKind;
+  use crate::error::{ErrMode, Needed};
   use crate::input::ParseTo;
   use crate::input::Streaming;
   use crate::sequence::pair;
-  use crate::{ErrMode, IResult, Needed};
+  use crate::IResult;
   use proptest::prelude::*;
 
   macro_rules! assert_parse(

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -36,7 +36,7 @@ mod complete {
     assert_parse!(alpha1(a), Ok((empty, a)));
     assert_eq!(
       alpha1(b),
-      Err(ErrMode::Error(Error::new(b, ErrorKind::Alpha)))
+      Err(ErrMode::Backtrack(Error::new(b, ErrorKind::Alpha)))
     );
     assert_eq!(alpha1::<_, Error<_>, false>(c), Ok((&c[1..], &b"a"[..])));
     assert_eq!(
@@ -45,16 +45,16 @@ mod complete {
     );
     assert_eq!(
       digit1(a),
-      Err(ErrMode::Error(Error::new(a, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Digit)))
     );
     assert_eq!(digit1::<_, Error<_>, false>(b), Ok((empty, b)));
     assert_eq!(
       digit1(c),
-      Err(ErrMode::Error(Error::new(c, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Digit)))
     );
     assert_eq!(
       digit1(d),
-      Err(ErrMode::Error(Error::new(d, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Digit)))
     );
     assert_eq!(hex_digit1::<_, Error<_>, false>(a), Ok((empty, a)));
     assert_eq!(hex_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
@@ -65,20 +65,20 @@ mod complete {
     );
     assert_eq!(
       hex_digit1(e),
-      Err(ErrMode::Error(Error::new(e, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(Error::new(e, ErrorKind::HexDigit)))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(ErrMode::Error(Error::new(a, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(a, ErrorKind::OctDigit)))
     );
     assert_eq!(oct_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
     assert_eq!(
       oct_digit1(c),
-      Err(ErrMode::Error(Error::new(c, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(c, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(ErrMode::Error(Error::new(d, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(d, ErrorKind::OctDigit)))
     );
     assert_eq!(alphanumeric1::<_, Error<_>, false>(a), Ok((empty, a)));
     //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
@@ -103,22 +103,22 @@ mod complete {
     assert_eq!(alpha1::<_, Error<_>, false>(a), Ok((empty, a)));
     assert_eq!(
       alpha1(b),
-      Err(ErrMode::Error(Error::new(b, ErrorKind::Alpha)))
+      Err(ErrMode::Backtrack(Error::new(b, ErrorKind::Alpha)))
     );
     assert_eq!(alpha1::<_, Error<_>, false>(c), Ok((&c[1..], "a")));
     assert_eq!(alpha1::<_, Error<_>, false>(d), Ok(("é12", "az")));
     assert_eq!(
       digit1(a),
-      Err(ErrMode::Error(Error::new(a, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Digit)))
     );
     assert_eq!(digit1::<_, Error<_>, false>(b), Ok((empty, b)));
     assert_eq!(
       digit1(c),
-      Err(ErrMode::Error(Error::new(c, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Digit)))
     );
     assert_eq!(
       digit1(d),
-      Err(ErrMode::Error(Error::new(d, ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Digit)))
     );
     assert_eq!(hex_digit1::<_, Error<_>, false>(a), Ok((empty, a)));
     assert_eq!(hex_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
@@ -126,20 +126,20 @@ mod complete {
     assert_eq!(hex_digit1::<_, Error<_>, false>(d), Ok(("zé12", "a")));
     assert_eq!(
       hex_digit1(e),
-      Err(ErrMode::Error(Error::new(e, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(Error::new(e, ErrorKind::HexDigit)))
     );
     assert_eq!(
       oct_digit1(a),
-      Err(ErrMode::Error(Error::new(a, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(a, ErrorKind::OctDigit)))
     );
     assert_eq!(oct_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
     assert_eq!(
       oct_digit1(c),
-      Err(ErrMode::Error(Error::new(c, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(c, ErrorKind::OctDigit)))
     );
     assert_eq!(
       oct_digit1(d),
-      Err(ErrMode::Error(Error::new(d, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(Error::new(d, ErrorKind::OctDigit)))
     );
     assert_eq!(alphanumeric1::<_, Error<_>, false>(a), Ok((empty, a)));
     //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
@@ -231,7 +231,7 @@ mod complete {
     let f = "βèƒôřè\rÂßÇáƒƭèř";
     assert_eq!(
       not_line_ending(f),
-      Err(ErrMode::Error(Error::new(f, ErrorKind::Tag)))
+      Err(ErrMode::Backtrack(Error::new(f, ErrorKind::Tag)))
     );
 
     let g2: &str = "ab12cd";
@@ -246,13 +246,13 @@ mod complete {
     let i = &b"g"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(error_position!(i, ErrorKind::HexDigit)))
     );
 
     let i = &b"G"[..];
     assert_parse!(
       hex_digit1(i),
-      Err(ErrMode::Error(error_position!(i, ErrorKind::HexDigit)))
+      Err(ErrMode::Backtrack(error_position!(i, ErrorKind::HexDigit)))
     );
 
     assert!(AsChar::is_hex_digit(b'0'));
@@ -277,7 +277,7 @@ mod complete {
     let i = &b"8"[..];
     assert_parse!(
       oct_digit1(i),
-      Err(ErrMode::Error(error_position!(i, ErrorKind::OctDigit)))
+      Err(ErrMode::Backtrack(error_position!(i, ErrorKind::OctDigit)))
     );
 
     assert!(AsChar::is_oct_digit(b'0'));
@@ -333,11 +333,14 @@ mod complete {
     assert_parse!(crlf(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_parse!(
       crlf(&b"\r"[..]),
-      Err(ErrMode::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!(
+        &b"\r"[..],
+        ErrorKind::CrLf
+      )))
     );
     assert_parse!(
       crlf(&b"\ra"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"\ra"[..],
         ErrorKind::CrLf
       )))
@@ -346,11 +349,11 @@ mod complete {
     assert_parse!(crlf("\r\na"), Ok(("a", "\r\n")));
     assert_parse!(
       crlf("\r"),
-      Err(ErrMode::Error(error_position!("\r", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\r", ErrorKind::CrLf)))
     );
     assert_parse!(
       crlf("\ra"),
-      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -360,11 +363,14 @@ mod complete {
     assert_parse!(line_ending(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
     assert_parse!(
       line_ending(&b"\r"[..]),
-      Err(ErrMode::Error(error_position!(&b"\r"[..], ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!(
+        &b"\r"[..],
+        ErrorKind::CrLf
+      )))
     );
     assert_parse!(
       line_ending(&b"\ra"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"\ra"[..],
         ErrorKind::CrLf
       )))
@@ -374,11 +380,11 @@ mod complete {
     assert_parse!(line_ending("\r\na"), Ok(("a", "\r\n")));
     assert_parse!(
       line_ending("\r"),
-      Err(ErrMode::Error(error_position!("\r", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\r", ErrorKind::CrLf)))
     );
     assert_parse!(
       line_ending("\ra"),
-      Err(ErrMode::Error(error_position!("\ra", ErrorKind::CrLf)))
+      Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::CrLf)))
     );
   }
 
@@ -394,7 +400,7 @@ mod complete {
     let (i, s) = match digit1::<_, crate::error::Error<_>, false>(i) {
       Ok((i, s)) => (i, s),
       Err(_) => {
-        return Err(ErrMode::Error(crate::error::Error::from_error_kind(
+        return Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
           input,
           ErrorKind::Digit,
         )))
@@ -409,7 +415,7 @@ mod complete {
           Ok((i, -n))
         }
       }
-      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -420,7 +426,7 @@ mod complete {
     let (i, s) = digit1(i)?;
     match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -485,7 +491,7 @@ mod complete {
     let remaining_exponent = "-1.234E-";
     assert_parse!(
       recognize_float(remaining_exponent),
-      Err(ErrMode::Failure(Error {
+      Err(ErrMode::Cut(Error {
         input: "",
         kind: ErrorKind::Digit
       }))
@@ -507,11 +513,11 @@ mod complete {
       Err(e) => Err(e),
       Ok((i, s)) => {
         if s.is_empty() {
-          return Err(ErrMode::Error(()));
+          return Err(ErrMode::Backtrack(()));
         }
         match s.parse_to() {
           Some(n) => Ok((i, n)),
-          None => Err(ErrMode::Error(())),
+          None => Err(ErrMode::Backtrack(())),
         }
       }
     }
@@ -577,14 +583,14 @@ mod complete {
     assert_eq!(esc(&b"ab\\\"12"[..]), Ok((&b"12"[..], &b"ab\\\""[..])));
     assert_eq!(
       esc(&b"AB\\"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"AB\\"[..],
         ErrorKind::Escaped
       )))
     );
     assert_eq!(
       esc(&b"AB\\A"[..]),
-      Err(ErrMode::Error(error_node_position!(
+      Err(ErrMode::Backtrack(error_node_position!(
         &b"AB\\A"[..],
         ErrorKind::Escaped,
         error_position!(&b"A"[..], ErrorKind::OneOf)
@@ -613,11 +619,14 @@ mod complete {
     assert_eq!(esc("ab\\\"12"), Ok(("12", "ab\\\"")));
     assert_eq!(
       esc("AB\\"),
-      Err(ErrMode::Error(error_position!("AB\\", ErrorKind::Escaped)))
+      Err(ErrMode::Backtrack(error_position!(
+        "AB\\",
+        ErrorKind::Escaped
+      )))
     );
     assert_eq!(
       esc("AB\\A"),
-      Err(ErrMode::Error(error_node_position!(
+      Err(ErrMode::Backtrack(error_node_position!(
         "AB\\A",
         ErrorKind::Escaped,
         error_position!("A", ErrorKind::OneOf)
@@ -644,7 +653,7 @@ mod complete {
 
     assert_eq!(
       esc("abcd"),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: "abcd",
         kind: ErrorKind::Escaped
       }))
@@ -691,14 +700,14 @@ mod complete {
     );
     assert_eq!(
       esc(&b"AB\\"[..]),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         &b"\\"[..],
         ErrorKind::EscapedTransform
       )))
     );
     assert_eq!(
       esc(&b"AB\\A"[..]),
-      Err(ErrMode::Error(error_node_position!(
+      Err(ErrMode::Backtrack(error_node_position!(
         &b"AB\\A"[..],
         ErrorKind::EscapedTransform,
         error_position!(&b"A"[..], ErrorKind::Tag)
@@ -751,14 +760,14 @@ mod complete {
     assert_eq!(esc("ab\\\"12"), Ok(("12", String::from("ab\""))));
     assert_eq!(
       esc("AB\\"),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         "\\",
         ErrorKind::EscapedTransform
       )))
     );
     assert_eq!(
       esc("AB\\A"),
-      Err(ErrMode::Error(error_node_position!(
+      Err(ErrMode::Backtrack(error_node_position!(
         "AB\\A",
         ErrorKind::EscapedTransform,
         error_position!("A", ErrorKind::Tag)
@@ -798,7 +807,7 @@ mod complete {
 
     assert_eq!(
       esc_trans("abcd"),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: "abcd",
         kind: ErrorKind::EscapedTransform
       }))
@@ -840,7 +849,10 @@ mod streaming {
     );
     assert_eq!(
       alpha1(Streaming(b)),
-      Err(ErrMode::Error(Error::new(Streaming(b), ErrorKind::Alpha)))
+      Err(ErrMode::Backtrack(Error::new(
+        Streaming(b),
+        ErrorKind::Alpha
+      )))
     );
     assert_eq!(
       alpha1::<_, Error<_>, true>(Streaming(c)),
@@ -852,7 +864,10 @@ mod streaming {
     );
     assert_eq!(
       digit1(Streaming(a)),
-      Err(ErrMode::Error(Error::new(Streaming(a), ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(
+        Streaming(a),
+        ErrorKind::Digit
+      )))
     );
     assert_eq!(
       digit1::<_, Error<_>, true>(Streaming(b)),
@@ -860,11 +875,17 @@ mod streaming {
     );
     assert_eq!(
       digit1(Streaming(c)),
-      Err(ErrMode::Error(Error::new(Streaming(c), ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(
+        Streaming(c),
+        ErrorKind::Digit
+      )))
     );
     assert_eq!(
       digit1(Streaming(d)),
-      Err(ErrMode::Error(Error::new(Streaming(d), ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(
+        Streaming(d),
+        ErrorKind::Digit
+      )))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(a)),
@@ -884,14 +905,14 @@ mod streaming {
     );
     assert_eq!(
       hex_digit1(Streaming(e)),
-      Err(ErrMode::Error(Error::new(
+      Err(ErrMode::Backtrack(Error::new(
         Streaming(e),
         ErrorKind::HexDigit
       )))
     );
     assert_eq!(
       oct_digit1(Streaming(a)),
-      Err(ErrMode::Error(Error::new(
+      Err(ErrMode::Backtrack(Error::new(
         Streaming(a),
         ErrorKind::OctDigit
       )))
@@ -902,14 +923,14 @@ mod streaming {
     );
     assert_eq!(
       oct_digit1(Streaming(c)),
-      Err(ErrMode::Error(Error::new(
+      Err(ErrMode::Backtrack(Error::new(
         Streaming(c),
         ErrorKind::OctDigit
       )))
     );
     assert_eq!(
       oct_digit1(Streaming(d)),
-      Err(ErrMode::Error(Error::new(
+      Err(ErrMode::Backtrack(Error::new(
         Streaming(d),
         ErrorKind::OctDigit
       )))
@@ -951,7 +972,10 @@ mod streaming {
     );
     assert_eq!(
       alpha1(Streaming(b)),
-      Err(ErrMode::Error(Error::new(Streaming(b), ErrorKind::Alpha)))
+      Err(ErrMode::Backtrack(Error::new(
+        Streaming(b),
+        ErrorKind::Alpha
+      )))
     );
     assert_eq!(
       alpha1::<_, Error<_>, true>(Streaming(c)),
@@ -963,7 +987,10 @@ mod streaming {
     );
     assert_eq!(
       digit1(Streaming(a)),
-      Err(ErrMode::Error(Error::new(Streaming(a), ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(
+        Streaming(a),
+        ErrorKind::Digit
+      )))
     );
     assert_eq!(
       digit1::<_, Error<_>, true>(Streaming(b)),
@@ -971,11 +998,17 @@ mod streaming {
     );
     assert_eq!(
       digit1(Streaming(c)),
-      Err(ErrMode::Error(Error::new(Streaming(c), ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(
+        Streaming(c),
+        ErrorKind::Digit
+      )))
     );
     assert_eq!(
       digit1(Streaming(d)),
-      Err(ErrMode::Error(Error::new(Streaming(d), ErrorKind::Digit)))
+      Err(ErrMode::Backtrack(Error::new(
+        Streaming(d),
+        ErrorKind::Digit
+      )))
     );
     assert_eq!(
       hex_digit1::<_, Error<_>, true>(Streaming(a)),
@@ -995,14 +1028,14 @@ mod streaming {
     );
     assert_eq!(
       hex_digit1(Streaming(e)),
-      Err(ErrMode::Error(Error::new(
+      Err(ErrMode::Backtrack(Error::new(
         Streaming(e),
         ErrorKind::HexDigit
       )))
     );
     assert_eq!(
       oct_digit1(Streaming(a)),
-      Err(ErrMode::Error(Error::new(
+      Err(ErrMode::Backtrack(Error::new(
         Streaming(a),
         ErrorKind::OctDigit
       )))
@@ -1013,14 +1046,14 @@ mod streaming {
     );
     assert_eq!(
       oct_digit1(Streaming(c)),
-      Err(ErrMode::Error(Error::new(
+      Err(ErrMode::Backtrack(Error::new(
         Streaming(c),
         ErrorKind::OctDigit
       )))
     );
     assert_eq!(
       oct_digit1(Streaming(d)),
-      Err(ErrMode::Error(Error::new(
+      Err(ErrMode::Backtrack(Error::new(
         Streaming(d),
         ErrorKind::OctDigit
       )))
@@ -1130,7 +1163,7 @@ mod streaming {
     let f = "βèƒôřè\rÂßÇáƒƭèř";
     assert_eq!(
       not_line_ending(Streaming(f)),
-      Err(ErrMode::Error(Error::new(Streaming(f), ErrorKind::Tag)))
+      Err(ErrMode::Backtrack(Error::new(Streaming(f), ErrorKind::Tag)))
     );
 
     let g2: &str = "ab12cd";
@@ -1151,7 +1184,7 @@ mod streaming {
     let i = &b"g"[..];
     assert_parse!(
       hex_digit1(Streaming(i)),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         Streaming(i),
         ErrorKind::HexDigit
       )))
@@ -1160,7 +1193,7 @@ mod streaming {
     let i = &b"G"[..];
     assert_parse!(
       hex_digit1(Streaming(i)),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         Streaming(i),
         ErrorKind::HexDigit
       )))
@@ -1191,7 +1224,7 @@ mod streaming {
     let i = &b"8"[..];
     assert_parse!(
       oct_digit1(Streaming(i)),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         Streaming(i),
         ErrorKind::OctDigit
       )))
@@ -1260,7 +1293,7 @@ mod streaming {
     );
     assert_parse!(
       crlf(Streaming(&b"\ra"[..])),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         Streaming(&b"\ra"[..]),
         ErrorKind::CrLf
       )))
@@ -1273,7 +1306,7 @@ mod streaming {
     );
     assert_parse!(
       crlf(Streaming("\ra")),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         Streaming("\ra"),
         ErrorKind::CrLf
       )))
@@ -1296,7 +1329,7 @@ mod streaming {
     );
     assert_parse!(
       line_ending(Streaming(&b"\ra"[..])),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         Streaming(&b"\ra"[..]),
         ErrorKind::CrLf
       )))
@@ -1313,7 +1346,7 @@ mod streaming {
     );
     assert_parse!(
       line_ending(Streaming("\ra")),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         Streaming("\ra"),
         ErrorKind::CrLf
       )))
@@ -1335,7 +1368,7 @@ mod streaming {
       Ok((i, s)) => (i, s),
       Err(ErrMode::Incomplete(i)) => return Err(ErrMode::Incomplete(i)),
       Err(_) => {
-        return Err(ErrMode::Error(crate::error::Error::from_error_kind(
+        return Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
           input,
           ErrorKind::Digit,
         )))
@@ -1349,7 +1382,7 @@ mod streaming {
           Ok((i, -n))
         }
       }
-      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),
@@ -1360,7 +1393,7 @@ mod streaming {
     let (i, s) = digit1(i)?;
     match s.parse_to() {
       Some(n) => Ok((i, n)),
-      None => Err(ErrMode::Error(crate::error::Error::from_error_kind(
+      None => Err(ErrMode::Backtrack(crate::error::Error::from_error_kind(
         i,
         ErrorKind::Digit,
       ))),

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -555,7 +555,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> H, H: Parser<I, O2, E>> Par
 
 /// Optional parser, will return `None` on [`ErrMode::Backtrack`].
 ///
-/// To chain an error up, see [`cut`].
+/// To chain an error up, see [`cut_err`].
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
@@ -1260,7 +1260,7 @@ where
 ///
 /// # Example
 ///
-/// Without `cut`:
+/// Without `cut_err`:
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// # use winnow::bytes::one_of;
@@ -1283,7 +1283,7 @@ where
 /// # }
 /// ```
 ///
-/// With `cut`:
+/// With `cut_err`:
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// # use winnow::bytes::one_of;
@@ -1291,12 +1291,12 @@ where
 /// # use winnow::combinator::rest;
 /// # use winnow::branch::alt;
 /// # use winnow::sequence::preceded;
-/// use winnow::combinator::cut;
+/// use winnow::combinator::cut_err;
 /// # fn main() {
 ///
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///   alt((
-///     preceded(one_of("+-"), cut(digit1)),
+///     preceded(one_of("+-"), cut_err(digit1)),
 ///     rest
 ///   ))(input)
 /// }
@@ -1306,7 +1306,7 @@ where
 /// assert_eq!(parser("+"), Err(ErrMode::Cut(Error { input: "", kind: ErrorKind::Digit })));
 /// # }
 /// ```
-pub fn cut<I, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, O, E>
+pub fn cut_err<I, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
   F: Parser<I, O, E>,
 {
@@ -1314,6 +1314,15 @@ where
     Err(ErrMode::Backtrack(e)) => Err(ErrMode::Cut(e)),
     rest => rest,
   }
+}
+
+/// Deprecated, see [`cut_err`]
+#[deprecated(since = "0.3.0", note = "Replaced with `cut_err`")]
+pub fn cut<I, O, E: ParseError<I>, F>(parser: F) -> impl FnMut(I) -> IResult<I, O, E>
+where
+  F: Parser<I, O, E>,
+{
+  cut_err(parser)
 }
 
 /// automatically converts the child parser's result to another type
@@ -1441,7 +1450,7 @@ where
 /// Call the iterator's [`ParserIterator::finish`] method to get the remaining input if successful,
 /// or the error value if we encountered an error.
 ///
-/// On [`ErrMode::Backtrack`], iteration will stop.  To instead chain an error up, see [`cut`].
+/// On [`ErrMode::Backtrack`], iteration will stop.  To instead chain an error up, see [`cut_err`].
 ///
 /// ```rust
 /// use winnow::{combinator::iterator, IResult, bytes::tag, character::alpha1, sequence::terminated};

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -90,6 +90,9 @@
 //!
 //! ## Error management and debugging
 //!
+//! - [`cut_err`]: Commit the parse result, disallowing alternative parsers from being attempted
+//! - [`backtrack_err`]: Attemmpts a parse, allowing alternative parsers to be attempted despite
+//!   use of `cut_err`
 //! - [`Parser::context`]: Add context to the error if the parser fails
 //! - [`Parser::dbg_err`]: Prints a message and the input if the parser fails
 //!

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -218,7 +218,7 @@ impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P> {
 /// **WARNING:** Deprecated, replaced with [`Parser::map`]
 ///
 /// ```rust
-/// use winnow::{Err, error::ErrorKind, error::Error, IResult,Parser};
+/// use winnow::{ErrMode, error::ErrorKind, error::Error, IResult,Parser};
 /// use winnow::character::digit1;
 /// use winnow::combinator::map;
 /// # fn main() {
@@ -229,7 +229,7 @@ impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P> {
 /// assert_eq!(parser.parse_next("123456"), Ok(("", 6)));
 ///
 /// // this will fail if digit1 fails
-/// assert_eq!(parser.parse_next("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Digit))));
+/// assert_eq!(parser.parse_next("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Digit))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::map")]
@@ -276,7 +276,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> for Ma
 /// **WARNING:** Deprecated, replaced with [`Parser::map_res`]
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::character::digit1;
 /// use winnow::combinator::map_res;
 /// # fn main() {
@@ -287,10 +287,10 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> for Ma
 /// assert_eq!(parse("123"), Ok(("", 123)));
 ///
 /// // this will fail if digit1 fails
-/// assert_eq!(parse("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Digit))));
+/// assert_eq!(parse("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Digit))));
 ///
 /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-/// assert_eq!(parse("123456"), Err(Err::Error(Error::new("123456", ErrorKind::MapRes))));
+/// assert_eq!(parse("123456"), Err(ErrMode::Error(Error::new("123456", ErrorKind::MapRes))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::map_res")]
@@ -307,7 +307,11 @@ where
     let (input, o1) = parser.parse_next(input)?;
     match f(o1) {
       Ok(o2) => Ok((input, o2)),
-      Err(e) => Err(Err::Error(E::from_external_error(i, ErrorKind::MapRes, e))),
+      Err(e) => Err(ErrMode::Error(E::from_external_error(
+        i,
+        ErrorKind::MapRes,
+        e,
+      ))),
     }
   }
 }
@@ -342,7 +346,11 @@ where
     let (input, o1) = self.f.parse_next(input)?;
     match (self.g)(o1) {
       Ok(o2) => Ok((input, o2)),
-      Err(e) => Err(Err::Error(E::from_external_error(i, ErrorKind::MapRes, e))),
+      Err(e) => Err(ErrMode::Error(E::from_external_error(
+        i,
+        ErrorKind::MapRes,
+        e,
+      ))),
     }
   }
 }
@@ -352,7 +360,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::map_opt`]
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::character::digit1;
 /// use winnow::combinator::map_opt;
 /// # fn main() {
@@ -363,10 +371,10 @@ where
 /// assert_eq!(parse("123"), Ok(("", 123)));
 ///
 /// // this will fail if digit1 fails
-/// assert_eq!(parse("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Digit))));
+/// assert_eq!(parse("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Digit))));
 ///
 /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-/// assert_eq!(parse("123456"), Err(Err::Error(Error::new("123456", ErrorKind::MapOpt))));
+/// assert_eq!(parse("123456"), Err(ErrMode::Error(Error::new("123456", ErrorKind::MapOpt))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::map_res")]
@@ -383,7 +391,7 @@ where
     let (input, o1) = parser.parse_next(input)?;
     match f(o1) {
       Some(o2) => Ok((input, o2)),
-      None => Err(Err::Error(E::from_error_kind(i, ErrorKind::MapOpt))),
+      None => Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::MapOpt))),
     }
   }
 }
@@ -418,7 +426,7 @@ where
     let (input, o1) = self.f.parse_next(input)?;
     match (self.g)(o1) {
       Some(o2) => Ok((input, o2)),
-      None => Err(Err::Error(E::from_error_kind(i, ErrorKind::MapOpt))),
+      None => Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::MapOpt))),
     }
   }
 }
@@ -428,7 +436,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::and_then`]
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::character::digit1;
 /// use winnow::bytes::take;
 /// use winnow::combinator::map_parser;
@@ -438,7 +446,7 @@ where
 ///
 /// assert_eq!(parse("12345"), Ok(("", "12345")));
 /// assert_eq!(parse("123ab"), Ok(("", "123")));
-/// assert_eq!(parse("123"), Err(Err::Error(Error::new("123", ErrorKind::Eof))));
+/// assert_eq!(parse("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Eof))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::and_then")]
@@ -490,7 +498,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, E>
 /// **WARNING:** Deprecated, replaced with [`Parser::flat_map`]
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::bytes::take;
 /// use winnow::number::u8;
 /// use winnow::combinator::flat_map;
@@ -499,7 +507,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, E>
 /// let mut parse = flat_map(u8, take);
 ///
 /// assert_eq!(parse(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
-/// assert_eq!(parse(&[4, 0, 1, 2][..]), Err(Err::Error(Error::new(&[0, 1, 2][..], ErrorKind::Eof))));
+/// assert_eq!(parse(&[4, 0, 1, 2][..]), Err(ErrMode::Error(Error::new(&[0, 1, 2][..], ErrorKind::Eof))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::flat_map")]
@@ -545,12 +553,12 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> H, H: Parser<I, O2, E>> Par
   }
 }
 
-/// Optional parser, will return `None` on [`Err::Error`].
+/// Optional parser, will return `None` on [`ErrMode::Error`].
 ///
 /// To chain an error up, see [`cut`].
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::opt;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -571,7 +579,7 @@ where
     let i = input.clone();
     match f.parse_next(input) {
       Ok((i, o)) => Ok((i, Some(o))),
-      Err(Err::Error(_)) => Ok((i, None)),
+      Err(ErrMode::Error(_)) => Ok((i, None)),
       Err(e) => Err(e),
     }
   }
@@ -616,8 +624,8 @@ impl<I: Clone, O, E: crate::error::ParseError<I>, F: Parser<I, O, E>, G: Parser<
 {
   fn parse_next(&mut self, i: I) -> IResult<I, O, E> {
     match self.f.parse_next(i.clone()) {
-      Err(Err::Error(e1)) => match self.g.parse_next(i) {
-        Err(Err::Error(e2)) => Err(Err::Error(e1.or(e2))),
+      Err(ErrMode::Error(e1)) => match self.g.parse_next(i) {
+        Err(ErrMode::Error(e2)) => Err(ErrMode::Error(e1.or(e2))),
         res => res,
       },
       res => res,
@@ -628,7 +636,7 @@ impl<I: Clone, O, E: crate::error::ParseError<I>, F: Parser<I, O, E>, G: Parser<
 /// Calls the parser if the condition is met.
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult};
 /// use winnow::combinator::cond;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -639,7 +647,7 @@ impl<I: Clone, O, E: crate::error::ParseError<I>, F: Parser<I, O, E>, G: Parser<
 ///
 /// assert_eq!(parser(true, "abcd;"), Ok((";", Some("abcd"))));
 /// assert_eq!(parser(false, "abcd;"), Ok(("abcd;", None)));
-/// assert_eq!(parser(true, "123;"), Err(Err::Error(Error::new("123;", ErrorKind::Alpha))));
+/// assert_eq!(parser(true, "123;"), Err(ErrMode::Error(Error::new("123;", ErrorKind::Alpha))));
 /// assert_eq!(parser(false, "123;"), Ok(("123;", None)));
 /// # }
 /// ```
@@ -665,7 +673,7 @@ where
 /// Tries to apply its parser without consuming the input.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::peek;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -673,7 +681,7 @@ where
 /// let mut parser = peek(alpha1);
 ///
 /// assert_eq!(parser("abcd;"), Ok(("abcd;", "abcd")));
-/// assert_eq!(parser("123;"), Err(Err::Error(Error::new("123;", ErrorKind::Alpha))));
+/// assert_eq!(parser("123;"), Err(ErrMode::Error(Error::new("123;", ErrorKind::Alpha))));
 /// # }
 /// ```
 pub fn peek<I: Clone, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
@@ -696,12 +704,12 @@ where
 ///
 /// ```
 /// # use std::str;
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// # use winnow::combinator::eof;
 ///
 /// # fn main() {
 /// let parser = eof;
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Eof))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Eof))));
 /// assert_eq!(parser(""), Ok(("", "")));
 /// # }
 /// ```
@@ -712,7 +720,7 @@ where
   if input.input_len() == 0 {
     Ok(input.next_slice(0))
   } else {
-    Err(Err::Error(E::from_error_kind(input, ErrorKind::Eof)))
+    Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Eof)))
   }
 }
 
@@ -721,7 +729,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::complete`]
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult, input::Streaming};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, input::Streaming};
 /// use winnow::bytes::take;
 /// use winnow::combinator::complete;
 /// # fn main() {
@@ -729,7 +737,7 @@ where
 /// let mut parser = complete(take(5u8));
 ///
 /// assert_eq!(parser(Streaming("abcdefg")), Ok((Streaming("fg"), "abcde")));
-/// assert_eq!(parser(Streaming("abcd")), Err(Err::Error(Error::new(Streaming("abcd"), ErrorKind::Complete))));
+/// assert_eq!(parser(Streaming("abcd")), Err(ErrMode::Error(Error::new(Streaming("abcd"), ErrorKind::Complete))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::complete")]
@@ -740,7 +748,9 @@ where
   move |input: I| {
     let i = input.clone();
     match f.parse_next(input) {
-      Err(Err::Incomplete(_)) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Complete))),
+      Err(ErrMode::Incomplete(_)) => {
+        Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Complete)))
+      }
       rest => rest,
     }
   }
@@ -767,7 +777,9 @@ where
   fn parse_next(&mut self, input: I) -> IResult<I, O, E> {
     let i = input.clone();
     match (self.f).parse_next(input) {
-      Err(Err::Incomplete(_)) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Complete))),
+      Err(ErrMode::Incomplete(_)) => {
+        Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Complete)))
+      }
       rest => rest,
     }
   }
@@ -779,7 +791,7 @@ where
 /// [`FinishIResult::finish`][crate::FinishIResult::finish]
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::all_consuming;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -787,8 +799,8 @@ where
 /// let mut parser = all_consuming(alpha1);
 ///
 /// assert_eq!(parser("abcd"), Ok(("", "abcd")));
-/// assert_eq!(parser("abcd;"),Err(Err::Error(Error::new(";", ErrorKind::Eof))));
-/// assert_eq!(parser("123abcd;"),Err(Err::Error(Error::new("123abcd;", ErrorKind::Alpha))));
+/// assert_eq!(parser("abcd;"),Err(ErrMode::Error(Error::new(";", ErrorKind::Eof))));
+/// assert_eq!(parser("123abcd;"),Err(ErrMode::Error(Error::new("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
 #[deprecated(
@@ -805,7 +817,7 @@ where
     if input.input_len() == 0 {
       Ok((input, res))
     } else {
-      Err(Err::Error(E::from_error_kind(input, ErrorKind::Eof)))
+      Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Eof)))
     }
   }
 }
@@ -818,7 +830,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::map`]
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::verify;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -826,8 +838,8 @@ where
 /// let mut parser = verify(alpha1, |s: &str| s.len() == 4);
 ///
 /// assert_eq!(parser("abcd"), Ok(("", "abcd")));
-/// assert_eq!(parser("abcde"), Err(Err::Error(Error::new("abcde", ErrorKind::Verify))));
-/// assert_eq!(parser("123abcd;"),Err(Err::Error(Error::new("123abcd;", ErrorKind::Alpha))));
+/// assert_eq!(parser("abcde"), Err(ErrMode::Error(Error::new("abcde", ErrorKind::Verify))));
+/// assert_eq!(parser("123abcd;"),Err(ErrMode::Error(Error::new("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::verify")]
@@ -848,7 +860,7 @@ where
     if second(o.borrow()) {
       Ok((input, o))
     } else {
-      Err(Err::Error(E::from_error_kind(i, ErrorKind::Verify)))
+      Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Verify)))
     }
   }
 }
@@ -887,7 +899,7 @@ where
     if (self.second)(o.borrow()) {
       Ok((input, o))
     } else {
-      Err(Err::Error(E::from_error_kind(i, ErrorKind::Verify)))
+      Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Verify)))
     }
   }
 }
@@ -897,7 +909,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::value`]
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::value;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -905,7 +917,7 @@ where
 /// let mut parser = value(1234, alpha1);
 ///
 /// assert_eq!(parser("abcd"), Ok(("", 1234)));
-/// assert_eq!(parser("123abcd;"), Err(Err::Error(Error::new("123abcd;", ErrorKind::Alpha))));
+/// assert_eq!(parser("123abcd;"), Err(ErrMode::Error(Error::new("123abcd;", ErrorKind::Alpha))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::value")]
@@ -972,7 +984,7 @@ impl<I, O, E: ParseError<I>, F: Parser<I, O, E>> Parser<I, (), E> for Void<F, O>
 /// Succeeds if the child parser returns an error.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::not;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -980,7 +992,7 @@ impl<I, O, E: ParseError<I>, F: Parser<I, O, E>> Parser<I, (), E> for Void<F, O>
 /// let mut parser = not(alpha1);
 ///
 /// assert_eq!(parser("123"), Ok(("123", ())));
-/// assert_eq!(parser("abcd"), Err(Err::Error(Error::new("abcd", ErrorKind::Not))));
+/// assert_eq!(parser("abcd"), Err(ErrMode::Error(Error::new("abcd", ErrorKind::Not))));
 /// # }
 /// ```
 pub fn not<I: Clone, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, (), E>
@@ -990,8 +1002,8 @@ where
   move |input: I| {
     let i = input.clone();
     match parser.parse_next(input) {
-      Ok(_) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Not))),
-      Err(Err::Error(_)) => Ok((i, ())),
+      Ok(_) => Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Not))),
+      Err(ErrMode::Error(_)) => Ok((i, ())),
       Err(e) => Err(e),
     }
   }
@@ -1002,7 +1014,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::recognize`]
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::recognize;
 /// use winnow::character::{alpha1};
 /// use winnow::sequence::separated_pair;
@@ -1011,7 +1023,7 @@ where
 /// let mut parser = recognize(separated_pair(alpha1, ',', alpha1));
 ///
 /// assert_eq!(parser("abcd,efgh"), Ok(("", "abcd,efgh")));
-/// assert_eq!(parser("abcd;"),Err(Err::Error(Error::new(";", ErrorKind::OneOf))));
+/// assert_eq!(parser("abcd;"),Err(ErrMode::Error(Error::new(";", ErrorKind::OneOf))));
 /// # }
 /// ```
 #[deprecated(since = "8.0.0", note = "Replaced with `Parser::recognize")]
@@ -1081,7 +1093,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::{consumed, value, recognize, map};
 /// use winnow::character::{alpha1};
 /// use winnow::bytes::tag;
@@ -1096,7 +1108,7 @@ where
 /// let mut consumed_parser = consumed(value(true, separated_pair(alpha1, ',', alpha1)));
 ///
 /// assert_eq!(consumed_parser("abcd,efgh1"), Ok(("1", ("abcd,efgh", true))));
-/// assert_eq!(consumed_parser("abcd;"),Err(Err::Error(Error::new(";", ErrorKind::OneOf))));
+/// assert_eq!(consumed_parser("abcd;"),Err(ErrMode::Error(Error::new(";", ErrorKind::OneOf))));
 ///
 ///
 /// // the first output (representing the consumed input)
@@ -1233,7 +1245,7 @@ where
   }
 }
 
-/// Transforms an [`Err::Error`] (recoverable) to [`Err::Failure`] (unrecoverable)
+/// Transforms an [`ErrMode::Error`] (recoverable) to [`ErrMode::Failure`] (unrecoverable)
 ///
 /// This commits the parse result, preventing alternative branch paths like with
 /// [`winnow::branch::alt`][crate::branch::alt].
@@ -1242,7 +1254,7 @@ where
 ///
 /// Without `cut`:
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// # use winnow::bytes::one_of;
 /// # use winnow::character::digit1;
 /// # use winnow::combinator::rest;
@@ -1265,7 +1277,7 @@ where
 ///
 /// With `cut`:
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// # use winnow::bytes::one_of;
 /// # use winnow::character::digit1;
 /// # use winnow::combinator::rest;
@@ -1283,7 +1295,7 @@ where
 ///
 /// assert_eq!(parser("+10 ab"), Ok((" ab", "10")));
 /// assert_eq!(parser("ab"), Ok(("", "ab")));
-/// assert_eq!(parser("+"), Err(Err::Failure(Error { input: "", kind: ErrorKind::Digit })));
+/// assert_eq!(parser("+"), Err(ErrMode::Failure(Error { input: "", kind: ErrorKind::Digit })));
 /// # }
 /// ```
 pub fn cut<I, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, O, E>
@@ -1291,7 +1303,7 @@ where
   F: Parser<I, O, E>,
 {
   move |input: I| match parser.parse_next(input) {
-    Err(Err::Error(e)) => Err(Err::Failure(e)),
+    Err(ErrMode::Error(e)) => Err(ErrMode::Failure(e)),
     rest => rest,
   }
 }
@@ -1335,9 +1347,9 @@ where
   //map(parser, Into::into)
   move |input: I| match parser.parse_next(input) {
     Ok((i, o)) => Ok((i, o.into())),
-    Err(Err::Error(e)) => Err(Err::Error(e.into())),
-    Err(Err::Failure(e)) => Err(Err::Failure(e.into())),
-    Err(Err::Incomplete(e)) => Err(Err::Incomplete(e)),
+    Err(ErrMode::Error(e)) => Err(ErrMode::Error(e.into())),
+    Err(ErrMode::Failure(e)) => Err(ErrMode::Failure(e.into())),
+    Err(ErrMode::Incomplete(e)) => Err(ErrMode::Incomplete(e)),
   }
 }
 
@@ -1409,9 +1421,9 @@ where
   fn parse_next(&mut self, i: I) -> IResult<I, O, E2> {
     match self.f.parse_next(i) {
       Ok(ok) => Ok(ok),
-      Err(Err::Error(e)) => Err(Err::Error(e.into())),
-      Err(Err::Failure(e)) => Err(Err::Failure(e.into())),
-      Err(Err::Incomplete(e)) => Err(Err::Incomplete(e)),
+      Err(ErrMode::Error(e)) => Err(ErrMode::Error(e.into())),
+      Err(ErrMode::Failure(e)) => Err(ErrMode::Failure(e.into())),
+      Err(ErrMode::Incomplete(e)) => Err(ErrMode::Incomplete(e)),
     }
   }
 }
@@ -1421,7 +1433,7 @@ where
 /// Call the iterator's [`ParserIterator::finish`] method to get the remaining input if successful,
 /// or the error value if we encountered an error.
 ///
-/// On [`Err::Error`], iteration will stop.  To instead chain an error up, see [`cut`].
+/// On [`ErrMode::Error`], iteration will stop.  To instead chain an error up, see [`cut`].
 ///
 /// ```rust
 /// use winnow::{combinator::iterator, IResult, bytes::tag, character::alpha1, sequence::terminated};
@@ -1462,8 +1474,8 @@ impl<I: Clone, O, E, F> ParserIterator<I, O, E, F> {
   pub fn finish(mut self) -> IResult<I, (), E> {
     match self.state.take().unwrap() {
       State::Running | State::Done => Ok((self.input, ())),
-      State::Failure(e) => Err(Err::Failure(e)),
-      State::Incomplete(i) => Err(Err::Incomplete(i)),
+      State::Failure(e) => Err(ErrMode::Failure(e)),
+      State::Incomplete(i) => Err(ErrMode::Incomplete(i)),
     }
   }
 }
@@ -1485,15 +1497,15 @@ where
           self.state = Some(State::Running);
           Some(o)
         }
-        Err(Err::Error(_)) => {
+        Err(ErrMode::Error(_)) => {
           self.state = Some(State::Done);
           None
         }
-        Err(Err::Failure(e)) => {
+        Err(ErrMode::Failure(e)) => {
           self.state = Some(State::Failure(e));
           None
         }
-        Err(Err::Incomplete(i)) => {
+        Err(ErrMode::Incomplete(i)) => {
           self.state = Some(State::Incomplete(i));
           None
         }
@@ -1517,7 +1529,7 @@ enum State<E> {
 /// specify the default case.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::branch::alt;
 /// use winnow::combinator::{success, value};
 /// # fn main() {
@@ -1538,12 +1550,12 @@ pub fn success<I, O: Clone, E: ParseError<I>>(val: O) -> impl Fn(I) -> IResult<I
 /// A parser which always fails.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::fail;
 ///
 /// let s = "string";
-/// assert_eq!(fail::<_, &str, _>(s), Err(Err::Error(Error::new(s, ErrorKind::Fail))));
+/// assert_eq!(fail::<_, &str, _>(s), Err(ErrMode::Error(Error::new(s, ErrorKind::Fail))));
 /// ```
 pub fn fail<I, O, E: ParseError<I>>(i: I) -> IResult<I, O, E> {
-  Err(Err::Error(E::from_error_kind(i, ErrorKind::Fail)))
+  Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Fail)))
 }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -149,7 +149,7 @@
 //! - [`space0`][crate::character::space0]: Recognizes zero or more spaces and tabs. [`space1`][crate::character::space1] does the same but returns at least one character
 //! - [`tab`][crate::character::tab]: Matches a tab character `\t`
 
-use crate::error::{ErrorKind, FromExternalError, ParseError};
+use crate::error::{ErrMode, ErrorKind, FromExternalError, Needed, ParseError};
 use crate::input::Offset;
 use crate::input::{Input, Location};
 use crate::lib::std::borrow::Borrow;
@@ -218,7 +218,7 @@ impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P> {
 /// **WARNING:** Deprecated, replaced with [`Parser::map`]
 ///
 /// ```rust
-/// use winnow::{ErrMode, error::ErrorKind, error::Error, IResult,Parser};
+/// use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult,Parser};
 /// use winnow::character::digit1;
 /// use winnow::combinator::map;
 /// # fn main() {
@@ -276,7 +276,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> for Ma
 /// **WARNING:** Deprecated, replaced with [`Parser::map_res`]
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::character::digit1;
 /// use winnow::combinator::map_res;
 /// # fn main() {
@@ -360,7 +360,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::map_opt`]
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::character::digit1;
 /// use winnow::combinator::map_opt;
 /// # fn main() {
@@ -436,7 +436,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::and_then`]
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::character::digit1;
 /// use winnow::bytes::take;
 /// use winnow::combinator::map_parser;
@@ -498,7 +498,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, E>
 /// **WARNING:** Deprecated, replaced with [`Parser::flat_map`]
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::bytes::take;
 /// use winnow::number::u8;
 /// use winnow::combinator::flat_map;
@@ -558,7 +558,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> H, H: Parser<I, O2, E>> Par
 /// To chain an error up, see [`cut`].
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::opt;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -636,7 +636,7 @@ impl<I: Clone, O, E: crate::error::ParseError<I>, F: Parser<I, O, E>, G: Parser<
 /// Calls the parser if the condition is met.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult};
 /// use winnow::combinator::cond;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -673,7 +673,7 @@ where
 /// Tries to apply its parser without consuming the input.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::peek;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -704,7 +704,7 @@ where
 ///
 /// ```
 /// # use std::str;
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// # use winnow::combinator::eof;
 ///
 /// # fn main() {
@@ -729,7 +729,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::complete`]
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult, input::Streaming};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, input::Streaming};
 /// use winnow::bytes::take;
 /// use winnow::combinator::complete;
 /// # fn main() {
@@ -791,7 +791,7 @@ where
 /// [`FinishIResult::finish`][crate::FinishIResult::finish]
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::all_consuming;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -830,7 +830,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::map`]
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::verify;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -909,7 +909,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::value`]
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::value;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -984,7 +984,7 @@ impl<I, O, E: ParseError<I>, F: Parser<I, O, E>> Parser<I, (), E> for Void<F, O>
 /// Succeeds if the child parser returns an error.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::not;
 /// use winnow::character::alpha1;
 /// # fn main() {
@@ -1014,7 +1014,7 @@ where
 /// **WARNING:** Deprecated, replaced with [`Parser::recognize`]
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::recognize;
 /// use winnow::character::{alpha1};
 /// use winnow::sequence::separated_pair;
@@ -1093,7 +1093,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::{consumed, value, recognize, map};
 /// use winnow::character::{alpha1};
 /// use winnow::bytes::tag;
@@ -1254,7 +1254,7 @@ where
 ///
 /// Without `cut`:
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// # use winnow::bytes::one_of;
 /// # use winnow::character::digit1;
 /// # use winnow::combinator::rest;
@@ -1277,7 +1277,7 @@ where
 ///
 /// With `cut`:
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// # use winnow::bytes::one_of;
 /// # use winnow::character::digit1;
 /// # use winnow::combinator::rest;
@@ -1529,7 +1529,7 @@ enum State<E> {
 /// specify the default case.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::branch::alt;
 /// use winnow::combinator::{success, value};
 /// # fn main() {
@@ -1550,7 +1550,7 @@ pub fn success<I, O: Clone, E: ParseError<I>>(val: O) -> impl Fn(I) -> IResult<I
 /// A parser which always fails.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
 /// use winnow::combinator::fail;
 ///
 /// let s = "string";

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1325,6 +1325,20 @@ where
   cut_err(parser)
 }
 
+/// Transforms an [`ErrMode::Cut`] (unrecoverable) to [`ErrMode::Backtrack`] (recoverable)
+///
+/// This attempts the parse, allowing other parsers to be tried on failure, like with
+/// [`winnow::branch::alt`][crate::branch::alt].
+pub fn backtrack_err<I, O, E: ParseError<I>, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, O, E>
+where
+  F: Parser<I, O, E>,
+{
+  move |input: I| match parser.parse_next(input) {
+    Err(ErrMode::Cut(e)) => Err(ErrMode::Backtrack(e)),
+    rest => rest,
+  }
+}
+
 /// automatically converts the child parser's result to another type
 ///
 /// it will be able to convert the output value and the error value

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -26,7 +26,10 @@ fn eof_on_slices() {
   let res_not_over = eof(not_over);
   assert_parse!(
     res_not_over,
-    Err(ErrMode::Error(error_position!(not_over, ErrorKind::Eof)))
+    Err(ErrMode::Backtrack(error_position!(
+      not_over,
+      ErrorKind::Eof
+    )))
   );
 
   let res_over = eof(is_over);
@@ -41,7 +44,10 @@ fn eof_on_strs() {
   let res_not_over = eof(not_over);
   assert_parse!(
     res_not_over,
-    Err(ErrMode::Error(error_position!(not_over, ErrorKind::Eof)))
+    Err(ErrMode::Backtrack(error_position!(
+      not_over,
+      ErrorKind::Eof
+    )))
   );
 
   let res_over = eof(is_over);
@@ -117,7 +123,7 @@ fn test_map_opt() {
   let input: &[u8] = &[50][..];
   assert_parse!(
     map_opt(u8, |u| if u < 20 { Some(u) } else { None })(input),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: &[50][..],
       kind: ErrorKind::MapOpt
     }))
@@ -134,7 +140,7 @@ fn test_parser_map_opt() {
   assert_parse!(
     u8.map_opt(|u| if u < 20 { Some(u) } else { None })
       .parse_next(input),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: &[50][..],
       kind: ErrorKind::MapOpt
     }))
@@ -171,7 +177,7 @@ fn test_all_consuming() {
   let input: &[u8] = &[100, 101, 102][..];
   assert_parse!(
     all_consuming(take(2usize))(input),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: &[102][..],
       kind: ErrorKind::Eof
     }))
@@ -193,7 +199,7 @@ fn test_verify_ref() {
   assert_eq!(parser1(&b"abcd"[..]), Ok((&b"d"[..], &b"abc"[..])));
   assert_eq!(
     parser1(&b"defg"[..]),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: &b"defg"[..],
       kind: ErrorKind::Verify
     }))
@@ -216,7 +222,7 @@ fn test_verify_alloc() {
   assert_eq!(parser1(&b"abcd"[..]), Ok((&b"d"[..], b"abc".to_vec())));
   assert_eq!(
     parser1(&b"defg"[..]),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: &b"defg"[..],
       kind: ErrorKind::Verify
     }))
@@ -287,7 +293,7 @@ fn peek_test() {
   );
   assert_eq!(
     peek_tag(Streaming(&b"xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -302,7 +308,7 @@ fn not_test() {
 
   assert_eq!(
     not_aaa(Streaming(&b"aaa"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"aaa"[..]),
       ErrorKind::Not
     )))
@@ -331,7 +337,7 @@ fn verify_test() {
   );
   assert_eq!(
     test(Streaming(&b"bcdefg"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"bcdefg"[..]),
       ErrorKind::Verify
     )))
@@ -357,7 +363,7 @@ fn test_parser_verify() {
   );
   assert_eq!(
     test(Streaming(&b"bcdefg"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"bcdefg"[..]),
       ErrorKind::Verify
     )))
@@ -381,7 +387,7 @@ fn test_parser_verify_ref() {
   );
   assert_eq!(
     parser1.parse_next(&b"defg"[..]),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: &b"defg"[..],
       kind: ErrorKind::Verify
     }))
@@ -408,7 +414,7 @@ fn test_parser_verify_alloc() {
   );
   assert_eq!(
     parser1.parse_next(&b"defg"[..]),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: &b"defg"[..],
       kind: ErrorKind::Verify
     }))
@@ -422,14 +428,14 @@ fn fail_test() {
 
   assert_eq!(
     fail::<_, &str, _>(a),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: a,
       kind: ErrorKind::Fail
     }))
   );
   assert_eq!(
     fail::<_, &str, _>(b),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: b,
       kind: ErrorKind::Fail
     }))

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -1,13 +1,15 @@
 use super::*;
 use crate::bytes::tag;
 use crate::bytes::take;
+use crate::error::ErrMode;
 use crate::error::Error;
 use crate::error::ErrorKind;
+use crate::error::Needed;
 use crate::error::ParseError;
 use crate::input::Streaming;
 use crate::number::u8;
+use crate::IResult;
 use crate::Parser;
-use crate::{ErrMode, IResult, Needed};
 
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -820,7 +820,7 @@ impl<I: fmt::Display> fmt::Display for Error<I> {
 }
 
 #[cfg(feature = "std")]
-impl<I: fmt::Debug + fmt::Display> std::error::Error for Error<I> {}
+impl<I: fmt::Debug + fmt::Display + Sync + Send + 'static> std::error::Error for Error<I> {}
 
 impl<I> ParseError<I> for () {
   fn from_error_kind(_: I, _: ErrorKind) -> Self {}
@@ -952,7 +952,7 @@ impl<I: fmt::Display> fmt::Display for VerboseError<I> {
 }
 
 #[cfg(feature = "std")]
-impl<I: fmt::Debug + fmt::Display> std::error::Error for VerboseError<I> {}
+impl<I: fmt::Debug + fmt::Display + Sync + Send + 'static> std::error::Error for VerboseError<I> {}
 
 /// Create a new error from an input position, a static string and an existing error.
 /// This is used mainly in the [context] combinator, to add user friendly information

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,37 +12,39 @@
 //! ```rust
 //! pub type IResult<I, O, E=winnow::error::Error<I>> = Result<(I, O), winnow::Err<E>>;
 //!
-//! #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-//! pub enum Needed {
-//!   Unknown,
-//!   Size(u32)
-//! }
-//!
 //! pub enum Err<E> {
 //!     Incomplete(Needed),
 //!     Error(E),
 //!     Failure(E),
 //! }
+//!
+//! #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+//! pub enum Needed {
+//!   Unknown,
+//!   Size(u32)
+//! }
 //! ```
 //!
 //! The result is either an `Ok((I, O))` containing the remaining input and the
 //! parsed value, or an `Err(winnow::Err<E>)` with `E` the error type.
-//! `winnow::Err<E>` is an enum because combinators can have different behaviours
-//! depending on the value.  The `Err<E>` enum expresses 3 conditions for a parser error:
-//! - `Incomplete` indicates that a parser did not have enough data to decide. This can be returned
-//!   by parsers found in `streaming` submodules to indicate that we should buffer more data from a
-//!   file or socket. Parsers in the `complete` submodules assume that they have the entire input
-//!   data, so if it was not sufficient, they will instead return a `Err::Error`
-//! - `Error` is a normal parser error. If a child parser of the `alt` combinator returns `Error`,
-//!   it will try another child parser
-//! - `Failure` is an error from which we cannot recover: The `alt` combinator will not try other
-//!   branches if a child parser returns `Failure`. If we know we were in the right branch (example:
-//!   we found a correct prefix character but input after that was wrong), we can transform a
-//!   `Err::Error` into a `Err::Failure` with the `cut()` combinator
+//! [`winnow::Err<E>`][Err] is an enum because combinators can have different behaviours
+//! depending on the value.  The [`Err<E>`] enum expresses 3 conditions for a parser error:
+//! - [`Incomplete`][Err::Incomplete] indicates that a parser did not have enough data to
+//!   decide. This can be returned by parsers found in `streaming` submodules to indicate that we
+//!   should buffer more data from a file or socket. Parsers in the `complete` submodules assume that
+//!   they have the entire input data, so if it was not sufficient, they will instead return a
+//!   `Err::Error`
+//! - [`Error`][Err::Error] is a normal parser error. If a child parser of the
+//!   [`alt`][crate::branch::alt] combinator returns `Error`, it will try another child parser
+//! - [`Failure`][Err::Failure] is an error from which we cannot recover: The
+//!   [`alt`][crate::branch::alt] combinator will not try other branches if a child parser returns
+//!   `Failure`. If we know we were in the right branch (example: we found a correct prefix character
+//!   but input after that was wrong), we can transform a `Err::Error` into a `Err::Failure` with the
+//!   [`cut()`][crate::combinator::cut] combinator
 //!
 //! If we are running a parser and know it will not return `Err::Incomplete`, we can
 //! directly extract the error type from `Err::Error` or `Err::Failure` with the
-//! `finish()` method:
+//! [`finish()`][crate::FinishIResult::finish] method:
 //!
 //! ```rust,ignore
 //! # use winnow::IResult;
@@ -66,32 +68,6 @@
 //!   parser(data).map_err(|e: E<&[u8]>| e.to_owned());
 //! ```
 //!
-//! nom provides a powerful error system that can adapt to your needs: you can
-//! get reduced error information if you want to improve performance, or you can
-//! get a precise trace of parser application, with fine grained position information.
-//!
-//! This is done through the third type parameter of `IResult`, nom's parser result
-//! type:
-//!
-//! ```rust
-//! pub type IResult<I, O, E=winnow::error::Error<I>> = Result<(I, O), Err<E>>;
-//!
-//! #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-//! pub enum Needed {
-//!   Unknown,
-//!   Size(u32)
-//! }
-//!
-//! pub enum Err<E> {
-//!     Incomplete(Needed),
-//!     Error(E),
-//!     Failure(E),
-//! }
-//! ```
-//!
-//! This error type is completely generic in nom's combinators, so you can choose
-//! exactly which error type you want to use when you define your parsers, or
-//! directly at the call site.
 //! See [the JSON parser](https://github.com/Geal/nom/blob/5405e1173f1052f7e006dcb0b9cfda2b06557b65/examples/json.rs#L209-L286)
 //! for an example of choosing different error types at the call site.
 //!

--- a/src/error.rs
+++ b/src/error.rs
@@ -658,17 +658,19 @@ impl<T> ErrMode<Error<T>> {
   }
 }
 
+#[cfg(feature = "alloc")]
 impl ErrMode<Error<&[u8]>> {
-  /// Obtaining ownership
-  #[cfg(feature = "alloc")]
+  /// Deprecated, replaced with [`Error::into_owned`]
+  #[deprecated(since = "0.3.0", note = "Replaced with `Error::into_owned`")]
   pub fn to_owned(self) -> ErrMode<Error<Vec<u8>>> {
     self.map_input(ToOwned::to_owned)
   }
 }
 
+#[cfg(feature = "alloc")]
 impl ErrMode<Error<&str>> {
-  /// Obtaining ownership
-  #[cfg(feature = "alloc")]
+  /// Deprecated, replaced with [`Error::into_owned`]
+  #[deprecated(since = "0.3.0", note = "Replaced with `Error::into_owned`")]
   pub fn to_owned(self) -> ErrMode<Error<String>> {
     self.map_input(ToOwned::to_owned)
   }
@@ -769,6 +771,17 @@ impl<I> Error<I> {
   /// creates a new basic error
   pub fn new(input: I, kind: ErrorKind) -> Error<I> {
     Error { input, kind }
+  }
+}
+
+#[cfg(feature = "alloc")]
+impl<I: ToOwned> Error<I> {
+  /// Obtaining ownership
+  pub fn into_owned(self) -> Error<<I as ToOwned>::Owned> {
+    Error {
+      input: self.input.to_owned(),
+      kind: self.kind,
+    }
   }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -692,16 +692,6 @@ where
   }
 }
 
-#[cfg(feature = "std")]
-impl<E> std::error::Error for ErrMode<E>
-where
-  E: fmt::Debug,
-{
-  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-    None // no underlying error
-  }
-}
-
 /// This trait must be implemented by the error type of a nom parser.
 ///
 /// There are already implementations of it for `(Input, ErrorKind)`

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@
 //!   [`alt`][crate::branch::alt] combinator will not try other branches if a child parser returns
 //!   `Failure`. If we know we were in the right branch (example: we found a correct prefix character
 //!   but input after that was wrong), we can transform a `ErrMode::Backtrack` into a `ErrMode::Cut` with the
-//!   [`cut()`][crate::combinator::cut] combinator
+//!   [`cut_err()`][crate::combinator::cut_err] combinator
 //!
 //! If we are running a parser and know it will not return `ErrMode::Incomplete`, we can
 //! directly extract the error type from `ErrMode::Backtrack` or `ErrMode::Cut` with the
@@ -156,13 +156,13 @@
 //! # use winnow::error::context;
 //! # use winnow::sequence::preceded;
 //! # use winnow::character::char;
-//! # use winnow::combinator::cut;
+//! # use winnow::combinator::cut_err;
 //! # use winnow::sequence::terminated;
 //! # let parse_str = winnow::bytes::take_while1(|c| c == ' ');
 //! # let i = " ";
 //! context(
 //!   "string",
-//!   preceded('\"', cut(terminated(parse_str, '\"'))),
+//!   preceded('\"', cut_err(terminated(parse_str, '\"'))),
 //! )(i);
 //! ```
 //!

--- a/src/error.rs
+++ b/src/error.rs
@@ -874,6 +874,21 @@ pub struct VerboseError<I> {
 }
 
 #[cfg(feature = "alloc")]
+impl<I: ToOwned> VerboseError<I> {
+  /// Obtaining ownership
+  pub fn into_owned(self) -> VerboseError<<I as ToOwned>::Owned> {
+    #[allow(clippy::redundant_clone)] // false positive
+    VerboseError {
+      errors: self
+        .errors
+        .into_iter()
+        .map(|(i, k)| (i.to_owned(), k))
+        .collect(),
+    }
+  }
+}
+
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Error context for `VerboseError`
 pub enum VerboseErrorKind {

--- a/src/error.rs
+++ b/src/error.rs
@@ -638,20 +638,6 @@ impl<E> ErrMode<E> {
   }
 }
 
-impl<T> ErrMode<(T, ErrorKind)> {
-  /// Maps `ErrMode<(T, ErrorKind)>` to `ErrMode<(U, ErrorKind)>` with the given `F: T -> U`
-  pub fn map_input<U, F>(self, f: F) -> ErrMode<(U, ErrorKind)>
-  where
-    F: FnOnce(T) -> U,
-  {
-    match self {
-      ErrMode::Incomplete(n) => ErrMode::Incomplete(n),
-      ErrMode::Cut((input, k)) => ErrMode::Cut((f(input), k)),
-      ErrMode::Backtrack((input, k)) => ErrMode::Backtrack((f(input), k)),
-    }
-  }
-}
-
 impl<T> ErrMode<Error<T>> {
   /// Maps `ErrMode<Error<T>>` to `ErrMode<Error<U>>` with the given `F: T -> U`
   pub fn map_input<U, F>(self, f: F) -> ErrMode<Error<U>>
@@ -669,24 +655,6 @@ impl<T> ErrMode<Error<T>> {
         kind,
       }),
     }
-  }
-}
-
-#[cfg(feature = "alloc")]
-use crate::lib::std::{borrow::ToOwned, string::String, vec::Vec};
-impl ErrMode<(&[u8], ErrorKind)> {
-  /// Obtaining ownership
-  #[cfg(feature = "alloc")]
-  pub fn to_owned(self) -> ErrMode<(Vec<u8>, ErrorKind)> {
-    self.map_input(ToOwned::to_owned)
-  }
-}
-
-impl ErrMode<(&str, ErrorKind)> {
-  /// Obtaining ownership
-  #[cfg(feature = "alloc")]
-  pub fn to_owned(self) -> ErrMode<(String, ErrorKind)> {
-    self.map_input(ToOwned::to_owned)
   }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -53,7 +53,7 @@
 
 use core::num::NonZeroUsize;
 
-use crate::error::{ErrorKind, ParseError};
+use crate::error::{ErrMode, ErrorKind, Needed, ParseError};
 use crate::lib::std::iter::{Cloned, Enumerate};
 use crate::lib::std::ops::{
   Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
@@ -62,7 +62,7 @@ use crate::lib::std::slice::Iter;
 use crate::lib::std::str::from_utf8;
 use crate::lib::std::str::CharIndices;
 use crate::lib::std::str::FromStr;
-use crate::{ErrMode, IResult, Needed};
+use crate::IResult;
 
 #[cfg(feature = "alloc")]
 use crate::lib::std::string::String;
@@ -187,7 +187,7 @@ impl<I, S> crate::lib::std::ops::Deref for Stateful<I, S> {
 /// Here is how it works in practice:
 ///
 /// ```rust
-/// use winnow::{IResult, ErrMode, Needed, error::{Error, ErrorKind}, bytes, character, input::Streaming};
+/// use winnow::{IResult, error::ErrMode, error::Needed, error::{Error, ErrorKind}, bytes, character, input::Streaming};
 ///
 /// fn take_streaming(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, &[u8]> {
 ///   bytes::take(4u8)(i)
@@ -1756,7 +1756,7 @@ impl<'a> AsChar for &'a char {
 /// For example, you could implement `hex_digit0` as:
 /// ```
 /// # use winnow::prelude::*;
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::bytes::take_while1;
 /// fn hex_digit1(input: &str) -> IResult<&str, &str> {
 ///     take_while1(('a'..='f', 'A'..='F', '0'..='9')).parse_next(input)

--- a/src/input.rs
+++ b/src/input.rs
@@ -178,7 +178,7 @@ impl<I, S> crate::lib::std::ops::Deref for Stateful<I, S> {
 /// input buffer can be full and need to be resized or refilled.
 /// - [`ErrMode::Incomplete`] will report how much more data is needed.
 /// - [`Parser::complete`][crate::Parser::complete] transform [`ErrMode::Incomplete`] to
-///   [`ErrMode::Error`]
+///   [`ErrMode::Backtrack`]
 ///
 /// See also [`InputIsStreaming`] to tell whether the input supports complete or streaming parsing.
 ///
@@ -206,7 +206,7 @@ impl<I, S> crate::lib::std::ops::Deref for Stateful<I, S> {
 /// assert_eq!(take_streaming(Streaming(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// // but the complete parser will return an error
-/// assert_eq!(take_complete(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(take_complete(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// // the alpha0 function recognizes 0 or more alphabetic characters
 /// fn alpha0_streaming(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
@@ -1763,8 +1763,8 @@ impl<'a> AsChar for &'a char {
 /// }
 ///
 /// assert_eq!(hex_digit1("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(hex_digit1("H2"), Err(ErrMode::Error(Error::new("H2", ErrorKind::TakeWhile1))));
-/// assert_eq!(hex_digit1(""), Err(ErrMode::Error(Error::new("", ErrorKind::TakeWhile1))));
+/// assert_eq!(hex_digit1("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::TakeWhile1))));
+/// assert_eq!(hex_digit1(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::TakeWhile1))));
 /// ```
 pub trait ContainsToken<T> {
   /// Returns true if self contains the token
@@ -2020,7 +2020,7 @@ where
     .offset_for(predicate)
     .ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))?;
   if offset == 0 {
-    Err(ErrMode::Error(E::from_error_kind(input.clone(), e)))
+    Err(ErrMode::Backtrack(E::from_error_kind(input.clone(), e)))
   } else {
     Ok(input.next_slice(offset))
   }
@@ -2061,7 +2061,7 @@ where
     .offset_for(predicate)
     .unwrap_or_else(|| input.input_len());
   if offset == 0 {
-    Err(ErrMode::Error(E::from_error_kind(input.clone(), e)))
+    Err(ErrMode::Backtrack(E::from_error_kind(input.clone(), e)))
   } else {
     Ok(input.next_slice(offset))
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@
 //! Here is another parser, written without using nom's combinators this time:
 //!
 //! ```rust
-//! use winnow::{IResult, ErrMode, Needed};
+//! use winnow::{IResult, error::ErrMode, error::Needed};
 //!
 //! # fn main() {
 //! fn take4(i: &[u8]) -> IResult<&[u8], &[u8]>{
@@ -146,7 +146,7 @@
 //! `IResult` is an alias for the `Result` type:
 //!
 //! ```rust
-//! use winnow::{Needed, error::Error};
+//! use winnow::{error::Needed, error::Error};
 //!
 //! type IResult<I, O, E = Error<I>> = Result<(I, O), Err<E>>;
 //!
@@ -205,7 +205,7 @@
 //!
 //! assert_eq!(alt_tags(&b"abcdxxx"[..]), Ok((&b"xxx"[..], &b"abcd"[..])));
 //! assert_eq!(alt_tags(&b"efghxxx"[..]), Ok((&b"xxx"[..], &b"efgh"[..])));
-//! assert_eq!(alt_tags(&b"ijklxxx"[..]), Err(winnow::ErrMode::Error(winnow::error::Error::new(&b"ijklxxx"[..], winnow::error::ErrorKind::Tag))));
+//! assert_eq!(alt_tags(&b"ijklxxx"[..]), Err(winnow::error::ErrMode::Error(winnow::error::Error::new(&b"ijklxxx"[..], winnow::error::ErrorKind::Tag))));
 //! ```
 //!
 //! The **`opt`** combinator makes a parser optional. If the child parser returns
@@ -259,7 +259,7 @@
 //! # fn main() {
 //! use winnow::prelude::*;
 //! use winnow::{
-//!     error::ErrorKind, error::Error, Needed,
+//!     error::ErrorKind, error::Error, error::Needed,
 //!     number::be_u16,
 //!     bytes::{tag, take},
 //!     input::Streaming,
@@ -274,9 +274,9 @@
 //!     (0x6162u16, &b"cde"[..], &b"fg"[..])
 //!   ))
 //! );
-//! assert_eq!(tpl.parse_next(Streaming(&b"abcde"[..])), Err(winnow::ErrMode::Incomplete(Needed::new(2))));
+//! assert_eq!(tpl.parse_next(Streaming(&b"abcde"[..])), Err(winnow::error::ErrMode::Incomplete(Needed::new(2))));
 //! let input = &b"abcdejk"[..];
-//! assert_eq!(tpl.parse_next(Streaming(input)), Err(winnow::ErrMode::Error(Error::new(Streaming(&input[5..]), ErrorKind::Tag))));
+//! assert_eq!(tpl.parse_next(Streaming(input)), Err(winnow::error::ErrMode::Error(Error::new(Streaming(&input[5..]), ErrorKind::Tag))));
 //! # }
 //! ```
 //!
@@ -457,26 +457,24 @@ pub mod lib {
   }
 }
 
-pub use self::parser::*;
-
 #[macro_use]
 mod macros;
+
 #[macro_use]
 pub mod error;
 
-pub mod branch;
-pub mod combinator;
-pub mod input;
-pub mod multi;
 mod parser;
-pub mod sequence;
+
+pub mod input;
 
 pub mod bits;
+pub mod branch;
 pub mod bytes;
-
 pub mod character;
-
+pub mod combinator;
+pub mod multi;
 pub mod number;
+pub mod sequence;
 
 #[cfg(feature = "unstable-doc")]
 pub mod _cookbook;
@@ -510,3 +508,7 @@ pub mod prelude {
   pub use crate::IResult;
   pub use crate::Parser as _;
 }
+
+pub use error::FinishIResult;
+pub use error::IResult;
+pub use parser::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,9 +160,9 @@
 //! It can have the following values:
 //!
 //! - A correct result `Ok((I,O))` with the first element being the remaining of the input (not parsed yet), and the second the output value;
-//! - An error `Err(ErrMode::Error(c))` with `c` an error that can be built from the input position and a parser specific error
+//! - An error `Err(ErrMode::Backtrack(c))` with `c` an error that can be built from the input position and a parser specific error
 //! - An error `Err(ErrMode::Incomplete(Needed))` indicating that more input is necessary. `Needed` can indicate how much data is needed
-//! - An error `Err(ErrMode::Failure(c))`. It works like the `Error` case, except it indicates an unrecoverable error: We cannot backtrack and test another parser
+//! - An error `Err(ErrMode::Cut(c))`. It works like the `Error` case, except it indicates an unrecoverable error: We cannot backtrack and test another parser
 //!
 //! Please refer to the ["choose a combinator" guide][combinator] for an exhaustive list of parsers.
 //! See also the rest of the documentation [here](https://github.com/Geal/nom/blob/main/doc).
@@ -205,7 +205,7 @@
 //!
 //! assert_eq!(alt_tags(&b"abcdxxx"[..]), Ok((&b"xxx"[..], &b"abcd"[..])));
 //! assert_eq!(alt_tags(&b"efghxxx"[..]), Ok((&b"xxx"[..], &b"efgh"[..])));
-//! assert_eq!(alt_tags(&b"ijklxxx"[..]), Err(winnow::error::ErrMode::Error(winnow::error::Error::new(&b"ijklxxx"[..], winnow::error::ErrorKind::Tag))));
+//! assert_eq!(alt_tags(&b"ijklxxx"[..]), Err(winnow::error::ErrMode::Backtrack(winnow::error::Error::new(&b"ijklxxx"[..], winnow::error::ErrorKind::Tag))));
 //! ```
 //!
 //! The **`opt`** combinator makes a parser optional. If the child parser returns
@@ -276,7 +276,7 @@
 //! );
 //! assert_eq!(tpl.parse_next(Streaming(&b"abcde"[..])), Err(winnow::error::ErrMode::Incomplete(Needed::new(2))));
 //! let input = &b"abcdejk"[..];
-//! assert_eq!(tpl.parse_next(Streaming(input)), Err(winnow::error::ErrMode::Error(Error::new(Streaming(&input[5..]), ErrorKind::Tag))));
+//! assert_eq!(tpl.parse_next(Streaming(input)), Err(winnow::error::ErrMode::Backtrack(Error::new(Streaming(&input[5..]), ErrorKind::Tag))));
 //! # }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,12 +103,12 @@
 //! Here is another parser, written without using nom's combinators this time:
 //!
 //! ```rust
-//! use winnow::{IResult, Err, Needed};
+//! use winnow::{IResult, ErrMode, Needed};
 //!
 //! # fn main() {
 //! fn take4(i: &[u8]) -> IResult<&[u8], &[u8]>{
 //!   if i.len() < 4 {
-//!     Err(Err::Incomplete(Needed::new(4)))
+//!     Err(ErrMode::Incomplete(Needed::new(4)))
 //!   } else {
 //!     Ok((&i[4..], &i[0..4]))
 //!   }
@@ -160,9 +160,9 @@
 //! It can have the following values:
 //!
 //! - A correct result `Ok((I,O))` with the first element being the remaining of the input (not parsed yet), and the second the output value;
-//! - An error `Err(Err::Error(c))` with `c` an error that can be built from the input position and a parser specific error
-//! - An error `Err(Err::Incomplete(Needed))` indicating that more input is necessary. `Needed` can indicate how much data is needed
-//! - An error `Err(Err::Failure(c))`. It works like the `Error` case, except it indicates an unrecoverable error: We cannot backtrack and test another parser
+//! - An error `Err(ErrMode::Error(c))` with `c` an error that can be built from the input position and a parser specific error
+//! - An error `Err(ErrMode::Incomplete(Needed))` indicating that more input is necessary. `Needed` can indicate how much data is needed
+//! - An error `Err(ErrMode::Failure(c))`. It works like the `Error` case, except it indicates an unrecoverable error: We cannot backtrack and test another parser
 //!
 //! Please refer to the ["choose a combinator" guide][combinator] for an exhaustive list of parsers.
 //! See also the rest of the documentation [here](https://github.com/Geal/nom/blob/main/doc).
@@ -205,7 +205,7 @@
 //!
 //! assert_eq!(alt_tags(&b"abcdxxx"[..]), Ok((&b"xxx"[..], &b"abcd"[..])));
 //! assert_eq!(alt_tags(&b"efghxxx"[..]), Ok((&b"xxx"[..], &b"efgh"[..])));
-//! assert_eq!(alt_tags(&b"ijklxxx"[..]), Err(winnow::Err::Error(winnow::error::Error::new(&b"ijklxxx"[..], winnow::error::ErrorKind::Tag))));
+//! assert_eq!(alt_tags(&b"ijklxxx"[..]), Err(winnow::ErrMode::Error(winnow::error::Error::new(&b"ijklxxx"[..], winnow::error::ErrorKind::Tag))));
 //! ```
 //!
 //! The **`opt`** combinator makes a parser optional. If the child parser returns
@@ -274,9 +274,9 @@
 //!     (0x6162u16, &b"cde"[..], &b"fg"[..])
 //!   ))
 //! );
-//! assert_eq!(tpl.parse_next(Streaming(&b"abcde"[..])), Err(winnow::Err::Incomplete(Needed::new(2))));
+//! assert_eq!(tpl.parse_next(Streaming(&b"abcde"[..])), Err(winnow::ErrMode::Incomplete(Needed::new(2))));
 //! let input = &b"abcdejk"[..];
-//! assert_eq!(tpl.parse_next(Streaming(input)), Err(winnow::Err::Error(Error::new(Streaming(&input[5..]), ErrorKind::Tag))));
+//! assert_eq!(tpl.parse_next(Streaming(input)), Err(winnow::ErrMode::Error(Error::new(Streaming(&input[5..]), ErrorKind::Tag))));
 //! # }
 //! ```
 //!

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -25,7 +25,7 @@ const MAX_INITIAL_CAPACITY_BYTES: usize = 65536;
 
 /// Repeats the embedded parser, gathering the results in a `Vec`.
 ///
-/// This stops on [`ErrMode::Error`].  To instead chain an error up, see
+/// This stops on [`ErrMode::Backtrack`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -60,12 +60,12 @@ where
     loop {
       let len = i.input_len();
       match f.parse_next(i.clone()) {
-        Err(ErrMode::Error(_)) => return Ok((i, acc)),
+        Err(ErrMode::Backtrack(_)) => return Ok((i, acc)),
         Err(e) => return Err(e),
         Ok((i1, o)) => {
           // infinite loop check: the parser must always consume
           if i1.input_len() == len {
-            return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many0)));
+            return Err(ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Many0)));
           }
 
           i = i1;
@@ -78,7 +78,7 @@ where
 
 /// Runs the embedded parser, gathering the results in a `Vec`.
 ///
-/// This stops on [`ErrMode::Error`] if there is at least one result.  To instead chain an error up,
+/// This stops on [`ErrMode::Backtrack`] if there is at least one result.  To instead chain an error up,
 /// see [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -99,8 +99,8 @@ where
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
 /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(Error::new("123123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// ```
 #[cfg(feature = "alloc")]
 pub fn many1<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
@@ -110,7 +110,7 @@ where
   E: ParseError<I>,
 {
   move |mut i: I| match f.parse_next(i.clone()) {
-    Err(ErrMode::Error(err)) => Err(ErrMode::Error(err.append(i, ErrorKind::Many1))),
+    Err(ErrMode::Backtrack(err)) => Err(ErrMode::Backtrack(err.append(i, ErrorKind::Many1))),
     Err(e) => Err(e),
     Ok((i1, o)) => {
       let mut acc = crate::lib::std::vec::Vec::with_capacity(4);
@@ -120,12 +120,12 @@ where
       loop {
         let len = i.input_len();
         match f.parse_next(i.clone()) {
-          Err(ErrMode::Error(_)) => return Ok((i, acc)),
+          Err(ErrMode::Backtrack(_)) => return Ok((i, acc)),
           Err(e) => return Err(e),
           Ok((i1, o)) => {
             // infinite loop check: the parser must always consume
             if i1.input_len() == len {
-              return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many1)));
+              return Err(ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Many1)));
             }
 
             i = i1;
@@ -141,7 +141,7 @@ where
 ///
 /// Returns a tuple of the results of `f` in a `Vec` and the result of `g`.
 ///
-/// `f` keeps going so long as `g` produces [`ErrMode::Error`]. To instead chain an error up, see [`cut`][crate::combinator::cut].
+/// `f` keeps going so long as `g` produces [`ErrMode::Backtrack`]. To instead chain an error up, see [`cut`][crate::combinator::cut].
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
@@ -153,9 +153,9 @@ where
 /// };
 ///
 /// assert_eq!(parser("abcabcend"), Ok(("", (vec!["abc", "abc"], "end"))));
-/// assert_eq!(parser("abc123end"), Err(ErrMode::Error(Error::new("123end", ErrorKind::Tag))));
-/// assert_eq!(parser("123123end"), Err(ErrMode::Error(Error::new("123123end", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("abc123end"), Err(ErrMode::Backtrack(Error::new("123end", ErrorKind::Tag))));
+/// assert_eq!(parser("123123end"), Err(ErrMode::Backtrack(Error::new("123123end", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
 /// ```
 #[cfg(feature = "alloc")]
@@ -175,16 +175,19 @@ where
       let len = i.input_len();
       match g.parse_next(i.clone()) {
         Ok((i1, o)) => return Ok((i1, (res, o))),
-        Err(ErrMode::Error(_)) => {
+        Err(ErrMode::Backtrack(_)) => {
           match f.parse_next(i.clone()) {
-            Err(ErrMode::Error(err)) => {
-              return Err(ErrMode::Error(err.append(i, ErrorKind::ManyTill)))
+            Err(ErrMode::Backtrack(err)) => {
+              return Err(ErrMode::Backtrack(err.append(i, ErrorKind::ManyTill)))
             }
             Err(e) => return Err(e),
             Ok((i1, o)) => {
               // infinite loop check: the parser must always consume
               if i1.input_len() == len {
-                return Err(ErrMode::Error(E::from_error_kind(i1, ErrorKind::ManyTill)));
+                return Err(ErrMode::Backtrack(E::from_error_kind(
+                  i1,
+                  ErrorKind::ManyTill,
+                )));
               }
 
               res.push(o);
@@ -200,7 +203,7 @@ where
 
 /// Alternates between two parsers to produce a list of elements.
 ///
-/// This stops when either parser returns [`ErrMode::Error`].  To instead chain an error up, see
+/// This stops when either parser returns [`ErrMode::Backtrack`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -237,7 +240,7 @@ where
     let mut res = Vec::new();
 
     match f.parse_next(i.clone()) {
-      Err(ErrMode::Error(_)) => return Ok((i, res)),
+      Err(ErrMode::Backtrack(_)) => return Ok((i, res)),
       Err(e) => return Err(e),
       Ok((i1, o)) => {
         res.push(o);
@@ -248,19 +251,19 @@ where
     loop {
       let len = i.input_len();
       match sep.parse_next(i.clone()) {
-        Err(ErrMode::Error(_)) => return Ok((i, res)),
+        Err(ErrMode::Backtrack(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
           // infinite loop check: the parser must always consume
           if i1.input_len() == len {
-            return Err(ErrMode::Error(E::from_error_kind(
+            return Err(ErrMode::Backtrack(E::from_error_kind(
               i1,
               ErrorKind::SeparatedList,
             )));
           }
 
           match f.parse_next(i1.clone()) {
-            Err(ErrMode::Error(_)) => return Ok((i, res)),
+            Err(ErrMode::Backtrack(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
               res.push(o);
@@ -273,11 +276,11 @@ where
   }
 }
 
-/// Alternates between two parsers to produce a list of elements until [`ErrMode::Error`].
+/// Alternates between two parsers to produce a list of elements until [`ErrMode::Backtrack`].
 ///
 /// Fails if the element parser does not produce at least one element.$
 ///
-/// This stops when either parser returns [`ErrMode::Error`].  To instead chain an error up, see
+/// This stops when either parser returns [`ErrMode::Backtrack`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -295,8 +298,8 @@ where
 /// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
 /// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
 /// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("def|abc"), Err(ErrMode::Error(Error::new("def|abc", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(Error::new("def|abc", ErrorKind::Tag))));
 /// ```
 #[cfg(feature = "alloc")]
 pub fn separated_list1<I, O, O2, E, F, G>(
@@ -324,19 +327,19 @@ where
     loop {
       let len = i.input_len();
       match sep.parse_next(i.clone()) {
-        Err(ErrMode::Error(_)) => return Ok((i, res)),
+        Err(ErrMode::Backtrack(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
           // infinite loop check: the parser must always consume
           if i1.input_len() == len {
-            return Err(ErrMode::Error(E::from_error_kind(
+            return Err(ErrMode::Backtrack(E::from_error_kind(
               i1,
               ErrorKind::SeparatedList,
             )));
           }
 
           match f.parse_next(i1.clone()) {
-            Err(ErrMode::Error(_)) => return Ok((i, res)),
+            Err(ErrMode::Backtrack(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
               res.push(o);
@@ -351,7 +354,7 @@ where
 
 /// Repeats the embedded parser `m..=n` times
 ///
-/// This stops before `n` when the parser returns [`ErrMode::Error`].  To instead chain an error up, see
+/// This stops before `n` when the parser returns [`ErrMode::Backtrack`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -391,10 +394,7 @@ where
 {
   move |mut input: I| {
     if min > max {
-      return Err(ErrMode::Failure(E::from_error_kind(
-        input,
-        ErrorKind::ManyMN,
-      )));
+      return Err(ErrMode::Cut(E::from_error_kind(input, ErrorKind::ManyMN)));
     }
 
     let max_initial_capacity =
@@ -406,15 +406,18 @@ where
         Ok((tail, value)) => {
           // infinite loop check: the parser must always consume
           if tail.input_len() == len {
-            return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::ManyMN)));
+            return Err(ErrMode::Backtrack(E::from_error_kind(
+              input,
+              ErrorKind::ManyMN,
+            )));
           }
 
           res.push(value);
           input = tail;
         }
-        Err(ErrMode::Error(e)) => {
+        Err(ErrMode::Backtrack(e)) => {
           if count < min {
-            return Err(ErrMode::Error(e.append(input, ErrorKind::ManyMN)));
+            return Err(ErrMode::Backtrack(e.append(input, ErrorKind::ManyMN)));
           } else {
             return Ok((input, res));
           }
@@ -431,7 +434,7 @@ where
 
 /// Repeats the embedded parser, counting the results
 ///
-/// This stops on [`ErrMode::Error`].  To instead chain an error up, see
+/// This stops on [`ErrMode::Backtrack`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -471,7 +474,7 @@ where
         Ok((i, _)) => {
           // infinite loop check: the parser must always consume
           if i.input_len() == len {
-            return Err(ErrMode::Error(E::from_error_kind(
+            return Err(ErrMode::Backtrack(E::from_error_kind(
               input,
               ErrorKind::Many0Count,
             )));
@@ -481,7 +484,7 @@ where
           count += 1;
         }
 
-        Err(ErrMode::Error(_)) => return Ok((input, count)),
+        Err(ErrMode::Backtrack(_)) => return Ok((input, count)),
 
         Err(e) => return Err(e),
       }
@@ -491,7 +494,7 @@ where
 
 /// Runs the embedded parser, counting the results.
 ///
-/// This stops on [`ErrMode::Error`] if there is at least one result.  To instead chain an error up,
+/// This stops on [`ErrMode::Backtrack`] if there is at least one result.  To instead chain an error up,
 /// see [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -512,8 +515,8 @@ where
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", 2)));
 /// assert_eq!(parser("abc123"), Ok(("123", 1)));
-/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Many1Count))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Many1Count))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(Error::new("123123", ErrorKind::Many1Count))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Many1Count))));
 /// ```
 pub fn many1_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
@@ -524,7 +527,10 @@ where
   move |i: I| {
     let i_ = i.clone();
     match f.parse_next(i_) {
-      Err(ErrMode::Error(_)) => Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many1Count))),
+      Err(ErrMode::Backtrack(_)) => Err(ErrMode::Backtrack(E::from_error_kind(
+        i,
+        ErrorKind::Many1Count,
+      ))),
       Err(i) => Err(i),
       Ok((i1, _)) => {
         let mut count = 1;
@@ -534,12 +540,15 @@ where
           let len = input.input_len();
           let input_ = input.clone();
           match f.parse_next(input_) {
-            Err(ErrMode::Error(_)) => return Ok((input, count)),
+            Err(ErrMode::Backtrack(_)) => return Ok((input, count)),
             Err(e) => return Err(e),
             Ok((i, _)) => {
               // infinite loop check: the parser must always consume
               if i.input_len() == len {
-                return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many1Count)));
+                return Err(ErrMode::Backtrack(E::from_error_kind(
+                  i,
+                  ErrorKind::Many1Count,
+                )));
               }
 
               count += 1;
@@ -567,9 +576,9 @@ where
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
-/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("abc123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(Error::new("123123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
 #[cfg(feature = "alloc")]
@@ -592,8 +601,8 @@ where
           res.push(o);
           input = i;
         }
-        Err(ErrMode::Error(e)) => {
-          return Err(ErrMode::Error(e.append(i, ErrorKind::Count)));
+        Err(ErrMode::Backtrack(e)) => {
+          return Err(ErrMode::Backtrack(e.append(i, ErrorKind::Count)));
         }
         Err(e) => {
           return Err(e);
@@ -624,9 +633,9 @@ where
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", ["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
-/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("abc123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(Error::new("123123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", ["abc", "abc"])));
 /// ```
 pub fn fill<'a, I, O, E, F>(mut f: F, buf: &'a mut [O]) -> impl FnMut(I) -> IResult<I, (), E> + 'a
@@ -645,8 +654,8 @@ where
           *elem = o;
           input = i;
         }
-        Err(ErrMode::Error(e)) => {
-          return Err(ErrMode::Error(e.append(i, ErrorKind::Count)));
+        Err(ErrMode::Backtrack(e)) => {
+          return Err(ErrMode::Backtrack(e.append(i, ErrorKind::Count)));
         }
         Err(e) => {
           return Err(e);
@@ -660,7 +669,7 @@ where
 
 /// Repeats the embedded parser, calling `g` to gather the results.
 ///
-/// This stops on [`ErrMode::Error`].  To instead chain an error up, see
+/// This stops on [`ErrMode::Backtrack`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -716,13 +725,16 @@ where
         Ok((i, o)) => {
           // infinite loop check: the parser must always consume
           if i.input_len() == len {
-            return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Many0)));
+            return Err(ErrMode::Backtrack(E::from_error_kind(
+              input,
+              ErrorKind::Many0,
+            )));
           }
 
           res = g(res, o);
           input = i;
         }
-        Err(ErrMode::Error(_)) => {
+        Err(ErrMode::Backtrack(_)) => {
           return Ok((input, res));
         }
         Err(e) => {
@@ -735,7 +747,7 @@ where
 
 /// Repeats the embedded parser, calling `g` to gather the results.
 ///
-/// This stops on [`ErrMode::Error`] if there is at least one result.  To instead chain an error up,
+/// This stops on [`ErrMode::Backtrack`] if there is at least one result.  To instead chain an error up,
 /// see [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -766,8 +778,8 @@ where
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
 /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Many1))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Many1))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(Error::new("123123", ErrorKind::Many1))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Many1))));
 /// ```
 pub fn fold_many1<I, O, E, F, G, H, R>(
   mut f: F,
@@ -785,7 +797,9 @@ where
     let _i = i.clone();
     let init = init();
     match f.parse_next(_i) {
-      Err(ErrMode::Error(_)) => Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many1))),
+      Err(ErrMode::Backtrack(_)) => {
+        Err(ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Many1)))
+      }
       Err(e) => Err(e),
       Ok((i1, o1)) => {
         let mut acc = g(init, o1);
@@ -795,14 +809,14 @@ where
           let _input = input.clone();
           let len = input.input_len();
           match f.parse_next(_input) {
-            Err(ErrMode::Error(_)) => {
+            Err(ErrMode::Backtrack(_)) => {
               break;
             }
             Err(e) => return Err(e),
             Ok((i, o)) => {
               // infinite loop check: the parser must always consume
               if i.input_len() == len {
-                return Err(ErrMode::Failure(E::from_error_kind(i, ErrorKind::Many1)));
+                return Err(ErrMode::Cut(E::from_error_kind(i, ErrorKind::Many1)));
               }
 
               acc = g(acc, o);
@@ -819,7 +833,7 @@ where
 
 /// Repeats the embedded parser `m..=n` times, calling `g` to gather the results
 ///
-/// This stops before `n` when the parser returns [`ErrMode::Error`].  To instead chain an error up, see
+/// This stops before `n` when the parser returns [`ErrMode::Backtrack`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -874,10 +888,7 @@ where
 {
   move |mut input: I| {
     if min > max {
-      return Err(ErrMode::Failure(E::from_error_kind(
-        input,
-        ErrorKind::ManyMN,
-      )));
+      return Err(ErrMode::Cut(E::from_error_kind(input, ErrorKind::ManyMN)));
     }
 
     let mut acc = init();
@@ -887,16 +898,19 @@ where
         Ok((tail, value)) => {
           // infinite loop check: the parser must always consume
           if tail.input_len() == len {
-            return Err(ErrMode::Error(E::from_error_kind(tail, ErrorKind::ManyMN)));
+            return Err(ErrMode::Backtrack(E::from_error_kind(
+              tail,
+              ErrorKind::ManyMN,
+            )));
           }
 
           acc = fold(acc, value);
           input = tail;
         }
         //FInputXMError: handle failure properly
-        Err(ErrMode::Error(err)) => {
+        Err(ErrMode::Backtrack(err)) => {
           if count < min {
-            return Err(ErrMode::Error(err.append(input, ErrorKind::ManyMN)));
+            return Err(ErrMode::Backtrack(err.append(input, ErrorKind::ManyMN)));
           } else {
             break;
           }
@@ -972,7 +986,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(Streaming(b"\x00\x03abcefg")), Ok((Streaming(&b"efg"[..]), &b"abc"[..])));
-/// assert_eq!(parser(Streaming(b"\x00\x03123123")), Err(ErrMode::Error(Error::new(Streaming(&b"123"[..]), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming(b"\x00\x03123123")), Err(ErrMode::Backtrack(Error::new(Streaming(&b"123"[..]), ErrorKind::Tag))));
 /// assert_eq!(parser(Streaming(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 pub fn length_value<I, O, N, E, F, G, const STREAMING: bool>(
@@ -1016,7 +1030,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x02abcabcabc"[..]), Ok(((&b"abc"[..], vec![&b"abc"[..], &b"abc"[..]]))));
-/// assert_eq!(parser(b"\x03123123123"), Err(ErrMode::Error(Error::new(&b"123123123"[..], ErrorKind::Tag))));
+/// assert_eq!(parser(b"\x03123123123"), Err(ErrMode::Backtrack(Error::new(&b"123123123"[..], ErrorKind::Tag))));
 /// ```
 #[cfg(feature = "alloc")]
 pub fn length_count<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
@@ -1041,8 +1055,8 @@ where
           res.push(o);
           input = i;
         }
-        Err(ErrMode::Error(e)) => {
-          return Err(ErrMode::Error(e.append(i, ErrorKind::Count)));
+        Err(ErrMode::Backtrack(e)) => {
+          return Err(ErrMode::Backtrack(e.append(i, ErrorKind::Count)));
         }
         Err(e) => {
           return Err(e);

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -26,7 +26,7 @@ const MAX_INITIAL_CAPACITY_BYTES: usize = 65536;
 /// Repeats the embedded parser, gathering the results in a `Vec`.
 ///
 /// This stops on [`ErrMode::Backtrack`].  To instead chain an error up, see
-/// [`cut`][crate::combinator::cut].
+/// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `f` The parser to apply.
@@ -79,7 +79,7 @@ where
 /// Runs the embedded parser, gathering the results in a `Vec`.
 ///
 /// This stops on [`ErrMode::Backtrack`] if there is at least one result.  To instead chain an error up,
-/// see [`cut`][crate::combinator::cut].
+/// see [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `f` The parser to apply.
@@ -141,7 +141,7 @@ where
 ///
 /// Returns a tuple of the results of `f` in a `Vec` and the result of `g`.
 ///
-/// `f` keeps going so long as `g` produces [`ErrMode::Backtrack`]. To instead chain an error up, see [`cut`][crate::combinator::cut].
+/// `f` keeps going so long as `g` produces [`ErrMode::Backtrack`]. To instead chain an error up, see [`cut_err`][crate::combinator::cut_err].
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
@@ -204,7 +204,7 @@ where
 /// Alternates between two parsers to produce a list of elements.
 ///
 /// This stops when either parser returns [`ErrMode::Backtrack`].  To instead chain an error up, see
-/// [`cut`][crate::combinator::cut].
+/// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `sep` Parses the separator between list elements.
@@ -281,7 +281,7 @@ where
 /// Fails if the element parser does not produce at least one element.$
 ///
 /// This stops when either parser returns [`ErrMode::Backtrack`].  To instead chain an error up, see
-/// [`cut`][crate::combinator::cut].
+/// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `sep` Parses the separator between list elements.
@@ -355,7 +355,7 @@ where
 /// Repeats the embedded parser `m..=n` times
 ///
 /// This stops before `n` when the parser returns [`ErrMode::Backtrack`].  To instead chain an error up, see
-/// [`cut`][crate::combinator::cut].
+/// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `m` The minimum number of iterations.
@@ -435,7 +435,7 @@ where
 /// Repeats the embedded parser, counting the results
 ///
 /// This stops on [`ErrMode::Backtrack`].  To instead chain an error up, see
-/// [`cut`][crate::combinator::cut].
+/// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `f` The parser to apply.
@@ -495,7 +495,7 @@ where
 /// Runs the embedded parser, counting the results.
 ///
 /// This stops on [`ErrMode::Backtrack`] if there is at least one result.  To instead chain an error up,
-/// see [`cut`][crate::combinator::cut].
+/// see [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `f` The parser to apply.
@@ -670,7 +670,7 @@ where
 /// Repeats the embedded parser, calling `g` to gather the results.
 ///
 /// This stops on [`ErrMode::Backtrack`].  To instead chain an error up, see
-/// [`cut`][crate::combinator::cut].
+/// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `f` The parser to apply.
@@ -748,7 +748,7 @@ where
 /// Repeats the embedded parser, calling `g` to gather the results.
 ///
 /// This stops on [`ErrMode::Backtrack`] if there is at least one result.  To instead chain an error up,
-/// see [`cut`][crate::combinator::cut].
+/// see [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `f` The parser to apply.
@@ -834,7 +834,7 @@ where
 /// Repeats the embedded parser `m..=n` times, calling `g` to gather the results
 ///
 /// This stops before `n` when the parser returns [`ErrMode::Backtrack`].  To instead chain an error up, see
-/// [`cut`][crate::combinator::cut].
+/// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
 /// * `m` The minimum number of iterations.

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -8,7 +8,7 @@ use crate::error::ParseError;
 use crate::input::{Input, InputIsStreaming, ToUsize, UpdateSlice};
 #[cfg(feature = "alloc")]
 use crate::lib::std::vec::Vec;
-use crate::{Err, IResult, Parser};
+use crate::{ErrMode, IResult, Parser};
 
 /// Don't pre-allocate more than 64KiB when calling `Vec::with_capacity`.
 ///
@@ -24,7 +24,7 @@ const MAX_INITIAL_CAPACITY_BYTES: usize = 65536;
 
 /// Repeats the embedded parser, gathering the results in a `Vec`.
 ///
-/// This stops on [`Err::Error`].  To instead chain an error up, see
+/// This stops on [`ErrMode::Error`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -34,7 +34,7 @@ const MAX_INITIAL_CAPACITY_BYTES: usize = 65536;
 /// return an error, to prevent going into an infinite loop
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::multi::many0;
 /// use winnow::bytes::tag;
 ///
@@ -59,12 +59,12 @@ where
     loop {
       let len = i.input_len();
       match f.parse_next(i.clone()) {
-        Err(Err::Error(_)) => return Ok((i, acc)),
+        Err(ErrMode::Error(_)) => return Ok((i, acc)),
         Err(e) => return Err(e),
         Ok((i1, o)) => {
           // infinite loop check: the parser must always consume
           if i1.input_len() == len {
-            return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many0)));
+            return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many0)));
           }
 
           i = i1;
@@ -77,7 +77,7 @@ where
 
 /// Runs the embedded parser, gathering the results in a `Vec`.
 ///
-/// This stops on [`Err::Error`] if there is at least one result.  To instead chain an error up,
+/// This stops on [`ErrMode::Error`] if there is at least one result.  To instead chain an error up,
 /// see [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -88,7 +88,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::multi::many1;
 /// use winnow::bytes::tag;
 ///
@@ -98,8 +98,8 @@ where
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
 /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
 /// ```
 #[cfg(feature = "alloc")]
 pub fn many1<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
@@ -109,7 +109,7 @@ where
   E: ParseError<I>,
 {
   move |mut i: I| match f.parse_next(i.clone()) {
-    Err(Err::Error(err)) => Err(Err::Error(err.append(i, ErrorKind::Many1))),
+    Err(ErrMode::Error(err)) => Err(ErrMode::Error(err.append(i, ErrorKind::Many1))),
     Err(e) => Err(e),
     Ok((i1, o)) => {
       let mut acc = crate::lib::std::vec::Vec::with_capacity(4);
@@ -119,12 +119,12 @@ where
       loop {
         let len = i.input_len();
         match f.parse_next(i.clone()) {
-          Err(Err::Error(_)) => return Ok((i, acc)),
+          Err(ErrMode::Error(_)) => return Ok((i, acc)),
           Err(e) => return Err(e),
           Ok((i1, o)) => {
             // infinite loop check: the parser must always consume
             if i1.input_len() == len {
-              return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1)));
+              return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many1)));
             }
 
             i = i1;
@@ -140,10 +140,10 @@ where
 ///
 /// Returns a tuple of the results of `f` in a `Vec` and the result of `g`.
 ///
-/// `f` keeps going so long as `g` produces [`Err::Error`]. To instead chain an error up, see [`cut`][crate::combinator::cut].
+/// `f` keeps going so long as `g` produces [`ErrMode::Error`]. To instead chain an error up, see [`cut`][crate::combinator::cut].
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::multi::many_till;
 /// use winnow::bytes::tag;
 ///
@@ -152,9 +152,9 @@ where
 /// };
 ///
 /// assert_eq!(parser("abcabcend"), Ok(("", (vec!["abc", "abc"], "end"))));
-/// assert_eq!(parser("abc123end"), Err(Err::Error(Error::new("123end", ErrorKind::Tag))));
-/// assert_eq!(parser("123123end"), Err(Err::Error(Error::new("123123end", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("abc123end"), Err(ErrMode::Error(Error::new("123end", ErrorKind::Tag))));
+/// assert_eq!(parser("123123end"), Err(ErrMode::Error(Error::new("123123end", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
 /// ```
 #[cfg(feature = "alloc")]
@@ -174,14 +174,16 @@ where
       let len = i.input_len();
       match g.parse_next(i.clone()) {
         Ok((i1, o)) => return Ok((i1, (res, o))),
-        Err(Err::Error(_)) => {
+        Err(ErrMode::Error(_)) => {
           match f.parse_next(i.clone()) {
-            Err(Err::Error(err)) => return Err(Err::Error(err.append(i, ErrorKind::ManyTill))),
+            Err(ErrMode::Error(err)) => {
+              return Err(ErrMode::Error(err.append(i, ErrorKind::ManyTill)))
+            }
             Err(e) => return Err(e),
             Ok((i1, o)) => {
               // infinite loop check: the parser must always consume
               if i1.input_len() == len {
-                return Err(Err::Error(E::from_error_kind(i1, ErrorKind::ManyTill)));
+                return Err(ErrMode::Error(E::from_error_kind(i1, ErrorKind::ManyTill)));
               }
 
               res.push(o);
@@ -197,7 +199,7 @@ where
 
 /// Alternates between two parsers to produce a list of elements.
 ///
-/// This stops when either parser returns [`Err::Error`].  To instead chain an error up, see
+/// This stops when either parser returns [`ErrMode::Error`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -205,7 +207,7 @@ where
 /// * `f` Parses the elements of the list.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::multi::separated_list0;
 /// use winnow::bytes::tag;
 ///
@@ -234,7 +236,7 @@ where
     let mut res = Vec::new();
 
     match f.parse_next(i.clone()) {
-      Err(Err::Error(_)) => return Ok((i, res)),
+      Err(ErrMode::Error(_)) => return Ok((i, res)),
       Err(e) => return Err(e),
       Ok((i1, o)) => {
         res.push(o);
@@ -245,16 +247,19 @@ where
     loop {
       let len = i.input_len();
       match sep.parse_next(i.clone()) {
-        Err(Err::Error(_)) => return Ok((i, res)),
+        Err(ErrMode::Error(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
           // infinite loop check: the parser must always consume
           if i1.input_len() == len {
-            return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
+            return Err(ErrMode::Error(E::from_error_kind(
+              i1,
+              ErrorKind::SeparatedList,
+            )));
           }
 
           match f.parse_next(i1.clone()) {
-            Err(Err::Error(_)) => return Ok((i, res)),
+            Err(ErrMode::Error(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
               res.push(o);
@@ -267,18 +272,18 @@ where
   }
 }
 
-/// Alternates between two parsers to produce a list of elements until [`Err::Error`].
+/// Alternates between two parsers to produce a list of elements until [`ErrMode::Error`].
 ///
 /// Fails if the element parser does not produce at least one element.$
 ///
-/// This stops when either parser returns [`Err::Error`].  To instead chain an error up, see
+/// This stops when either parser returns [`ErrMode::Error`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
 /// * `sep` Parses the separator between list elements.
 /// * `f` Parses the elements of the list.
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::multi::separated_list1;
 /// use winnow::bytes::tag;
 ///
@@ -289,8 +294,8 @@ where
 /// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
 /// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
 /// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("def|abc"), Err(Err::Error(Error::new("def|abc", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("def|abc"), Err(ErrMode::Error(Error::new("def|abc", ErrorKind::Tag))));
 /// ```
 #[cfg(feature = "alloc")]
 pub fn separated_list1<I, O, O2, E, F, G>(
@@ -318,16 +323,19 @@ where
     loop {
       let len = i.input_len();
       match sep.parse_next(i.clone()) {
-        Err(Err::Error(_)) => return Ok((i, res)),
+        Err(ErrMode::Error(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
           // infinite loop check: the parser must always consume
           if i1.input_len() == len {
-            return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
+            return Err(ErrMode::Error(E::from_error_kind(
+              i1,
+              ErrorKind::SeparatedList,
+            )));
           }
 
           match f.parse_next(i1.clone()) {
-            Err(Err::Error(_)) => return Ok((i, res)),
+            Err(ErrMode::Error(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
               res.push(o);
@@ -342,7 +350,7 @@ where
 
 /// Repeats the embedded parser `m..=n` times
 ///
-/// This stops before `n` when the parser returns [`Err::Error`].  To instead chain an error up, see
+/// This stops before `n` when the parser returns [`ErrMode::Error`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -355,7 +363,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::multi::many_m_n;
 /// use winnow::bytes::tag;
 ///
@@ -382,7 +390,10 @@ where
 {
   move |mut input: I| {
     if min > max {
-      return Err(Err::Failure(E::from_error_kind(input, ErrorKind::ManyMN)));
+      return Err(ErrMode::Failure(E::from_error_kind(
+        input,
+        ErrorKind::ManyMN,
+      )));
     }
 
     let max_initial_capacity =
@@ -394,15 +405,15 @@ where
         Ok((tail, value)) => {
           // infinite loop check: the parser must always consume
           if tail.input_len() == len {
-            return Err(Err::Error(E::from_error_kind(input, ErrorKind::ManyMN)));
+            return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::ManyMN)));
           }
 
           res.push(value);
           input = tail;
         }
-        Err(Err::Error(e)) => {
+        Err(ErrMode::Error(e)) => {
           if count < min {
-            return Err(Err::Error(e.append(input, ErrorKind::ManyMN)));
+            return Err(ErrMode::Error(e.append(input, ErrorKind::ManyMN)));
           } else {
             return Ok((input, res));
           }
@@ -419,7 +430,7 @@ where
 
 /// Repeats the embedded parser, counting the results
 ///
-/// This stops on [`Err::Error`].  To instead chain an error up, see
+/// This stops on [`ErrMode::Error`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -429,7 +440,7 @@ where
 /// return an error, to prevent going into an infinite loop
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::multi::many0_count;
 /// use winnow::bytes::tag;
 ///
@@ -459,14 +470,17 @@ where
         Ok((i, _)) => {
           // infinite loop check: the parser must always consume
           if i.input_len() == len {
-            return Err(Err::Error(E::from_error_kind(input, ErrorKind::Many0Count)));
+            return Err(ErrMode::Error(E::from_error_kind(
+              input,
+              ErrorKind::Many0Count,
+            )));
           }
 
           input = i;
           count += 1;
         }
 
-        Err(Err::Error(_)) => return Ok((input, count)),
+        Err(ErrMode::Error(_)) => return Ok((input, count)),
 
         Err(e) => return Err(e),
       }
@@ -476,7 +490,7 @@ where
 
 /// Runs the embedded parser, counting the results.
 ///
-/// This stops on [`Err::Error`] if there is at least one result.  To instead chain an error up,
+/// This stops on [`ErrMode::Error`] if there is at least one result.  To instead chain an error up,
 /// see [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -487,7 +501,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::multi::many1_count;
 /// use winnow::bytes::tag;
 ///
@@ -497,8 +511,8 @@ where
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", 2)));
 /// assert_eq!(parser("abc123"), Ok(("123", 1)));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Many1Count))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Many1Count))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Many1Count))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Many1Count))));
 /// ```
 pub fn many1_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
@@ -509,7 +523,7 @@ where
   move |i: I| {
     let i_ = i.clone();
     match f.parse_next(i_) {
-      Err(Err::Error(_)) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1Count))),
+      Err(ErrMode::Error(_)) => Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many1Count))),
       Err(i) => Err(i),
       Ok((i1, _)) => {
         let mut count = 1;
@@ -519,12 +533,12 @@ where
           let len = input.input_len();
           let input_ = input.clone();
           match f.parse_next(input_) {
-            Err(Err::Error(_)) => return Ok((input, count)),
+            Err(ErrMode::Error(_)) => return Ok((input, count)),
             Err(e) => return Err(e),
             Ok((i, _)) => {
               // infinite loop check: the parser must always consume
               if i.input_len() == len {
-                return Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1Count)));
+                return Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many1Count)));
               }
 
               count += 1;
@@ -543,7 +557,7 @@ where
 /// * `f` The parser to apply.
 /// * `count` How often to apply the parser.
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::multi::count;
 /// use winnow::bytes::tag;
 ///
@@ -552,9 +566,9 @@ where
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("abc123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
 #[cfg(feature = "alloc")]
@@ -577,8 +591,8 @@ where
           res.push(o);
           input = i;
         }
-        Err(Err::Error(e)) => {
-          return Err(Err::Error(e.append(i, ErrorKind::Count)));
+        Err(ErrMode::Error(e)) => {
+          return Err(ErrMode::Error(e.append(i, ErrorKind::Count)));
         }
         Err(e) => {
           return Err(e);
@@ -598,7 +612,7 @@ where
 /// * `f` The parser to apply.
 /// * `buf` The slice to fill
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::multi::fill;
 /// use winnow::bytes::tag;
 ///
@@ -609,9 +623,9 @@ where
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", ["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("abc123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", ["abc", "abc"])));
 /// ```
 pub fn fill<'a, I, O, E, F>(mut f: F, buf: &'a mut [O]) -> impl FnMut(I) -> IResult<I, (), E> + 'a
@@ -630,8 +644,8 @@ where
           *elem = o;
           input = i;
         }
-        Err(Err::Error(e)) => {
-          return Err(Err::Error(e.append(i, ErrorKind::Count)));
+        Err(ErrMode::Error(e)) => {
+          return Err(ErrMode::Error(e.append(i, ErrorKind::Count)));
         }
         Err(e) => {
           return Err(e);
@@ -645,7 +659,7 @@ where
 
 /// Repeats the embedded parser, calling `g` to gather the results.
 ///
-/// This stops on [`Err::Error`].  To instead chain an error up, see
+/// This stops on [`ErrMode::Error`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -658,7 +672,7 @@ where
 /// return an error, to prevent going into an infinite loop
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::multi::fold_many0;
 /// use winnow::bytes::tag;
 ///
@@ -701,13 +715,13 @@ where
         Ok((i, o)) => {
           // infinite loop check: the parser must always consume
           if i.input_len() == len {
-            return Err(Err::Error(E::from_error_kind(input, ErrorKind::Many0)));
+            return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Many0)));
           }
 
           res = g(res, o);
           input = i;
         }
-        Err(Err::Error(_)) => {
+        Err(ErrMode::Error(_)) => {
           return Ok((input, res));
         }
         Err(e) => {
@@ -720,7 +734,7 @@ where
 
 /// Repeats the embedded parser, calling `g` to gather the results.
 ///
-/// This stops on [`Err::Error`] if there is at least one result.  To instead chain an error up,
+/// This stops on [`ErrMode::Error`] if there is at least one result.  To instead chain an error up,
 /// see [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -734,7 +748,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::multi::fold_many1;
 /// use winnow::bytes::tag;
 ///
@@ -751,8 +765,8 @@ where
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
 /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Many1))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Many1))));
+/// assert_eq!(parser("123123"), Err(ErrMode::Error(Error::new("123123", ErrorKind::Many1))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Many1))));
 /// ```
 pub fn fold_many1<I, O, E, F, G, H, R>(
   mut f: F,
@@ -770,7 +784,7 @@ where
     let _i = i.clone();
     let init = init();
     match f.parse_next(_i) {
-      Err(Err::Error(_)) => Err(Err::Error(E::from_error_kind(i, ErrorKind::Many1))),
+      Err(ErrMode::Error(_)) => Err(ErrMode::Error(E::from_error_kind(i, ErrorKind::Many1))),
       Err(e) => Err(e),
       Ok((i1, o1)) => {
         let mut acc = g(init, o1);
@@ -780,14 +794,14 @@ where
           let _input = input.clone();
           let len = input.input_len();
           match f.parse_next(_input) {
-            Err(Err::Error(_)) => {
+            Err(ErrMode::Error(_)) => {
               break;
             }
             Err(e) => return Err(e),
             Ok((i, o)) => {
               // infinite loop check: the parser must always consume
               if i.input_len() == len {
-                return Err(Err::Failure(E::from_error_kind(i, ErrorKind::Many1)));
+                return Err(ErrMode::Failure(E::from_error_kind(i, ErrorKind::Many1)));
               }
 
               acc = g(acc, o);
@@ -804,7 +818,7 @@ where
 
 /// Repeats the embedded parser `m..=n` times, calling `g` to gather the results
 ///
-/// This stops before `n` when the parser returns [`Err::Error`].  To instead chain an error up, see
+/// This stops before `n` when the parser returns [`ErrMode::Error`].  To instead chain an error up, see
 /// [`cut`][crate::combinator::cut].
 ///
 /// # Arguments
@@ -820,7 +834,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
 /// use winnow::multi::fold_many_m_n;
 /// use winnow::bytes::tag;
 ///
@@ -859,7 +873,10 @@ where
 {
   move |mut input: I| {
     if min > max {
-      return Err(Err::Failure(E::from_error_kind(input, ErrorKind::ManyMN)));
+      return Err(ErrMode::Failure(E::from_error_kind(
+        input,
+        ErrorKind::ManyMN,
+      )));
     }
 
     let mut acc = init();
@@ -869,16 +886,16 @@ where
         Ok((tail, value)) => {
           // infinite loop check: the parser must always consume
           if tail.input_len() == len {
-            return Err(Err::Error(E::from_error_kind(tail, ErrorKind::ManyMN)));
+            return Err(ErrMode::Error(E::from_error_kind(tail, ErrorKind::ManyMN)));
           }
 
           acc = fold(acc, value);
           input = tail;
         }
         //FInputXMError: handle failure properly
-        Err(Err::Error(err)) => {
+        Err(ErrMode::Error(err)) => {
           if count < min {
-            return Err(Err::Error(err.append(input, ErrorKind::ManyMN)));
+            return Err(ErrMode::Error(err.append(input, ErrorKind::ManyMN)));
           } else {
             break;
           }
@@ -896,12 +913,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Arguments
 /// * `f` The parser to apply.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, Needed, IResult, input::Streaming};
+/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult, input::Streaming};
 /// use winnow::number::be_u16;
 /// use winnow::multi::length_data;
 /// use winnow::bytes::tag;
@@ -911,7 +928,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(Streaming(b"\x00\x03abcefg")), Ok((Streaming(&b"efg"[..]), &b"abc"[..])));
-/// assert_eq!(parser(Streaming(b"\x00\x03a")), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Streaming(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 pub fn length_data<I, N, E, F, const STREAMING: bool>(
   mut f: F,
@@ -938,13 +955,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Arguments
 /// * `f` The parser to apply.
 /// * `g` The parser to apply on the subslice.
 /// ```rust
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult, input::Streaming};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult, input::Streaming};
 /// use winnow::number::be_u16;
 /// use winnow::multi::length_value;
 /// use winnow::bytes::tag;
@@ -954,8 +971,8 @@ where
 /// }
 ///
 /// assert_eq!(parser(Streaming(b"\x00\x03abcefg")), Ok((Streaming(&b"efg"[..]), &b"abc"[..])));
-/// assert_eq!(parser(Streaming(b"\x00\x03123123")), Err(Err::Error(Error::new(Streaming(&b"123"[..]), ErrorKind::Tag))));
-/// assert_eq!(parser(Streaming(b"\x00\x03a")), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Streaming(b"\x00\x03123123")), Err(ErrMode::Error(Error::new(Streaming(&b"123"[..]), ErrorKind::Tag))));
+/// assert_eq!(parser(Streaming(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 pub fn length_value<I, O, N, E, F, G, const STREAMING: bool>(
   mut f: F,
@@ -984,7 +1001,7 @@ where
 /// * `g` The parser to apply repeatedly.
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{Err, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
 /// use winnow::number::u8;
 /// use winnow::multi::length_count;
 /// use winnow::bytes::tag;
@@ -998,7 +1015,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x02abcabcabc"[..]), Ok(((&b"abc"[..], vec![&b"abc"[..], &b"abc"[..]]))));
-/// assert_eq!(parser(b"\x03123123123"), Err(Err::Error(Error::new(&b"123123123"[..], ErrorKind::Tag))));
+/// assert_eq!(parser(b"\x03123123123"), Err(ErrMode::Error(Error::new(&b"123123123"[..], ErrorKind::Tag))));
 /// ```
 #[cfg(feature = "alloc")]
 pub fn length_count<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
@@ -1023,8 +1040,8 @@ where
           res.push(o);
           input = i;
         }
-        Err(Err::Error(e)) => {
-          return Err(Err::Error(e.append(i, ErrorKind::Count)));
+        Err(ErrMode::Error(e)) => {
+          return Err(ErrMode::Error(e.append(i, ErrorKind::Count)));
         }
         Err(e) => {
           return Err(e);

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -3,12 +3,13 @@
 #[cfg(test)]
 mod tests;
 
+use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{Input, InputIsStreaming, ToUsize, UpdateSlice};
 #[cfg(feature = "alloc")]
 use crate::lib::std::vec::Vec;
-use crate::{ErrMode, IResult, Parser};
+use crate::{IResult, Parser};
 
 /// Don't pre-allocate more than 64KiB when calling `Vec::with_capacity`.
 ///
@@ -34,7 +35,7 @@ const MAX_INITIAL_CAPACITY_BYTES: usize = 65536;
 /// return an error, to prevent going into an infinite loop
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::multi::many0;
 /// use winnow::bytes::tag;
 ///
@@ -88,7 +89,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::many1;
 /// use winnow::bytes::tag;
 ///
@@ -143,7 +144,7 @@ where
 /// `f` keeps going so long as `g` produces [`ErrMode::Error`]. To instead chain an error up, see [`cut`][crate::combinator::cut].
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::many_till;
 /// use winnow::bytes::tag;
 ///
@@ -207,7 +208,7 @@ where
 /// * `f` Parses the elements of the list.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::multi::separated_list0;
 /// use winnow::bytes::tag;
 ///
@@ -283,7 +284,7 @@ where
 /// * `sep` Parses the separator between list elements.
 /// * `f` Parses the elements of the list.
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::separated_list1;
 /// use winnow::bytes::tag;
 ///
@@ -363,7 +364,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::multi::many_m_n;
 /// use winnow::bytes::tag;
 ///
@@ -440,7 +441,7 @@ where
 /// return an error, to prevent going into an infinite loop
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::multi::many0_count;
 /// use winnow::bytes::tag;
 ///
@@ -501,7 +502,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::many1_count;
 /// use winnow::bytes::tag;
 ///
@@ -557,7 +558,7 @@ where
 /// * `f` The parser to apply.
 /// * `count` How often to apply the parser.
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::count;
 /// use winnow::bytes::tag;
 ///
@@ -612,7 +613,7 @@ where
 /// * `f` The parser to apply.
 /// * `buf` The slice to fill
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::fill;
 /// use winnow::bytes::tag;
 ///
@@ -672,7 +673,7 @@ where
 /// return an error, to prevent going into an infinite loop
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::multi::fold_many0;
 /// use winnow::bytes::tag;
 ///
@@ -748,7 +749,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::fold_many1;
 /// use winnow::bytes::tag;
 ///
@@ -834,7 +835,7 @@ where
 /// to prevent going into an infinite loop.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::multi::fold_many_m_n;
 /// use winnow::bytes::tag;
 ///
@@ -913,12 +914,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Arguments
 /// * `f` The parser to apply.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, Needed, IResult, input::Streaming};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult, input::Streaming};
 /// use winnow::number::be_u16;
 /// use winnow::multi::length_data;
 /// use winnow::bytes::tag;
@@ -955,13 +956,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Arguments
 /// * `f` The parser to apply.
 /// * `g` The parser to apply on the subslice.
 /// ```rust
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult, input::Streaming};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult, input::Streaming};
 /// use winnow::number::be_u16;
 /// use winnow::multi::length_value;
 /// use winnow::bytes::tag;
@@ -1001,7 +1002,7 @@ where
 /// * `g` The parser to apply repeatedly.
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{ErrMode, error::{Error, ErrorKind}, Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::number::u8;
 /// use winnow::multi::length_count;
 /// use winnow::bytes::tag;

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -60,7 +60,7 @@ fn separated_list0_test() {
   let i_err_pos = &i[3..];
   assert_eq!(
     empty_sep(Streaming(i)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(i_err_pos),
       ErrorKind::SeparatedList
     )))
@@ -107,7 +107,7 @@ fn separated_list1_test() {
   assert_eq!(multi(Streaming(b)), Ok((Streaming(&b"ef"[..]), res2)));
   assert_eq!(
     multi(Streaming(c)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(c),
       ErrorKind::Tag
     )))
@@ -165,7 +165,7 @@ fn many0_test() {
   );
   assert_eq!(
     multi_empty(Streaming(&b"abcdef"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"abcdef"[..]),
       ErrorKind::Many0
     )))
@@ -190,7 +190,7 @@ fn many1_test() {
   assert_eq!(multi(Streaming(b)), Ok((Streaming(&b"efgh"[..]), res2)));
   assert_eq!(
     multi(Streaming(c)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(c),
       ErrorKind::Tag
     )))
@@ -219,7 +219,7 @@ fn many_till_test() {
   assert_eq!(multi(&b[..]), Ok((&b"abcd"[..], res_b)));
   assert_eq!(
     multi(&c[..]),
-    Err(ErrMode::Error(error_node_position!(
+    Err(ErrMode::Backtrack(error_node_position!(
       &c[..],
       ErrorKind::ManyTill,
       error_position!(&c[..], ErrorKind::Tag)
@@ -232,7 +232,7 @@ fn many_till_test() {
 fn infinite_many() {
   fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
     println!("input: {:?}", input);
-    Err(ErrMode::Error(error_position!(input, ErrorKind::Tag)))
+    Err(ErrMode::Backtrack(error_position!(input, ErrorKind::Tag)))
   }
 
   // should not go into an infinite loop
@@ -248,7 +248,7 @@ fn infinite_many() {
   let a = &b"abcdef"[..];
   assert_eq!(
     multi1(a),
-    Err(ErrMode::Error(error_position!(a, ErrorKind::Tag)))
+    Err(ErrMode::Backtrack(error_position!(a, ErrorKind::Tag)))
   );
 }
 
@@ -267,7 +267,7 @@ fn many_m_n_test() {
 
   assert_eq!(
     multi(Streaming(a)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"ef"[..]),
       ErrorKind::Tag
     )))
@@ -306,21 +306,21 @@ fn count_test() {
   );
   assert_eq!(
     cnt_2(Streaming(&b"xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     cnt_2(Streaming(&b"xxxabcabcdef"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxxabcabcdef"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     cnt_2(Streaming(&b"abcxxxabcdef"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxxabcdef"[..]),
       ErrorKind::Tag
     )))
@@ -412,14 +412,14 @@ fn length_count_test() {
   );
   assert_eq!(
     cnt(Streaming(&b"xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Digit
     )))
   );
   assert_eq!(
     cnt(Streaming(&b"2abcxxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -449,7 +449,7 @@ fn length_data_test() {
   );
   assert_eq!(
     take(Streaming(&b"xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Digit
     )))
@@ -472,14 +472,14 @@ fn length_value_test() {
   let i1 = [0, 5, 6];
   assert_eq!(
     length_value_1(Streaming(&i1)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b""[..]),
       ErrorKind::Complete
     )))
   );
   assert_eq!(
     length_value_2(Streaming(&i1)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b""[..]),
       ErrorKind::Complete
     )))
@@ -488,14 +488,14 @@ fn length_value_test() {
   let i2 = [1, 5, 6, 3];
   assert_eq!(
     length_value_1(Streaming(&i2)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&i2[1..2]),
       ErrorKind::Complete
     )))
   );
   assert_eq!(
     length_value_2(Streaming(&i2)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&i2[1..2]),
       ErrorKind::Complete
     )))
@@ -562,7 +562,7 @@ fn fold_many0_test() {
   );
   assert_eq!(
     multi_empty(Streaming(&b"abcdef"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"abcdef"[..]),
       ErrorKind::Many0
     )))
@@ -591,7 +591,7 @@ fn fold_many1_test() {
   assert_eq!(multi(Streaming(b)), Ok((Streaming(&b"efgh"[..]), res2)));
   assert_eq!(
     multi(Streaming(c)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(c),
       ErrorKind::Many1
     )))
@@ -621,7 +621,7 @@ fn fold_many_m_n_test() {
 
   assert_eq!(
     multi(Streaming(a)),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"ef"[..]),
       ErrorKind::Tag
     )))
@@ -671,7 +671,7 @@ fn many1_count_test() {
 
   assert_eq!(
     count1_nums(&b"hello"[..]),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       &b"hello"[..],
       ErrorKind::Many1Count
     )))

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -4,10 +4,10 @@ use crate::Parser;
 use crate::{
   bytes::tag,
   character::digit1 as digit,
-  error::{ErrorKind, ParseError},
+  error::{ErrMode, ErrorKind, Needed, ParseError},
   lib::std::str::{self, FromStr},
   number::{be_u16, be_u8},
-  {ErrMode, IResult, Needed},
+  IResult,
 };
 #[cfg(feature = "alloc")]
 use crate::{

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -6,7 +6,7 @@
 use crate::branch::alt;
 use crate::bytes::complete::tag;
 use crate::character::complete::{char, digit1, sign};
-use crate::combinator::{cut, map, opt};
+use crate::combinator::{cut_err, map, opt};
 use crate::error::ParseError;
 use crate::error::{make_error, ErrMode, ErrorKind};
 use crate::input::{AsBytes, AsChar, Compare, Input, Offset, SliceLen};
@@ -1516,7 +1516,7 @@ where
       opt(tuple((
         alt((char('e'), char('E'))),
         opt(alt((char('+'), char('-')))),
-        cut(digit1)
+        cut_err(digit1)
       )))
     ))
   .recognize().parse_next(input)
@@ -1640,7 +1640,7 @@ where
     .unwrap_or((i, false));
 
   let (i, exp) = if e {
-    cut(crate::character::complete::i32)(i)?
+    cut_err(crate::character::complete::i32)(i)?
   } else {
     (i2, 0)
   };

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -18,7 +18,7 @@ use crate::*;
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u8;
 ///
@@ -27,7 +27,7 @@ use crate::*;
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -44,7 +44,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u16;
 ///
@@ -53,7 +53,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -71,7 +71,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u24;
 ///
@@ -80,7 +80,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -98,7 +98,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u32;
 ///
@@ -107,7 +107,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -125,7 +125,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u64;
 ///
@@ -134,7 +134,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -152,7 +152,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_u128;
 ///
@@ -161,7 +161,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -184,7 +184,7 @@ where
 {
   let offset = input
     .offset_at(bound)
-    .map_err(|_err| Err::Error(make_error(input.clone(), ErrorKind::Eof)))?;
+    .map_err(|_err| ErrMode::Error(make_error(input.clone(), ErrorKind::Eof)))?;
   let (input, number) = input.next_slice(offset);
   let number = number.as_bytes();
 
@@ -207,7 +207,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i8;
 ///
@@ -216,7 +216,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -233,7 +233,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i16;
 ///
@@ -242,7 +242,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -260,7 +260,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i24;
 ///
@@ -269,7 +269,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -296,7 +296,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i32;
 ///
@@ -305,7 +305,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -323,7 +323,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i64;
 ///
@@ -332,7 +332,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -350,7 +350,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_i128;
 ///
@@ -359,7 +359,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -377,7 +377,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u8;
 ///
@@ -386,7 +386,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -403,7 +403,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u16;
 ///
@@ -412,7 +412,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -430,7 +430,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u24;
 ///
@@ -439,7 +439,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -457,7 +457,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u32;
 ///
@@ -466,7 +466,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -484,7 +484,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u64;
 ///
@@ -493,7 +493,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -511,7 +511,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_u128;
 ///
@@ -520,7 +520,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -543,7 +543,7 @@ where
 {
   let offset = input
     .offset_at(bound)
-    .map_err(|_err| Err::Error(make_error(input.clone(), ErrorKind::Eof)))?;
+    .map_err(|_err| ErrMode::Error(make_error(input.clone(), ErrorKind::Eof)))?;
   let (input, number) = input.next_slice(offset);
   let number = number.as_bytes();
 
@@ -559,7 +559,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i8;
 ///
@@ -568,7 +568,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -585,7 +585,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i16;
 ///
@@ -594,7 +594,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -612,7 +612,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i24;
 ///
@@ -621,7 +621,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -648,7 +648,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i32;
 ///
@@ -657,7 +657,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -675,7 +675,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i64;
 ///
@@ -684,7 +684,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -702,7 +702,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_i128;
 ///
@@ -711,7 +711,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -730,7 +730,7 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u8;
 ///
@@ -739,7 +739,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -751,7 +751,7 @@ where
 {
   input
     .next_token()
-    .ok_or_else(|| Err::Error(make_error(input, ErrorKind::Eof)))
+    .ok_or_else(|| ErrMode::Error(make_error(input, ErrorKind::Eof)))
 }
 
 /// Recognizes an unsigned 2 bytes integer
@@ -761,7 +761,7 @@ where
 /// *complete version*: returns an error if there is not enough input data
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u16;
 ///
@@ -770,14 +770,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u16 = |s| {
 ///   u16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -804,7 +804,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u24 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u24;
 ///
@@ -813,14 +813,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u24 = |s| {
 ///   u24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -847,7 +847,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u32 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u32;
 ///
@@ -856,14 +856,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u32 = |s| {
 ///   u32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -890,7 +890,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u64 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u64;
 ///
@@ -899,14 +899,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u64 = |s| {
 ///   u64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -933,7 +933,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u128 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::u128;
 ///
@@ -942,14 +942,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u128 = |s| {
 ///   u128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -975,7 +975,7 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i8;
 ///
@@ -984,7 +984,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1003,7 +1003,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i16 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i16;
 ///
@@ -1012,14 +1012,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i16 = |s| {
 ///   i16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1046,7 +1046,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i24 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i24;
 ///
@@ -1055,14 +1055,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i24 = |s| {
 ///   i24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1089,7 +1089,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i32 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i32;
 ///
@@ -1098,14 +1098,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i32 = |s| {
 ///   i32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1132,7 +1132,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i64 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i64;
 ///
@@ -1141,14 +1141,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i64 = |s| {
 ///   i64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1175,7 +1175,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i128 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::i128;
 ///
@@ -1184,14 +1184,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i128 = |s| {
 ///   i128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1216,7 +1216,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_f32;
 ///
@@ -1225,7 +1225,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1246,7 +1246,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::be_f64;
 ///
@@ -1255,7 +1255,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1276,7 +1276,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_f32;
 ///
@@ -1285,7 +1285,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1306,7 +1306,7 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::le_f64;
 ///
@@ -1315,7 +1315,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1338,7 +1338,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f32 float.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::f32;
 ///
@@ -1347,14 +1347,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f32 = |s| {
 ///   f32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1381,7 +1381,7 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f64 float.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::f64;
 ///
@@ -1390,14 +1390,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f64 = |s| {
 ///   f64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1422,7 +1422,7 @@ where
 ///
 /// *Complete version*: Will parse until the end of input if it has less than 8 bytes.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::hex_u32;
 ///
@@ -1432,7 +1432,7 @@ where
 ///
 /// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
 /// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(&b"ggg"[..]), Err(ErrMode::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 #[inline]
 ///
@@ -1456,7 +1456,7 @@ where
     .unwrap_or_else(|_err| input.input_len());
   let offset = invalid_offset.min(max_offset);
   if offset == 0 {
-    return Err(Err::Error(E::from_error_kind(input, ErrorKind::IsA)));
+    return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::IsA)));
   }
   let (remaining, parsed) = input.next_slice(offset);
 
@@ -1479,7 +1479,7 @@ where
 /// *Complete version*: Can parse until the end of input.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::recognize_float;
 ///
@@ -1490,7 +1490,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
 /// assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Char))));
 /// ```
 #[rustfmt::skip]
 ///
@@ -1540,22 +1540,24 @@ where
   alt((
     |i: T| {
       recognize_float::<_, E>(i.clone()).map_err(|e| match e {
-        crate::Err::Error(_) => crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)),
-        crate::Err::Failure(_) => crate::Err::Failure(E::from_error_kind(i, ErrorKind::Float)),
-        crate::Err::Incomplete(needed) => crate::Err::Incomplete(needed),
+        crate::ErrMode::Error(_) => crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)),
+        crate::ErrMode::Failure(_) => {
+          crate::ErrMode::Failure(E::from_error_kind(i, ErrorKind::Float))
+        }
+        crate::ErrMode::Incomplete(needed) => crate::ErrMode::Incomplete(needed),
       })
     },
     |i: T| {
       crate::bytes::complete::tag_no_case::<_, _, E>("nan")(i.clone())
-        .map_err(|_err| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::complete::tag_no_case::<_, _, E>("inf")(i.clone())
-        .map_err(|_err| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::complete::tag_no_case::<_, _, E>("infinity")(i.clone())
-        .map_err(|_err| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))(input)
 }
@@ -1619,7 +1621,7 @@ where
   };
 
   if integer.slice_len() == 0 && fraction.slice_len() == 0 {
-    return Err(Err::Error(E::from_error_kind(input, ErrorKind::Float)));
+    return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Float)));
   }
 
   let i2 = i.clone();
@@ -1644,7 +1646,7 @@ use crate::input::ParseTo;
 ///
 /// *Complete version*: Can parse until the end of input.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::float;
 ///
@@ -1655,7 +1657,7 @@ use crate::input::ParseTo;
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f32`][crate::character::f32]
@@ -1672,7 +1674,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::Err::Error(E::from_error_kind(
+    None => Err(crate::ErrMode::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -1683,7 +1685,7 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::double;
 ///
@@ -1694,7 +1696,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f64`][crate::character::f64]
@@ -1711,7 +1713,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::Err::Error(E::from_error_kind(
+    None => Err(crate::ErrMode::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -1723,7 +1725,7 @@ mod tests {
   use super::*;
   use crate::error::Error;
   use crate::error::ErrorKind;
-  use crate::Err;
+  use crate::ErrMode;
   use proptest::prelude::*;
 
   macro_rules! assert_parse(
@@ -2019,7 +2021,7 @@ mod tests {
   fn hex_u32_tests() {
     assert_parse!(
       hex_u32(&b";"[..]),
-      Err(Err::Error(error_position!(&b";"[..], ErrorKind::IsA)))
+      Err(ErrMode::Error(error_position!(&b";"[..], ErrorKind::IsA)))
     );
     assert_parse!(hex_u32(&b"ff;"[..]), Ok((&b";"[..], 255)));
     assert_parse!(hex_u32(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
@@ -2076,7 +2078,7 @@ mod tests {
     let remaining_exponent = "-1.234E-";
     assert_parse!(
       recognize_float(remaining_exponent),
-      Err(Err::Failure(Error::new("", ErrorKind::Digit)))
+      Err(ErrMode::Failure(Error::new("", ErrorKind::Digit)))
     );
 
     let (_i, nan) = float::<_, ()>("NaN").unwrap();
@@ -2177,11 +2179,11 @@ mod tests {
       Err(e) => Err(e),
       Ok((i, s)) => {
         if s.is_empty() {
-          return Err(Err::Error(()));
+          return Err(ErrMode::Error(()));
         }
         match s.parse_to() {
           Some(n) => Ok((i, n)),
-          None => Err(Err::Error(())),
+          None => Err(ErrMode::Error(())),
         }
       }
     }

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -8,7 +8,7 @@ use crate::bytes::complete::tag;
 use crate::character::complete::{char, digit1, sign};
 use crate::combinator::{cut, map, opt};
 use crate::error::ParseError;
-use crate::error::{make_error, ErrorKind};
+use crate::error::{make_error, ErrMode, ErrorKind};
 use crate::input::{AsBytes, AsChar, Compare, Input, Offset, SliceLen};
 use crate::lib::std::ops::{Add, Shl};
 use crate::sequence::{pair, tuple};
@@ -18,8 +18,8 @@ use crate::*;
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_u8;
 ///
 /// let parser = |s| {
@@ -44,8 +44,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_u16;
 ///
 /// let parser = |s| {
@@ -71,8 +71,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_u24;
 ///
 /// let parser = |s| {
@@ -98,8 +98,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_u32;
 ///
 /// let parser = |s| {
@@ -125,8 +125,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_u64;
 ///
 /// let parser = |s| {
@@ -152,8 +152,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_u128;
 ///
 /// let parser = |s| {
@@ -207,8 +207,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_i8;
 ///
 /// let parser = |s| {
@@ -233,8 +233,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_i16;
 ///
 /// let parser = |s| {
@@ -260,8 +260,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_i24;
 ///
 /// let parser = |s| {
@@ -296,8 +296,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_i32;
 ///
 /// let parser = |s| {
@@ -323,8 +323,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_i64;
 ///
 /// let parser = |s| {
@@ -350,8 +350,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_i128;
 ///
 /// let parser = |s| {
@@ -377,8 +377,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_u8;
 ///
 /// let parser = |s| {
@@ -403,8 +403,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_u16;
 ///
 /// let parser = |s| {
@@ -430,8 +430,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_u24;
 ///
 /// let parser = |s| {
@@ -457,8 +457,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_u32;
 ///
 /// let parser = |s| {
@@ -484,8 +484,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_u64;
 ///
 /// let parser = |s| {
@@ -511,8 +511,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_u128;
 ///
 /// let parser = |s| {
@@ -559,8 +559,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_i8;
 ///
 /// let parser = |s| {
@@ -585,8 +585,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_i16;
 ///
 /// let parser = |s| {
@@ -612,8 +612,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_i24;
 ///
 /// let parser = |s| {
@@ -648,8 +648,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_i32;
 ///
 /// let parser = |s| {
@@ -675,8 +675,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_i64;
 ///
 /// let parser = |s| {
@@ -702,8 +702,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_i128;
 ///
 /// let parser = |s| {
@@ -730,8 +730,8 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::u8;
 ///
 /// let parser = |s| {
@@ -761,8 +761,8 @@ where
 /// *complete version*: returns an error if there is not enough input data
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::u16;
 ///
 /// let be_u16 = |s| {
@@ -804,8 +804,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u24 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::u24;
 ///
 /// let be_u24 = |s| {
@@ -847,8 +847,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u32 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::u32;
 ///
 /// let be_u32 = |s| {
@@ -890,8 +890,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u64 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::u64;
 ///
 /// let be_u64 = |s| {
@@ -933,8 +933,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u128 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::u128;
 ///
 /// let be_u128 = |s| {
@@ -975,8 +975,8 @@ where
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::i8;
 ///
 /// let parser = |s| {
@@ -1003,8 +1003,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i16 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::i16;
 ///
 /// let be_i16 = |s| {
@@ -1046,8 +1046,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i24 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::i24;
 ///
 /// let be_i24 = |s| {
@@ -1089,8 +1089,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i32 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::i32;
 ///
 /// let be_i32 = |s| {
@@ -1132,8 +1132,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i64 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::i64;
 ///
 /// let be_i64 = |s| {
@@ -1175,8 +1175,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i128 integer.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::i128;
 ///
 /// let be_i128 = |s| {
@@ -1216,8 +1216,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_f32;
 ///
 /// let parser = |s| {
@@ -1246,8 +1246,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::be_f64;
 ///
 /// let parser = |s| {
@@ -1276,8 +1276,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_f32;
 ///
 /// let parser = |s| {
@@ -1306,8 +1306,8 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::le_f64;
 ///
 /// let parser = |s| {
@@ -1338,8 +1338,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f32 float.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::f32;
 ///
 /// let be_f32 = |s| {
@@ -1381,8 +1381,8 @@ where
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f64 float.
 /// *complete version*: returns an error if there is not enough input data
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::f64;
 ///
 /// let be_f64 = |s| {
@@ -1422,8 +1422,8 @@ where
 ///
 /// *Complete version*: Will parse until the end of input if it has less than 8 bytes.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::hex_u32;
 ///
 /// let parser = |s| {
@@ -1479,8 +1479,8 @@ where
 /// *Complete version*: Can parse until the end of input.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::recognize_float;
 ///
 /// let parser = |s| {
@@ -1540,24 +1540,26 @@ where
   alt((
     |i: T| {
       recognize_float::<_, E>(i.clone()).map_err(|e| match e {
-        crate::ErrMode::Error(_) => crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)),
-        crate::ErrMode::Failure(_) => {
-          crate::ErrMode::Failure(E::from_error_kind(i, ErrorKind::Float))
+        crate::error::ErrMode::Error(_) => {
+          crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float))
         }
-        crate::ErrMode::Incomplete(needed) => crate::ErrMode::Incomplete(needed),
+        crate::error::ErrMode::Failure(_) => {
+          crate::error::ErrMode::Failure(E::from_error_kind(i, ErrorKind::Float))
+        }
+        crate::error::ErrMode::Incomplete(needed) => crate::error::ErrMode::Incomplete(needed),
       })
     },
     |i: T| {
       crate::bytes::complete::tag_no_case::<_, _, E>("nan")(i.clone())
-        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::complete::tag_no_case::<_, _, E>("inf")(i.clone())
-        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::complete::tag_no_case::<_, _, E>("infinity")(i.clone())
-        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))(input)
 }
@@ -1646,8 +1648,8 @@ use crate::input::ParseTo;
 ///
 /// *Complete version*: Can parse until the end of input.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::float;
 ///
 /// let parser = |s| {
@@ -1674,7 +1676,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::ErrMode::Error(E::from_error_kind(
+    None => Err(crate::error::ErrMode::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -1685,8 +1687,8 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::double;
 ///
 /// let parser = |s| {
@@ -1713,7 +1715,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::ErrMode::Error(E::from_error_kind(
+    None => Err(crate::error::ErrMode::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -1723,9 +1725,9 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::error::ErrMode;
   use crate::error::Error;
   use crate::error::ErrorKind;
-  use crate::ErrMode;
   use proptest::prelude::*;
 
   macro_rules! assert_parse(

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -27,7 +27,7 @@ use crate::*;
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -53,7 +53,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -80,7 +80,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -107,7 +107,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -134,7 +134,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -161,7 +161,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -184,7 +184,7 @@ where
 {
   let offset = input
     .offset_at(bound)
-    .map_err(|_err| ErrMode::Error(make_error(input.clone(), ErrorKind::Eof)))?;
+    .map_err(|_err| ErrMode::Backtrack(make_error(input.clone(), ErrorKind::Eof)))?;
   let (input, number) = input.next_slice(offset);
   let number = number.as_bytes();
 
@@ -216,7 +216,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -242,7 +242,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -269,7 +269,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -305,7 +305,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -332,7 +332,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -359,7 +359,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -386,7 +386,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -412,7 +412,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -439,7 +439,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -466,7 +466,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -493,7 +493,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -520,7 +520,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -543,7 +543,7 @@ where
 {
   let offset = input
     .offset_at(bound)
-    .map_err(|_err| ErrMode::Error(make_error(input.clone(), ErrorKind::Eof)))?;
+    .map_err(|_err| ErrMode::Backtrack(make_error(input.clone(), ErrorKind::Eof)))?;
   let (input, number) = input.next_slice(offset);
   let number = number.as_bytes();
 
@@ -568,7 +568,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -594,7 +594,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -621,7 +621,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -657,7 +657,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -684,7 +684,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -711,7 +711,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -739,7 +739,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -751,7 +751,7 @@ where
 {
   input
     .next_token()
-    .ok_or_else(|| ErrMode::Error(make_error(input, ErrorKind::Eof)))
+    .ok_or_else(|| ErrMode::Backtrack(make_error(input, ErrorKind::Eof)))
 }
 
 /// Recognizes an unsigned 2 bytes integer
@@ -770,14 +770,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u16 = |s| {
 ///   u16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -813,14 +813,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u24 = |s| {
 ///   u24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -856,14 +856,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u32 = |s| {
 ///   u32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -899,14 +899,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u64 = |s| {
 ///   u64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -942,14 +942,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u128 = |s| {
 ///   u128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -984,7 +984,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1012,14 +1012,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i16 = |s| {
 ///   i16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1055,14 +1055,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i24 = |s| {
 ///   i24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1098,14 +1098,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i32 = |s| {
 ///   i32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1141,14 +1141,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i64 = |s| {
 ///   i64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1184,14 +1184,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i128 = |s| {
 ///   i128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1225,7 +1225,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1255,7 +1255,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1285,7 +1285,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1315,7 +1315,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1347,14 +1347,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f32 = |s| {
 ///   f32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1390,14 +1390,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f64 = |s| {
 ///   f64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 #[inline]
 ///
@@ -1432,7 +1432,7 @@ where
 ///
 /// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
 /// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser(&b"ggg"[..]), Err(ErrMode::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(&b"ggg"[..]), Err(ErrMode::Backtrack(Error::new(&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 #[inline]
 ///
@@ -1456,7 +1456,10 @@ where
     .unwrap_or_else(|_err| input.input_len());
   let offset = invalid_offset.min(max_offset);
   if offset == 0 {
-    return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::IsA)));
+    return Err(ErrMode::Backtrack(E::from_error_kind(
+      input,
+      ErrorKind::IsA,
+    )));
   }
   let (remaining, parsed) = input.next_slice(offset);
 
@@ -1490,7 +1493,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
 /// assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Char))));
 /// ```
 #[rustfmt::skip]
 ///
@@ -1540,26 +1543,26 @@ where
   alt((
     |i: T| {
       recognize_float::<_, E>(i.clone()).map_err(|e| match e {
-        crate::error::ErrMode::Error(_) => {
-          crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float))
+        crate::error::ErrMode::Backtrack(_) => {
+          crate::error::ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Float))
         }
-        crate::error::ErrMode::Failure(_) => {
-          crate::error::ErrMode::Failure(E::from_error_kind(i, ErrorKind::Float))
+        crate::error::ErrMode::Cut(_) => {
+          crate::error::ErrMode::Cut(E::from_error_kind(i, ErrorKind::Float))
         }
         crate::error::ErrMode::Incomplete(needed) => crate::error::ErrMode::Incomplete(needed),
       })
     },
     |i: T| {
       crate::bytes::complete::tag_no_case::<_, _, E>("nan")(i.clone())
-        .map_err(|_err| crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::error::ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::complete::tag_no_case::<_, _, E>("inf")(i.clone())
-        .map_err(|_err| crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::error::ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::complete::tag_no_case::<_, _, E>("infinity")(i.clone())
-        .map_err(|_err| crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::error::ErrMode::Backtrack(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))(input)
 }
@@ -1623,7 +1626,10 @@ where
   };
 
   if integer.slice_len() == 0 && fraction.slice_len() == 0 {
-    return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Float)));
+    return Err(ErrMode::Backtrack(E::from_error_kind(
+      input,
+      ErrorKind::Float,
+    )));
   }
 
   let i2 = i.clone();
@@ -1659,7 +1665,7 @@ use crate::input::ParseTo;
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f32`][crate::character::f32]
@@ -1676,7 +1682,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::error::ErrMode::Error(E::from_error_kind(
+    None => Err(crate::error::ErrMode::Backtrack(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -1698,7 +1704,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f64`][crate::character::f64]
@@ -1715,7 +1721,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::error::ErrMode::Error(E::from_error_kind(
+    None => Err(crate::error::ErrMode::Backtrack(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -2023,7 +2029,10 @@ mod tests {
   fn hex_u32_tests() {
     assert_parse!(
       hex_u32(&b";"[..]),
-      Err(ErrMode::Error(error_position!(&b";"[..], ErrorKind::IsA)))
+      Err(ErrMode::Backtrack(error_position!(
+        &b";"[..],
+        ErrorKind::IsA
+      )))
     );
     assert_parse!(hex_u32(&b"ff;"[..]), Ok((&b";"[..], 255)));
     assert_parse!(hex_u32(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
@@ -2080,7 +2089,7 @@ mod tests {
     let remaining_exponent = "-1.234E-";
     assert_parse!(
       recognize_float(remaining_exponent),
-      Err(ErrMode::Failure(Error::new("", ErrorKind::Digit)))
+      Err(ErrMode::Cut(Error::new("", ErrorKind::Digit)))
     );
 
     let (_i, nan) = float::<_, ()>("NaN").unwrap();
@@ -2181,11 +2190,11 @@ mod tests {
       Err(e) => Err(e),
       Ok((i, s)) => {
         if s.is_empty() {
-          return Err(ErrMode::Error(()));
+          return Err(ErrMode::Backtrack(()));
         }
         match s.parse_to() {
           Some(n) => Ok((i, n)),
-          None => Err(ErrMode::Error(())),
+          None => Err(ErrMode::Backtrack(())),
         }
       }
     }

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -26,13 +26,13 @@ pub enum Endianness {
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u8;
 ///
 /// let parser = |s| {
@@ -44,7 +44,7 @@ pub enum Endianness {
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u8;
 ///
@@ -72,13 +72,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u16;
 ///
 /// let parser = |s| {
@@ -90,7 +90,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u16;
 ///
@@ -119,13 +119,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u24;
 ///
 /// let parser = |s| {
@@ -137,7 +137,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u24;
 ///
@@ -166,13 +166,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u32;
 ///
 /// let parser = |s| {
@@ -184,7 +184,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u32;
 ///
@@ -213,13 +213,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u64;
 ///
 /// let parser = |s| {
@@ -231,7 +231,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u64;
 ///
@@ -260,13 +260,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u128;
 ///
 /// let parser = |s| {
@@ -278,7 +278,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u128;
 ///
@@ -307,13 +307,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i8;
 ///
 /// let parser = |s| {
@@ -325,7 +325,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i8;
 ///
@@ -351,13 +351,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i16;
 ///
 /// let parser = |s| {
@@ -369,7 +369,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i16;
 ///
@@ -396,13 +396,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i24;
 ///
 /// let parser = |s| {
@@ -414,7 +414,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i24;
 ///
@@ -441,13 +441,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i32;
 ///
 /// let parser = |s| {
@@ -459,7 +459,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i32;
 ///
@@ -486,13 +486,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i64;
 ///
 /// let parser = |s| {
@@ -504,7 +504,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i64;
 ///
@@ -531,13 +531,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i128;
 ///
 /// let parser = |s| {
@@ -549,7 +549,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i128;
 ///
@@ -576,13 +576,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u8;
 ///
 /// let parser = |s| {
@@ -594,7 +594,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u8;
 ///
@@ -620,13 +620,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u16;
 ///
 /// let parser = |s| {
@@ -638,7 +638,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u16;
 ///
@@ -667,13 +667,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u24;
 ///
 /// let parser = |s| {
@@ -685,7 +685,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u24;
 ///
@@ -714,13 +714,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u32;
 ///
 /// let parser = |s| {
@@ -732,7 +732,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u32;
 ///
@@ -761,13 +761,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u64;
 ///
 /// let parser = |s| {
@@ -779,7 +779,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u64;
 ///
@@ -808,13 +808,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u128;
 ///
 /// let parser = |s| {
@@ -826,7 +826,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u128;
 ///
@@ -855,13 +855,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i8;
 ///
 /// let parser = |s| {
@@ -873,7 +873,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i8;
 ///
@@ -899,13 +899,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i16;
 ///
 /// let parser = |s| {
@@ -917,7 +917,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i16;
 ///
@@ -946,13 +946,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i24;
 ///
 /// let parser = |s| {
@@ -964,7 +964,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i24;
 ///
@@ -993,13 +993,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i32;
 ///
 /// let parser = |s| {
@@ -1011,7 +1011,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i32;
 ///
@@ -1040,13 +1040,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i64;
 ///
 /// let parser = |s| {
@@ -1058,7 +1058,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i64;
 ///
@@ -1087,13 +1087,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i128;
 ///
 /// let parser = |s| {
@@ -1105,7 +1105,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i128;
 ///
@@ -1136,13 +1136,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::u8;
 ///
 /// let parser = |s| {
@@ -1154,8 +1154,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u8;
 ///
@@ -1186,13 +1186,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::u16;
 ///
 /// let be_u16 = |s| {
@@ -1211,8 +1211,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u16;
 ///
@@ -1253,13 +1253,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::u24;
 ///
 /// let be_u24 = |s| {
@@ -1278,8 +1278,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u24;
 ///
@@ -1320,13 +1320,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::u32;
 ///
 /// let be_u32 = |s| {
@@ -1345,8 +1345,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u32;
 ///
@@ -1387,13 +1387,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::u64;
 ///
 /// let be_u64 = |s| {
@@ -1412,8 +1412,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u64;
 ///
@@ -1454,13 +1454,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::u128;
 ///
 /// let be_u128 = |s| {
@@ -1479,8 +1479,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u128;
 ///
@@ -1520,13 +1520,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::i8;
 ///
 /// let parser = |s| {
@@ -1538,8 +1538,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i8;
 ///
@@ -1570,13 +1570,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::i16;
 ///
 /// let be_i16 = |s| {
@@ -1595,8 +1595,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i16;
 ///
@@ -1637,13 +1637,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::i24;
 ///
 /// let be_i24 = |s| {
@@ -1662,8 +1662,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i24;
 ///
@@ -1704,13 +1704,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::i32;
 ///
 /// let be_i32 = |s| {
@@ -1729,8 +1729,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i32;
 ///
@@ -1771,13 +1771,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::i64;
 ///
 /// let be_i64 = |s| {
@@ -1796,8 +1796,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i64;
 ///
@@ -1838,13 +1838,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::i128;
 ///
 /// let be_i128 = |s| {
@@ -1863,8 +1863,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i128;
 ///
@@ -1902,13 +1902,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_f32;
 ///
 /// let parser = |s| {
@@ -1920,7 +1920,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_f32;
 ///
@@ -1949,13 +1949,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::be_f64;
 ///
 /// let parser = |s| {
@@ -1967,7 +1967,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_f64;
 ///
@@ -1996,13 +1996,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_f32;
 ///
 /// let parser = |s| {
@@ -2014,7 +2014,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_f32;
 ///
@@ -2043,13 +2043,13 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::le_f64;
 ///
 /// let parser = |s| {
@@ -2061,7 +2061,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_f64;
 ///
@@ -2093,13 +2093,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::f32;
 ///
 /// let be_f32 = |s| {
@@ -2118,8 +2118,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::f32;
 ///
@@ -2160,13 +2160,13 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::f64;
 ///
 /// let be_f64 = |s| {
@@ -2185,8 +2185,8 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::f64;
 ///
@@ -2224,13 +2224,13 @@ where
 ///
 /// *Complete version*: Will parse until the end of input if it has less than 8 bytes.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::hex_u32;
 ///
 /// let parser = |s| {
@@ -2243,7 +2243,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::hex_u32;
 ///

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -40,7 +40,7 @@ pub enum Endianness {
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -86,7 +86,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -133,7 +133,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -180,7 +180,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -227,7 +227,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -274,7 +274,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -321,7 +321,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -365,7 +365,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -410,7 +410,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -455,7 +455,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -500,7 +500,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -545,7 +545,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -590,7 +590,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -634,7 +634,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -681,7 +681,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -728,7 +728,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -775,7 +775,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -822,7 +822,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -869,7 +869,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -913,7 +913,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -960,7 +960,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1007,7 +1007,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1054,7 +1054,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1101,7 +1101,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1150,7 +1150,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1200,14 +1200,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u16 = |s| {
 ///   u16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1267,14 +1267,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u24 = |s| {
 ///   u24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1334,14 +1334,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u32 = |s| {
 ///   u32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1401,14 +1401,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u64 = |s| {
 ///   u64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1468,14 +1468,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u128 = |s| {
 ///   u128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1534,7 +1534,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1584,14 +1584,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i16 = |s| {
 ///   i16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1651,14 +1651,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i24 = |s| {
 ///   i24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1718,14 +1718,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i32 = |s| {
 ///   i32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1785,14 +1785,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i64 = |s| {
 ///   i64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1852,14 +1852,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i128 = |s| {
 ///   i128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1916,7 +1916,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -1963,7 +1963,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -2010,7 +2010,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -2057,7 +2057,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -2107,14 +2107,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f32 = |s| {
 ///   f32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -2174,14 +2174,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f64 = |s| {
 ///   f64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
@@ -2239,7 +2239,7 @@ where
 ///
 /// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
 /// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser(&b"ggg"[..]), Err(ErrMode::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(&b"ggg"[..]), Err(ErrMode::Backtrack(Error::new(&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 ///
 /// ```rust
@@ -2253,7 +2253,7 @@ where
 ///
 /// assert_eq!(parser(Streaming(&b"01AE;"[..])), Ok((Streaming(&b";"[..]), 0x01AE)));
 /// assert_eq!(parser(Streaming(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Streaming(&b"ggg"[..])), Err(ErrMode::Error(Error::new(Streaming(&b"ggg"[..]), ErrorKind::IsA))));
+/// assert_eq!(parser(Streaming(&b"ggg"[..])), Err(ErrMode::Backtrack(Error::new(Streaming(&b"ggg"[..]), ErrorKind::IsA))));
 /// ```
 #[inline(always)]
 pub fn hex_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -26,12 +26,12 @@ pub enum Endianness {
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u8;
 ///
@@ -40,11 +40,11 @@ pub enum Endianness {
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u8;
 ///
@@ -53,7 +53,7 @@ pub enum Endianness {
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn be_u8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u8, E>
@@ -72,12 +72,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u16;
 ///
@@ -86,11 +86,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u16;
 ///
@@ -99,7 +99,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn be_u16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u16, E>
@@ -119,12 +119,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u24;
 ///
@@ -133,11 +133,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u24;
 ///
@@ -146,7 +146,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x000102)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn be_u24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
@@ -166,12 +166,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u32;
 ///
@@ -180,11 +180,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u32;
 ///
@@ -193,7 +193,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn be_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
@@ -213,12 +213,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u64;
 ///
@@ -227,11 +227,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u64;
 ///
@@ -240,7 +240,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001020304050607)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn be_u64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u64, E>
@@ -260,12 +260,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_u128;
 ///
@@ -274,11 +274,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_u128;
 ///
@@ -287,7 +287,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn be_u128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u128, E>
@@ -307,12 +307,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i8;
 ///
@@ -321,18 +321,18 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i8;
 ///
 /// let parser = be_i8::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn be_i8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i8, E>
@@ -351,12 +351,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i16;
 ///
@@ -365,18 +365,18 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i16;
 ///
 /// let parser = be_i16::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001)));
-/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn be_i16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i16, E>
@@ -396,12 +396,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i24;
 ///
@@ -410,18 +410,18 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i24;
 ///
 /// let parser = be_i24::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x000102)));
-/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn be_i24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
@@ -441,12 +441,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i32;
 ///
@@ -455,18 +455,18 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i32;
 ///
 /// let parser = be_i32::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203)));
-/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(4))));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
 pub fn be_i32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
@@ -486,12 +486,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i64;
 ///
@@ -500,18 +500,18 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i64;
 ///
 /// let parser = be_i64::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0001020304050607)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn be_i64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i64, E>
@@ -531,12 +531,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_i128;
 ///
@@ -545,18 +545,18 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_i128;
 ///
 /// let parser = be_i128::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn be_i128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i128, E>
@@ -576,12 +576,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u8;
 ///
@@ -590,18 +590,18 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u8;
 ///
 /// let parser = le_u8::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_u8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u8, E>
@@ -620,12 +620,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u16;
 ///
@@ -634,11 +634,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u16;
 ///
@@ -647,7 +647,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_u16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u16, E>
@@ -667,12 +667,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u24;
 ///
@@ -681,11 +681,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u24;
 ///
@@ -694,7 +694,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x020100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn le_u24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
@@ -714,12 +714,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u32;
 ///
@@ -728,11 +728,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u32;
 ///
@@ -741,7 +741,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x03020100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn le_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>
@@ -761,12 +761,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u64;
 ///
@@ -775,11 +775,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u64;
 ///
@@ -788,7 +788,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0706050403020100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn le_u64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u64, E>
@@ -808,12 +808,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_u128;
 ///
@@ -822,11 +822,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_u128;
 ///
@@ -835,7 +835,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn le_u128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u128, E>
@@ -855,12 +855,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i8;
 ///
@@ -869,18 +869,18 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i8;
 ///
 /// let parser = le_i8::<_, Error<_>, true>;
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_i8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i8, E>
@@ -899,12 +899,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i16;
 ///
@@ -913,11 +913,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i16;
 ///
@@ -926,7 +926,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_i16<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i16, E>
@@ -946,12 +946,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i24;
 ///
@@ -960,11 +960,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i24;
 ///
@@ -973,7 +973,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x020100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn le_i24<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
@@ -993,12 +993,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i32;
 ///
@@ -1007,11 +1007,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i32;
 ///
@@ -1020,7 +1020,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x03020100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn le_i32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i32, E>
@@ -1040,12 +1040,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i64;
 ///
@@ -1054,11 +1054,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i64;
 ///
@@ -1067,7 +1067,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x0706050403020100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn le_i64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i64, E>
@@ -1087,12 +1087,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_i128;
 ///
@@ -1101,11 +1101,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_i128;
 ///
@@ -1114,7 +1114,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Streaming(&b"abcd"[..]), 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn le_i128<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i128, E>
@@ -1136,12 +1136,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u8;
 ///
@@ -1150,11 +1150,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u8;
@@ -1164,7 +1164,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"\x03abcefg"[..]), 0x00)));
-/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn u8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u8, E>
@@ -1186,12 +1186,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u16;
 ///
@@ -1200,18 +1200,18 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u16 = |s| {
 ///   u16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u16;
@@ -1221,14 +1221,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0003)));
-/// assert_eq!(be_u16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(be_u16(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_u16 = |s| {
 ///   u16::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0300)));
-/// assert_eq!(le_u16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(le_u16(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn u16<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1253,12 +1253,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u24;
 ///
@@ -1267,18 +1267,18 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u24 = |s| {
 ///   u24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u24;
@@ -1288,14 +1288,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x000305)));
-/// assert_eq!(be_u24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(be_u24(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_u24 = |s| {
 ///   u24::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x050300)));
-/// assert_eq!(le_u24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(le_u24(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn u24<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1320,12 +1320,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u32;
 ///
@@ -1334,18 +1334,18 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u32 = |s| {
 ///   u32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u32;
@@ -1355,14 +1355,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00030507)));
-/// assert_eq!(be_u32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(be_u32(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_u32 = |s| {
 ///   u32::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07050300)));
-/// assert_eq!(le_u32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(le_u32(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn u32<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1387,12 +1387,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u64;
 ///
@@ -1401,18 +1401,18 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u64 = |s| {
 ///   u64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u64;
@@ -1422,14 +1422,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0001020304050607)));
-/// assert_eq!(be_u64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(be_u64(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_u64 = |s| {
 ///   u64::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0706050403020100)));
-/// assert_eq!(le_u64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(le_u64(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn u64<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1454,12 +1454,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::u128;
 ///
@@ -1468,18 +1468,18 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_u128 = |s| {
 ///   u128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::u128;
@@ -1489,14 +1489,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(be_u128(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_u128 = |s| {
 ///   u128::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(le_u128(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn u128<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1520,12 +1520,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i8;
 ///
@@ -1534,11 +1534,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error(Error::new(&[][..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&[][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i8;
@@ -1548,7 +1548,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"\x03abcefg"[..]), 0x00)));
-/// assert_eq!(parser(Streaming(&b""[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn i8<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, i8, E>
@@ -1570,12 +1570,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i16;
 ///
@@ -1584,18 +1584,18 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i16 = |s| {
 ///   i16(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i16;
@@ -1605,14 +1605,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0003)));
-/// assert_eq!(be_i16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(be_i16(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_i16 = |s| {
 ///   i16::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(Streaming(&b"\x00\x03abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0300)));
-/// assert_eq!(le_i16(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(le_i16(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn i16<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1637,12 +1637,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i24;
 ///
@@ -1651,18 +1651,18 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i24 = |s| {
 ///   i24(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i24;
@@ -1672,14 +1672,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x000305)));
-/// assert_eq!(be_i24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(be_i24(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_i24 = |s| {
 ///   i24::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(Streaming(&b"\x00\x03\x05abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x050300)));
-/// assert_eq!(le_i24(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(le_i24(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn i24<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1704,12 +1704,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i32;
 ///
@@ -1718,18 +1718,18 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i32 = |s| {
 ///   i32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i32;
@@ -1739,14 +1739,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00030507)));
-/// assert_eq!(be_i32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(be_i32(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_i32 = |s| {
 ///   i32::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(Streaming(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07050300)));
-/// assert_eq!(le_i32(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(le_i32(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn i32<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1771,12 +1771,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i64;
 ///
@@ -1785,18 +1785,18 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i64 = |s| {
 ///   i64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i64;
@@ -1806,14 +1806,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0001020304050607)));
-/// assert_eq!(be_i64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(be_i64(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_i64 = |s| {
 ///   i64::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x0706050403020100)));
-/// assert_eq!(le_i64(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(le_i64(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn i64<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1838,12 +1838,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::i128;
 ///
@@ -1852,18 +1852,18 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 ///
 /// let le_i128 = |s| {
 ///   i128(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(ErrMode::Error(Error::new(&[0x01][..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::i128;
@@ -1873,14 +1873,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(be_i128(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_i128 = |s| {
 ///   i128::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(Streaming(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Streaming(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(Streaming(&b"\x01"[..])), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(le_i128(Streaming(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn i128<I, E: ParseError<I>, const STREAMING: bool>(
@@ -1902,12 +1902,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_f32;
 ///
@@ -1916,11 +1916,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_f32;
 ///
@@ -1929,7 +1929,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&[0x40, 0x29, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 2.640625)));
-/// assert_eq!(parser(Streaming(&[0x01][..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Streaming(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn be_f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f32, E>
@@ -1949,12 +1949,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::be_f64;
 ///
@@ -1963,11 +1963,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::be_f64;
 ///
@@ -1976,7 +1976,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 12.5)));
-/// assert_eq!(parser(Streaming(&[0x01][..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Streaming(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn be_f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f64, E>
@@ -1996,12 +1996,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_f32;
 ///
@@ -2010,11 +2010,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_f32;
 ///
@@ -2023,7 +2023,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Streaming(&b""[..]), 12.5)));
-/// assert_eq!(parser(Streaming(&[0x01][..])), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Streaming(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn le_f32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f32, E>
@@ -2043,12 +2043,12 @@ where
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::le_f64;
 ///
@@ -2057,11 +2057,11 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::le_f64;
 ///
@@ -2070,7 +2070,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Streaming(&b""[..]), 3145728.0)));
-/// assert_eq!(parser(Streaming(&[0x01][..])), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Streaming(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn le_f64<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, f64, E>
@@ -2093,12 +2093,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::f32;
 ///
@@ -2107,18 +2107,18 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f32 = |s| {
 ///   f32(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::f32;
@@ -2128,14 +2128,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(Streaming(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 12.5)));
-/// assert_eq!(be_f32(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(be_f32(Streaming(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_f32 = |s| {
 ///   f32::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(Streaming(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Streaming(&b""[..]), 12.5)));
-/// assert_eq!(le_f32(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(le_f32(Streaming(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn f32<I, E: ParseError<I>, const STREAMING: bool>(
@@ -2160,12 +2160,12 @@ where
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::f64;
 ///
@@ -2174,18 +2174,18 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 ///
 /// let le_f64 = |s| {
 ///   f64(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(ErrMode::Error(Error::new(&b"abc"[..], ErrorKind::Eof))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// # use winnow::input::Streaming;
 /// use winnow::number::f64;
@@ -2195,14 +2195,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(Streaming(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Streaming(&b""[..]), 12.5)));
-/// assert_eq!(be_f64(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(5))));
+/// assert_eq!(be_f64(Streaming(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 ///
 /// let le_f64 = |s| {
 ///   f64::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Streaming(&b""[..]), 12.5)));
-/// assert_eq!(le_f64(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(5))));
+/// assert_eq!(le_f64(Streaming(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
 pub fn f64<I, E: ParseError<I>, const STREAMING: bool>(
@@ -2224,12 +2224,12 @@ where
 ///
 /// *Complete version*: Will parse until the end of input if it has less than 8 bytes.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::hex_u32;
 ///
@@ -2239,11 +2239,11 @@ where
 ///
 /// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
 /// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(&b"ggg"[..]), Err(ErrMode::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::input::Streaming;
 /// use winnow::number::hex_u32;
 ///
@@ -2252,8 +2252,8 @@ where
 /// };
 ///
 /// assert_eq!(parser(Streaming(&b"01AE;"[..])), Ok((Streaming(&b";"[..]), 0x01AE)));
-/// assert_eq!(parser(Streaming(&b"abc"[..])), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Streaming(&b"ggg"[..])), Err(Err::Error(Error::new(Streaming(&b"ggg"[..]), ErrorKind::IsA))));
+/// assert_eq!(parser(Streaming(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Streaming(&b"ggg"[..])), Err(ErrMode::Error(Error::new(Streaming(&b"ggg"[..]), ErrorKind::IsA))));
 /// ```
 #[inline(always)]
 pub fn hex_u32<I, E: ParseError<I>, const STREAMING: bool>(input: I) -> IResult<I, u32, E>

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -15,9 +15,9 @@ use crate::*;
 
 /// Recognizes an unsigned 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u8;
 ///
 /// let parser = |s| {
@@ -25,7 +25,7 @@ use crate::*;
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -43,10 +43,10 @@ where
 
 /// Recognizes a big endian unsigned 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u16;
 ///
 /// let parser = |s| {
@@ -54,7 +54,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -73,10 +73,10 @@ where
 
 /// Recognizes a big endian unsigned 3 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u24;
 ///
 /// let parser = |s| {
@@ -84,7 +84,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
 ///
@@ -103,10 +103,10 @@ where
 
 /// Recognizes a big endian unsigned 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u32;
 ///
 /// let parser = |s| {
@@ -114,7 +114,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
 ///
@@ -133,10 +133,10 @@ where
 
 /// Recognizes a big endian unsigned 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u64;
 ///
 /// let parser = |s| {
@@ -144,7 +144,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
 ///
@@ -163,9 +163,9 @@ where
 
 /// Recognizes a big endian unsigned 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_u128;
 ///
 /// let parser = |s| {
@@ -173,7 +173,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 ///
@@ -197,7 +197,7 @@ where
   <I as Input>::Slice: AsBytes,
   Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
 {
-  let offset = input.offset_at(bound).map_err(Err::Incomplete)?;
+  let offset = input.offset_at(bound).map_err(ErrMode::Incomplete)?;
   let (input, number) = input.next_slice(offset);
   let number = number.as_bytes();
 
@@ -218,15 +218,15 @@ where
 
 /// Recognizes a signed 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i8;
 ///
 /// let parser = be_i8::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -244,15 +244,15 @@ where
 
 /// Recognizes a big endian signed 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i16;
 ///
 /// let parser = be_i16::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
 ///
@@ -271,15 +271,15 @@ where
 
 /// Recognizes a big endian signed 3 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i24;
 ///
 /// let parser = be_i24::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
 ///
@@ -307,15 +307,15 @@ where
 
 /// Recognizes a big endian signed 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i32;
 ///
 /// let parser = be_i32::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline]
 ///
@@ -334,16 +334,16 @@ where
 
 /// Recognizes a big endian signed 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i64;
 ///
 /// let parser = be_i64::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
 ///
@@ -362,15 +362,15 @@ where
 
 /// Recognizes a big endian signed 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_i128;
 ///
 /// let parser = be_i128::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 ///
@@ -389,15 +389,15 @@ where
 
 /// Recognizes an unsigned 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u8;
 ///
 /// let parser = le_u8::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -415,10 +415,10 @@ where
 
 /// Recognizes a little endian unsigned 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u16;
 ///
 /// let parser = |s| {
@@ -426,7 +426,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -445,10 +445,10 @@ where
 
 /// Recognizes a little endian unsigned 3 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u24;
 ///
 /// let parser = |s| {
@@ -456,7 +456,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
 ///
@@ -475,10 +475,10 @@ where
 
 /// Recognizes a little endian unsigned 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u32;
 ///
 /// let parser = |s| {
@@ -486,7 +486,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
 ///
@@ -505,10 +505,10 @@ where
 
 /// Recognizes a little endian unsigned 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u64;
 ///
 /// let parser = |s| {
@@ -516,7 +516,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
 ///
@@ -535,10 +535,10 @@ where
 
 /// Recognizes a little endian unsigned 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_u128;
 ///
 /// let parser = |s| {
@@ -546,7 +546,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 ///
@@ -570,7 +570,7 @@ where
   <I as Input>::Slice: AsBytes,
   Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
 {
-  let offset = input.offset_at(bound).map_err(Err::Incomplete)?;
+  let offset = input.offset_at(bound).map_err(ErrMode::Incomplete)?;
   let (input, number) = input.next_slice(offset);
   let number = number.as_bytes();
 
@@ -584,15 +584,15 @@ where
 
 /// Recognizes a signed 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i8;
 ///
 /// let parser = le_i8::<_, Error<_>>;
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -610,10 +610,10 @@ where
 
 /// Recognizes a little endian signed 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i16;
 ///
 /// let parser = |s| {
@@ -621,7 +621,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -640,10 +640,10 @@ where
 
 /// Recognizes a little endian signed 3 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i24;
 ///
 /// let parser = |s| {
@@ -651,7 +651,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
 ///
@@ -679,10 +679,10 @@ where
 
 /// Recognizes a little endian signed 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i32;
 ///
 /// let parser = |s| {
@@ -690,7 +690,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
 ///
@@ -709,10 +709,10 @@ where
 
 /// Recognizes a little endian signed 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i64;
 ///
 /// let parser = |s| {
@@ -720,7 +720,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
 ///
@@ -739,10 +739,10 @@ where
 
 /// Recognizes a little endian signed 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_i128;
 ///
 /// let parser = |s| {
@@ -750,7 +750,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 ///
@@ -770,9 +770,9 @@ where
 /// Recognizes an unsigned 1 byte integer
 ///
 /// Note that endianness does not apply to 1 byte numbers.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u8;
 ///
@@ -781,7 +781,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -796,17 +796,17 @@ where
 {
   input
     .next_token()
-    .ok_or_else(|| Err::Incomplete(Needed::new(1)))
+    .ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))
 }
 
 /// Recognizes an unsigned 2 bytes integer
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u16 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u16 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u16;
 ///
@@ -815,14 +815,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_u16 = |s| {
 ///   u16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(le_u16(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -850,9 +850,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u24 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u24 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u24;
 ///
@@ -861,14 +861,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_u24 = |s| {
 ///   u24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(le_u24(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
 ///
@@ -896,9 +896,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u32 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u32 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u32;
 ///
@@ -907,14 +907,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_u32 = |s| {
 ///   u32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(le_u32(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
 ///
@@ -942,9 +942,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u64 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u64 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u64;
 ///
@@ -953,14 +953,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_u64 = |s| {
 ///   u64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(le_u64(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
 ///
@@ -988,9 +988,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u128 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u128 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::u128;
 ///
@@ -999,14 +999,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_u128 = |s| {
 ///   u128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(le_u128(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 ///
@@ -1033,9 +1033,9 @@ where
 /// Recognizes a signed 1 byte integer
 ///
 /// Note that endianness does not apply to 1 byte numbers.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i8;
 ///
@@ -1044,7 +1044,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -1064,9 +1064,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i16 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i16 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i16;
 ///
@@ -1075,14 +1075,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_i16 = |s| {
 ///   i16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(le_i16(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -1110,9 +1110,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i24 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i24 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i24;
 ///
@@ -1121,14 +1121,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_i24 = |s| {
 ///   i24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// assert_eq!(le_i24(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline]
 ///
@@ -1156,9 +1156,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i32 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i32 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i32;
 ///
@@ -1167,14 +1167,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_i32 = |s| {
 ///   i32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(le_i32(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
 ///
@@ -1202,9 +1202,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i64 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i64 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i64;
 ///
@@ -1213,14 +1213,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_i64 = |s| {
 ///   i64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(le_i64(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
 ///
@@ -1248,9 +1248,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i128 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i128 integer.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::i128;
 ///
@@ -1259,14 +1259,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_i128 = |s| {
 ///   i128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// assert_eq!(le_i128(&b"\x01"[..]), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline]
 ///
@@ -1292,9 +1292,9 @@ where
 
 /// Recognizes a big endian 4 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_f32;
 ///
 /// let parser = |s| {
@@ -1302,7 +1302,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00][..]), Ok((&b""[..], 2.640625)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&[0x01][..]), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
 ///
@@ -1324,9 +1324,9 @@ where
 
 /// Recognizes a big endian 8 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::be_f64;
 ///
 /// let parser = |s| {
@@ -1334,7 +1334,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&[0x01][..]), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
 ///
@@ -1356,9 +1356,9 @@ where
 
 /// Recognizes a little endian 4 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_f32;
 ///
 /// let parser = |s| {
@@ -1366,7 +1366,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(&[0x01][..]), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline]
 ///
@@ -1388,9 +1388,9 @@ where
 
 /// Recognizes a little endian 8 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::le_f64;
 ///
 /// let parser = |s| {
@@ -1398,7 +1398,7 @@ where
 /// };
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 3145728.0)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(&[0x01][..]), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline]
 ///
@@ -1422,9 +1422,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian f32 float,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f32 float.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::f32;
 ///
@@ -1433,14 +1433,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_f32 = |s| {
 ///   f32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// assert_eq!(le_f32(&b"abc"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline]
 ///
@@ -1468,9 +1468,9 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian f64 float,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f64 float.
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::streaming::f64;
 ///
@@ -1479,14 +1479,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+/// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Incomplete(Needed::new(5))));
 ///
 /// let le_f64 = |s| {
 ///   f64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+/// assert_eq!(le_f64(&b"abc"[..]), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline]
 ///
@@ -1512,9 +1512,9 @@ where
 
 /// Recognizes a hex-encoded integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::hex_u32;
 ///
 /// let parser = |s| {
@@ -1522,8 +1522,8 @@ where
 /// };
 ///
 /// assert_eq!(parser(&b"01AE;"[..]), Ok((&b";"[..], 0x01AE)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
+/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(&b"ggg"[..]), Err(ErrMode::Error(Error::new(&b"ggg"[..], ErrorKind::IsA))));
 /// ```
 #[inline]
 ///
@@ -1551,14 +1551,14 @@ where
     Err(_) => {
       if invalid_offset == input.input_len() {
         // Only the next byte is guaranteed required
-        return Err(Err::Incomplete(Needed::new(1)));
+        return Err(ErrMode::Incomplete(Needed::new(1)));
       } else {
         invalid_offset
       }
     }
   };
   if offset == 0 {
-    return Err(Err::Error(E::from_error_kind(input, ErrorKind::IsA)));
+    return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::IsA)));
   }
   let (remaining, parsed) = input.next_slice(offset);
 
@@ -1578,10 +1578,10 @@ where
 
 /// Recognizes a floating point number in text format and returns the corresponding part of the input.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if it reaches the end of input.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if it reaches the end of input.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// use winnow::number::streaming::recognize_float;
 ///
 /// let parser = |s| {
@@ -1591,7 +1591,7 @@ where
 /// assert_eq!(parser("11e-1;"), Ok((";", "11e-1")));
 /// assert_eq!(parser("123E-02;"), Ok((";", "123E-02")));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Char))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Char))));
 /// ```
 #[rustfmt::skip]
 ///
@@ -1641,22 +1641,24 @@ where
   alt((
     |i: T| {
       recognize_float::<_, E>(i.clone()).map_err(|e| match e {
-        crate::Err::Error(_) => crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)),
-        crate::Err::Failure(_) => crate::Err::Failure(E::from_error_kind(i, ErrorKind::Float)),
-        crate::Err::Incomplete(needed) => crate::Err::Incomplete(needed),
+        crate::ErrMode::Error(_) => crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)),
+        crate::ErrMode::Failure(_) => {
+          crate::ErrMode::Failure(E::from_error_kind(i, ErrorKind::Float))
+        }
+        crate::ErrMode::Incomplete(needed) => crate::ErrMode::Incomplete(needed),
       })
     },
     |i: T| {
       crate::bytes::streaming::tag_no_case::<_, _, E>("nan")(i.clone())
-        .map_err(|_err| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::streaming::tag_no_case::<_, _, E>("inf")(i.clone())
-        .map_err(|_err| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::streaming::tag_no_case::<_, _, E>("infinity")(i.clone())
-        .map_err(|_err| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))(input)
 }
@@ -1666,7 +1668,7 @@ where
 /// It returns a tuple of (`sign`, `integer part`, `fraction part` and `exponent`) of the input
 /// data.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::recognize_float_parts`][crate::character::recognize_float_parts] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -1710,7 +1712,7 @@ where
       }
     }
 
-    let offset = offset.ok_or_else(|| Err::Incomplete(Needed::new(1)))?;
+    let offset = offset.ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))?;
 
     // trim right zeroes
     let trimmed_offset = (offset - zero_count).max(1);
@@ -1721,7 +1723,7 @@ where
   };
 
   if integer.slice_len() == 0 && fraction.slice_len() == 0 {
-    return Err(Err::Error(E::from_error_kind(input, ErrorKind::Float)));
+    return Err(ErrMode::Error(E::from_error_kind(input, ErrorKind::Float)));
   }
 
   let i2 = i.clone();
@@ -1742,10 +1744,10 @@ where
 
 /// Recognizes floating point number in text format and returns a f32.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::float;
 ///
@@ -1756,7 +1758,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f32`][crate::character::f32] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -1776,7 +1778,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::Err::Error(E::from_error_kind(
+    None => Err(crate::ErrMode::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -1785,10 +1787,10 @@ where
 
 /// Recognizes floating point number in text format and returns a f64.
 ///
-/// *Streaming version*: Will return `Err(winnow::Err::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::number::complete::double;
 ///
@@ -1799,7 +1801,7 @@ where
 /// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(Error::new("abc", ErrorKind::Float))));
+/// assert_eq!(parser("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Float))));
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::f64`][crate::character::f64] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -1819,7 +1821,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::Err::Error(E::from_error_kind(
+    None => Err(crate::ErrMode::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -1831,7 +1833,7 @@ mod tests {
   use super::*;
   use crate::error::Error;
   use crate::error::ErrorKind;
-  use crate::{Err, Needed};
+  use crate::{ErrMode, Needed};
   use proptest::prelude::*;
 
   macro_rules! assert_parse(
@@ -1847,7 +1849,7 @@ mod tests {
     assert_parse!(be_i8(&[0x7f][..]), Ok((&b""[..], 127)));
     assert_parse!(be_i8(&[0xff][..]), Ok((&b""[..], -1)));
     assert_parse!(be_i8(&[0x80][..]), Ok((&b""[..], -128)));
-    assert_parse!(be_i8(&[][..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_parse!(be_i8(&[][..]), Err(ErrMode::Incomplete(Needed::new(1))));
   }
 
   #[test]
@@ -1856,8 +1858,11 @@ mod tests {
     assert_parse!(be_i16(&[0x7f, 0xff][..]), Ok((&b""[..], 32_767_i16)));
     assert_parse!(be_i16(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
     assert_parse!(be_i16(&[0x80, 0x00][..]), Ok((&b""[..], -32_768_i16)));
-    assert_parse!(be_i16(&[][..]), Err(Err::Incomplete(Needed::new(2))));
-    assert_parse!(be_i16(&[0x00][..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_parse!(be_i16(&[][..]), Err(ErrMode::Incomplete(Needed::new(2))));
+    assert_parse!(
+      be_i16(&[0x00][..]),
+      Err(ErrMode::Incomplete(Needed::new(1)))
+    );
   }
 
   #[test]
@@ -1868,11 +1873,14 @@ mod tests {
       be_u24(&[0x12, 0x34, 0x56][..]),
       Ok((&b""[..], 1_193_046_u32))
     );
-    assert_parse!(be_u24(&[][..]), Err(Err::Incomplete(Needed::new(3))));
-    assert_parse!(be_u24(&[0x00][..]), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(be_u24(&[][..]), Err(ErrMode::Incomplete(Needed::new(3))));
+    assert_parse!(
+      be_u24(&[0x00][..]),
+      Err(ErrMode::Incomplete(Needed::new(2)))
+    );
     assert_parse!(
       be_u24(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1884,11 +1892,14 @@ mod tests {
       be_i24(&[0xED, 0xCB, 0xAA][..]),
       Ok((&b""[..], -1_193_046_i32))
     );
-    assert_parse!(be_i24(&[][..]), Err(Err::Incomplete(Needed::new(3))));
-    assert_parse!(be_i24(&[0x00][..]), Err(Err::Incomplete(Needed::new(2))));
+    assert_parse!(be_i24(&[][..]), Err(ErrMode::Incomplete(Needed::new(3))));
+    assert_parse!(
+      be_i24(&[0x00][..]),
+      Err(ErrMode::Incomplete(Needed::new(2)))
+    );
     assert_parse!(
       be_i24(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1904,15 +1915,18 @@ mod tests {
       be_i32(&[0x80, 0x00, 0x00, 0x00][..]),
       Ok((&b""[..], -2_147_483_648_i32))
     );
-    assert_parse!(be_i32(&[][..]), Err(Err::Incomplete(Needed::new(4))));
-    assert_parse!(be_i32(&[0x00][..]), Err(Err::Incomplete(Needed::new(3))));
+    assert_parse!(be_i32(&[][..]), Err(ErrMode::Incomplete(Needed::new(4))));
+    assert_parse!(
+      be_i32(&[0x00][..]),
+      Err(ErrMode::Incomplete(Needed::new(3)))
+    );
     assert_parse!(
       be_i32(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i32(&[0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -1934,31 +1948,34 @@ mod tests {
       be_i64(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
       Ok((&b""[..], -9_223_372_036_854_775_808_i64))
     );
-    assert_parse!(be_i64(&[][..]), Err(Err::Incomplete(Needed::new(8))));
-    assert_parse!(be_i64(&[0x00][..]), Err(Err::Incomplete(Needed::new(7))));
+    assert_parse!(be_i64(&[][..]), Err(ErrMode::Incomplete(Needed::new(8))));
+    assert_parse!(
+      be_i64(&[0x00][..]),
+      Err(ErrMode::Incomplete(Needed::new(7)))
+    );
     assert_parse!(
       be_i64(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(6)))
+      Err(ErrMode::Incomplete(Needed::new(6)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(5)))
+      Err(ErrMode::Incomplete(Needed::new(5)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(4)))
+      Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(3)))
+      Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -2006,68 +2023,71 @@ mod tests {
         -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
       ))
     );
-    assert_parse!(be_i128(&[][..]), Err(Err::Incomplete(Needed::new(16))));
-    assert_parse!(be_i128(&[0x00][..]), Err(Err::Incomplete(Needed::new(15))));
+    assert_parse!(be_i128(&[][..]), Err(ErrMode::Incomplete(Needed::new(16))));
+    assert_parse!(
+      be_i128(&[0x00][..]),
+      Err(ErrMode::Incomplete(Needed::new(15)))
+    );
     assert_parse!(
       be_i128(&[0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(14)))
+      Err(ErrMode::Incomplete(Needed::new(14)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(13)))
+      Err(ErrMode::Incomplete(Needed::new(13)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(12)))
+      Err(ErrMode::Incomplete(Needed::new(12)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(11)))
+      Err(ErrMode::Incomplete(Needed::new(11)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(10)))
+      Err(ErrMode::Incomplete(Needed::new(10)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(9)))
+      Err(ErrMode::Incomplete(Needed::new(9)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(8)))
+      Err(ErrMode::Incomplete(Needed::new(8)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(7)))
+      Err(ErrMode::Incomplete(Needed::new(7)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(6)))
+      Err(ErrMode::Incomplete(Needed::new(6)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(5)))
+      Err(ErrMode::Incomplete(Needed::new(5)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(4)))
+      Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_parse!(
       be_i128(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-      Err(Err::Incomplete(Needed::new(3)))
+      Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_parse!(
       be_i128(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
       ),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i128(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
           [..]
       ),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -2233,7 +2253,7 @@ mod tests {
   fn hex_u32_tests() {
     assert_parse!(
       hex_u32(&b";"[..]),
-      Err(Err::Error(error_position!(&b";"[..], ErrorKind::IsA)))
+      Err(ErrMode::Error(error_position!(&b";"[..], ErrorKind::IsA)))
     );
     assert_parse!(hex_u32(&b"ff;"[..]), Ok((&b";"[..], 255)));
     assert_parse!(hex_u32(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
@@ -2246,7 +2266,10 @@ mod tests {
     );
     assert_parse!(hex_u32(&b"ffffffff;"[..]), Ok((&b";"[..], 4_294_967_295)));
     assert_parse!(hex_u32(&b"0x1be2;"[..]), Ok((&b"x1be2;"[..], 0)));
-    assert_parse!(hex_u32(&b"12af"[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_parse!(
+      hex_u32(&b"12af"[..]),
+      Err(ErrMode::Incomplete(Needed::new(1)))
+    );
   }
 
   #[test]
@@ -2291,7 +2314,7 @@ mod tests {
     let remaining_exponent = "-1.234E-";
     assert_parse!(
       recognize_float(remaining_exponent),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
 
     let (_i, nan) = float::<_, ()>("NaN").unwrap();
@@ -2392,11 +2415,11 @@ mod tests {
       Err(e) => Err(e),
       Ok((i, s)) => {
         if s.is_empty() {
-          return Err(Err::Error(()));
+          return Err(ErrMode::Error(()));
         }
         match s.parse_to() {
           Some(n) => Ok((i, n)),
-          None => Err(Err::Error(())),
+          None => Err(ErrMode::Error(())),
         }
       }
     }

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -7,7 +7,7 @@ use crate::branch::alt;
 use crate::bytes::streaming::tag;
 use crate::character::streaming::{char, digit1, sign};
 use crate::combinator::{cut, map, opt};
-use crate::error::{ErrorKind, ParseError};
+use crate::error::{ErrMode, ErrorKind, Needed, ParseError};
 use crate::input::{AsBytes, AsChar, Compare, Input, Offset, ParseTo, SliceLen};
 use crate::lib::std::ops::{Add, Shl};
 use crate::sequence::{pair, tuple};
@@ -15,9 +15,9 @@ use crate::*;
 
 /// Recognizes an unsigned 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_u8;
 ///
 /// let parser = |s| {
@@ -43,10 +43,10 @@ where
 
 /// Recognizes a big endian unsigned 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_u16;
 ///
 /// let parser = |s| {
@@ -73,10 +73,10 @@ where
 
 /// Recognizes a big endian unsigned 3 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_u24;
 ///
 /// let parser = |s| {
@@ -103,10 +103,10 @@ where
 
 /// Recognizes a big endian unsigned 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_u32;
 ///
 /// let parser = |s| {
@@ -133,10 +133,10 @@ where
 
 /// Recognizes a big endian unsigned 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_u64;
 ///
 /// let parser = |s| {
@@ -163,9 +163,9 @@ where
 
 /// Recognizes a big endian unsigned 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_u128;
 ///
 /// let parser = |s| {
@@ -218,9 +218,9 @@ where
 
 /// Recognizes a signed 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_i8;
 ///
 /// let parser = be_i8::<_, Error<_>>;
@@ -244,9 +244,9 @@ where
 
 /// Recognizes a big endian signed 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_i16;
 ///
 /// let parser = be_i16::<_, Error<_>>;
@@ -271,9 +271,9 @@ where
 
 /// Recognizes a big endian signed 3 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_i24;
 ///
 /// let parser = be_i24::<_, Error<_>>;
@@ -307,9 +307,9 @@ where
 
 /// Recognizes a big endian signed 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_i32;
 ///
 /// let parser = be_i32::<_, Error<_>>;
@@ -334,10 +334,10 @@ where
 
 /// Recognizes a big endian signed 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_i64;
 ///
 /// let parser = be_i64::<_, Error<_>>;
@@ -362,9 +362,9 @@ where
 
 /// Recognizes a big endian signed 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_i128;
 ///
 /// let parser = be_i128::<_, Error<_>>;
@@ -389,9 +389,9 @@ where
 
 /// Recognizes an unsigned 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_u8;
 ///
 /// let parser = le_u8::<_, Error<_>>;
@@ -415,10 +415,10 @@ where
 
 /// Recognizes a little endian unsigned 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_u16;
 ///
 /// let parser = |s| {
@@ -445,10 +445,10 @@ where
 
 /// Recognizes a little endian unsigned 3 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_u24;
 ///
 /// let parser = |s| {
@@ -475,10 +475,10 @@ where
 
 /// Recognizes a little endian unsigned 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_u32;
 ///
 /// let parser = |s| {
@@ -505,10 +505,10 @@ where
 
 /// Recognizes a little endian unsigned 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_u64;
 ///
 /// let parser = |s| {
@@ -535,10 +535,10 @@ where
 
 /// Recognizes a little endian unsigned 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_u128;
 ///
 /// let parser = |s| {
@@ -584,9 +584,9 @@ where
 
 /// Recognizes a signed 1 byte integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_i8;
 ///
 /// let parser = le_i8::<_, Error<_>>;
@@ -610,10 +610,10 @@ where
 
 /// Recognizes a little endian signed 2 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_i16;
 ///
 /// let parser = |s| {
@@ -640,10 +640,10 @@ where
 
 /// Recognizes a little endian signed 3 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_i24;
 ///
 /// let parser = |s| {
@@ -679,10 +679,10 @@ where
 
 /// Recognizes a little endian signed 4 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_i32;
 ///
 /// let parser = |s| {
@@ -709,10 +709,10 @@ where
 
 /// Recognizes a little endian signed 8 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_i64;
 ///
 /// let parser = |s| {
@@ -739,10 +739,10 @@ where
 
 /// Recognizes a little endian signed 16 bytes integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_i128;
 ///
 /// let parser = |s| {
@@ -770,10 +770,10 @@ where
 /// Recognizes an unsigned 1 byte integer
 ///
 /// Note that endianness does not apply to 1 byte numbers.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::u8;
 ///
 /// let parser = |s| {
@@ -803,11 +803,11 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u16 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u16 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::u16;
 ///
 /// let be_u16 = |s| {
@@ -850,10 +850,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u24 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u24 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::u24;
 ///
 /// let be_u24 = |s| {
@@ -896,10 +896,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u32 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u32 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::u32;
 ///
 /// let be_u32 = |s| {
@@ -942,10 +942,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u64 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u64 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::u64;
 ///
 /// let be_u64 = |s| {
@@ -988,10 +988,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian u128 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian u128 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::u128;
 ///
 /// let be_u128 = |s| {
@@ -1033,10 +1033,10 @@ where
 /// Recognizes a signed 1 byte integer
 ///
 /// Note that endianness does not apply to 1 byte numbers.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::i8;
 ///
 /// let parser = |s| {
@@ -1064,10 +1064,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i16 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i16 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::i16;
 ///
 /// let be_i16 = |s| {
@@ -1110,10 +1110,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i24 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i24 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::i24;
 ///
 /// let be_i24 = |s| {
@@ -1156,10 +1156,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i32 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i32 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::i32;
 ///
 /// let be_i32 = |s| {
@@ -1202,10 +1202,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i64 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i64 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::i64;
 ///
 /// let be_i64 = |s| {
@@ -1248,10 +1248,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian i128 integer,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian i128 integer.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::i128;
 ///
 /// let be_i128 = |s| {
@@ -1292,9 +1292,9 @@ where
 
 /// Recognizes a big endian 4 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_f32;
 ///
 /// let parser = |s| {
@@ -1324,9 +1324,9 @@ where
 
 /// Recognizes a big endian 8 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::be_f64;
 ///
 /// let parser = |s| {
@@ -1356,9 +1356,9 @@ where
 
 /// Recognizes a little endian 4 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_f32;
 ///
 /// let parser = |s| {
@@ -1388,9 +1388,9 @@ where
 
 /// Recognizes a little endian 8 bytes floating point number.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::le_f64;
 ///
 /// let parser = |s| {
@@ -1422,10 +1422,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian f32 float,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f32 float.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::f32;
 ///
 /// let be_f32 = |s| {
@@ -1468,10 +1468,10 @@ where
 ///
 /// If the parameter is `winnow::number::Endianness::Big`, parse a big endian f64 float,
 /// otherwise if `winnow::number::Endianness::Little` parse a little endian f64 float.
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::streaming::f64;
 ///
 /// let be_f64 = |s| {
@@ -1512,9 +1512,9 @@ where
 
 /// Recognizes a hex-encoded integer.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::hex_u32;
 ///
 /// let parser = |s| {
@@ -1578,10 +1578,10 @@ where
 
 /// Recognizes a floating point number in text format and returns the corresponding part of the input.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if it reaches the end of input.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if it reaches the end of input.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// use winnow::number::streaming::recognize_float;
 ///
 /// let parser = |s| {
@@ -1641,24 +1641,26 @@ where
   alt((
     |i: T| {
       recognize_float::<_, E>(i.clone()).map_err(|e| match e {
-        crate::ErrMode::Error(_) => crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)),
-        crate::ErrMode::Failure(_) => {
-          crate::ErrMode::Failure(E::from_error_kind(i, ErrorKind::Float))
+        crate::error::ErrMode::Error(_) => {
+          crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float))
         }
-        crate::ErrMode::Incomplete(needed) => crate::ErrMode::Incomplete(needed),
+        crate::error::ErrMode::Failure(_) => {
+          crate::error::ErrMode::Failure(E::from_error_kind(i, ErrorKind::Float))
+        }
+        crate::error::ErrMode::Incomplete(needed) => crate::error::ErrMode::Incomplete(needed),
       })
     },
     |i: T| {
       crate::bytes::streaming::tag_no_case::<_, _, E>("nan")(i.clone())
-        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::streaming::tag_no_case::<_, _, E>("inf")(i.clone())
-        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
       crate::bytes::streaming::tag_no_case::<_, _, E>("infinity")(i.clone())
-        .map_err(|_err| crate::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
+        .map_err(|_err| crate::error::ErrMode::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))(input)
 }
@@ -1668,7 +1670,7 @@ where
 /// It returns a tuple of (`sign`, `integer part`, `fraction part` and `exponent`) of the input
 /// data.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 ///
 /// **WARNING:** Deprecated, replaced with [`winnow::character::recognize_float_parts`][crate::character::recognize_float_parts] with input wrapped in [`winnow::input::Streaming`][crate::input::Streaming]
@@ -1744,11 +1746,11 @@ where
 
 /// Recognizes floating point number in text format and returns a f32.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::float;
 ///
 /// let parser = |s| {
@@ -1778,7 +1780,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::ErrMode::Error(E::from_error_kind(
+    None => Err(crate::error::ErrMode::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -1787,11 +1789,11 @@ where
 
 /// Recognizes floating point number in text format and returns a f64.
 ///
-/// *Streaming version*: Will return `Err(winnow::ErrMode::Incomplete(_))` if there is not enough data.
+/// *Streaming version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::number::complete::double;
 ///
 /// let parser = |s| {
@@ -1821,7 +1823,7 @@ where
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
     Some(f) => Ok((i, f)),
-    None => Err(crate::ErrMode::Error(E::from_error_kind(
+    None => Err(crate::error::ErrMode::Error(E::from_error_kind(
       i,
       crate::error::ErrorKind::Float,
     ))),
@@ -1833,7 +1835,7 @@ mod tests {
   use super::*;
   use crate::error::Error;
   use crate::error::ErrorKind;
-  use crate::{ErrMode, Needed};
+  use crate::error::{ErrMode, Needed};
   use proptest::prelude::*;
 
   macro_rules! assert_parse(

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -6,7 +6,7 @@
 use crate::branch::alt;
 use crate::bytes::streaming::tag;
 use crate::character::streaming::{char, digit1, sign};
-use crate::combinator::{cut, map, opt};
+use crate::combinator::{cut_err, map, opt};
 use crate::error::{ErrMode, ErrorKind, Needed, ParseError};
 use crate::input::{AsBytes, AsChar, Compare, Input, Offset, ParseTo, SliceLen};
 use crate::lib::std::ops::{Add, Shl};
@@ -1617,7 +1617,7 @@ where
       opt(tuple((
         alt((char('e'), char('E'))),
         opt(alt((char('+'), char('-')))),
-        cut(digit1)
+        cut_err(digit1)
       )))
     ))
   .recognize().parse_next(input)
@@ -1742,7 +1742,7 @@ where
     .unwrap_or((i, false));
 
   let (i, exp) = if e {
-    cut(crate::character::streaming::i32)(i)?
+    cut_err(crate::character::streaming::i32)(i)?
   } else {
     (i2, 0)
   };

--- a/src/number/tests.rs
+++ b/src/number/tests.rs
@@ -299,7 +299,10 @@ mod complete {
   fn hex_u32_tests() {
     assert_parse!(
       hex_u32(&b";"[..]),
-      Err(ErrMode::Error(error_position!(&b";"[..], ErrorKind::IsA)))
+      Err(ErrMode::Backtrack(error_position!(
+        &b";"[..],
+        ErrorKind::IsA
+      )))
     );
     assert_parse!(hex_u32(&b"ff;"[..]), Ok((&b";"[..], 255)));
     assert_parse!(hex_u32(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
@@ -967,7 +970,7 @@ mod streaming {
   fn hex_u32_tests() {
     assert_parse!(
       hex_u32(Streaming(&b";"[..])),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         Streaming(&b";"[..]),
         ErrorKind::IsA
       )))

--- a/src/number/tests.rs
+++ b/src/number/tests.rs
@@ -2,9 +2,9 @@ use super::*;
 
 mod complete {
   use super::*;
+  use crate::error::ErrMode;
   use crate::error::Error;
   use crate::error::ErrorKind;
-  use crate::ErrMode;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
@@ -409,10 +409,11 @@ mod complete {
 
 mod streaming {
   use super::*;
+  use crate::error::ErrMode;
   use crate::error::Error;
   use crate::error::ErrorKind;
+  use crate::error::Needed;
   use crate::input::Streaming;
-  use crate::{ErrMode, Needed};
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {

--- a/src/number/tests.rs
+++ b/src/number/tests.rs
@@ -4,7 +4,7 @@ mod complete {
   use super::*;
   use crate::error::Error;
   use crate::error::ErrorKind;
-  use crate::Err;
+  use crate::ErrMode;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
@@ -299,7 +299,7 @@ mod complete {
   fn hex_u32_tests() {
     assert_parse!(
       hex_u32(&b";"[..]),
-      Err(Err::Error(error_position!(&b";"[..], ErrorKind::IsA)))
+      Err(ErrMode::Error(error_position!(&b";"[..], ErrorKind::IsA)))
     );
     assert_parse!(hex_u32(&b"ff;"[..]), Ok((&b";"[..], 255)));
     assert_parse!(hex_u32(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
@@ -412,7 +412,7 @@ mod streaming {
   use crate::error::Error;
   use crate::error::ErrorKind;
   use crate::input::Streaming;
-  use crate::{Err, Needed};
+  use crate::{ErrMode, Needed};
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
@@ -435,7 +435,7 @@ mod streaming {
     );
     assert_parse!(
       be_i8(Streaming(&[][..])),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -459,11 +459,11 @@ mod streaming {
     );
     assert_parse!(
       be_i16(Streaming(&[][..])),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i16(Streaming(&[0x00][..])),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -483,15 +483,15 @@ mod streaming {
     );
     assert_parse!(
       be_u24(Streaming(&[][..])),
-      Err(Err::Incomplete(Needed::new(3)))
+      Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_parse!(
       be_u24(Streaming(&[0x00][..])),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_u24(Streaming(&[0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -511,15 +511,15 @@ mod streaming {
     );
     assert_parse!(
       be_i24(Streaming(&[][..])),
-      Err(Err::Incomplete(Needed::new(3)))
+      Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_parse!(
       be_i24(Streaming(&[0x00][..])),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i24(Streaming(&[0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -543,19 +543,19 @@ mod streaming {
     );
     assert_parse!(
       be_i32(Streaming(&[][..])),
-      Err(Err::Incomplete(Needed::new(4)))
+      Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_parse!(
       be_i32(Streaming(&[0x00][..])),
-      Err(Err::Incomplete(Needed::new(3)))
+      Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_parse!(
       be_i32(Streaming(&[0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i32(Streaming(&[0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -587,35 +587,35 @@ mod streaming {
     );
     assert_parse!(
       be_i64(Streaming(&[][..])),
-      Err(Err::Incomplete(Needed::new(8)))
+      Err(ErrMode::Incomplete(Needed::new(8)))
     );
     assert_parse!(
       be_i64(Streaming(&[0x00][..])),
-      Err(Err::Incomplete(Needed::new(7)))
+      Err(ErrMode::Incomplete(Needed::new(7)))
     );
     assert_parse!(
       be_i64(Streaming(&[0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(6)))
+      Err(ErrMode::Incomplete(Needed::new(6)))
     );
     assert_parse!(
       be_i64(Streaming(&[0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(5)))
+      Err(ErrMode::Incomplete(Needed::new(5)))
     );
     assert_parse!(
       be_i64(Streaming(&[0x00, 0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(4)))
+      Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_parse!(
       be_i64(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(3)))
+      Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_parse!(
       be_i64(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i64(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -665,84 +665,84 @@ mod streaming {
     );
     assert_parse!(
       be_i128(Streaming(&[][..])),
-      Err(Err::Incomplete(Needed::new(16)))
+      Err(ErrMode::Incomplete(Needed::new(16)))
     );
     assert_parse!(
       be_i128(Streaming(&[0x00][..])),
-      Err(Err::Incomplete(Needed::new(15)))
+      Err(ErrMode::Incomplete(Needed::new(15)))
     );
     assert_parse!(
       be_i128(Streaming(&[0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(14)))
+      Err(ErrMode::Incomplete(Needed::new(14)))
     );
     assert_parse!(
       be_i128(Streaming(&[0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(13)))
+      Err(ErrMode::Incomplete(Needed::new(13)))
     );
     assert_parse!(
       be_i128(Streaming(&[0x00, 0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(12)))
+      Err(ErrMode::Incomplete(Needed::new(12)))
     );
     assert_parse!(
       be_i128(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(11)))
+      Err(ErrMode::Incomplete(Needed::new(11)))
     );
     assert_parse!(
       be_i128(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(10)))
+      Err(ErrMode::Incomplete(Needed::new(10)))
     );
     assert_parse!(
       be_i128(Streaming(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
-      Err(Err::Incomplete(Needed::new(9)))
+      Err(ErrMode::Incomplete(Needed::new(9)))
     );
     assert_parse!(
       be_i128(Streaming(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
       )),
-      Err(Err::Incomplete(Needed::new(8)))
+      Err(ErrMode::Incomplete(Needed::new(8)))
     );
     assert_parse!(
       be_i128(Streaming(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
       )),
-      Err(Err::Incomplete(Needed::new(7)))
+      Err(ErrMode::Incomplete(Needed::new(7)))
     );
     assert_parse!(
       be_i128(Streaming(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
       )),
-      Err(Err::Incomplete(Needed::new(6)))
+      Err(ErrMode::Incomplete(Needed::new(6)))
     );
     assert_parse!(
       be_i128(Streaming(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
       )),
-      Err(Err::Incomplete(Needed::new(5)))
+      Err(ErrMode::Incomplete(Needed::new(5)))
     );
     assert_parse!(
       be_i128(Streaming(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
       )),
-      Err(Err::Incomplete(Needed::new(4)))
+      Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_parse!(
       be_i128(Streaming(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
       )),
-      Err(Err::Incomplete(Needed::new(3)))
+      Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_parse!(
       be_i128(Streaming(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
       )),
-      Err(Err::Incomplete(Needed::new(2)))
+      Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_parse!(
       be_i128(Streaming(
         &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
           [..]
       )),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 
@@ -966,7 +966,7 @@ mod streaming {
   fn hex_u32_tests() {
     assert_parse!(
       hex_u32(Streaming(&b";"[..])),
-      Err(Err::Error(error_position!(
+      Err(ErrMode::Error(error_position!(
         Streaming(&b";"[..]),
         ErrorKind::IsA
       )))
@@ -1013,7 +1013,7 @@ mod streaming {
     );
     assert_parse!(
       hex_u32(Streaming(&b"12af"[..])),
-      Err(Err::Incomplete(Needed::new(1)))
+      Err(ErrMode::Incomplete(Needed::new(1)))
     );
   }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -116,7 +116,7 @@ pub trait Parser<I, O, E> {
   /// let mut parser = alpha1.value(1234);
   ///
   /// assert_eq!(parser.parse_next("abcd"), Ok(("", 1234)));
-  /// assert_eq!(parser.parse_next("123abcd;"), Err(ErrMode::Error(Error::new("123abcd;", ErrorKind::Alpha))));
+  /// assert_eq!(parser.parse_next("123abcd;"), Err(ErrMode::Backtrack(Error::new("123abcd;", ErrorKind::Alpha))));
   /// # }
   /// ```
   fn value<O2>(self, val: O2) -> Value<Self, O, O2>
@@ -139,7 +139,7 @@ pub trait Parser<I, O, E> {
   /// let mut parser = alpha1.void();
   ///
   /// assert_eq!(parser.parse_next("abcd"), Ok(("", ())));
-  /// assert_eq!(parser.parse_next("123abcd;"), Err(ErrMode::Error(Error::new("123abcd;", ErrorKind::Alpha))));
+  /// assert_eq!(parser.parse_next("123abcd;"), Err(ErrMode::Backtrack(Error::new("123abcd;", ErrorKind::Alpha))));
   /// # }
   /// ```
   fn void(self) -> Void<Self, O>
@@ -191,7 +191,7 @@ pub trait Parser<I, O, E> {
   /// let mut parser = separated_pair(alpha1, ',', alpha1).recognize();
   ///
   /// assert_eq!(parser.parse_next("abcd,efgh"), Ok(("", "abcd,efgh")));
-  /// assert_eq!(parser.parse_next("abcd;"),Err(ErrMode::Error(Error::new(";", ErrorKind::OneOf))));
+  /// assert_eq!(parser.parse_next("abcd;"),Err(ErrMode::Backtrack(Error::new(";", ErrorKind::OneOf))));
   /// # }
   /// ```
   fn recognize(self) -> Recognize<Self, O>
@@ -228,7 +228,7 @@ pub trait Parser<I, O, E> {
   /// let mut consumed_parser = separated_pair(alpha1, ',', alpha1).value(true).with_recognized();
   ///
   /// assert_eq!(consumed_parser.parse_next("abcd,efgh1"), Ok(("1", (true, "abcd,efgh"))));
-  /// assert_eq!(consumed_parser.parse_next("abcd;"),Err(ErrMode::Error(Error::new(";", ErrorKind::OneOf))));
+  /// assert_eq!(consumed_parser.parse_next("abcd;"),Err(ErrMode::Backtrack(Error::new(";", ErrorKind::OneOf))));
   ///
   /// // the second output (representing the consumed input)
   /// // should be the same as that of the `recognize` parser.
@@ -260,7 +260,7 @@ pub trait Parser<I, O, E> {
   /// let mut parser = separated_pair(alpha1.span(), ',', alpha1.span());
   ///
   /// assert_eq!(parser.parse_next(Located::new("abcd,efgh")).finish(), Ok((0..4, 5..9)));
-  /// assert_eq!(parser.parse_next(Located::new("abcd;")),Err(ErrMode::Error(Error::new(Located::new("abcd;").next_slice(4).0, ErrorKind::OneOf))));
+  /// assert_eq!(parser.parse_next(Located::new("abcd;")),Err(ErrMode::Backtrack(Error::new(Located::new("abcd;").next_slice(4).0, ErrorKind::OneOf))));
   /// ```
   fn span(self) -> Span<Self, O>
   where
@@ -298,7 +298,7 @@ pub trait Parser<I, O, E> {
   /// let mut consumed_parser = separated_pair(alpha1.value(1).with_span(), ',', alpha1.value(2).with_span());
   ///
   /// assert_eq!(consumed_parser.parse_next(Located::new("abcd,efgh")).finish(), Ok(((1, 0..4), (2, 5..9))));
-  /// assert_eq!(consumed_parser.parse_next(Located::new("abcd;")),Err(ErrMode::Error(Error::new(Located::new("abcd;").next_slice(4).0, ErrorKind::OneOf))));
+  /// assert_eq!(consumed_parser.parse_next(Located::new("abcd;")),Err(ErrMode::Backtrack(Error::new(Located::new("abcd;").next_slice(4).0, ErrorKind::OneOf))));
   ///
   /// // the second output (representing the consumed input)
   /// // should be the same as that of the `span` parser.
@@ -332,7 +332,7 @@ pub trait Parser<I, O, E> {
   /// assert_eq!(parser.parse_next("123456"), Ok(("", 6)));
   ///
   /// // this will fail if digit1 fails
-  /// assert_eq!(parser.parse_next("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Digit))));
+  /// assert_eq!(parser.parse_next("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Digit))));
   /// # }
   /// ```
   fn map<G, O2>(self, g: G) -> Map<Self, G, O>
@@ -358,10 +358,10 @@ pub trait Parser<I, O, E> {
   /// assert_eq!(parse.parse_next("123"), Ok(("", 123)));
   ///
   /// // this will fail if digit1 fails
-  /// assert_eq!(parse.parse_next("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Digit))));
+  /// assert_eq!(parse.parse_next("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Digit))));
   ///
   /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-  /// assert_eq!(parse.parse_next("123456"), Err(ErrMode::Error(Error::new("123456", ErrorKind::MapRes))));
+  /// assert_eq!(parse.parse_next("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::MapRes))));
   /// # }
   /// ```
   fn map_res<G, O2, E2>(self, g: G) -> MapRes<Self, G, O>
@@ -387,10 +387,10 @@ pub trait Parser<I, O, E> {
   /// assert_eq!(parse.parse_next("123"), Ok(("", 123)));
   ///
   /// // this will fail if digit1 fails
-  /// assert_eq!(parse.parse_next("abc"), Err(ErrMode::Error(Error::new("abc", ErrorKind::Digit))));
+  /// assert_eq!(parse.parse_next("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Digit))));
   ///
   /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-  /// assert_eq!(parse.parse_next("123456"), Err(ErrMode::Error(Error::new("123456", ErrorKind::MapOpt))));
+  /// assert_eq!(parse.parse_next("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::MapOpt))));
   /// # }
   /// ```
   fn map_opt<G, O2>(self, g: G) -> MapOpt<Self, G, O>
@@ -414,7 +414,7 @@ pub trait Parser<I, O, E> {
   /// let mut length_data = u8.flat_map(take);
   ///
   /// assert_eq!(length_data.parse_next(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
-  /// assert_eq!(length_data.parse_next(&[4, 0, 1, 2][..]), Err(ErrMode::Error(Error::new(&[0, 1, 2][..], ErrorKind::Eof))));
+  /// assert_eq!(length_data.parse_next(&[4, 0, 1, 2][..]), Err(ErrMode::Backtrack(Error::new(&[0, 1, 2][..], ErrorKind::Eof))));
   /// # }
   /// ```
   fn flat_map<G, H, O2>(self, g: G) -> FlatMap<Self, G, O>
@@ -440,7 +440,7 @@ pub trait Parser<I, O, E> {
   ///
   /// assert_eq!(digits.parse_next("12345"), Ok(("", "12345")));
   /// assert_eq!(digits.parse_next("123ab"), Ok(("", "123")));
-  /// assert_eq!(digits.parse_next("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Eof))));
+  /// assert_eq!(digits.parse_next("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Eof))));
   /// # }
   /// ```
   fn and_then<G, O2>(self, g: G) -> AndThen<Self, G, O>
@@ -466,8 +466,8 @@ pub trait Parser<I, O, E> {
   /// let mut parser = alpha1.verify(|s: &str| s.len() == 4);
   ///
   /// assert_eq!(parser.parse_next("abcd"), Ok(("", "abcd")));
-  /// assert_eq!(parser.parse_next("abcde"), Err(ErrMode::Error(Error::new("abcde", ErrorKind::Verify))));
-  /// assert_eq!(parser.parse_next("123abcd;"),Err(ErrMode::Error(Error::new("123abcd;", ErrorKind::Alpha))));
+  /// assert_eq!(parser.parse_next("abcde"), Err(ErrMode::Backtrack(Error::new("abcde", ErrorKind::Verify))));
+  /// assert_eq!(parser.parse_next("123abcd;"),Err(ErrMode::Backtrack(Error::new("123abcd;", ErrorKind::Alpha))));
   /// # }
   /// ```
   fn verify<G, O2: ?Sized>(self, second: G) -> Verify<Self, G, O2>
@@ -491,7 +491,7 @@ pub trait Parser<I, O, E> {
     Context::new(self, context)
   }
 
-  /// Transforms [`Incomplete`][crate::error::ErrMode::Incomplete] into [`Error`][crate::error::ErrMode::Error]
+  /// Transforms [`Incomplete`][crate::error::ErrMode::Incomplete] into [`Error`][crate::error::ErrMode::Backtrack]
   ///
   /// # Example
   ///
@@ -503,7 +503,7 @@ pub trait Parser<I, O, E> {
   /// let mut parser = take(5u8).complete();
   ///
   /// assert_eq!(parser.parse_next(Streaming("abcdefg")), Ok((Streaming("fg"), "abcde")));
-  /// assert_eq!(parser.parse_next(Streaming("abcd")), Err(ErrMode::Error(Error::new(Streaming("abcd"), ErrorKind::Complete))));
+  /// assert_eq!(parser.parse_next(Streaming("abcd")), Err(ErrMode::Backtrack(Error::new(Streaming("abcd"), ErrorKind::Complete))));
   /// # }
   /// ```
   fn complete(self) -> Complete<Self>
@@ -600,9 +600,9 @@ where
 ///     b'a'.parse_next(i)
 /// }
 /// assert_eq!(parser(&b"abc"[..]), Ok((&b"bc"[..], b'a')));
-/// assert_eq!(parser(&b" abc"[..]), Err(ErrMode::Error(Error::new(&b" abc"[..], ErrorKind::OneOf))));
-/// assert_eq!(parser(&b"bc"[..]), Err(ErrMode::Error(Error::new(&b"bc"[..], ErrorKind::OneOf))));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&b""[..], ErrorKind::OneOf))));
+/// assert_eq!(parser(&b" abc"[..]), Err(ErrMode::Backtrack(Error::new(&b" abc"[..], ErrorKind::OneOf))));
+/// assert_eq!(parser(&b"bc"[..]), Err(ErrMode::Backtrack(Error::new(&b"bc"[..], ErrorKind::OneOf))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&b""[..], ErrorKind::OneOf))));
 /// ```
 impl<I, E> Parser<I, u8, E> for u8
 where
@@ -626,9 +626,9 @@ where
 ///     'a'.parse_next(i)
 /// }
 /// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser(" abc"), Err(ErrMode::Error(Error::new(" abc", ErrorKind::OneOf))));
-/// assert_eq!(parser("bc"), Err(ErrMode::Error(Error::new("bc", ErrorKind::OneOf))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::OneOf))));
+/// assert_eq!(parser(" abc"), Err(ErrMode::Backtrack(Error::new(" abc", ErrorKind::OneOf))));
+/// assert_eq!(parser("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::OneOf))));
 /// ```
 impl<I, E> Parser<I, <I as Input>::Token, E> for char
 where
@@ -657,8 +657,8 @@ where
 ///
 /// assert_eq!(parser(&b"Hello, World!"[..]), Ok((&b", World!"[..], &b"Hello"[..])));
 /// assert_eq!(parser(&b"Something"[..]), Ok((&b"hing"[..], &b"Somet"[..])));
-/// assert_eq!(parser(&b"Some"[..]), Err(ErrMode::Error(Error::new(&b"Some"[..], ErrorKind::Eof))));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&b""[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"Some"[..]), Err(ErrMode::Backtrack(Error::new(&b"Some"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&b""[..], ErrorKind::Eof))));
 /// ```
 impl<'s, I, E: ParseError<I>> Parser<I, <I as Input>::Slice, E> for &'s [u8]
 where
@@ -685,8 +685,8 @@ where
 ///
 /// assert_eq!(parser(&b"Hello, World!"[..]), Ok((&b", World!"[..], &b"Hello"[..])));
 /// assert_eq!(parser(&b"Something"[..]), Ok((&b"hing"[..], &b"Somet"[..])));
-/// assert_eq!(parser(&b"Some"[..]), Err(ErrMode::Error(Error::new(&b"Some"[..], ErrorKind::Eof))));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Error(Error::new(&b""[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b"Some"[..]), Err(ErrMode::Backtrack(Error::new(&b"Some"[..], ErrorKind::Eof))));
+/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&b""[..], ErrorKind::Eof))));
 /// ```
 impl<'s, I, E: ParseError<I>, const N: usize> Parser<I, <I as Input>::Slice, E> for &'s [u8; N]
 where
@@ -713,8 +713,8 @@ where
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("Something"), Ok(("hing", "Somet")));
-/// assert_eq!(parser("Some"), Err(ErrMode::Error(Error::new("Some", ErrorKind::Eof))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Eof))));
+/// assert_eq!(parser("Some"), Err(ErrMode::Backtrack(Error::new("Some", ErrorKind::Eof))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Eof))));
 /// ```
 impl<'s, I, E: ParseError<I>> Parser<I, <I as Input>::Slice, E> for &'s str
 where
@@ -828,8 +828,8 @@ mod tests {
 
   #[test]
   fn err_map_test() {
-    let e = ErrMode::Error(1);
-    assert_eq!(e.map(|v| v + 1), ErrMode::Error(2));
+    let e = ErrMode::Backtrack(1);
+    assert_eq!(e.map(|v| v + 1), ErrMode::Backtrack(2));
   }
 
   #[test]
@@ -841,7 +841,7 @@ mod tests {
     assert_eq!(parser.parse_next("abc123def"), Ok(("123def", ("abc",))));
     assert_eq!(
       parser.parse_next("123def"),
-      Err(ErrMode::Error(Error {
+      Err(ErrMode::Backtrack(Error {
         input: "123def",
         kind: ErrorKind::Alpha
       }))
@@ -869,7 +869,7 @@ mod tests {
     );
     assert_eq!(
       tuple_3(Streaming(&b"abcdejk"[..])),
-      Err(ErrMode::Error(error_position!(
+      Err(ErrMode::Backtrack(error_position!(
         Streaming(&b"jk"[..]),
         ErrorKind::Tag
       )))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,7 @@
 //! Basic types to build the parsers
 
 use crate::combinator::*;
-#[cfg(feature = "std")]
-use crate::error::DbgErr;
-use crate::error::{Context, ContextError, IResult, ParseError};
+use crate::error::{ContextError, IResult, ParseError};
 use crate::input::{AsChar, Compare, Input, InputIsStreaming, Location};
 
 /// All nom parsers implement this trait

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -25,8 +25,8 @@ use crate::{IResult, Parser};
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 #[deprecated(since = "8.0.0", note = "`Parser` is directly implemented for tuples")]
 pub fn pair<I, O1, O2, E: ParseError<I>, F, G>(
@@ -60,8 +60,8 @@ where
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "efg")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "efg")));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn preceded<I, O1, O2, E: ParseError<I>, F, G>(
   mut first: F,
@@ -94,8 +94,8 @@ where
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "abc")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "abc")));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn terminated<I, O1, O2, E: ParseError<I>, F, G>(
   mut first: F,
@@ -130,8 +130,8 @@ where
 ///
 /// assert_eq!(parser("abc|efg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abc|efghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn separated_pair<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
   mut first: F,
@@ -169,8 +169,8 @@ where
 ///
 /// assert_eq!(parser("(abc)"), Ok(("", "abc")));
 /// assert_eq!(parser("(abc)def"), Ok(("def", "abc")));
-/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn delimited<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
   mut first: F,
@@ -299,7 +299,7 @@ impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
 /// let mut parser = tuple((alpha1, digit1, alpha1));
 ///
 /// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
-/// assert_eq!(parser("123def"), Err(ErrMode::Error(Error::new("123def", ErrorKind::Alpha))));
+/// assert_eq!(parser("123def"), Err(ErrMode::Backtrack(Error::new("123def", ErrorKind::Alpha))));
 /// ```
 #[deprecated(since = "8.0.0", note = "`Parser` is directly implemented for tuples")]
 #[allow(deprecated)]

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -16,7 +16,7 @@ use crate::{IResult, Parser};
 /// * `second` The second parser to apply.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::pair;
 /// use winnow::bytes::tag;
@@ -25,8 +25,8 @@ use crate::{IResult, Parser};
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 #[deprecated(since = "8.0.0", note = "`Parser` is directly implemented for tuples")]
 pub fn pair<I, O1, O2, E: ParseError<I>, F, G>(
@@ -51,7 +51,7 @@ where
 /// * `second` The second parser to get object.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::preceded;
 /// use winnow::bytes::tag;
@@ -60,8 +60,8 @@ where
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "efg")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "efg")));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn preceded<I, O1, O2, E: ParseError<I>, F, G>(
   mut first: F,
@@ -85,7 +85,7 @@ where
 /// * `second` The second parser to match an object.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::terminated;
 /// use winnow::bytes::tag;
@@ -94,8 +94,8 @@ where
 ///
 /// assert_eq!(parser("abcefg"), Ok(("", "abc")));
 /// assert_eq!(parser("abcefghij"), Ok(("hij", "abc")));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn terminated<I, O1, O2, E: ParseError<I>, F, G>(
   mut first: F,
@@ -121,7 +121,7 @@ where
 /// * `second` The second parser to apply.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::separated_pair;
 /// use winnow::bytes::tag;
@@ -130,8 +130,8 @@ where
 ///
 /// assert_eq!(parser("abc|efg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser("abc|efghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn separated_pair<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
   mut first: F,
@@ -160,7 +160,7 @@ where
 /// * `third` The third parser to apply and discard.
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error, Needed};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
 /// # use winnow::Needed::Size;
 /// use winnow::sequence::delimited;
 /// use winnow::bytes::tag;
@@ -169,8 +169,8 @@ where
 ///
 /// assert_eq!(parser("(abc)"), Ok(("", "abc")));
 /// assert_eq!(parser("(abc)def"), Ok(("def", "abc")));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Error(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("123"), Err(ErrMode::Error(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn delimited<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
   mut first: F,
@@ -293,13 +293,13 @@ impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
 /// **WARNING:** Deprecated, [`Parser`] is directly implemented for tuples
 ///
 /// ```rust
-/// # use winnow::{Err, error::ErrorKind, error::Error};
+/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
 /// use winnow::sequence::tuple;
 /// use winnow::character::{alpha1, digit1};
 /// let mut parser = tuple((alpha1, digit1, alpha1));
 ///
 /// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
-/// assert_eq!(parser("123def"), Err(Err::Error(Error::new("123def", ErrorKind::Alpha))));
+/// assert_eq!(parser("123def"), Err(ErrMode::Error(Error::new("123def", ErrorKind::Alpha))));
 /// ```
 #[deprecated(since = "8.0.0", note = "`Parser` is directly implemented for tuples")]
 #[allow(deprecated)]

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -16,8 +16,8 @@ use crate::{IResult, Parser};
 /// * `second` The second parser to apply.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::sequence::pair;
 /// use winnow::bytes::tag;
 ///
@@ -51,8 +51,8 @@ where
 /// * `second` The second parser to get object.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::sequence::preceded;
 /// use winnow::bytes::tag;
 ///
@@ -85,8 +85,8 @@ where
 /// * `second` The second parser to match an object.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::sequence::terminated;
 /// use winnow::bytes::tag;
 ///
@@ -121,8 +121,8 @@ where
 /// * `second` The second parser to apply.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::sequence::separated_pair;
 /// use winnow::bytes::tag;
 ///
@@ -160,8 +160,8 @@ where
 /// * `third` The third parser to apply and discard.
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error, Needed};
-/// # use winnow::Needed::Size;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::error::Needed::Size;
 /// use winnow::sequence::delimited;
 /// use winnow::bytes::tag;
 ///
@@ -293,7 +293,7 @@ impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
 /// **WARNING:** Deprecated, [`Parser`] is directly implemented for tuples
 ///
 /// ```rust
-/// # use winnow::{ErrMode, error::ErrorKind, error::Error};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// use winnow::sequence::tuple;
 /// use winnow::character::{alpha1, digit1};
 /// let mut parser = tuple((alpha1, digit1, alpha1));

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -1,15 +1,15 @@
 use super::*;
 use crate::bytes::{tag, take};
-use crate::error::{Error, ErrorKind};
+use crate::error::{ErrMode, Error, ErrorKind, Needed};
 use crate::input::Streaming;
 use crate::number::be_u16;
-use crate::{ErrMode, IResult, Needed};
+use crate::IResult;
 
 #[test]
 fn single_element_tuples() {
   #![allow(deprecated)]
   use crate::character::alpha1;
-  use crate::{error::ErrorKind, ErrMode};
+  use crate::error::ErrorKind;
 
   let mut parser = tuple((alpha1,));
   assert_eq!(parser("abc123def"), Ok(("123def", ("abc",))));

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -3,19 +3,19 @@ use crate::bytes::{tag, take};
 use crate::error::{Error, ErrorKind};
 use crate::input::Streaming;
 use crate::number::be_u16;
-use crate::{Err, IResult, Needed};
+use crate::{ErrMode, IResult, Needed};
 
 #[test]
 fn single_element_tuples() {
   #![allow(deprecated)]
   use crate::character::alpha1;
-  use crate::{error::ErrorKind, Err};
+  use crate::{error::ErrorKind, ErrMode};
 
   let mut parser = tuple((alpha1,));
   assert_eq!(parser("abc123def"), Ok(("123def", ("abc",))));
   assert_eq!(
     parser("123def"),
-    Err(Err::Error(Error {
+    Err(ErrMode::Error(Error {
       input: "123def",
       kind: ErrorKind::Alpha
     }))
@@ -46,7 +46,7 @@ fn complete() {
   let res_a = err_test(a);
   assert_eq!(
     res_a,
-    Err(Err::Error(error_position!(&b"mn"[..], ErrorKind::Tag)))
+    Err(ErrMode::Error(error_position!(&b"mn"[..], ErrorKind::Tag)))
   );
 }
 
@@ -64,29 +64,29 @@ fn pair_test() {
   );
   assert_eq!(
     pair_abc_def(Streaming(&b"ab"[..])),
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(ErrMode::Incomplete(Needed::new(1)))
   );
   assert_eq!(
     pair_abc_def(Streaming(&b"abcd"[..])),
-    Err(Err::Incomplete(Needed::new(2)))
+    Err(ErrMode::Incomplete(Needed::new(2)))
   );
   assert_eq!(
     pair_abc_def(Streaming(&b"xxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     pair_abc_def(Streaming(&b"xxxdef"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxxdef"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     pair_abc_def(Streaming(&b"abcxxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -106,29 +106,29 @@ fn separated_pair_test() {
   );
   assert_eq!(
     sep_pair_abc_def(Streaming(&b"ab"[..])),
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(ErrMode::Incomplete(Needed::new(1)))
   );
   assert_eq!(
     sep_pair_abc_def(Streaming(&b"abc,d"[..])),
-    Err(Err::Incomplete(Needed::new(2)))
+    Err(ErrMode::Incomplete(Needed::new(2)))
   );
   assert_eq!(
     sep_pair_abc_def(Streaming(&b"xxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     sep_pair_abc_def(Streaming(&b"xxx,def"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx,def"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     sep_pair_abc_def(Streaming(&b"abc,xxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -147,29 +147,29 @@ fn preceded_test() {
   );
   assert_eq!(
     preceded_abcd_efgh(Streaming(&b"ab"[..])),
-    Err(Err::Incomplete(Needed::new(2)))
+    Err(ErrMode::Incomplete(Needed::new(2)))
   );
   assert_eq!(
     preceded_abcd_efgh(Streaming(&b"abcde"[..])),
-    Err(Err::Incomplete(Needed::new(3)))
+    Err(ErrMode::Incomplete(Needed::new(3)))
   );
   assert_eq!(
     preceded_abcd_efgh(Streaming(&b"xxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     preceded_abcd_efgh(Streaming(&b"xxxxdef"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxxxdef"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     preceded_abcd_efgh(Streaming(&b"abcdxxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -188,29 +188,29 @@ fn terminated_test() {
   );
   assert_eq!(
     terminated_abcd_efgh(Streaming(&b"ab"[..])),
-    Err(Err::Incomplete(Needed::new(2)))
+    Err(ErrMode::Incomplete(Needed::new(2)))
   );
   assert_eq!(
     terminated_abcd_efgh(Streaming(&b"abcde"[..])),
-    Err(Err::Incomplete(Needed::new(3)))
+    Err(ErrMode::Incomplete(Needed::new(3)))
   );
   assert_eq!(
     terminated_abcd_efgh(Streaming(&b"xxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     terminated_abcd_efgh(Streaming(&b"xxxxdef"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxxxdef"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     terminated_abcd_efgh(Streaming(&b"abcdxxxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxxx"[..]),
       ErrorKind::Tag
     )))
@@ -229,40 +229,40 @@ fn delimited_test() {
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"ab"[..])),
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(ErrMode::Incomplete(Needed::new(1)))
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"abcde"[..])),
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(ErrMode::Incomplete(Needed::new(1)))
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"abcdefgh"[..])),
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(ErrMode::Incomplete(Needed::new(1)))
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"xxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"xxxdefghi"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxxdefghi"[..]),
       ErrorKind::Tag
     ),))
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"abcxxxghi"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxxghi"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"abcdefxxx"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -283,15 +283,15 @@ fn tuple_test() {
   );
   assert_eq!(
     tuple_3(Streaming(&b"abcd"[..])),
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(ErrMode::Incomplete(Needed::new(1)))
   );
   assert_eq!(
     tuple_3(Streaming(&b"abcde"[..])),
-    Err(Err::Incomplete(Needed::new(2)))
+    Err(ErrMode::Incomplete(Needed::new(2)))
   );
   assert_eq!(
     tuple_3(Streaming(&b"abcdejk"[..])),
-    Err(Err::Error(error_position!(
+    Err(ErrMode::Error(error_position!(
       Streaming(&b"jk"[..]),
       ErrorKind::Tag
     )))

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -15,7 +15,7 @@ fn single_element_tuples() {
   assert_eq!(parser("abc123def"), Ok(("123def", ("abc",))));
   assert_eq!(
     parser("123def"),
-    Err(ErrMode::Error(Error {
+    Err(ErrMode::Backtrack(Error {
       input: "123def",
       kind: ErrorKind::Alpha
     }))
@@ -46,7 +46,10 @@ fn complete() {
   let res_a = err_test(a);
   assert_eq!(
     res_a,
-    Err(ErrMode::Error(error_position!(&b"mn"[..], ErrorKind::Tag)))
+    Err(ErrMode::Backtrack(error_position!(
+      &b"mn"[..],
+      ErrorKind::Tag
+    )))
   );
 }
 
@@ -72,21 +75,21 @@ fn pair_test() {
   );
   assert_eq!(
     pair_abc_def(Streaming(&b"xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     pair_abc_def(Streaming(&b"xxxdef"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxxdef"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     pair_abc_def(Streaming(&b"abcxxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -114,21 +117,21 @@ fn separated_pair_test() {
   );
   assert_eq!(
     sep_pair_abc_def(Streaming(&b"xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     sep_pair_abc_def(Streaming(&b"xxx,def"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx,def"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     sep_pair_abc_def(Streaming(&b"abc,xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -155,21 +158,21 @@ fn preceded_test() {
   );
   assert_eq!(
     preceded_abcd_efgh(Streaming(&b"xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     preceded_abcd_efgh(Streaming(&b"xxxxdef"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxxxdef"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     preceded_abcd_efgh(Streaming(&b"abcdxxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -196,21 +199,21 @@ fn terminated_test() {
   );
   assert_eq!(
     terminated_abcd_efgh(Streaming(&b"xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     terminated_abcd_efgh(Streaming(&b"xxxxdef"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxxxdef"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     terminated_abcd_efgh(Streaming(&b"abcdxxxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxxx"[..]),
       ErrorKind::Tag
     )))
@@ -241,28 +244,28 @@ fn delimited_test() {
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"xxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"xxxdefghi"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxxdefghi"[..]),
       ErrorKind::Tag
     ),))
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"abcxxxghi"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxxghi"[..]),
       ErrorKind::Tag
     )))
   );
   assert_eq!(
     delimited_abc_def_ghi(Streaming(&b"abcdefxxx"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"xxx"[..]),
       ErrorKind::Tag
     )))
@@ -291,7 +294,7 @@ fn tuple_test() {
   );
   assert_eq!(
     tuple_3(Streaming(&b"abcdejk"[..])),
-    Err(ErrMode::Error(error_position!(
+    Err(ErrMode::Backtrack(error_position!(
       Streaming(&b"jk"[..]),
       ErrorKind::Tag
     )))

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -4,7 +4,7 @@
 
 use winnow::input::Streaming;
 use winnow::prelude::*;
-use winnow::{error::ErrorKind, ErrMode, IResult, Needed};
+use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 
 #[allow(dead_code)]
 struct Range {
@@ -137,7 +137,7 @@ mod issue_647 {
   use winnow::bytes::tag;
   use winnow::multi::separated_list0;
   use winnow::prelude::*;
-  use winnow::{error::Error, number::be_f64, ErrMode, IResult};
+  use winnow::{error::ErrMode, error::Error, number::be_f64, IResult};
   pub type Input<'a> = winnow::input::Streaming<&'a [u8]>;
 
   #[derive(PartialEq, Debug, Clone)]
@@ -266,12 +266,12 @@ fn issue_1459_clamp_capacity() {
   // shouldn't panic
   use winnow::multi::many_m_n;
   let mut parser = many_m_n::<_, _, (), _>(usize::MAX, usize::MAX, 'a');
-  assert_eq!(parser("a"), Err(winnow::ErrMode::Error(())));
+  assert_eq!(parser("a"), Err(winnow::error::ErrMode::Error(())));
 
   // shouldn't panic
   use winnow::multi::count;
   let mut parser = count::<_, _, (), _>('a', usize::MAX);
-  assert_eq!(parser("a"), Err(winnow::ErrMode::Error(())));
+  assert_eq!(parser("a"), Err(winnow::error::ErrMode::Error(())));
 }
 
 #[test]

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -175,7 +175,7 @@ fn issue_848_overflow_incomplete_bits_to_bytes() {
   }
   assert_eq!(
     parser(Streaming(&b""[..])),
-    Err(ErrMode::Failure(winnow::error::Error {
+    Err(ErrMode::Cut(winnow::error::Error {
       input: Streaming(&b""[..]),
       kind: ErrorKind::TooLarge
     }))
@@ -209,7 +209,7 @@ fn issue_1027_convert_error_panic_nonempty() {
 
   let result: IResult<_, _, VerboseError<&str>> = ('a', 'b').parse_next(input);
   let err = match result.unwrap_err() {
-    ErrMode::Error(e) => e,
+    ErrMode::Backtrack(e) => e,
     _ => unreachable!(),
   };
 
@@ -255,7 +255,7 @@ fn issue_x_looser_fill_bounds() {
   );
   assert_eq!(
     fill_pair(b"123,,"),
-    Err(ErrMode::Error(winnow::error::Error {
+    Err(ErrMode::Backtrack(winnow::error::Error {
       input: &b","[..],
       kind: ErrorKind::Digit
     }))
@@ -266,12 +266,12 @@ fn issue_1459_clamp_capacity() {
   // shouldn't panic
   use winnow::multi::many_m_n;
   let mut parser = many_m_n::<_, _, (), _>(usize::MAX, usize::MAX, 'a');
-  assert_eq!(parser("a"), Err(winnow::error::ErrMode::Error(())));
+  assert_eq!(parser("a"), Err(winnow::error::ErrMode::Backtrack(())));
 
   // shouldn't panic
   use winnow::multi::count;
   let mut parser = count::<_, _, (), _>('a', usize::MAX);
-  assert_eq!(parser("a"), Err(winnow::error::ErrMode::Error(())));
+  assert_eq!(parser("a"), Err(winnow::error::ErrMode::Backtrack(())));
 }
 
 #[test]

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -4,7 +4,7 @@
 
 use winnow::input::Streaming;
 use winnow::prelude::*;
-use winnow::{error::ErrorKind, Err, IResult, Needed};
+use winnow::{error::ErrorKind, ErrMode, IResult, Needed};
 
 #[allow(dead_code)]
 struct Range {
@@ -16,7 +16,7 @@ pub fn take_char(input: &[u8]) -> IResult<&[u8], char> {
   if !input.is_empty() {
     Ok((&input[1..], input[0] as char))
   } else {
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(ErrMode::Incomplete(Needed::new(1)))
   }
 }
 
@@ -87,7 +87,7 @@ fn take_till_issue() {
 
   assert_eq!(
     nothing(Streaming(b"")),
-    Err(Err::Incomplete(Needed::new(1)))
+    Err(ErrMode::Incomplete(Needed::new(1)))
   );
   assert_eq!(
     nothing(Streaming(b"abc")),
@@ -137,7 +137,7 @@ mod issue_647 {
   use winnow::bytes::tag;
   use winnow::multi::separated_list0;
   use winnow::prelude::*;
-  use winnow::{error::Error, number::be_f64, Err, IResult};
+  use winnow::{error::Error, number::be_f64, ErrMode, IResult};
   pub type Input<'a> = winnow::input::Streaming<&'a [u8]>;
 
   #[derive(PartialEq, Debug, Clone)]
@@ -147,7 +147,10 @@ mod issue_647 {
   }
 
   #[allow(clippy::type_complexity)]
-  fn list<'a>(input: Input<'a>, _cs: &f64) -> Result<(Input<'a>, Vec<f64>), Err<Error<Input<'a>>>> {
+  fn list<'a>(
+    input: Input<'a>,
+    _cs: &f64,
+  ) -> Result<(Input<'a>, Vec<f64>), ErrMode<Error<Input<'a>>>> {
     separated_list0(tag(",").complete(), be_f64.complete())(input)
   }
 
@@ -172,7 +175,7 @@ fn issue_848_overflow_incomplete_bits_to_bytes() {
   }
   assert_eq!(
     parser(Streaming(&b""[..])),
-    Err(Err::Failure(winnow::error::Error {
+    Err(ErrMode::Failure(winnow::error::Error {
       input: Streaming(&b""[..]),
       kind: ErrorKind::TooLarge
     }))
@@ -206,7 +209,7 @@ fn issue_1027_convert_error_panic_nonempty() {
 
   let result: IResult<_, _, VerboseError<&str>> = ('a', 'b').parse_next(input);
   let err = match result.unwrap_err() {
-    Err::Error(e) => e,
+    ErrMode::Error(e) => e,
     _ => unreachable!(),
   };
 
@@ -252,7 +255,7 @@ fn issue_x_looser_fill_bounds() {
   );
   assert_eq!(
     fill_pair(b"123,,"),
-    Err(Err::Error(winnow::error::Error {
+    Err(ErrMode::Error(winnow::error::Error {
       input: &b","[..],
       kind: ErrorKind::Digit
     }))
@@ -263,12 +266,12 @@ fn issue_1459_clamp_capacity() {
   // shouldn't panic
   use winnow::multi::many_m_n;
   let mut parser = many_m_n::<_, _, (), _>(usize::MAX, usize::MAX, 'a');
-  assert_eq!(parser("a"), Err(winnow::Err::Error(())));
+  assert_eq!(parser("a"), Err(winnow::ErrMode::Error(())));
 
   // shouldn't panic
   use winnow::multi::count;
   let mut parser = count::<_, _, (), _>('a', usize::MAX);
-  assert_eq!(parser("a"), Err(winnow::Err::Error(())));
+  assert_eq!(parser("a"), Err(winnow::ErrMode::Error(())));
 }
 
 #[test]

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -8,7 +8,7 @@ use winnow::multi::{length_data, many0};
 #[cfg(feature = "alloc")]
 use winnow::number::be_u64;
 use winnow::prelude::*;
-use winnow::{Err, Needed};
+use winnow::{ErrMode, Needed};
 
 // Parser definition
 
@@ -22,7 +22,7 @@ fn parser02(i: Streaming<&[u8]>) -> IResult<Streaming<&[u8]>, (&[u8], &[u8])> {
 fn overflow_incomplete_tuple() {
   assert_eq!(
     parser02(Streaming(&b"3"[..])),
-    Err(Err::Incomplete(Needed::new(18446744073709551615)))
+    Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
   );
 }
 
@@ -38,7 +38,7 @@ fn overflow_incomplete_length_bytes() {
     multi(Streaming(
       &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]
     )),
-    Err(Err::Incomplete(Needed::new(18446744073709551615)))
+    Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
   );
 }
 
@@ -54,7 +54,7 @@ fn overflow_incomplete_many0() {
     multi(Streaming(
       &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
     )),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -72,7 +72,7 @@ fn overflow_incomplete_many1() {
     multi(Streaming(
       &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
     )),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -91,7 +91,7 @@ fn overflow_incomplete_many_till() {
     multi(Streaming(
       &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
     )),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -109,7 +109,7 @@ fn overflow_incomplete_many_m_n() {
     multi(Streaming(
       &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
     )),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -126,7 +126,7 @@ fn overflow_incomplete_count() {
     counter(Streaming(
       &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
     )),
-    Err(Err::Incomplete(Needed::new(18446744073709551599)))
+    Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
   );
 }
 
@@ -144,7 +144,7 @@ fn overflow_incomplete_length_count() {
     multi(Streaming(
       &b"\x04\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xee"[..]
     )),
-    Err(Err::Incomplete(Needed::new(18446744073709551598)))
+    Err(ErrMode::Incomplete(Needed::new(18446744073709551598)))
   );
 }
 
@@ -159,6 +159,6 @@ fn overflow_incomplete_length_data() {
     multi(Streaming(
       &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]
     )),
-    Err(Err::Incomplete(Needed::new(18446744073709551615)))
+    Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
   );
 }

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -2,13 +2,13 @@
 #![cfg(target_pointer_width = "64")]
 
 use winnow::bytes::take;
+use winnow::error::{ErrMode, Needed};
 use winnow::input::Streaming;
 #[cfg(feature = "alloc")]
 use winnow::multi::{length_data, many0};
 #[cfg(feature = "alloc")]
 use winnow::number::be_u64;
 use winnow::prelude::*;
-use winnow::{ErrMode, Needed};
 
 // Parser definition
 

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -7,7 +7,7 @@ mod test {
   use winnow::{
     bytes::{tag, take, take_till, take_till1, take_until, take_while1},
     error::{self, Error, ErrorKind},
-    Err, IResult,
+    ErrMode, IResult,
   };
 
   #[test]
@@ -46,7 +46,7 @@ mod test {
 
     let res: IResult<_, _, error::Error<_>> = tag(TAG)(Streaming(INPUT));
     match res {
-      Err(Err::Incomplete(_)) => (),
+      Err(ErrMode::Incomplete(_)) => (),
       other => {
         panic!(
           "Parser `tag` didn't require more input when it should have. \
@@ -64,7 +64,7 @@ mod test {
 
     let res: IResult<_, _, error::Error<_>> = tag(TAG)(INPUT);
     match res {
-      Err(Err::Error(_)) => (),
+      Err(ErrMode::Error(_)) => (),
       other => {
         panic!(
           "Parser `tag` didn't fail when it should have. Got `{:?}`.`",
@@ -122,7 +122,7 @@ mod test {
 
     let res: IResult<_, _, Error<_>> = take(13_usize)(Streaming(INPUT));
     match res {
-      Err(Err::Incomplete(_)) => (),
+      Err(ErrMode::Incomplete(_)) => (),
       other => panic!(
         "Parser `take` didn't require more input when it should have. \
          Got `{:?}`.",
@@ -172,7 +172,7 @@ mod test {
 
     let res: IResult<_, _, Error<_>> = take_until(FIND)(Streaming(INPUT));
     match res {
-      Err(Err::Incomplete(_)) => (),
+      Err(ErrMode::Incomplete(_)) => (),
       other => panic!(
         "Parser `take_until` didn't require more input when it should have. \
          Got `{:?}`.",
@@ -190,7 +190,7 @@ mod test {
 
     let res: IResult<_, _, Error<_>> = take_until(FIND)(Streaming(INPUT));
     match res {
-      Err(Err::Incomplete(_)) => (),
+      Err(ErrMode::Incomplete(_)) => (),
       other => panic!(
         "Parser `take_until` didn't fail when it should have. \
          Got `{:?}`.",
@@ -217,8 +217,8 @@ mod test {
     let c = "abcd123";
     let d = "123";
 
-    assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(f(Streaming(b)), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(Streaming(b)), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(f(Streaming(c)), Ok((Streaming(d), b)));
     assert_eq!(f(Streaming(d)), Ok((Streaming(d), a)));
   }
@@ -305,12 +305,12 @@ mod test {
     let c = "abcd123";
     let d = "123";
 
-    assert_eq!(f(Streaming(a)), Err(Err::Incomplete(Needed::new(1))));
-    assert_eq!(f(Streaming(b)), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(f(Streaming(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(Streaming(b)), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(f(Streaming(c)), Ok((Streaming("123"), b)));
     assert_eq!(
       f(Streaming(d)),
-      Err(Err::Error(winnow::error::Error {
+      Err(ErrMode::Error(winnow::error::Error {
         input: Streaming(d),
         kind: ErrorKind::TakeWhile1
       }))
@@ -395,7 +395,7 @@ mod test {
       take_while1(while1_s)(input)
     }
     match test(INPUT) {
-      Err(Err::Error(_)) => (),
+      Err(ErrMode::Error(_)) => (),
       other => panic!(
         "Parser `take_while1` didn't fail when it should have. \
          Got `{:?}`.",
@@ -412,7 +412,7 @@ mod test {
       take_while1(MATCH)(input)
     }
     match test(INPUT) {
-      Err(Err::Error(_)) => (),
+      Err(ErrMode::Error(_)) => (),
       other => panic!(
         "Parser `is_a` didn't fail when it should have. Got `{:?}`.",
         other
@@ -492,7 +492,7 @@ mod test {
       take_till1(AVOID)(input)
     }
     match test(INPUT) {
-      Err(Err::Error(_)) => (),
+      Err(ErrMode::Error(_)) => (),
       other => panic!(
         "Parser `is_not` didn't fail when it should have. Got `{:?}`.",
         other

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -6,8 +6,9 @@ mod test {
   use winnow::{branch::alt, bytes::tag_no_case, multi::many1};
   use winnow::{
     bytes::{tag, take, take_till, take_till1, take_until, take_while1},
+    error::ErrMode,
     error::{self, Error, ErrorKind},
-    ErrMode, IResult,
+    IResult,
   };
 
   #[test]
@@ -205,7 +206,7 @@ mod test {
 
   #[test]
   fn take_while_str() {
-    use winnow::Needed;
+    use winnow::error::Needed;
 
     use winnow::bytes::take_while;
 
@@ -295,7 +296,7 @@ mod test {
 
   #[test]
   fn test_take_while1_str() {
-    use winnow::Needed;
+    use winnow::error::Needed;
 
     fn f(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
       take_while1(is_alphabetic)(i)

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -65,7 +65,7 @@ mod test {
 
     let res: IResult<_, _, error::Error<_>> = tag(TAG)(INPUT);
     match res {
-      Err(ErrMode::Error(_)) => (),
+      Err(ErrMode::Backtrack(_)) => (),
       other => {
         panic!(
           "Parser `tag` didn't fail when it should have. Got `{:?}`.`",
@@ -311,7 +311,7 @@ mod test {
     assert_eq!(f(Streaming(c)), Ok((Streaming("123"), b)));
     assert_eq!(
       f(Streaming(d)),
-      Err(ErrMode::Error(winnow::error::Error {
+      Err(ErrMode::Backtrack(winnow::error::Error {
         input: Streaming(d),
         kind: ErrorKind::TakeWhile1
       }))
@@ -396,7 +396,7 @@ mod test {
       take_while1(while1_s)(input)
     }
     match test(INPUT) {
-      Err(ErrMode::Error(_)) => (),
+      Err(ErrMode::Backtrack(_)) => (),
       other => panic!(
         "Parser `take_while1` didn't fail when it should have. \
          Got `{:?}`.",
@@ -413,7 +413,7 @@ mod test {
       take_while1(MATCH)(input)
     }
     match test(INPUT) {
-      Err(ErrMode::Error(_)) => (),
+      Err(ErrMode::Backtrack(_)) => (),
       other => panic!(
         "Parser `is_a` didn't fail when it should have. Got `{:?}`.",
         other
@@ -493,7 +493,7 @@ mod test {
       take_till1(AVOID)(input)
     }
     match test(INPUT) {
-      Err(ErrMode::Error(_)) => (),
+      Err(ErrMode::Backtrack(_)) => (),
       other => panic!(
         "Parser `is_not` didn't fail when it should have. Got `{:?}`.",
         other


### PR DESCRIPTION
`Err` has problems
- Lack of specificity makes it hard to understand its role
- Overlapping with `Result::Err` is confusing

We've now
- Moved `IResult`, `Err`, and `Needed` into `error` module so all error stuff can be found in one place
- Renamed `Err` to `ErrMode`
- Renamed `Err::Error` to `ErrMode::Backtrack` to help distinguish from `Failure`
- Renamed `Err::Failure` to `ErrMode::Cut` to help distinguish from `Error` and help make connections with `cut`
- Renamed `cut` to `cut_err` to make it clearer when reading that this affects the error path
- Added `backtrack_err` combinator as we saw it requested within nom and in case we can implement #75
- Shifted focus from `ErrMode` to `Error` / `VerboseError` by moving functionality over
- Removed more cases of `(I, ErrorKind)` lingering around
- Moved combinatorics out of `error` to clean it up