### PR TITLE
chore: Bump MSRV to 1.60.0

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.56.0"  # MSRV
+msrv = "1.60.0"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     - name: No-default features
       run: cargo test --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.56.0"
+    name: "Check MSRV: 1.60.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -79,7 +79,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.56.0  # MSRV
+        toolchain: 1.60.0  # MSRV
     - uses: Swatinem/rust-cache@v2
     - name: Default features
       run: cargo check --workspace --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/winnow-rs/winnow"
 categories = ["parsing"]
 keywords = ["parser", "parser-combinators", "parsing", "streaming", "bit"]
 edition = "2021"
-rust-version = "1.56.0"  # MSRV
+rust-version = "1.60.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",


### PR DESCRIPTION
I really want string interpolation for `format!` which came in 1.58 for #156.  I went to 1.60 since that is a nice round number that I've previously bumped a lot of projects to and it is almost a year old, so its still relatively conservative.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
