### PR TITLE
feat(trace): New `trace` combinator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,18 @@
 version = 3
 
 [[package]]
+name = "anstyle"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bb0ec944fe041c41e32dcd60b49327fcb7ff761433838878cc97ddecf16db7"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -71,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +98,23 @@ dependencies = [
  "textwrap",
  "unicode-width",
 ]
+
+[[package]]
+name = "concolor"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015267563b1df20adccdd00cb05257b1dfbea70a04928e9cf88ffb850c1a40af"
+dependencies = [
+ "atty",
+ "bitflags",
+ "concolor-query",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
 
 [[package]]
 name = "criterion"
@@ -201,6 +230,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,12 +292,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -299,6 +377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +421,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -540,6 +624,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +731,16 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
+dependencies = [
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -788,12 +896,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
 name = "winnow"
 version = "0.2.0"
 dependencies = [
+ "anstyle",
+ "concolor",
  "criterion",
  "doc-comment",
+ "is-terminal",
  "lexopt",
  "memchr",
  "proptest",
+ "terminal_size",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,20 @@ pre-release-replacements = [
 ]
 
 [features]
+default = ["std"]
 alloc = []
 std = ["alloc", "memchr/std"]
-default = ["std"]
+# debug = ["dep:anstyle", "dep:is-terminal", "dep:terminal_size", "dep:concolor"]  # Requires MSRV 1.60
+debug = ["anstyle", "is-terminal", "terminal_size", "concolor"]
 
 unstable-doc = ["alloc", "std"]
 
 [dependencies]
+anstyle = { version = "0.2.5", optional = true }
+is-terminal = { version = "0.4.3", optional = true }
 memchr = { version = "2.3", default-features = false }
+terminal_size = { version = "0.2.3", optional = true }
+concolor = { version = "0.0.8", optional = true, features = ["auto"] }
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -6,6 +6,8 @@ mod tests;
 use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::ParseError;
+use crate::stream::Stream;
+use crate::trace::trace;
 use crate::{IResult, Parser};
 
 #[doc(inline)]
@@ -53,10 +55,10 @@ pub trait Alt<I, O, E> {
 /// assert_eq!(parser(" "), Err(ErrMode::Backtrack(error_position!(" ", ErrorKind::Digit))));
 /// # }
 /// ```
-pub fn alt<I: Clone, O, E: ParseError<I>, List: Alt<I, O, E>>(
+pub fn alt<I: Stream, O, E: ParseError<I>, List: Alt<I, O, E>>(
     mut l: List,
 ) -> impl FnMut(I) -> IResult<I, O, E> {
-    move |i: I| l.choice(i)
+    trace("alt", move |i: I| l.choice(i))
 }
 
 /// Helper trait for the [permutation()] combinator.
@@ -112,10 +114,10 @@ pub trait Permutation<I, O, E> {
 /// assert_eq!(parser("ab"), Err(ErrMode::Backtrack(Error::new("b", ErrorKind::OneOf))));
 /// ```
 ///
-pub fn permutation<I: Clone, O, E: ParseError<I>, List: Permutation<I, O, E>>(
+pub fn permutation<I: Stream, O, E: ParseError<I>, List: Permutation<I, O, E>>(
     mut l: List,
 ) -> impl FnMut(I) -> IResult<I, O, E> {
-    move |i: I| l.permutation(i)
+    trace("permutation", move |i: I| l.permutation(i))
 }
 
 macro_rules! alt_trait(

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -9,6 +9,7 @@ use crate::error::ParseError;
 use crate::stream::{
     Compare, ContainsToken, FindSlice, SliceLen, Stream, StreamIsPartial, ToUsize,
 };
+use crate::trace::trace;
 use crate::IResult;
 
 /// Matches one token
@@ -43,11 +44,13 @@ where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
 {
-    if PARTIAL {
-        streaming::any(input)
-    } else {
-        complete::any(input)
-    }
+    trace("any", move |input| {
+        if PARTIAL {
+            streaming::any(input)
+        } else {
+            complete::any(input)
+        }
+    })(input)
 }
 
 /// Recognizes a literal
@@ -98,14 +101,14 @@ where
     I: Stream + Compare<T>,
     T: SliceLen + Clone,
 {
-    move |i: I| {
+    trace("tag", move |i: I| {
         let t = tag.clone();
         if PARTIAL {
             streaming::tag_internal(i, t)
         } else {
             complete::tag_internal(i, t)
         }
-    }
+    })
 }
 
 /// Recognizes a case insensitive literal.
@@ -154,14 +157,14 @@ where
     I: Stream + Compare<T>,
     T: SliceLen + Clone,
 {
-    move |i: I| {
+    trace("tag_no_case", move |i: I| {
         let t = tag.clone();
         if PARTIAL {
             streaming::tag_no_case_internal(i, t)
         } else {
             complete::tag_no_case_internal(i, t)
         }
-    }
+    })
 }
 
 /// Returns a token that matches the [pattern][ContainsToken]
@@ -219,13 +222,13 @@ where
     <I as Stream>::Token: Copy,
     T: ContainsToken<<I as Stream>::Token>,
 {
-    move |i: I| {
+    trace("one_of", move |i: I| {
         if PARTIAL {
             streaming::one_of_internal(i, &list)
         } else {
             complete::one_of_internal(i, &list)
         }
-    }
+    })
 }
 
 /// Returns a token that does not match the [pattern][ContainsToken]
@@ -262,13 +265,13 @@ where
     <I as Stream>::Token: Copy,
     T: ContainsToken<<I as Stream>::Token>,
 {
-    move |i: I| {
+    trace("none_of", move |i: I| {
         if PARTIAL {
             streaming::none_of_internal(i, &list)
         } else {
             complete::none_of_internal(i, &list)
         }
-    }
+    })
 }
 
 /// Returns the longest input slice (if any) that matches the [pattern][ContainsToken]
@@ -314,13 +317,13 @@ where
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
-    move |i: I| {
+    trace("take_while0", move |i: I| {
         if PARTIAL {
             streaming::take_while_internal(i, &list)
         } else {
             complete::take_while_internal(i, &list)
         }
-    }
+    })
 }
 
 /// Returns the longest (at least 1) input slice that matches the [pattern][ContainsToken]
@@ -387,13 +390,13 @@ where
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
-    move |i: I| {
+    trace("take_while1", move |i: I| {
         if PARTIAL {
             streaming::take_while1_internal(i, &list)
         } else {
             complete::take_while1_internal(i, &list)
         }
-    }
+    })
 }
 
 /// Returns the longest (m <= len <= n) input slice that matches the [pattern][ContainsToken]
@@ -447,13 +450,13 @@ where
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
-    move |i: I| {
+    trace("take_while_m_n", move |i: I| {
         if PARTIAL {
             streaming::take_while_m_n_internal(i, m, n, &list)
         } else {
             complete::take_while_m_n_internal(i, m, n, &list)
         }
-    }
+    })
 }
 
 /// Returns the longest input slice (if any) till a [pattern][ContainsToken] is met.
@@ -499,13 +502,13 @@ where
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
-    move |i: I| {
+    trace("take_till0", move |i: I| {
         if PARTIAL {
             streaming::take_till_internal(i, &list)
         } else {
             complete::take_till_internal(i, &list)
         }
-    }
+    })
 }
 
 /// Returns the longest (at least 1) input slice till a [pattern][ContainsToken] is met.
@@ -572,13 +575,13 @@ where
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
-    move |i: I| {
+    trace("take_till1", move |i: I| {
         if PARTIAL {
             streaming::take_till1_internal(i, &list)
         } else {
             complete::take_till1_internal(i, &list)
         }
-    }
+    })
 }
 
 /// Returns an input slice containing the first N input elements (I[..N]).
@@ -643,13 +646,13 @@ where
     C: ToUsize,
 {
     let c = count.to_usize();
-    move |i: I| {
+    trace("take", move |i: I| {
         if PARTIAL {
             streaming::take_internal(i, c)
         } else {
             complete::take_internal(i, c)
         }
-    }
+    })
 }
 
 /// Returns the input slice up to the first occurrence of the literal.
@@ -699,13 +702,13 @@ where
     I: Stream + FindSlice<T>,
     T: SliceLen + Clone,
 {
-    move |i: I| {
+    trace("take_until0", move |i: I| {
         if PARTIAL {
             streaming::take_until_internal(i, tag.clone())
         } else {
             complete::take_until_internal(i, tag.clone())
         }
-    }
+    })
 }
 
 /// Returns the non empty input slice up to the first occurrence of the literal.
@@ -758,11 +761,11 @@ where
     I: Stream + FindSlice<T>,
     T: SliceLen + Clone,
 {
-    move |i: I| {
+    trace("take_until1", move |i: I| {
         if PARTIAL {
             streaming::take_until1_internal(i, tag.clone())
         } else {
             complete::take_until1_internal(i, tag.clone())
         }
-    }
+    })
 }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -16,6 +16,7 @@ use crate::error::ParseError;
 use crate::error::{ErrMode, ErrorKind, Needed};
 use crate::stream::Compare;
 use crate::stream::{AsBStr, AsChar, Offset, ParseSlice, Stream, StreamIsPartial};
+use crate::trace::trace;
 use crate::IResult;
 use crate::Parser;
 
@@ -56,11 +57,13 @@ where
     I: Stream,
     I: Compare<&'static str>,
 {
-    if PARTIAL {
-        streaming::crlf(input)
-    } else {
-        complete::crlf(input)
-    }
+    trace("crlf", move |input| {
+        if PARTIAL {
+            streaming::crlf(input)
+        } else {
+            complete::crlf(input)
+        }
+    })(input)
 }
 
 /// Recognizes a string of any char except '\r\n' or '\n'.
@@ -106,11 +109,13 @@ where
     I: Compare<&'static str>,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::not_line_ending(input)
-    } else {
-        complete::not_line_ending(input)
-    }
+    trace("not_line_ending", move |input| {
+        if PARTIAL {
+            streaming::not_line_ending(input)
+        } else {
+            complete::not_line_ending(input)
+        }
+    })(input)
 }
 
 /// Recognizes an end of line (both '\n' and '\r\n').
@@ -150,11 +155,13 @@ where
     I: Stream,
     I: Compare<&'static str>,
 {
-    if PARTIAL {
-        streaming::line_ending(input)
-    } else {
-        complete::line_ending(input)
-    }
+    trace("line_ending", move |input| {
+        if PARTIAL {
+            streaming::line_ending(input)
+        } else {
+            complete::line_ending(input)
+        }
+    })(input)
 }
 
 /// Matches a newline character '\n'.
@@ -192,11 +199,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::newline(input)
-    } else {
-        complete::newline(input)
-    }
+    trace("newline", move |input| {
+        if PARTIAL {
+            streaming::newline(input)
+        } else {
+            complete::newline(input)
+        }
+    })(input)
 }
 
 /// Matches a tab character '\t'.
