### PR TITLE
fix!: Remove `lib` from the pub API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,12 +413,11 @@ doc_comment::doctest!("../README.md");
 
 /// Lib module to re-export everything needed from `std` or `core`/`alloc`. This is how `serde` does
 /// it, albeit there it is not public.
-#[cfg_attr(nightly, allow(rustdoc::missing_doc_code_examples))]
+#[doc(hidden)]
 pub mod lib {
   /// `std` facade allowing `std`/`core` to be interchangeable. Reexports `alloc` crate optionally,
   /// as well as `core` or `std`
   #[cfg(not(feature = "std"))]
-  #[cfg_attr(nightly, allow(rustdoc::missing_doc_code_examples))]
   /// internal std exports for no_std compatibility
   pub mod std {
     #[doc(hidden)]
@@ -440,7 +439,6 @@ pub mod lib {
   }
 
   #[cfg(feature = "std")]
-  #[cfg_attr(nightly, allow(rustdoc::missing_doc_code_examples))]
   /// internal std exports for `no_std` compatibility
   pub mod std {
     #[doc(hidden)]


### PR DESCRIPTION
Our core/alloc/std abstrcaction is incomplete, so there is limited value in people relying on it.

It clutters the documentation.

For me, this feels more like an artifact of the prior macro design.

Gone.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
