### PR TITLE
fix(input)!: Prevent `str` from being processed as arbitrary bytes

### DIFF
--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -9,7 +9,7 @@ use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
 use crate::input::{
-  split_at_offset1_complete, split_at_offset_complete, AsBytes, AsChar, ContainsToken, Input,
+  split_at_offset1_complete, split_at_offset_complete, AsBStr, AsChar, ContainsToken, Input,
 };
 use crate::input::{Compare, CompareResult};
 use crate::IResult;
@@ -204,7 +204,7 @@ where
 )]
 pub fn not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as Input>::Slice, E>
 where
-  T: Input + AsBytes,
+  T: Input + AsBStr,
   T: Compare<&'static str>,
   <T as Input>::Token: AsChar,
 {
@@ -215,7 +215,7 @@ where
     None => Ok(input.next_slice(input.input_len())),
     Some(offset) => {
       let (new_input, res) = input.next_slice(offset);
-      let bytes = new_input.as_bytes();
+      let bytes = new_input.as_bstr();
       let nth = bytes[0];
       if nth == b'\r' {
         let comp = new_input.compare("\r\n");
@@ -952,7 +952,7 @@ mod tests {
     let a: &[u8] = b"abcd";
     let b: &[u8] = b"1234";
     let c: &[u8] = b"a123";
-    let d: &[u8] = "azé12".as_bytes();
+    let d: &[u8] = "azé12".as_bstr();
     let e: &[u8] = b" ";
     let f: &[u8] = b" ;";
     //assert_eq!(alpha1::<_, Error<_>>(a), Err(ErrMode::Incomplete(Needed::Size(1))));
@@ -965,7 +965,7 @@ mod tests {
       }))
     );
     assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], &b"a"[..])));