@@ -234,11 +243,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::tab(input)
-    } else {
-        complete::tab(input)
-    }
+    trace("tag", move |input| {
+        if PARTIAL {
+            streaming::tab(input)
+        } else {
+            complete::tab(input)
+        }
+    })(input)
 }
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
@@ -280,11 +291,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::alpha0(input)
-    } else {
-        complete::alpha0(input)
-    }
+    trace("alpha0", move |input| {
+        if PARTIAL {
+            streaming::alpha0(input)
+        } else {
+            complete::alpha0(input)
+        }
+    })(input)
 }
 
 /// Recognizes one or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
@@ -326,11 +339,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::alpha1(input)
-    } else {
-        complete::alpha1(input)
-    }
+    trace("alpha1", move |input| {
+        if PARTIAL {
+            streaming::alpha1(input)
+        } else {
+            complete::alpha1(input)
+        }
+    })(input)
 }
 
 /// Recognizes zero or more ASCII numerical characters: 0-9
@@ -373,11 +388,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::digit0(input)
-    } else {
-        complete::digit0(input)
-    }
+    trace("digit0", move |input| {
+        if PARTIAL {
+            streaming::digit0(input)
+        } else {
+            complete::digit0(input)
+        }
+    })(input)
 }
 
 /// Recognizes one or more ASCII numerical characters: 0-9
