### PR TITLE
fix(bytes)!: Ensure take_while_m_n handles UTF-8 correctly

### DIFF
--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -413,7 +413,7 @@ where
 }
 
 pub(crate) fn take_while_m_n_internal<T, I, Error: ParseError<I>>(
-  i: I,
+  input: I,
   m: usize,
   n: usize,
   list: &T,
@@ -422,43 +422,35 @@ where
   I: Input,
   T: ContainsToken<<I as Input>::Token>,
 {
-  let input = i;
+  if n < m {
+    return Err(ErrMode::from_error_kind(input, ErrorKind::TakeWhileMN));
+  }
 
-  match input.offset_for(|c| !list.contains_token(c)) {
-    Some(idx) => {
-      if idx >= m {
-        if idx <= n {
-          let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(idx) {
-            Ok(input.next_slice(index))
-          } else {
-            Err(ErrMode::from_error_kind(input, ErrorKind::TakeWhileMN))
-          };
-          res
-        } else {
-          let res: IResult<_, _, Error> = if let Ok(index) = input.offset_at(n) {
-            Ok(input.next_slice(index))
-          } else {
-            Err(ErrMode::from_error_kind(input, ErrorKind::TakeWhileMN))
-          };
-          res
-        }
+  let mut final_count = 0;
+  for (processed, (offset, token)) in input.iter_offsets().enumerate() {
+    if !list.contains_token(token) {
+      if processed < m {
+        return Err(ErrMode::from_error_kind(input, ErrorKind::TakeWhileMN));
       } else {
-        let e = ErrorKind::TakeWhileMN;
-        Err(ErrMode::from_error_kind(input, e))
+        return Ok(input.next_slice(offset));
       }
-    }
-    None => {
-      let len = input.input_len();
-      if len >= n {
-        match input.offset_at(n) {
-          Ok(index) => Ok(input.next_slice(index)),
-          Err(_needed) => Err(ErrMode::from_error_kind(input, ErrorKind::TakeWhileMN)),
-        }
-      } else {
-        let needed = if m > len { m - len } else { 1 };
-        Err(ErrMode::Incomplete(Needed::new(needed)))
+    } else {
+      if processed == n {
+        return Ok(input.next_slice(offset));
       }
+      final_count = processed + 1;
     }
+  }
+
+  if final_count == n {
+    Ok(input.next_slice(input.input_len()))
+  } else {
+    let needed = if m > input.input_len() {
+      m - input.input_len()
+    } else {
+      1
+    };
+    Err(ErrMode::Incomplete(Needed::new(needed)))
   }
 }
 

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -14,19 +14,18 @@ use crate::Parser;
 
 #[test]
 fn complete_take_while_m_n_utf8_all_matching() {
-  let result: IResult<&str, &str> = super::take_while_m_n(1, 4, |c: char| c.is_alphabetic())("øn");
+  let result: IResult<&str, &str> = take_while_m_n(1, 4, |c: char| c.is_alphabetic())("øn");
   assert_eq!(result, Ok(("", "øn")));
 }
 
 #[test]
 fn complete_take_while_m_n_utf8_all_matching_substring() {
-  let result: IResult<&str, &str> = super::take_while_m_n(1, 1, |c: char| c.is_alphabetic())("øn");
+  let result: IResult<&str, &str> = take_while_m_n(1, 1, |c: char| c.is_alphabetic())("øn");
   assert_eq!(result, Ok(("n", "ø")));
 }
 
 #[test]
 fn streaming_any_str() {
-  use super::any;
   assert_eq!(
     any::<_, Error<Streaming<&str>>, true>(Streaming("Ә")),
     Ok((Streaming(""), 'Ә'))
@@ -433,7 +432,7 @@ fn streaming_take_utf8() {
 }
 
 #[test]
-fn streaming_take_while_m_n_utf8() {
+fn streaming_take_while_m_n_utf8_fixed() {
   fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
     take_while_m_n(1, 1, |c| c == 'A' || c == '😃')(i)
   }
@@ -442,11 +441,28 @@ fn streaming_take_while_m_n_utf8() {
 }
 
 #[test]
-fn streaming_take_while_m_n_utf8_full_match() {
+fn streaming_take_while_m_n_utf8_range() {
+  fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_while_m_n(1, 2, |c| c == 'A' || c == '😃')(i)
+  }
+  assert_eq!(parser(Streaming("A!")), Ok((Streaming("!"), "A")));
+  assert_eq!(parser(Streaming("😃!")), Ok((Streaming(""), "😃!")));
+}
+
+#[test]
+fn streaming_take_while_m_n_utf8_full_match_fixed() {
   fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
     take_while_m_n(1, 1, |c: char| c.is_alphabetic())(i)
   }
   assert_eq!(parser(Streaming("øn")), Ok((Streaming("n"), "ø")));
+}
+
+#[test]
+fn streaming_take_while_m_n_utf8_full_match_range() {
+  fn parser(i: Streaming<&str>) -> IResult<Streaming<&str>, &str> {
+    take_while_m_n(1, 2, |c: char| c.is_alphabetic())(i)
+  }
+  assert_eq!(parser(Streaming("øn")), Ok((Streaming(""), "øn")));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #93

BREAKING CHANGE: `take_while_m_n` now errors if `n < m`