-    assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bytes(), &b"az"[..])));
+    assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bstr(), &b"az"[..])));
     assert_eq!(
       digit1(a),
       Err(ErrMode::Backtrack(Error {
@@ -993,7 +993,7 @@ mod tests {
     assert_eq!(hex_digit1::<_, Error<_>>(c), Ok((empty, c)));
     assert_eq!(
       hex_digit1::<_, Error<_>>(d),
-      Ok(("zé12".as_bytes(), &b"a"[..]))
+      Ok(("zé12".as_bstr(), &b"a"[..]))
     );
     assert_eq!(
       hex_digit1(e),
@@ -1029,7 +1029,7 @@ mod tests {
     assert_eq!(alphanumeric1::<_, Error<_>>(c), Ok((empty, c)));
     assert_eq!(
       alphanumeric1::<_, Error<_>>(d),
-      Ok(("é12".as_bytes(), &b"az"[..]))
+      Ok(("é12".as_bstr(), &b"az"[..]))
     );
     assert_eq!(space1::<_, Error<_>>(e), Ok((empty, e)));
     assert_eq!(space1::<_, Error<_>>(f), Ok((&b";"[..], &b" "[..])));

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -15,7 +15,7 @@ use crate::combinator::opt;
 use crate::error::ParseError;
 use crate::error::{ErrMode, ErrorKind, Needed};
 use crate::input::Compare;
-use crate::input::{AsBytes, AsChar, Input, InputIsStreaming, Offset, ParseTo};
+use crate::input::{AsBStr, AsChar, Input, InputIsStreaming, Offset, ParseTo};
 use crate::IResult;
 use crate::Parser;
 
@@ -102,7 +102,7 @@ pub fn not_line_ending<I, E: ParseError<I>, const STREAMING: bool>(
 ) -> IResult<I, <I as Input>::Slice, E>
 where
   I: InputIsStreaming<STREAMING>,
-  I: Input + AsBytes,
+  I: Input + AsBStr,
   I: Compare<&'static str>,
   <I as Input>::Token: AsChar,
 {
@@ -1178,7 +1178,7 @@ where
   I: Input,
   O: HexUint,
   <I as Input>::Token: AsChar,
-  <I as Input>::Slice: AsBytes,
+  <I as Input>::Slice: AsBStr,
 {
   let invalid_offset = input
     .offset_for(|c| {
@@ -1213,7 +1213,7 @@ where
   let (remaining, parsed) = input.next_slice(offset);
 
   let mut res = O::default();
-  for c in parsed.as_bytes() {
+  for c in parsed.as_bstr() {
     let nibble = *c as char;
     let nibble = nibble.to_digit(16).unwrap_or(0) as u8;
     let nibble = O::from(nibble);
@@ -1316,7 +1316,7 @@ where
   <I as Input>::Slice: ParseTo<O>,
   <I as Input>::Token: AsChar + Copy,
   <I as Input>::IterOffsets: Clone,
-  I: AsBytes,
+  I: AsBStr,
 {
   let (i, s) = if STREAMING {
     crate::number::streaming::recognize_float_or_exceptions(input)?

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -10,7 +10,7 @@ use crate::error::ErrorKind;
 use crate::error::Needed;
 use crate::error::ParseError;
 use crate::input::{
-  split_at_offset1_streaming, split_at_offset_streaming, AsBytes, AsChar, ContainsToken, Input,
+  split_at_offset1_streaming, split_at_offset_streaming, AsBStr, AsChar, ContainsToken, Input,
 };
 use crate::input::{Compare, CompareResult};
 use crate::IResult;
@@ -220,7 +220,7 @@ where
 )]
 pub fn not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as Input>::Slice, E>
 where
-  T: Input + AsBytes,
+  T: Input + AsBStr,
   T: Compare<&'static str>,
   <T as Input>::Token: AsChar,
 {
@@ -231,7 +231,7 @@ where
     None => Err(ErrMode::Incomplete(Needed::Unknown)),
     Some(offset) => {
       let (new_input, res) = input.next_slice(offset);
-      let bytes = new_input.as_bytes();
+      let bytes = new_input.as_bstr();
       let nth = bytes[0];
       if nth == b'\r' {
         let comp = new_input.compare("\r\n");
@@ -900,7 +900,7 @@ mod tests {
     let a: &[u8] = b"abcd";
     let b: &[u8] = b"1234";
     let c: &[u8] = b"a123";
-    let d: &[u8] = "azé12".as_bytes();
+    let d: &[u8] = "azé12".as_bstr();
     let e: &[u8] = b" ";
     let f: &[u8] = b" ;";
     //assert_eq!(alpha1::<_, Error<_>>(a), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -910,7 +910,7 @@ mod tests {
       Err(ErrMode::Backtrack(Error::new(b, ErrorKind::Alpha)))
     );
     assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], &b"a"[..])));
-    assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bytes(), &b"az"[..])));
+    assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bstr(), &b"az"[..])));
     assert_eq!(
       digit1(a),
       Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Digit)))
@@ -941,7 +941,7 @@ mod tests {
     );
     assert_eq!(
       hex_digit1::<_, Error<_>>(d),
-      Ok(("zé12".as_bytes(), &b"a"[..]))
+      Ok(("zé12".as_bstr(), &b"a"[..]))
     );
     assert_eq!(
       hex_digit1(e),
@@ -974,7 +974,7 @@ mod tests {
     );
     assert_eq!(
       alphanumeric1::<_, Error<_>>(d),
-      Ok(("é12".as_bytes(), &b"az"[..]))
+      Ok(("é12".as_bstr(), &b"az"[..]))
     );
     assert_eq!(
       space1::<_, Error<_>>(e),

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -9,7 +9,7 @@ use crate::character::complete::{char, digit1, sign};
 use crate::combinator::{cut_err, map, opt};
 use crate::error::ParseError;
 use crate::error::{make_error, ErrMode, ErrorKind};
-use crate::input::{AsBytes, AsChar, Compare, Input, Offset, SliceLen};
+use crate::input::{AsBStr, AsBytes, AsChar, Compare, Input, Offset, SliceLen};
 use crate::lib::std::ops::{Add, Shl};
 use crate::sequence::{pair, tuple};
 use crate::*;
@@ -1442,7 +1442,7 @@ pub fn hex_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Input,
   <I as Input>::Token: AsChar,
-  <I as Input>::Slice: AsBytes,
+  <I as Input>::Slice: AsBStr,
 {
   let invalid_offset = input
     .offset_for(|c| {
@@ -1461,7 +1461,7 @@ where
   let (remaining, parsed) = input.next_slice(offset);
 
   let res = parsed
-    .as_bytes()
+    .as_bstr()
     .iter()
     .rev()
     .enumerate()
@@ -1482,7 +1482,7 @@ where
   T: Offset + Compare<&'static str>,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::IterOffsets: Clone,
-  T: AsBytes,
+  T: AsBStr,
 {
   tuple((
     opt(alt((char('+'), char('-')))),
@@ -1510,7 +1510,7 @@ where
   T: Offset + Compare<&'static str>,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::IterOffsets: Clone,
-  T: AsBytes,
+  T: AsBStr,
 {
   alt((
     |i: T| {
@@ -1546,7 +1546,7 @@ pub fn recognize_float_parts<T, E: ParseError<T>>(
   input: T,
 ) -> IResult<T, (bool, <T as Input>::Slice, <T as Input>::Slice, i32), E>
 where
-  T: Input + Compare<&'static [u8]> + AsBytes,
+  T: Input + Compare<&'static [u8]> + AsBStr,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::Slice: SliceLen,
 {
@@ -1564,7 +1564,7 @@ where
     // match number
     let mut zero_count = 0usize;
     let mut offset = None;
-    for (pos, c) in i.as_bytes().iter().enumerate() {
+    for (pos, c) in i.as_bstr().iter().enumerate() {
       if *c >= b'0' && *c <= b'9' {
         if *c == b'0' {
           zero_count += 1;
@@ -1635,7 +1635,7 @@ where
   <T as Input>::Slice: ParseTo<f32>,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::IterOffsets: Clone,
-  T: AsBytes,
+  T: AsBStr,
 {
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
@@ -1674,7 +1674,7 @@ where
   <T as Input>::Slice: ParseTo<f64>,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::IterOffsets: Clone,
-  T: AsBytes,
+  T: AsBStr,
 {
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -8,7 +8,7 @@ use crate::bytes::streaming::tag;
 use crate::character::streaming::{char, digit1, sign};
 use crate::combinator::{cut_err, map, opt};
 use crate::error::{ErrMode, ErrorKind, Needed, ParseError};
-use crate::input::{AsBytes, AsChar, Compare, Input, Offset, ParseTo, SliceLen};
+use crate::input::{AsBStr, AsBytes, AsChar, Compare, Input, Offset, ParseTo, SliceLen};
 use crate::lib::std::ops::{Add, Shl};
 use crate::sequence::{pair, tuple};
 use crate::*;
@@ -1536,7 +1536,7 @@ pub fn hex_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
   I: Input,
   <I as Input>::Token: AsChar,
-  <I as Input>::Slice: AsBytes,
+  <I as Input>::Slice: AsBStr,
 {
   let invalid_offset = input
     .offset_for(|c| {
@@ -1563,7 +1563,7 @@ where
   let (remaining, parsed) = input.next_slice(offset);
 
   let res = parsed
-    .as_bytes()
+    .as_bstr()
     .iter()
     .rev()
     .enumerate()
@@ -1584,7 +1584,7 @@ where
   T: Offset + Compare<&'static str>,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::IterOffsets: Clone,
-  T: AsBytes,
+  T: AsBStr,
 {
   tuple((
     opt(alt((char('+'), char('-')))),
@@ -1612,7 +1612,7 @@ where
   T: Offset + Compare<&'static str>,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::IterOffsets: Clone,
-  T: AsBytes,
+  T: AsBStr,
 {
   alt((
     |i: T| {
@@ -1648,7 +1648,7 @@ pub fn recognize_float_parts<T, E: ParseError<T>>(
   input: T,
 ) -> IResult<T, (bool, <T as Input>::Slice, <T as Input>::Slice, i32), E>
 where
-  T: Input + Compare<&'static [u8]> + AsBytes,
+  T: Input + Compare<&'static [u8]> + AsBStr,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::Slice: SliceLen,
 {
@@ -1666,7 +1666,7 @@ where
     // match number
     let mut zero_count = 0usize;
     let mut offset = None;
-    for (pos, c) in i.as_bytes().iter().enumerate() {
+    for (pos, c) in i.as_bstr().iter().enumerate() {
       if *c >= b'0' && *c <= b'9' {
         if *c == b'0' {
           zero_count += 1;
@@ -1740,7 +1740,7 @@ where
   <T as Input>::Slice: ParseTo<f32>,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::IterOffsets: Clone,
-  T: AsBytes,
+  T: AsBStr,
 {
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {
@@ -1783,7 +1783,7 @@ where
   <T as Input>::Slice: ParseTo<f64>,
   <T as Input>::Token: AsChar + Copy,
   <T as Input>::IterOffsets: Clone,
-  T: AsBytes,
+  T: AsBStr,
 {
   let (i, s) = recognize_float_or_exceptions(input)?;
   match s.parse_to() {


### PR DESCRIPTION
This will turn panics into compile errors and open the way for some unsafe for #115

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