@@ -435,11 +452,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::digit1(input)
-    } else {
-        complete::digit1(input)
-    }
+    trace("digit1", move |input| {
+        if PARTIAL {
+            streaming::digit1(input)
+        } else {
+            complete::digit1(input)
+        }
+    })(input)
 }
 
 /// Recognizes zero or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -480,11 +499,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::hex_digit0(input)
-    } else {
-        complete::hex_digit0(input)
-    }
+    trace("hex_digit0", move |input| {
+        if PARTIAL {
+            streaming::hex_digit0(input)
+        } else {
+            complete::hex_digit0(input)
+        }
+    })(input)
 }
 
 /// Recognizes one or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -526,11 +547,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::hex_digit1(input)
-    } else {
-        complete::hex_digit1(input)
-    }
+    trace("hex_digit1", move |input| {
+        if PARTIAL {
+            streaming::hex_digit1(input)
+        } else {
+            complete::hex_digit1(input)
+        }
+    })(input)
 }
 
 /// Recognizes zero or more octal characters: 0-7
@@ -572,11 +595,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::oct_digit0(input)
-    } else {
-        complete::oct_digit0(input)
-    }
+    trace("oct_digit0", move |input| {
+        if PARTIAL {
+            streaming::oct_digit0(input)
+        } else {
+            complete::oct_digit0(input)
+        }
+    })(input)
 }
 
 /// Recognizes one or more octal characters: 0-7
@@ -618,11 +643,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::oct_digit1(input)
-    } else {
-        complete::oct_digit1(input)
-    }
+    trace("oct_digit0", move |input| {
+        if PARTIAL {
+            streaming::oct_digit1(input)
+        } else {
+            complete::oct_digit1(input)
+        }
+    })(input)
 }
 
 /// Recognizes zero or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -664,11 +691,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::alphanumeric0(input)
-    } else {
-        complete::alphanumeric0(input)
-    }
+    trace("alphanumeric0", move |input| {
+        if PARTIAL {
+            streaming::alphanumeric0(input)
+        } else {
+            complete::alphanumeric0(input)
+        }
+    })(input)
 }
 
 /// Recognizes one or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -710,11 +739,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::alphanumeric1(input)
-    } else {
-        complete::alphanumeric1(input)
-    }
+    trace("alphanumeric1", move |input| {
+        if PARTIAL {
+            streaming::alphanumeric1(input)
+        } else {
+            complete::alphanumeric1(input)
+        }
+    })(input)
 }
 
 /// Recognizes zero or more spaces and tabs.
