### PR TITLE
bench(json): Include `VerboseError`

### DIFF
--- a/examples/json/bench.rs
+++ b/examples/json/bench.rs
@@ -12,11 +12,16 @@ fn json_bench(c: &mut criterion::Criterion) {
         let len = sample.len();
         group.throughput(criterion::Throughput::Bytes(len as u64));
 
+        group.bench_with_input(criterion::BenchmarkId::new("basic", name), &len, |b, _| {
+            type Error<'i> = winnow::error::Error<parser::Stream<'i>>;
+
+            b.iter(|| parser::json::<Error>(sample).unwrap());
+        });
         group.bench_with_input(
-            criterion::BenchmarkId::new("complete", name),
+            criterion::BenchmarkId::new("verbose", name),
             &len,
             |b, _| {
-                type Error<'i> = winnow::error::Error<parser::Stream<'i>>;
+                type Error<'i> = winnow::error::VerboseError<parser::Stream<'i>>;
 
                 b.iter(|| parser::json::<Error>(sample).unwrap());
             },


### PR DESCRIPTION
Inspired by rust-bakery/nom/#1639

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
