### PR TITLE
chore: Bump MSRV to 1.56.0 

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.54.0"  # MSRV
+msrv = "1.56.0"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     - name: No-default features
       run: cargo test --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.54.0"
+    name: "Check MSRV: 1.56.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -79,7 +79,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.54.0  # MSRV
+        toolchain: 1.56.0  # MSRV
     - uses: Swatinem/rust-cache@v2
     - name: Default features
       run: cargo check --workspace --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 repository = "https://github.com/winnow-rs/winnow"
 categories = ["parsing"]
 keywords = ["parser", "parser-combinators", "parsing", "streaming", "bit"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.56.0"  # MSRV
 include = [
   "build.rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/winnow-rs/winnow"
 categories = ["parsing"]
 keywords = ["parser", "parser-combinators", "parsing", "streaming", "bit"]
 edition = "2018"
-rust-version = "1.54.0"  # MSRV
+rust-version = "1.56.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",


### PR DESCRIPTION
This was needed to use one of our dependencies in https://github.com/winnow-rs/winnow/pull/156