@@ -744,11 +775,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::space0(input)
-    } else {
-        complete::space0(input)
-    }
+    trace("space0", move |input| {
+        if PARTIAL {
+            streaming::space0(input)
+        } else {
+            complete::space0(input)
+        }
+    })(input)
 }
 
 /// Recognizes one or more spaces and tabs.
@@ -790,11 +823,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::space1(input)
-    } else {
-        complete::space1(input)
-    }
+    trace("space1", move |input| {
+        if PARTIAL {
+            streaming::space1(input)
+        } else {
+            complete::space1(input)
+        }
+    })(input)
 }
 
 /// Recognizes zero or more spaces, tabs, carriage returns and line feeds.
@@ -836,11 +871,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::multispace0(input)
-    } else {
-        complete::multispace0(input)
-    }
+    trace("multispace0", move |input| {
+        if PARTIAL {
+            streaming::multispace0(input)
+        } else {
+            complete::multispace0(input)
+        }
+    })(input)
 }
 
 /// Recognizes one or more spaces, tabs, carriage returns and line feeds.
@@ -882,11 +919,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    if PARTIAL {
-        streaming::multispace1(input)
-    } else {
-        complete::multispace1(input)
-    }
+    trace("multispace1", move |input| {
+        if PARTIAL {
+            streaming::multispace1(input)
+        } else {
+            complete::multispace1(input)
+        }
+    })(input)
 }
 
 /// Decode a decimal unsigned integer
