### PR TITLE
feat(multi): Switch from Vec to impl Accumulate 

### DIFF
--- a/examples/ini/parser.rs
+++ b/examples/ini/parser.rs
@@ -16,9 +16,8 @@ pub fn categories(i: Input<'_>) -> IResult<Input<'_>, HashMap<&str, HashMap<&str
   many0(separated_pair(
     category,
     opt(multispace),
-    many0(terminated(key_value, opt(multispace))).map(|vec: Vec<_>| vec.into_iter().collect()),
+    many0(terminated(key_value, opt(multispace))),
   ))
-  .map(|vec: Vec<_>| vec.into_iter().collect())
   .parse_next(i)
 }
 

--- a/examples/ini/parser_str.rs
+++ b/examples/ini/parser_str.rs
@@ -12,15 +12,7 @@ use winnow::{
 pub type Input<'i> = &'i str;
 
 pub fn categories(input: Input<'_>) -> IResult<Input<'_>, HashMap<&str, HashMap<&str, &str>>> {
-  match categories_aggregator(input) {
-    Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
-    Err(e) => Err(e),
-  }
-}
-
-#[allow(clippy::type_complexity)]
-fn categories_aggregator(i: Input<'_>) -> IResult<Input<'_>, Vec<(&str, HashMap<&str, &str>)>> {
-  many0(category_and_keys)(i)
+  many0(category_and_keys)(input)
 }
 
 fn category_and_keys(i: Input<'_>) -> IResult<Input<'_>, (&str, HashMap<&str, &str>)> {
@@ -35,14 +27,7 @@ fn category(i: Input<'_>) -> IResult<Input<'_>, &str> {
 }
 
 fn keys_and_values(input: Input<'_>) -> IResult<Input<'_>, HashMap<&str, &str>> {
-  match keys_and_values_aggregator(input) {
-    Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
-    Err(e) => Err(e),
-  }
-}
-
-fn keys_and_values_aggregator(i: Input<'_>) -> IResult<Input<'_>, Vec<(&str, &str)>> {
-  many0(key_value)(i)
+  many0(key_value)(input)
 }
 
 fn key_value(i: Input<'_>) -> IResult<Input<'_>, (&str, &str)> {

--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -175,8 +175,7 @@ fn object<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
   preceded(
     ('{', ws),
     cut_err(terminated(
-      separated_list0((ws, ',', ws), key_value)
-        .map(|tuple_vec| tuple_vec.into_iter().map(|(k, v)| (k, v)).collect()),
+      separated_list0((ws, ',', ws), key_value),
       (ws, '}'),
     )),
   )

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -184,8 +184,7 @@ fn object<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
   preceded(
     ('{', ws),
     cut_err(terminated(
-      separated_list0((ws, ',', ws), key_value)
-        .map(|tuple_vec| tuple_vec.into_iter().map(|(k, v)| (k, v)).collect()),
+      separated_list0((ws, ',', ws), key_value),
       (ws, '}'),
     )),
   )

--- a/examples/json/parser_streaming.rs
+++ b/examples/json/parser_streaming.rs
@@ -184,8 +184,7 @@ fn object<'i, E: ParseError<Input<'i>> + ContextError<Input<'i>, &'static str>>(
   preceded(
     (one_of('{'), ws),
     cut_err(terminated(
-      separated_list0((ws, one_of(','), ws), key_value)
-        .map(|tuple_vec| tuple_vec.into_iter().map(|(k, v)| (k, v)).collect()),
+      separated_list0((ws, one_of(','), ws), key_value),
       (ws, one_of('}')),
     )),
   )

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -227,7 +227,7 @@ fn array(i: &str) -> IResult<&str, ()> {
   preceded(
     '[',
     cut_err(terminated(
-      separated_list0(preceded(sp, ','), value).map(|_| ()),
+      separated_list0(preceded(sp, ','), value),
       preceded(sp, ']'),
     )),
   )
@@ -243,7 +243,7 @@ fn hash(i: &str) -> IResult<&str, ()> {
   preceded(
     '{',
     cut_err(terminated(
-      separated_list0(preceded(sp, ','), key_value).map(|_| ()),
+      separated_list0(preceded(sp, ','), key_value),
       preceded(sp, '}'),
     )),
   )

--- a/src/_cookbook.rs
+++ b/src/_cookbook.rs
@@ -169,8 +169,8 @@
 //!   preceded(
 //!     alt(("0x", "0X")),
 //!     many1(
-//!       terminated(one_of("0123456789abcdefABCDEF"), many0('_'))
-//!     ).recognize()
+//!       terminated(one_of("0123456789abcdefABCDEF"), many0('_').map(|()| ()))
+//!     ).map(|()| ()).recognize()
 //!   )(input)
 //! }
 //! ```
@@ -191,8 +191,8 @@
 //!   preceded(
 //!     alt(("0x", "0X")),
 //!     many1(
-//!       terminated(one_of("0123456789abcdefABCDEF"), many0('_'))
-//!     ).recognize()
+//!       terminated(one_of("0123456789abcdefABCDEF"), many0('_').map(|()| ()))
+//!     ).map(|()| ()).recognize()
 //!   ).map_res(
 //!     |out: &str| i64::from_str_radix(&str::replace(&out, "_", ""), 16)
 //!   ).parse_next(input)
@@ -215,8 +215,8 @@
 //!   preceded(
 //!     alt(("0o", "0O")),
 //!     many1(
-//!       terminated(one_of("01234567"), many0('_'))
-//!     ).recognize()
+//!       terminated(one_of("01234567"), many0('_').map(|()| ()))
+//!     ).map(|()| ()).recognize()
 //!   )(input)
 //! }
 //! ```
@@ -237,8 +237,8 @@
 //!   preceded(
 //!     alt(("0b", "0B")),
 //!     many1(
-//!       terminated(one_of("01"), many0('_'))
-//!     ).recognize()
+//!       terminated(one_of("01"), many0('_').map(|()| ()))
+//!     ).map(|()| ()).recognize()
 //!   )(input)
 //! }
 //! ```
@@ -256,8 +256,8 @@
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
 //!   many1(
-//!     terminated(one_of("0123456789"), many0('_'))
-//!   )
+//!     terminated(one_of("0123456789"), many0('_').map(|()| ()))
+//!   ).map(|()| ())
 //!     .recognize()
 //!     .parse_next(input)
 //! }
@@ -311,8 +311,8 @@
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
 //!   many1(
-//!     terminated(one_of("0123456789"), many0('_'))
-//!   )
+//!     terminated(one_of("0123456789"), many0('_').map(|()| ()))
+//!   ).map(|()| ())
 //!     .recognize()
 //!     .parse_next(input)
 //! }

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -805,7 +805,7 @@ where
   since = "8.0.0",
   note = "Replaced with `winnow::character::escaped_transform`"
 )]
-pub fn escaped_transform<I, Error, F, G, O1, O2, ExtendItem, Output>(
+pub fn escaped_transform<I, Error, F, G, Output>(
   mut normal: F,
   control_char: char,
   mut transform: G,
@@ -813,18 +813,16 @@ pub fn escaped_transform<I, Error, F, G, O1, O2, ExtendItem, Output>(
 where
   I: Input + Offset,
   <I as Input>::Token: crate::input::AsChar,
-  I: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O1: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O2: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  F: Parser<I, O1, Error>,
-  G: Parser<I, O2, Error>,
+  Output: crate::input::Accumulate<<I as Input>::Slice>,
+  F: Parser<I, <I as Input>::Slice, Error>,
+  G: Parser<I, <I as Input>::Slice, Error>,
   Error: ParseError<I>,
 {
   move |input: I| escaped_transform_internal(input, &mut normal, control_char, &mut transform)
 }
 
 #[cfg(feature = "alloc")]
-pub(crate) fn escaped_transform_internal<I, Error, F, G, O1, O2, ExtendItem, Output>(
+pub(crate) fn escaped_transform_internal<I, Error, F, G, Output>(
   input: I,
   normal: &mut F,
   control_char: char,
@@ -833,17 +831,15 @@ pub(crate) fn escaped_transform_internal<I, Error, F, G, O1, O2, ExtendItem, Out
 where
   I: Input + Offset,
   <I as Input>::Token: crate::input::AsChar,
-  I: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O1: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O2: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  F: Parser<I, O1, Error>,
-  G: Parser<I, O2, Error>,
+  Output: crate::input::Accumulate<<I as Input>::Slice>,
+  F: Parser<I, <I as Input>::Slice, Error>,
+  G: Parser<I, <I as Input>::Slice, Error>,
   Error: ParseError<I>,
 {
   use crate::input::AsChar;
 
   let mut offset = 0;
-  let mut res = input.new_builder();
+  let mut res = Output::initial(Some(input.input_len()));
 
   let i = input.clone();
 
@@ -852,7 +848,7 @@ where
     let (remainder, _) = i.next_slice(offset);
     match normal.parse_next(remainder.clone()) {
       Ok((i2, o)) => {
-        o.extend_into(&mut res);
+        res.accumulate(o);
         if i2.input_len() == 0 {
           return Ok((i.next_slice(i.input_len()).0, res));
         } else if i2.input_len() == current_len {
@@ -874,7 +870,7 @@ where
           } else {
             match transform.parse_next(i.next_slice(next).0) {
               Ok((i2, o)) => {
-                o.extend_into(&mut res);
+                res.accumulate(o);
                 if i2.input_len() == 0 {
                   return Ok((i.next_slice(i.input_len()).0, res));
                 } else {

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -861,7 +861,7 @@ where
   since = "8.0.0",
   note = "Replaced with `winnow::character::escaped_transform` with input wrapped in `winnow::input::Streaming`"
 )]
-pub fn escaped_transform<I, Error, F, G, O1, O2, ExtendItem, Output>(
+pub fn escaped_transform<I, Error, F, G, Output>(
   mut normal: F,
   control_char: char,
   mut transform: G,
@@ -869,18 +869,16 @@ pub fn escaped_transform<I, Error, F, G, O1, O2, ExtendItem, Output>(
 where
   I: Input + Offset,
   <I as Input>::Token: crate::input::AsChar,
-  I: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O1: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O2: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  F: Parser<I, O1, Error>,
-  G: Parser<I, O2, Error>,
+  Output: crate::input::Accumulate<<I as Input>::Slice>,
+  F: Parser<I, <I as Input>::Slice, Error>,
+  G: Parser<I, <I as Input>::Slice, Error>,
   Error: ParseError<I>,
 {
   move |input: I| escaped_transform_internal(input, &mut normal, control_char, &mut transform)
 }
 
 #[cfg(feature = "alloc")]
-pub(crate) fn escaped_transform_internal<I, Error, F, G, O1, O2, ExtendItem, Output>(
+pub(crate) fn escaped_transform_internal<I, Error, F, G, Output>(
   input: I,
   normal: &mut F,
   control_char: char,
@@ -889,17 +887,15 @@ pub(crate) fn escaped_transform_internal<I, Error, F, G, O1, O2, ExtendItem, Out
 where
   I: Input + Offset,
   <I as Input>::Token: crate::input::AsChar,
-  I: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O1: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O2: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  F: Parser<I, O1, Error>,
-  G: Parser<I, O2, Error>,
+  Output: crate::input::Accumulate<<I as Input>::Slice>,
+  F: Parser<I, <I as Input>::Slice, Error>,
+  G: Parser<I, <I as Input>::Slice, Error>,
   Error: ParseError<I>,
 {
   use crate::input::AsChar;
 
   let mut offset = 0;
-  let mut res = input.new_builder();
+  let mut res = Output::initial(Some(input.input_len()));
 
   let i = input.clone();
 
@@ -908,7 +904,7 @@ where
     let remainder = i.next_slice(offset).0;
     match normal.parse_next(remainder.clone()) {
       Ok((i2, o)) => {
-        o.extend_into(&mut res);
+        res.accumulate(o);
         if i2.input_len() == 0 {
           return Err(ErrMode::Incomplete(Needed::Unknown));
         } else if i2.input_len() == current_len {
@@ -927,7 +923,7 @@ where
           } else {
             match transform.parse_next(i.next_slice(next).0) {
               Ok((i2, o)) => {
-                o.extend_into(&mut res);
+                res.accumulate(o);
                 if i2.input_len() == 0 {
                   return Err(ErrMode::Incomplete(Needed::Unknown));
                 } else {

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -1256,7 +1256,7 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 #[inline(always)]
-pub fn escaped_transform<I, Error, F, G, O1, O2, ExtendItem, Output, const STREAMING: bool>(
+pub fn escaped_transform<I, Error, F, G, Output, const STREAMING: bool>(
   mut normal: F,
   control_char: char,
   mut transform: G,
@@ -1265,11 +1265,9 @@ where
   I: InputIsStreaming<STREAMING>,
   I: Input + Offset,
   <I as Input>::Token: crate::input::AsChar,
-  I: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O1: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  O2: crate::input::ExtendInto<Item = ExtendItem, Extender = Output>,
-  F: Parser<I, O1, Error>,
-  G: Parser<I, O2, Error>,
+  Output: crate::input::Accumulate<<I as Input>::Slice>,
+  F: Parser<I, <I as Input>::Slice, Error>,
+  G: Parser<I, <I as Input>::Slice, Error>,
   Error: ParseError<I>,
 {
   move |input: I| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,10 +426,10 @@ pub(crate) mod lib {
 
     #[cfg(feature = "alloc")]
     #[doc(hidden)]
-    pub use alloc::{borrow, boxed, string, vec};
+    pub use alloc::{borrow, boxed, collections, string, vec};
 
     #[doc(hidden)]
-    pub use core::{cmp, convert, fmt, iter, mem, ops, option, result, slice, str};
+    pub use core::{cmp, convert, fmt, hash, iter, mem, ops, option, result, slice, str};
 
     /// internal reproduction of std prelude
     #[doc(hidden)]

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -429,6 +429,9 @@ where
 /// assert_eq!(parser("123123"), Ok(("123123", 0)));
 /// assert_eq!(parser(""), Ok(("", 0)));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`many0`]
+#[deprecated(since = "0.3.0", note = "Replaced with `many0`")]
 pub fn many0_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
   I: Input,
@@ -487,6 +490,9 @@ where
 /// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(Error::new("123123", ErrorKind::Many1Count))));
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Many1Count))));
 /// ```
+///
+/// **WARNING:** Deprecated, replaced with [`many0`]
+#[deprecated(since = "0.3.0", note = "Replaced with `many0`")]
 pub fn many1_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
   I: Input,

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -6,11 +6,8 @@ mod tests;
 use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
-#[cfg(feature = "alloc")]
-use crate::input::clamp_capacity;
+use crate::input::Accumulate;
 use crate::input::{Input, InputIsStreaming, ToUsize, UpdateSlice};
-#[cfg(feature = "alloc")]
-use crate::lib::std::vec::Vec;
 use crate::{IResult, Parser};
 
 /// Repeats the embedded parser, gathering the results in a `Vec`.
@@ -24,7 +21,8 @@ use crate::{IResult, Parser};
 /// *Note*: if the parser passed in accepts empty inputs (like `alpha0` or `digit0`), `many0` will
 /// return an error, to prevent going into an infinite loop
 ///
-/// ```rust
+#[cfg_attr(not(feature = "std"), doc = "```ignore")]
+#[cfg_attr(feature = "std", doc = "```")]
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::multi::many0;
 /// use winnow::bytes::tag;
@@ -38,15 +36,15 @@ use crate::{IResult, Parser};
 /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// ```
-#[cfg(feature = "alloc")]
-pub fn many0<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
+pub fn many0<I, O, C, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, C, E>
 where
   I: Input,
+  C: Accumulate<O>,
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
   move |mut i: I| {
-    let mut acc = crate::lib::std::vec::Vec::with_capacity(4);
+    let mut acc = C::initial(None);
     loop {
       let len = i.input_len();
       match f.parse_next(i.clone()) {
@@ -59,7 +57,7 @@ where
           }
 
           i = i1;
-          acc.push(o);
+          acc.accumulate(o);
         }
       }
     }
@@ -78,7 +76,8 @@ where
 /// (like `alpha0` or `digit0`), `many1` will return an error,
 /// to prevent going into an infinite loop.
 ///
-/// ```rust
+#[cfg_attr(not(feature = "std"), doc = "```ignore")]
+#[cfg_attr(feature = "std", doc = "```")]
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::many1;
 /// use winnow::bytes::tag;
@@ -92,18 +91,18 @@ where
 /// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(Error::new("123123", ErrorKind::Tag))));
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// ```
-#[cfg(feature = "alloc")]
-pub fn many1<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
+pub fn many1<I, O, C, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, C, E>
 where
   I: Input,
+  C: Accumulate<O>,
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
   move |mut i: I| match f.parse_next(i.clone()) {
     Err(e) => Err(e.append(i, ErrorKind::Many1)),
     Ok((i1, o)) => {
-      let mut acc = crate::lib::std::vec::Vec::with_capacity(4);
-      acc.push(o);
+      let mut acc = C::initial(None);
+      acc.accumulate(o);
       i = i1;
 
       loop {
@@ -118,7 +117,7 @@ where
             }
 
             i = i1;
-            acc.push(o);
+            acc.accumulate(o);
           }
         }
       }
@@ -132,7 +131,8 @@ where
 ///
 /// `f` keeps going so long as `g` produces [`ErrMode::Backtrack`]. To instead chain an error up, see [`cut_err`][crate::combinator::cut_err].
 ///
-/// ```rust
+#[cfg_attr(not(feature = "std"), doc = "```ignore")]
+#[cfg_attr(feature = "std", doc = "```")]
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::many_till;
 /// use winnow::bytes::tag;
@@ -147,19 +147,16 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
 /// ```
-#[cfg(feature = "alloc")]
-pub fn many_till<I, O, P, E, F, G>(
-  mut f: F,
-  mut g: G,
-) -> impl FnMut(I) -> IResult<I, (Vec<O>, P), E>
+pub fn many_till<I, O, C, P, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, (C, P), E>
 where
   I: Input,
+  C: Accumulate<O>,
   F: Parser<I, O, E>,
   G: Parser<I, P, E>,
   E: ParseError<I>,
 {
   move |mut i: I| {
-    let mut res = crate::lib::std::vec::Vec::new();
+    let mut res = C::initial(None);
     loop {
       let len = i.input_len();
       match g.parse_next(i.clone()) {
@@ -173,7 +170,7 @@ where
                 return Err(ErrMode::from_error_kind(i1, ErrorKind::ManyTill));
               }
 
-              res.push(o);
+              res.accumulate(o);
               i = i1;
             }
           }
@@ -193,7 +190,8 @@ where
 /// * `sep` Parses the separator between list elements.
 /// * `f` Parses the elements of the list.
 ///
-/// ```rust
+#[cfg_attr(not(feature = "std"), doc = "```ignore")]
+#[cfg_attr(feature = "std", doc = "```")]
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::multi::separated_list0;
 /// use winnow::bytes::tag;
@@ -208,25 +206,25 @@ where
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// assert_eq!(parser("def|abc"), Ok(("def|abc", vec![])));
 /// ```
-#[cfg(feature = "alloc")]
-pub fn separated_list0<I, O, O2, E, F, G>(
+pub fn separated_list0<I, O, C, O2, E, F, G>(
   mut sep: G,
   mut f: F,
-) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
+) -> impl FnMut(I) -> IResult<I, C, E>
 where
   I: Input,
+  C: Accumulate<O>,
   F: Parser<I, O, E>,
   G: Parser<I, O2, E>,
   E: ParseError<I>,
 {
   move |mut i: I| {
-    let mut res = Vec::new();
+    let mut res = C::initial(None);
 
     match f.parse_next(i.clone()) {
       Err(ErrMode::Backtrack(_)) => return Ok((i, res)),
       Err(e) => return Err(e),
       Ok((i1, o)) => {
-        res.push(o);
+        res.accumulate(o);
         i = i1;
       }
     }
@@ -246,7 +244,7 @@ where
             Err(ErrMode::Backtrack(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
-              res.push(o);
+              res.accumulate(o);
               i = i2;
             }
           }
@@ -266,7 +264,8 @@ where
 /// # Arguments
 /// * `sep` Parses the separator between list elements.
 /// * `f` Parses the elements of the list.
-/// ```rust
+#[cfg_attr(not(feature = "std"), doc = "```ignore")]
+#[cfg_attr(feature = "std", doc = "```")]
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::separated_list1;
 /// use winnow::bytes::tag;
@@ -281,25 +280,25 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(Error::new("def|abc", ErrorKind::Tag))));
 /// ```
-#[cfg(feature = "alloc")]
-pub fn separated_list1<I, O, O2, E, F, G>(
+pub fn separated_list1<I, O, C, O2, E, F, G>(
   mut sep: G,
   mut f: F,
-) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
+) -> impl FnMut(I) -> IResult<I, C, E>
 where
   I: Input,
+  C: Accumulate<O>,
   F: Parser<I, O, E>,
   G: Parser<I, O2, E>,
   E: ParseError<I>,
 {
   move |mut i: I| {
-    let mut res = Vec::new();
+    let mut res = C::initial(None);
 
     // Parse the first element
     match f.parse_next(i.clone()) {
       Err(e) => return Err(e),
       Ok((i1, o)) => {
-        res.push(o);
+        res.accumulate(o);
         i = i1;
       }
     }
@@ -319,7 +318,7 @@ where
             Err(ErrMode::Backtrack(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
-              res.push(o);
+              res.accumulate(o);
               i = i2;
             }
           }
@@ -343,7 +342,8 @@ where
 /// (like `alpha0` or `digit0`), `many1` will return an error,
 /// to prevent going into an infinite loop.
 ///
-/// ```rust
+#[cfg_attr(not(feature = "std"), doc = "```ignore")]
+#[cfg_attr(feature = "std", doc = "```")]
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
 /// use winnow::multi::many_m_n;
 /// use winnow::bytes::tag;
@@ -358,14 +358,14 @@ where
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
-#[cfg(feature = "alloc")]
-pub fn many_m_n<I, O, E, F>(
+pub fn many_m_n<I, O, C, E, F>(
   min: usize,
   max: usize,
   mut parse: F,
-) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
+) -> impl FnMut(I) -> IResult<I, C, E>
 where
   I: Input,
+  C: Accumulate<O>,
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
@@ -374,7 +374,7 @@ where
       return Err(ErrMode::Cut(E::from_error_kind(input, ErrorKind::ManyMN)));
     }
 
-    let mut res = crate::lib::std::vec::Vec::with_capacity(clamp_capacity::<O>(min));
+    let mut res = C::initial(Some(min));
     for count in 0..max {
       let len = input.input_len();
       match parse.parse_next(input.clone()) {
@@ -384,7 +384,7 @@ where
             return Err(ErrMode::from_error_kind(input, ErrorKind::ManyMN));
           }
 
-          res.push(value);
+          res.accumulate(value);
           input = tail;
         }
         Err(ErrMode::Backtrack(e)) => {
@@ -529,7 +529,8 @@ where
 /// # Arguments
 /// * `f` The parser to apply.
 /// * `count` How often to apply the parser.
-/// ```rust
+#[cfg_attr(not(feature = "std"), doc = "```ignore")]
+#[cfg_attr(feature = "std", doc = "```")]
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::multi::count;
 /// use winnow::bytes::tag;
@@ -544,22 +545,22 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
-#[cfg(feature = "alloc")]
-pub fn count<I, O, E, F>(mut f: F, count: usize) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
+pub fn count<I, O, C, E, F>(mut f: F, count: usize) -> impl FnMut(I) -> IResult<I, C, E>
 where
   I: Clone + PartialEq,
+  C: Accumulate<O>,
   F: Parser<I, O, E>,
   E: ParseError<I>,
 {
   move |i: I| {
     let mut input = i.clone();
-    let mut res = crate::lib::std::vec::Vec::with_capacity(clamp_capacity::<O>(count));
+    let mut res = C::initial(Some(count));
 
     for _ in 0..count {
       let input_ = input.clone();
       match f.parse_next(input_) {
         Ok((i, o)) => {
-          res.push(o);
+          res.accumulate(o);
           input = i;
         }
         Err(e) => {
@@ -961,7 +962,8 @@ where
 /// # Arguments
 /// * `f` The parser to apply to obtain the count.
 /// * `g` The parser to apply repeatedly.
-/// ```rust
+#[cfg_attr(not(feature = "std"), doc = "```ignore")]
+#[cfg_attr(feature = "std", doc = "```")]
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
 /// use winnow::number::u8;
@@ -979,11 +981,11 @@ where
 /// assert_eq!(parser(&b"\x02abcabcabc"[..]), Ok(((&b"abc"[..], vec![&b"abc"[..], &b"abc"[..]]))));
 /// assert_eq!(parser(b"\x03123123123"), Err(ErrMode::Backtrack(Error::new(&b"123123123"[..], ErrorKind::Tag))));
 /// ```
-#[cfg(feature = "alloc")]
-pub fn length_count<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
+pub fn length_count<I, O, C, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, C, E>
 where
   I: Clone,
   N: ToUsize,
+  C: Accumulate<O>,
   F: Parser<I, N, E>,
   G: Parser<I, O, E>,
   E: ParseError<I>,
@@ -991,13 +993,13 @@ where
   move |i: I| {
     let (i, count) = f.parse_next(i)?;
     let mut input = i.clone();
-    let mut res = Vec::with_capacity(clamp_capacity::<O>(count.to_usize()));
+    let mut res = C::initial(Some(count.to_usize()));
 
     for _ in 0..count.to_usize() {
       let input_ = input.clone();
       match g.parse_next(input_) {
         Ok((i, o)) => {
-          res.push(o);
+          res.accumulate(o);
           input = i;
         }
         Err(e) => {

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -1,4 +1,4 @@
-use super::{length_data, length_value, many0_count, many1_count};
+use super::{length_data, length_value, many0, many1};
 use crate::input::Streaming;
 use crate::Parser;
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
 use crate::{
   lib::std::vec::Vec,
   multi::{
-    count, fold_many0, fold_many1, fold_many_m_n, length_count, many0, many1, many_m_n, many_till,
+    count, fold_many0, fold_many1, fold_many_m_n, length_count, many_m_n, many_till,
     separated_list0, separated_list1,
   },
 };
@@ -641,7 +641,7 @@ fn fold_many_m_n_test() {
 #[test]
 fn many0_count_test() {
   fn count0_nums(i: &[u8]) -> IResult<&[u8], usize> {
-    many0_count((digit, tag(",")))(i)
+    many0((digit, tag(",")))(i)
   }
 
   assert_eq!(count0_nums(&b"123,junk"[..]), Ok((&b"junk"[..], 1)));
@@ -659,7 +659,7 @@ fn many0_count_test() {
 #[test]
 fn many1_count_test() {
   fn count1_nums(i: &[u8]) -> IResult<&[u8], usize> {
-    many1_count((digit, tag(",")))(i)
+    many1((digit, tag(",")))(i)
   }
 
   assert_eq!(count1_nums(&b"123,45,junk"[..]), Ok((&b"junk"[..], 2)));
@@ -673,7 +673,7 @@ fn many1_count_test() {
     count1_nums(&b"hello"[..]),
     Err(ErrMode::Backtrack(error_position!(
       &b"hello"[..],
-      ErrorKind::Many1Count
+      ErrorKind::Digit
     )))
   );
 }

--- a/tests/testsuite/fnmut.rs
+++ b/tests/testsuite/fnmut.rs
@@ -1,16 +1,17 @@
 #![cfg(feature = "alloc")]
 
-use winnow::{
-  bytes::tag,
-  multi::{many0, many0_count},
-};
+use winnow::bytes::tag;
+#[cfg(feature = "std")]
+use winnow::multi::many0;
+use winnow::multi::many0_count;
 
 #[test]
+#[cfg(feature = "std")]
 fn parse() {
   let mut counter = 0;
 
   let res = {
-    let mut parser = many0::<_, _, (), _>(|i| {
+    let mut parser = many0::<_, _, Vec<_>, (), _>(|i| {
       counter += 1;
       tag("abc")(i)
     });

--- a/tests/testsuite/fnmut.rs
+++ b/tests/testsuite/fnmut.rs
@@ -1,9 +1,7 @@
 #![cfg(feature = "alloc")]
 
 use winnow::bytes::tag;
-#[cfg(feature = "std")]
 use winnow::multi::many0;
-use winnow::multi::many0_count;
 
 #[test]
 #[cfg(feature = "std")]
@@ -28,7 +26,7 @@ fn accumulate() {
   let mut v = Vec::new();
 
   let (_, count) = {
-    let mut parser = many0_count::<_, _, (), _>(|i| {
+    let mut parser = many0::<_, _, usize, (), _>(|i| {
       let (i, o) = tag("abc")(i)?;
       v.push(o);
       Ok((i, ()))

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -188,8 +188,8 @@ fn issue_942() {
   pub fn parser<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
     i: &'a str,
   ) -> IResult<&'a str, usize, E> {
-    use winnow::{bytes::one_of, multi::many0_count};
-    many0_count(one_of('a').context("char_a"))(i)
+    use winnow::{bytes::one_of, multi::many0};
+    many0(one_of('a').context("char_a"))(i)
   }
   assert_eq!(parser::<()>("aaa"), Ok(("", 3)));
 }

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -195,9 +195,10 @@ fn issue_942() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn issue_many_m_n_with_zeros() {
   use winnow::multi::many_m_n;
-  let mut parser = many_m_n::<_, _, (), _>(0, 0, 'a');
+  let mut parser = many_m_n::<_, _, Vec<_>, (), _>(0, 0, 'a');
   assert_eq!(parser("aaa"), Ok(("aaa", vec![])));
 }
 
@@ -262,15 +263,16 @@ fn issue_x_looser_fill_bounds() {
   );
 }
 
+#[cfg(feature = "std")]
 fn issue_1459_clamp_capacity() {
   // shouldn't panic
   use winnow::multi::many_m_n;
-  let mut parser = many_m_n::<_, _, (), _>(usize::MAX, usize::MAX, 'a');
+  let mut parser = many_m_n::<_, _, Vec<_>, (), _>(usize::MAX, usize::MAX, 'a');
   assert_eq!(parser("a"), Err(winnow::error::ErrMode::Backtrack(())));
 
   // shouldn't panic
   use winnow::multi::count;
-  let mut parser = count::<_, _, (), _>('a', usize::MAX);
+  let mut parser = count::<_, _, Vec<_>, (), _>('a', usize::MAX);
   assert_eq!(parser("a"), Err(winnow::error::ErrMode::Backtrack(())));
 }
 

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -509,7 +509,9 @@ mod test {
     let b = "ababcd";
 
     fn f(i: &str) -> IResult<&str, &str> {
-      many1(alt((tag("a"), tag("b")))).recognize().parse_next(i)
+      many1::<_, _, (), _, _>(alt((tag("a"), tag("b"))))
+        .recognize()
+        .parse_next(i)
     }
 
     assert_eq!(f(a), Ok((&a[6..], a)));


### PR DESCRIPTION
I went with a custom trait so we could cover `()` and `usize` as well as
support custom capacities.

This comes at the cost of supporting any container possible.  We could
possibly do that with a `Extendable(T: Default + Extend)` newtype.

As an alternative to `()` and `usize` is GATs.  The main difference is
who drives the types.

This allowed us to deprecate `many[01]_count`.

Along the way, we also updated `escaped_transform` to this so we use this consistently.  This exposed why #19 was broken.  `ExtendInto` was implemented both for input and for outputs for the two parsers, which was meant to include `char`.  The backward design of  the trait made this less obvious what was happening which I feel is a win for the new trait design.

However, now that `Accumulate` has no `input` connection, there isn't quite a proper home for this...

I am conflicted about needing to annotate types when passing a `many` into something that ignores the output, like `recognize`.  In some respects, I want to require the output type into parsers like `recognize` to be `()` but that that will require a lot of `void()` as that is the minority case.  This is a benefit to the GAT approach.

Fixes #122

BREAKING CHANGE: The trait and behavior for `escaped_transform` changed due to replacing `ExtendInto` with `Accumulate`.