### PR TITLE
fix(parser)!: Rename Parser::map_opt to Parser::verify_map 

### DIFF
--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -105,7 +105,7 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
     let (input, c) = none_of("\"")(input)?;
     if c == '\\' {
         alt((
-            any.map_opt(|c| {
+            any.verify_map(|c| {
                 Some(match c {
                     '"' | '\\' | '/' => c,
                     'b' => '\x08',
@@ -140,7 +140,7 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
                 (high_ten << 10) + low_ten + 0x10000
             }),
     ))
-    .map_opt(
+    .verify_map(
         // Could be probably replaced with .unwrap() or _unchecked due to the verify checks
         std::char::from_u32,
     )
@@ -149,7 +149,7 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
 
 fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, u16, E> {
     take(4usize)
-        .map_opt(|s| u16::from_str_radix(s, 16).ok())
+        .verify_map(|s| u16::from_str_radix(s, 16).ok())
         .parse_next(input)
 }
 

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -149,7 +149,7 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
                 (high_ten << 10) + low_ten + 0x10000
             }),
     ))
-    .map_opt(
+    .verify_map(
         // Could be probably replaced with .unwrap() or _unchecked due to the verify checks
         std::char::from_u32,
     )
@@ -158,7 +158,7 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
 
 fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, u16, E> {
     take(4usize)
-        .map_opt(|s| u16::from_str_radix(s, 16).ok())
+        .verify_map(|s| u16::from_str_radix(s, 16).ok())
         .parse_next(input)
 }
 

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -114,7 +114,7 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
     let (input, c) = none_of("\"")(input)?;
     if c == '\\' {
         alt((
-            any.map_opt(|c| {
+            any.verify_map(|c| {
                 Some(match c {
                     '"' | '\\' | '/' => c,
                     'b' => '\x08',
@@ -149,7 +149,7 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
                 (high_ten << 10) + low_ten + 0x10000
             }),
     ))
-    .map_opt(
+    .verify_map(
         // Could be probably replaced with .unwrap() or _unchecked due to the verify checks
         std::char::from_u32,
     )
@@ -158,7 +158,7 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
 
 fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, u16, E> {
     take(4usize)
-        .map_opt(|s| u16::from_str_radix(s, 16).ok())
+        .verify_map(|s| u16::from_str_radix(s, 16).ok())
         .parse_next(input)
 }
 

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -50,11 +50,11 @@ where
     // convert them to a u32.
     let parse_u32 = parse_delimited_hex.map_res(move |hex| u32::from_str_radix(hex, 16));
 
-    // map_opt is like map_res, but it takes an Option instead of a Result. If
-    // the function returns None, map_opt returns an error. In this case, because
+    // verify_map is like map_res, but it takes an Option instead of a Result. If
+    // the function returns None, verify_map returns an error. In this case, because
     // not all u32 values are valid unicode code points, we have to fallibly
     // convert to char with from_u32.
-    parse_u32.map_opt(std::char::from_u32).parse_next(input)
+    parse_u32.verify_map(std::char::from_u32).parse_next(input)
 }
 
 /// Parse an escaped character: \n, \t, \r, \u{00AC}, etc.

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -373,7 +373,7 @@ where
 /// assert_eq!(parse("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Digit))));
 ///
 /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-/// assert_eq!(parse("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::MapOpt))));
+/// assert_eq!(parse("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::Verify))));
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::verify_map")]
@@ -390,7 +390,7 @@ where
         let (input, o1) = parser.parse_next(input)?;
         match f(o1) {
             Some(o2) => Ok((input, o2)),
-            None => Err(ErrMode::from_error_kind(i, ErrorKind::MapOpt)),
+            None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
         }
     }
 }
@@ -425,7 +425,7 @@ where
         let (input, o1) = self.f.parse_next(input)?;
         match (self.g)(o1) {
             Some(o2) => Ok((input, o2)),
-            None => Err(ErrMode::from_error_kind(i, ErrorKind::MapOpt)),
+            None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
         }
     }
 }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -76,7 +76,7 @@
 //! - [`Parser::value`][crate::Parser::value]: method to replace the result of a parser
 //! - [`Parser::map`][crate::Parser::map]: method to map a function on the result of a parser
 //! - [`Parser::and_then`][crate::Parser::and_then]: Applies a second parser over the output of the first one
-//! - [`Parser::map_opt`][Parser::map_opt]: Maps a function returning an `Option` on the output of a parser
+//! - [`Parser::verify_map`][Parser::verify_map]: Maps a function returning an `Option` on the output of a parser
 //! - [`Parser::map_res`][Parser::map_res]: Maps a function returning a `Result` on the output of a parser
 //! - [`Parser::parse_to`][crate::Parser::parse_to]: Apply [`std::str::FromStr`] to the output of the parser
 //! - [`not`][not]: Returns a result only if the embedded parser returns `Backtrack` or `Incomplete`. Does not consume the input
@@ -356,7 +356,7 @@ where
 
 /// Applies a function returning an `Option` over the result of a parser.
 ///
-/// **WARNING:** Deprecated, replaced with [`Parser::map_opt`]
+/// **WARNING:** Deprecated, replaced with [`Parser::verify_map`]
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
@@ -376,7 +376,7 @@ where
 /// assert_eq!(parse("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::MapOpt))));
 /// # }
 /// ```
-#[deprecated(since = "0.1.0", note = "Replaced with `Parser::map_res")]
+#[deprecated(since = "0.1.0", note = "Replaced with `Parser::verify_map")]
 pub fn map_opt<I: Clone, O1, O2, E: ParseError<I>, F, G>(
     mut parser: F,
     mut f: G,
@@ -395,15 +395,15 @@ where
     }
 }
 
-/// Implementation of [`Parser::map_opt`]
+/// Implementation of [`Parser::verify_map`]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
-pub struct MapOpt<F, G, O1> {
+pub struct VerifyMap<F, G, O1> {
     f: F,
     g: G,
     phantom: core::marker::PhantomData<O1>,
 }
 
-impl<F, G, O1> MapOpt<F, G, O1> {
+impl<F, G, O1> VerifyMap<F, G, O1> {
     pub(crate) fn new(f: F, g: G) -> Self {
         Self {
             f,
@@ -413,7 +413,7 @@ impl<F, G, O1> MapOpt<F, G, O1> {
     }
 }
 
-impl<I, O1, O2, E, F, G> Parser<I, O2, E> for MapOpt<F, G, O1>
+impl<I, O1, O2, E, F, G> Parser<I, O2, E> for VerifyMap<F, G, O1>
 where
     I: Clone,
     F: Parser<I, O1, E>,

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -125,7 +125,7 @@ fn test_map_opt() {
         map_opt(u8, |u| if u < 20 { Some(u) } else { None })(input),
         Err(ErrMode::Backtrack(Error {
             input: &[50][..],
-            kind: ErrorKind::MapOpt
+            kind: ErrorKind::Verify
         }))
     );
     assert_parse!(
@@ -142,7 +142,7 @@ fn test_parser_verify_map() {
             .parse_next(input),
         Err(ErrMode::Backtrack(Error {
             input: &[50][..],
-            kind: ErrorKind::MapOpt
+            kind: ErrorKind::Verify
         }))
     );
     assert_parse!(

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -135,10 +135,10 @@ fn test_map_opt() {
 }
 
 #[test]
-fn test_parser_map_opt() {
+fn test_parser_verify_map() {
     let input: &[u8] = &[50][..];
     assert_parse!(
-        u8.map_opt(|u| if u < 20 { Some(u) } else { None })
+        u8.verify_map(|u| if u < 20 { Some(u) } else { None })
             .parse_next(input),
         Err(ErrMode::Backtrack(Error {
             input: &[50][..],
@@ -146,7 +146,7 @@ fn test_parser_map_opt() {
         }))
     );
     assert_parse!(
-        u8.map_opt(|u| if u > 20 { Some(u) } else { None })
+        u8.verify_map(|u| if u > 20 { Some(u) } else { None })
             .parse_next(input),
         Ok((&[][..], 50))
     );

--- a/src/error.rs
+++ b/src/error.rs
@@ -1109,7 +1109,6 @@ pub fn convert_error<I: core::ops::Deref<Target = str>>(
 pub enum ErrorKind {
   Tag,
   MapRes,
-  MapOpt,
   Alt,
   IsNot,
   IsA,
@@ -1170,7 +1169,6 @@ impl ErrorKind {
     match *self {
       ErrorKind::Tag                       => "Tag",
       ErrorKind::MapRes                    => "Map on Result",
-      ErrorKind::MapOpt                    => "Map on Option",
       ErrorKind::Alt                       => "Alternative",
       ErrorKind::IsNot                     => "IsNot",
       ErrorKind::IsA                       => "IsA",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -388,7 +388,7 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parse.parse_next("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Digit))));
     ///
     /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-    /// assert_eq!(parse.parse_next("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::MapOpt))));
+    /// assert_eq!(parse.parse_next("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::Verify))));
     /// # }
     /// ```
     fn verify_map<G, O2>(self, g: G) -> VerifyMap<Self, G, O>

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -370,7 +370,7 @@ pub trait Parser<I, O, E> {
         MapRes::new(self, g)
     }
 
-    /// Applies a function returning an `Option` over the result of a parser.
+    /// Apply both [`Parser::verify`] and [`Parser::map`].
     ///
     /// # Example
     ///
@@ -379,7 +379,7 @@ pub trait Parser<I, O, E> {
     /// use winnow::character::digit1;
     /// # fn main() {
     ///
-    /// let mut parse = digit1.map_opt(|s: &str| s.parse::<u8>().ok());
+    /// let mut parse = digit1.verify_map(|s: &str| s.parse::<u8>().ok());
     ///
     /// // the parser will convert the result of digit1 to a number
     /// assert_eq!(parse.parse_next("123"), Ok(("", 123)));
@@ -391,12 +391,12 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parse.parse_next("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::MapOpt))));
     /// # }
     /// ```
-    fn map_opt<G, O2>(self, g: G) -> MapOpt<Self, G, O>
+    fn verify_map<G, O2>(self, g: G) -> VerifyMap<Self, G, O>
     where
         Self: core::marker::Sized,
         G: FnMut(O) -> Option<O2>,
     {
-        MapOpt::new(self, g)
+        VerifyMap::new(self, g)
     }
 
     /// Creates a second parser from the output of the first one, then apply over the rest of the input


### PR DESCRIPTION
Like `filter` + `map` is `filter_map`, this aligns the names to make
this more discoverable.

BREAKING CHANGE:
- Compared to `nom8`, the `Parser::map_opt` function has been renamed to `Parser::verify_map`
- `ErrorKind::MapOpt` has been removed in favor of `ErrorKind::Verify`