@@ -901,41 +940,43 @@ where
     <I as Stream>::Token: AsChar + Copy,
     O: Uint,
 {
-    let i = input.clone();
+    trace("dec_uint", move |input: I| {
+        let i = input.clone();
 
-    if i.eof_offset() == 0 {
-        if PARTIAL {
-            return Err(ErrMode::Incomplete(Needed::new(1)));
-        } else {
-            return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
+        if i.eof_offset() == 0 {
+            if PARTIAL {
+                return Err(ErrMode::Incomplete(Needed::new(1)));
+            } else {
+                return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
+            }
         }
-    }
 
-    let mut value = O::default();
-    for (offset, c) in i.iter_offsets() {
-        match c.as_char().to_digit(10) {
-            Some(d) => match value.checked_mul(10, sealed::SealedMarker).and_then(|v| {
-                let d = d as u8;
-                v.checked_add(d, sealed::SealedMarker)
-            }) {
-                None => return Err(ErrMode::from_error_kind(input, ErrorKind::Digit)),
-                Some(v) => value = v,
-            },
-            None => {
-                if offset == 0 {
-                    return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
-                } else {
-                    return Ok((i.next_slice(offset).0, value));
+        let mut value = O::default();
+        for (offset, c) in i.iter_offsets() {
+            match c.as_char().to_digit(10) {
+                Some(d) => match value.checked_mul(10, sealed::SealedMarker).and_then(|v| {
+                    let d = d as u8;
+                    v.checked_add(d, sealed::SealedMarker)
+                }) {
+                    None => return Err(ErrMode::from_error_kind(input, ErrorKind::Digit)),
+                    Some(v) => value = v,
+                },
+                None => {
+                    if offset == 0 {
+                        return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
+                    } else {
+                        return Ok((i.next_slice(offset).0, value));
+                    }
                 }
             }
         }
-    }
 
-    if PARTIAL {
-        Err(ErrMode::Incomplete(Needed::new(1)))
-    } else {
-        Ok((i.next_slice(i.eof_offset()).0, value))
-    }
+        if PARTIAL {
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        } else {
+            Ok((i.next_slice(i.eof_offset()).0, value))
+        }
+    })(input)
 }
 
 /// Metadata for parsing unsigned integers
@@ -1048,53 +1089,55 @@ where
     <I as Stream>::Token: AsChar + Copy,
     O: Int,
 {
-    let i = input.clone();
+    trace("dec_int", move |input: I| {
+        let i = input.clone();
 
-    fn sign(token: impl AsChar) -> bool {
-        let token = token.as_char();
-        token == '+' || token == '-'
-    }
-    let (i, sign) = opt(crate::bytes::one_of(sign).map(AsChar::as_char))
-        .map(|c| c != Some('-'))
-        .parse_next(i)?;
-
-    if i.eof_offset() == 0 {
-        if PARTIAL {
-            return Err(ErrMode::Incomplete(Needed::new(1)));
-        } else {
-            return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
+        fn sign(token: impl AsChar) -> bool {
+            let token = token.as_char();
+            token == '+' || token == '-'
         }
-    }
+        let (i, sign) = opt(crate::bytes::one_of(sign).map(AsChar::as_char))
+            .map(|c| c != Some('-'))
+            .parse_next(i)?;
 
-    let mut value = O::default();
-    for (offset, c) in i.iter_offsets() {
-        match c.as_char().to_digit(10) {
-            Some(d) => match value.checked_mul(10, sealed::SealedMarker).and_then(|v| {
-                let d = d as u8;
-                if sign {
-                    v.checked_add(d, sealed::SealedMarker)
-                } else {
-                    v.checked_sub(d, sealed::SealedMarker)
-                }
-            }) {
-                None => return Err(ErrMode::from_error_kind(input, ErrorKind::Digit)),
-                Some(v) => value = v,
-            },
-            None => {
-                if offset == 0 {
-                    return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
-                } else {
-                    return Ok((i.next_slice(offset).0, value));
+        if i.eof_offset() == 0 {
+            if PARTIAL {
+                return Err(ErrMode::Incomplete(Needed::new(1)));
+            } else {
+                return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
+            }
+        }
+
+        let mut value = O::default();
+        for (offset, c) in i.iter_offsets() {
+            match c.as_char().to_digit(10) {
+                Some(d) => match value.checked_mul(10, sealed::SealedMarker).and_then(|v| {
+                    let d = d as u8;
+                    if sign {
+                        v.checked_add(d, sealed::SealedMarker)
+                    } else {
+                        v.checked_sub(d, sealed::SealedMarker)
+                    }
+                }) {
+                    None => return Err(ErrMode::from_error_kind(input, ErrorKind::Digit)),
+                    Some(v) => value = v,
+                },
+                None => {
+                    if offset == 0 {
+                        return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
+                    } else {
+                        return Ok((i.next_slice(offset).0, value));
+                    }
                 }
             }
         }
-    }
 
-    if PARTIAL {
-        Err(ErrMode::Incomplete(Needed::new(1)))
-    } else {
-        Ok((i.next_slice(i.eof_offset()).0, value))
-    }
+        if PARTIAL {
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        } else {
+            Ok((i.next_slice(i.eof_offset()).0, value))
+        }
+    })(input)
 }
 
 /// Metadata for parsing signed integers
@@ -1180,47 +1223,49 @@ where
     <I as Stream>::Token: AsChar,
     <I as Stream>::Slice: AsBStr,
 {
-    let invalid_offset = input
-        .offset_for(|c| {
-            let c = c.as_char();
-            !"0123456789abcdefABCDEF".contains(c)
-        })
-        .unwrap_or_else(|| input.eof_offset());
-    let max_nibbles = O::max_nibbles(sealed::SealedMarker);
-    let max_offset = input.offset_at(max_nibbles);
-    let offset = match max_offset {
-        Ok(max_offset) => {
-            if max_offset < invalid_offset {
-                // Overflow
-                return Err(ErrMode::from_error_kind(input, ErrorKind::IsA));
-            } else {
-                invalid_offset
+    trace("hex_uint", move |input: I| {
+        let invalid_offset = input
+            .offset_for(|c| {
+                let c = c.as_char();
+                !"0123456789abcdefABCDEF".contains(c)
+            })
+            .unwrap_or_else(|| input.eof_offset());
+        let max_nibbles = O::max_nibbles(sealed::SealedMarker);
+        let max_offset = input.offset_at(max_nibbles);
+        let offset = match max_offset {
+            Ok(max_offset) => {
+                if max_offset < invalid_offset {
+                    // Overflow
+                    return Err(ErrMode::from_error_kind(input, ErrorKind::IsA));
+                } else {
+                    invalid_offset
+                }
             }
-        }
-        Err(_) => {
-            if PARTIAL && invalid_offset == input.eof_offset() {
-                // Only the next byte is guaranteed required
-                return Err(ErrMode::Incomplete(Needed::new(1)));
-            } else {
-                invalid_offset
+            Err(_) => {
+                if PARTIAL && invalid_offset == input.eof_offset() {
+                    // Only the next byte is guaranteed required
+                    return Err(ErrMode::Incomplete(Needed::new(1)));
+                } else {
+                    invalid_offset
+                }
             }
+        };
+        if offset == 0 {
+            // Must be at least one digit
+            return Err(ErrMode::from_error_kind(input, ErrorKind::IsA));
         }
-    };
-    if offset == 0 {
-        // Must be at least one digit
-        return Err(ErrMode::from_error_kind(input, ErrorKind::IsA));
-    }
-    let (remaining, parsed) = input.next_slice(offset);
+        let (remaining, parsed) = input.next_slice(offset);
 
-    let mut res = O::default();
-    for c in parsed.as_bstr() {
-        let nibble = *c as char;
-        let nibble = nibble.to_digit(16).unwrap_or(0) as u8;
-        let nibble = O::from(nibble);
-        res = (res << O::from(4)) + nibble;
-    }
+        let mut res = O::default();
+        for c in parsed.as_bstr() {
+            let nibble = *c as char;
+            let nibble = nibble.to_digit(16).unwrap_or(0) as u8;
+            let nibble = O::from(nibble);
+            res = (res << O::from(4)) + nibble;
+        }
 
-    Ok((remaining, res))
+        Ok((remaining, res))
+    })(input)
 }
 
 /// Metadata for parsing hex numbers
@@ -1318,15 +1363,17 @@ where
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
 {
-    let (i, s) = if PARTIAL {
-        crate::number::streaming::recognize_float_or_exceptions(input)?
-    } else {
-        crate::number::complete::recognize_float_or_exceptions(input)?
-    };
-    match s.parse_slice() {
-        Some(f) => Ok((i, f)),
-        None => Err(ErrMode::from_error_kind(i, ErrorKind::Float)),
-    }
+    trace("float", move |input: I| {
+        let (i, s) = if PARTIAL {
+            crate::number::streaming::recognize_float_or_exceptions(input)?
+        } else {
+            crate::number::complete::recognize_float_or_exceptions(input)?
+        };
+        match s.parse_slice() {
+            Some(f) => Ok((i, f)),
+            None => Err(ErrMode::from_error_kind(i, ErrorKind::Float)),
+        }
+    })(input)
 }
 
 /// Matches a byte string with escaped characters.
@@ -1377,7 +1424,7 @@ where
     G: Parser<I, O2, Error>,
     Error: ParseError<I>,
 {
-    move |input: I| {
+    trace("escaped", move |input: I| {
         if PARTIAL {
             crate::bytes::streaming::escaped_internal(
                 input,
@@ -1393,7 +1440,7 @@ where
                 &mut escapable,
             )
         }
-    }
+    })
 }
 
 /// Matches a byte string with escaped characters.
@@ -1471,7 +1518,7 @@ where
     G: Parser<I, <I as Stream>::Slice, Error>,
     Error: ParseError<I>,
 {
-    move |input: I| {
+    trace("escaped_transform", move |input: I| {
         if PARTIAL {
             crate::bytes::streaming::escaped_transform_internal(
                 input,
@@ -1487,7 +1534,7 @@ where
                 &mut transform,
             )
         }
-    }
+    })
 }
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,6 +473,7 @@ pub mod combinator;
 pub mod multi;
 pub mod number;
 pub mod sequence;
+pub mod trace;
 
 #[cfg(feature = "unstable-doc")]
 pub mod _cookbook;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,7 +40,7 @@
 #[macro_export]
 macro_rules! dispatch {
     ($match_parser: expr; $( $pat:pat $(if $pred:expr)? => $expr: expr ),+ $(,)? ) => {
-        move |i|
+        $crate::trace::trace("dispatch", move |i|
         {
             use $crate::Parser;
             let (i, initial) = $match_parser.parse_next(i)?;
@@ -49,7 +49,7 @@ macro_rules! dispatch {
                     $pat $(if $pred)? => $expr.parse_next(i),
                 )*
             }
-        }
+        })
     }
 }
 

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -9,6 +9,7 @@ mod tests;
 
 use crate::error::ParseError;
 use crate::stream::{AsBytes, Stream, StreamIsPartial};
+use crate::trace::trace;
 use crate::IResult;
 
 /// Configurable endianness
@@ -61,11 +62,13 @@ where
     I: StreamIsPartial<PARTIAL>,
     I: Stream<Token = u8>,
 {
-    if PARTIAL {
-        streaming::be_u8(input)
-    } else {
-        complete::be_u8(input)
-    }
+    trace("be_u8", move |input| {
+        if PARTIAL {
+            streaming::be_u8(input)
+        } else {
+            complete::be_u8(input)
+        }
+    })(input)
 }
 
 /// Recognizes a big endian unsigned 2 bytes integer.

--- a/src/trace/internals.rs
+++ b/src/trace/internals.rs
@@ -1,0 +1,230 @@
+#![cfg(feature = "std")]
+
+use std::io::Write;
+
+use crate::error::ErrMode;
+use crate::stream::Stream;
+use crate::IResult;
+
+pub struct Depth(usize);
+
+impl Depth {
+    pub fn new() -> Self {
+        let depth = DEPTH.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Self(depth)
+    }
+}
+
+impl Drop for Depth {
+    fn drop(&mut self) {
+        let _ = DEPTH.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+impl AsRef<usize> for Depth {
+    #[inline(always)]
+    fn as_ref(&self) -> &usize {
+        &self.0
+    }
+}
+
+impl crate::lib::std::ops::Deref for Depth {
+    type Target = usize;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+static DEPTH: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+pub enum Severity {
+    Success,
+    Backtrack,
+    Cut,
+    Incomplete,
+}
+
+impl Severity {
+    pub fn with_iresult<I, O, E>(result: &IResult<I, O, E>) -> Self {
+        match result {
+            Ok(_) => Self::Success,
+            Err(ErrMode::Backtrack(_)) => Self::Backtrack,
+            Err(ErrMode::Cut(_)) => Self::Cut,
+            Err(ErrMode::Incomplete(_)) => Self::Incomplete,
+        }
+    }
+}
+
+pub fn start<I: Stream>(
+    depth: usize,
+    name: &dyn crate::lib::std::fmt::Display,
+    count: usize,
+    input: &I,
+) {
+    let ansi_color = ansi_color();
+    let reset = if ansi_color {
+        anstyle::Reset.render().to_string()
+    } else {
+        "".to_owned()
+    };
+    let gutter_style = if ansi_color {
+        anstyle::Style::new().bold()
+    } else {
+        anstyle::Style::new()
+    }
+    .render();
+    let input_style = if ansi_color {
+        anstyle::Style::new().underline()
+    } else {
+        anstyle::Style::new()
+    }
+    .render();
+    let eof_style = if ansi_color {
+        anstyle::Style::new().fg_color(Some(anstyle::AnsiColor::Cyan.into()))
+    } else {
+        anstyle::Style::new()
+    }
+    .render();
+
+    let (call_width, input_width) = column_widths();
+
+    let count = if 0 < count {
+        format!(":{count}")
+    } else {
+        "".to_owned()
+    };
+    let call_column = format!("{:depth$}> {name}{count}", "");
+
+    let eof_offset = input.eof_offset();
+    let offset = input.offset_at(input_width).unwrap_or(eof_offset);
+    let (_, slice) = input.next_slice(offset);
+
+    // The debug version of `slice` might be wider, either due to rendering one byte as two nibbles or
+    // escaping in strings.
+    let mut debug_slice = format!("{:#?}", slice);
+    let (debug_slice, eof) = if let Some(debug_offset) = debug_slice
+        .char_indices()
+        .enumerate()
+        .find_map(|(pos, (offset, _))| (input_width <= pos).then(|| offset))
+    {
+        debug_slice.truncate(debug_offset);
+        let eof = "";
+        (debug_slice, eof)
+    } else {
+        let eof = if debug_slice.chars().count() < input_width {
+            "∅"
+        } else {
+            ""
+        };
+        (debug_slice, eof)
+    };
+
+    let writer = std::io::stderr();
+    let mut writer = writer.lock();
+    let _ = writeln!(writer, "{call_column:call_width$} {gutter_style}|{reset} {input_style}{debug_slice}{eof_style}{eof}{reset}");
+}
+
+pub fn end(
+    depth: usize,
+    name: &dyn crate::lib::std::fmt::Display,
+    count: usize,
+    consumed: Option<usize>,
+    severity: Severity,
+) {
+    let ansi_color = ansi_color();
+    let reset = if ansi_color {
+        anstyle::Reset.render().to_string()
+    } else {
+        "".to_owned()
+    };
+    let gutter_style = if ansi_color {
+        anstyle::Style::new().bold()
+    } else {
+        anstyle::Style::new()
+    }
+    .render();
+
+    let (call_width, _) = column_widths();
+
+    let count = if 0 < count {
+        format!(":{count}")
+    } else {
+        "".to_owned()
+    };
+    let call_column = format!("{:depth$}< {name}{count}", "");
+
+    let (status_style, status) = match severity {
+        Severity::Success => {
+            let style = anstyle::Style::new()
+                .fg_color(Some(anstyle::AnsiColor::Green.into()))
+                .render();
+            let status = format!("+{}", consumed.unwrap_or_default());
+            (style, status)
+        }
+        Severity::Backtrack => (
+            anstyle::Style::new()
+                .fg_color(Some(anstyle::AnsiColor::Yellow.into()))
+                .render(),
+            "backtrack".to_owned(),
+        ),
+        Severity::Cut => (
+            anstyle::Style::new()
+                .fg_color(Some(anstyle::AnsiColor::Red.into()))
+                .render(),
+            "cut".to_owned(),
+        ),
+        Severity::Incomplete => (
+            anstyle::Style::new()
+                .fg_color(Some(anstyle::AnsiColor::Red.into()))
+                .render(),
+            "incomplete".to_owned(),
+        ),
+    };
+
+    let writer = std::io::stderr();
+    let mut writer = writer.lock();
+    let _ = writeln!(
+        writer,
+        "{status_style}{call_column:call_width$}{reset} {gutter_style}|{reset} {status_style}{status}{reset}"
+    );
+}
+
+fn ansi_color() -> bool {
+    concolor::get(concolor::Stream::Stderr).ansi_color()
+}
+
+fn column_widths() -> (usize, usize) {
+    let term_width = term_width();
+
+    let min_call_width = 40;
+    let min_input_width = 20;
+    let decor_width = 3;
+    let extra_width = term_width
+        .checked_sub(min_call_width + min_input_width + decor_width)
+        .unwrap_or_default();
+    let call_width = min_call_width + 2 * extra_width / 3;
+    let input_width = min_input_width + extra_width / 3;
+
+    (call_width, input_width)
+}
+
+fn term_width() -> usize {
+    columns_env().or_else(query_width).unwrap_or(80)
+}
+
+fn query_width() -> Option<usize> {
+    use is_terminal::IsTerminal;
+    if std::io::stderr().is_terminal() {
+        terminal_size::terminal_size().map(|(w, _h)| w.0.into())
+    } else {
+        None
+    }
+}
+
+fn columns_env() -> Option<usize> {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|c| c.parse::<usize>().ok())
+}

--- a/src/trace/internals.rs
+++ b/src/trace/internals.rs
@@ -4,27 +4,38 @@ use std::io::Write;
 
 use crate::error::ErrMode;
 use crate::stream::Stream;
-use crate::IResult;
 
-pub struct Depth(usize);
+pub struct Depth {
+    depth: usize,
+    inc: bool,
+}
 
 impl Depth {
     pub fn new() -> Self {
         let depth = DEPTH.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        Self(depth)
+        let inc = true;
+        Self { depth, inc }
+    }
+
+    pub fn existing() -> Self {
+        let depth = DEPTH.load(std::sync::atomic::Ordering::SeqCst);
+        let inc = false;
+        Self { depth, inc }
     }
 }
 
 impl Drop for Depth {
     fn drop(&mut self) {
-        let _ = DEPTH.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        if self.inc {
+            let _ = DEPTH.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        }
     }
 }
 
 impl AsRef<usize> for Depth {
     #[inline(always)]
     fn as_ref(&self) -> &usize {
-        &self.0
+        &self.depth
     }
 }
 
@@ -33,7 +44,7 @@ impl crate::lib::std::ops::Deref for Depth {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.depth
     }
 }
 
@@ -47,7 +58,7 @@ pub enum Severity {
 }
 
 impl Severity {
-    pub fn with_iresult<I, O, E>(result: &IResult<I, O, E>) -> Self {
+    pub fn with_result<T, E>(result: &Result<T, ErrMode<E>>) -> Self {
         match result {
             Ok(_) => Self::Success,
             Err(ErrMode::Backtrack(_)) => Self::Backtrack,
@@ -185,6 +196,58 @@ pub fn end(
 
     let writer = std::io::stderr();
     let mut writer = writer.lock();
+    let _ = writeln!(
+        writer,
+        "{status_style}{call_column:call_width$}{reset} {gutter_style}|{reset} {status_style}{status}{reset}"
+    );
+}
+
+pub fn result(depth: usize, name: &dyn crate::lib::std::fmt::Display, severity: Severity) {
+    let ansi_color = ansi_color();
+    let reset = if ansi_color {
+        anstyle::Reset.render().to_string()
+    } else {
+        "".to_owned()
+    };
+    let gutter_style = if ansi_color {
+        anstyle::Style::new().bold()
+    } else {
+        anstyle::Style::new()
+    }
+    .render();
+
+    let (call_width, _) = column_widths();
+
+    let call_column = format!("{:depth$}| {name}", "");
+
+    let (status_style, status) = match severity {
+        Severity::Success => (
+            anstyle::Style::new()
+                .fg_color(Some(anstyle::AnsiColor::Green.into()))
+                .render(),
+            "",
+        ),
+        Severity::Backtrack => (
+            anstyle::Style::new()
+                .fg_color(Some(anstyle::AnsiColor::Yellow.into()))
+                .render(),
+            "backtrack",
+        ),
+        Severity::Cut => (
+            anstyle::Style::new()
+                .fg_color(Some(anstyle::AnsiColor::Red.into()))
+                .render(),
+            "cut",
+        ),
+        Severity::Incomplete => (
+            anstyle::Style::new()
+                .fg_color(Some(anstyle::AnsiColor::Red.into()))
+                .render(),
+            "incomplete",
+        ),
+    };
+
+    let mut writer = std::io::stderr().lock();
     let _ = writeln!(
         writer,
         "{status_style}{call_column:call_width$}{reset} {gutter_style}|{reset} {status_style}{status}{reset}"

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -1,0 +1,41 @@
+//! Parser execution tracing
+
+#[cfg(feature = "debug")]
+mod internals;
+
+use crate::stream::Stream;
+use crate::IResult;
+use crate::Parser;
+
+#[cfg(all(feature = "debug", not(feature = "std")))]
+compile_error!("`debug` requires `std`");
+
+/// Trace the execution of the parser
+#[cfg_attr(not(feature = "debug"), allow(unused_variables))]
+pub fn trace<I: Stream, O, E>(
+    name: impl crate::lib::std::fmt::Display,
+    mut parser: impl Parser<I, O, E>,
+) -> impl FnMut(I) -> IResult<I, O, E> {
+    #[cfg(feature = "debug")]
+    {
+        let mut call_count = 0;
+        move |i| {
+            let depth = internals::Depth::new();
+            let original = i.clone();
+            internals::start(*depth, &name, call_count, &original);
+
+            let res = parser.parse_next(i);
+
+            let consumed = res.as_ref().ok().map(|(i, _)| original.offset_to(i));
+            let severity = internals::Severity::with_iresult(&res);
+            internals::end(*depth, &name, call_count, consumed, severity);
+            call_count += 1;
+
+            res
+        }
+    }
+    #[cfg(not(feature = "debug"))]
+    {
+        move |i| parser.parse_next(i)
+    }
+}


### PR DESCRIPTION
This will report what a parser has done for easier debugging.

I really hoped to have the success path highlight what of the input was
captured but
- That gets messy when the `input_width` isn't wide enough
- That gets messy when the data we are consuming is in terms of the
  original input but we are manipulating the debug output

Example output:
![image](https://user-images.githubusercontent.com/60961/218810876-1e1d1567-75e3-4fef-81ec-cf097740efd9.png)

Fixes #102