### PR TITLE
fix(multi)!: Panic at the infinite loop

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -53,7 +53,7 @@ where
                 Ok((i1, o)) => {
                     // infinite loop check: the parser must always consume
                     if i1.eof_offset() == len {
-                        return Err(ErrMode::from_error_kind(i, ErrorKind::Many0));
+                        return Err(ErrMode::assert(i, "many parsers must always consume"));
                     }
 
                     i = i1;
@@ -113,7 +113,7 @@ where
                     Ok((i1, o)) => {
                         // infinite loop check: the parser must always consume
                         if i1.eof_offset() == len {
-                            return Err(ErrMode::from_error_kind(i, ErrorKind::Many1));
+                            return Err(ErrMode::assert(i, "many parsers must always consume"));
                         }
 
                         i = i1;
@@ -180,7 +180,7 @@ where
                         Ok((i1, o)) => {
                             // infinite loop check: the parser must always consume
                             if i1.eof_offset() == len {
-                                return Err(ErrMode::from_error_kind(i1, ErrorKind::ManyTill));
+                                return Err(ErrMode::assert(i, "many parsers must always consume"));
                             }
 
                             res.accumulate(o);
@@ -250,7 +250,7 @@ where
                 Ok((i1, _)) => {
                     // infinite loop check: the parser must always consume
                     if i1.eof_offset() == len {
-                        return Err(ErrMode::from_error_kind(i1, ErrorKind::SeparatedList));
+                        return Err(ErrMode::assert(i, "many parsers must always consume"));
                     }
 
                     match parser.parse_next(i1.clone()) {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -393,7 +393,7 @@ where
 }
 
 /// Core definition for parser input state
-pub trait Stream: Clone {
+pub trait Stream: Clone + crate::lib::std::fmt::Debug {
     /// The smallest unit being parsed
     ///
     /// Example: `u8` for `&[u8]` or `char` for `&str`
@@ -444,7 +444,7 @@ pub trait Stream: Clone {
 
 impl<'i, T> Stream for &'i [T]
 where
-    T: Clone,
+    T: Clone + crate::lib::std::fmt::Debug,
 {
     type Token = T;
     type Slice = &'i [T];
@@ -687,7 +687,7 @@ impl<I: Stream> Stream for Located<I> {
     }
 }
 
-impl<I: Stream, S: Clone> Stream for Stateful<I, S> {
+impl<I: Stream, S: Clone + crate::lib::std::fmt::Debug> Stream for Stateful<I, S> {
     type Token = <I as Stream>::Token;
     type Slice = <I as Stream>::Slice;
 
@@ -1600,7 +1600,7 @@ pub trait UpdateSlice: Stream {
 
 impl<'a, T> UpdateSlice for &'a [T]
 where
-    T: Clone,
+    T: Clone + crate::lib::std::fmt::Debug,
 {
     #[inline(always)]
     fn update_slice(self, inner: Self::Slice) -> Self {
@@ -1643,7 +1643,7 @@ where
 impl<I, S> UpdateSlice for Stateful<I, S>
 where
     I: UpdateSlice,
-    S: Clone,
+    S: Clone + crate::lib::std::fmt::Debug,
 {
     #[inline(always)]
     fn update_slice(mut self, inner: Self::Slice) -> Self {


### PR DESCRIPTION
This helps improve the debug experience  (#102) while avoiding panic code being generated in release builds and gives end-users control over what is happening

BREAKING CHANGE: Some parsers now return `ErrorKind::Assert` rather than parser-specific `ErrorKind`s