### PR TITLE
fix!: Consistently be `FnMut` parsers

### DIFF
--- a/src/_tutorial.rs
+++ b/src/_tutorial.rs
@@ -115,7 +115,7 @@
 //! fn request_line(i: &[u8]) -> IResult<&[u8], Request> {
 //!   // first implement the basic parsers
 //!   let method = take_while1(AsChar::is_alpha);
-//!   let space = take_while1(|c| c == b' ');
+//!   let space = |i| take_while1(|c| c == b' ')(i);
 //!   let url = take_while1(|c| c != b' ');
 //!   let is_version = |c| c >= b'0' && c <= b'9' || c == b'.';
 //!   let version = take_while1(is_version);
@@ -128,7 +128,7 @@
 //!
 //!   // A tuple of parsers will evaluate each parser sequentally and return a tuple of the results
 //!   let (input, (method, _, url, _, version, _)) =
-//!     (method, &space, url, &space, http_version, line_ending).parse_next(i)?;
+//!     (method, space, url, space, http_version, line_ending).parse_next(i)?;
 //!
 //!   Ok((input, Request { method, url, version }))
 //! }

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -157,7 +157,7 @@ where
 #[inline(always)]
 pub fn take<I, O, C, E: ParseError<(I, usize)>, const PARTIAL: bool>(
     count: C,
-) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
+) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E>
 where
     I: Stream<Token = u8> + AsBytes + StreamIsPartial<PARTIAL>,
     C: ToUsize,
@@ -230,7 +230,7 @@ where
 pub fn tag<I, O, C, E: ParseError<(I, usize)>, const PARTIAL: bool>(
     pattern: O,
     count: C,
-) -> impl Fn((I, usize)) -> IResult<(I, usize), O, E>
+) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E>
 where
     I: Stream<Token = u8> + AsBytes + StreamIsPartial<PARTIAL>,
     C: ToUsize,

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -92,7 +92,7 @@ where
 #[inline(always)]
 pub fn tag<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     tag: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream + Compare<T>,
@@ -148,7 +148,7 @@ where
 #[inline(always)]
 pub fn tag_no_case<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     tag: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream + Compare<T>,
@@ -212,7 +212,7 @@ where
 #[inline(always)]
 pub fn one_of<I, T, Error: ParseError<I>, const PARTIAL: bool>(
     list: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Token, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Token, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
@@ -255,7 +255,7 @@ where
 #[inline(always)]
 pub fn none_of<I, T, Error: ParseError<I>, const PARTIAL: bool>(
     list: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Token, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Token, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
@@ -308,7 +308,7 @@ where
 #[inline(always)]
 pub fn take_while0<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     list: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
@@ -381,7 +381,7 @@ where
 #[inline(always)]
 pub fn take_while1<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     list: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
@@ -441,7 +441,7 @@ pub fn take_while_m_n<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     m: usize,
     n: usize,
     list: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
@@ -493,7 +493,7 @@ where
 #[inline(always)]
 pub fn take_till0<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     list: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
@@ -566,7 +566,7 @@ where
 #[inline(always)]
 pub fn take_till1<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     list: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
@@ -636,7 +636,7 @@ where
 #[inline(always)]
 pub fn take<C, I, Error: ParseError<I>, const PARTIAL: bool>(
     count: C,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
@@ -693,7 +693,7 @@ where
 #[inline(always)]
 pub fn take_until0<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     tag: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream + FindSlice<T>,
@@ -752,7 +752,7 @@ where
 #[inline(always)]
 pub fn take_until1<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     tag: T,
-) -> impl Fn(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial<PARTIAL>,
     I: Stream + FindSlice<T>,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1613,7 +1613,7 @@ enum State<E> {
 /// assert_eq!(sign("10"), Ok(("10", 1)));
 /// # }
 /// ```
-pub fn success<I, O: Clone, E: ParseError<I>>(val: O) -> impl Fn(I) -> IResult<I, O, E> {
+pub fn success<I, O: Clone, E: ParseError<I>>(val: O) -> impl FnMut(I) -> IResult<I, O, E> {
     move |input: I| Ok((input, val.clone()))
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1300,14 +1300,14 @@ macro_rules! error_node_position(
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::dbg_err")]
 #[cfg(feature = "std")]
 pub fn dbg_dmp<'a, F, O, E: std::fmt::Debug>(
-    f: F,
+    mut f: F,
     context: &'static str,
-) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], O, E>
+) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], O, E>
 where
-    F: Fn(&'a [u8]) -> IResult<&'a [u8], O, E>,
+    F: Parser<&'a [u8], O, E>,
 {
     use crate::stream::HexDisplay;
-    move |i: &'a [u8]| match f(i) {
+    move |i: &'a [u8]| match f.parse_next(i) {
         Err(e) => {
             println!("{}: Error({:?}) at:\n{}", context, e, i.to_hex(8));
             Err(e)

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -232,7 +232,7 @@ fn issue_1231_bits_expect_fn_closure() {
 fn issue_1282_findtoken_char() {
     use winnow::bytes::one_of;
     use winnow::error::Error;
-    let parser = one_of::<_, _, Error<_>, false>(&['a', 'b', 'c'][..]);
+    let mut parser = one_of::<_, _, Error<_>, false>(&['a', 'b', 'c'][..]);
     assert_eq!(parser("aaa"), Ok(("aa", 'a')));
 }
 


### PR DESCRIPTION
This gives us more implementation freedom

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
