### PR TITLE
feat(stream)!: Allow runtime selection of the partial/complete

### DIFF
--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -168,7 +168,7 @@ where
 {
     let count = count.to_usize();
     trace("take", move |input: (I, usize)| {
-        if PARTIAL {
+        if input.is_partial() {
             streaming::take_internal(input, count)
         } else {
             complete::take_internal(input, count)
@@ -241,7 +241,7 @@ where
 {
     let count = count.to_usize();
     trace("tag", move |input: (I, usize)| {
-        if PARTIAL {
+        if input.is_partial() {
             streaming::tag_internal(input, &pattern, count)
         } else {
             complete::tag_internal(input, &pattern, count)
@@ -279,8 +279,8 @@ where
     I: Stream<Token = u8> + AsBytes + StreamIsPartial<PARTIAL>,
 {
     #![allow(deprecated)]
-    trace("bool", |input| {
-        if PARTIAL {
+    trace("bool", |input: (I, usize)| {
+        if input.is_partial() {
             streaming::bool(input)
         } else {
             complete::bool(input)

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -44,8 +44,8 @@ where
     I: StreamIsPartial<PARTIAL>,
     I: Stream,
 {
-    trace("any", move |input| {
-        if PARTIAL {
+    trace("any", move |input: I| {
+        if input.is_partial() {
             streaming::any(input)
         } else {
             complete::any(input)
@@ -103,7 +103,7 @@ where
 {
     trace("tag", move |i: I| {
         let t = tag.clone();
-        if PARTIAL {
+        if i.is_partial() {
             streaming::tag_internal(i, t)
         } else {
             complete::tag_internal(i, t)
@@ -159,7 +159,7 @@ where
 {
     trace("tag_no_case", move |i: I| {
         let t = tag.clone();
-        if PARTIAL {
+        if i.is_partial() {
             streaming::tag_no_case_internal(i, t)
         } else {
             complete::tag_no_case_internal(i, t)
@@ -223,7 +223,7 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("one_of", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::one_of_internal(i, &list)
         } else {
             complete::one_of_internal(i, &list)
@@ -266,7 +266,7 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("none_of", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::none_of_internal(i, &list)
         } else {
             complete::none_of_internal(i, &list)
@@ -318,7 +318,7 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("take_while0", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::take_while_internal(i, &list)
         } else {
             complete::take_while_internal(i, &list)
@@ -391,7 +391,7 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("take_while1", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::take_while1_internal(i, &list)
         } else {
             complete::take_while1_internal(i, &list)
@@ -451,7 +451,7 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("take_while_m_n", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::take_while_m_n_internal(i, m, n, &list)
         } else {
             complete::take_while_m_n_internal(i, m, n, &list)
@@ -503,7 +503,7 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("take_till0", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::take_till_internal(i, &list)
         } else {
             complete::take_till_internal(i, &list)
@@ -576,7 +576,7 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("take_till1", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::take_till1_internal(i, &list)
         } else {
             complete::take_till1_internal(i, &list)
@@ -647,7 +647,7 @@ where
 {
     let c = count.to_usize();
     trace("take", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::take_internal(i, c)
         } else {
             complete::take_internal(i, c)
@@ -703,7 +703,7 @@ where
     T: SliceLen + Clone,
 {
     trace("take_until0", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::take_until_internal(i, tag.clone())
         } else {
             complete::take_until_internal(i, tag.clone())
@@ -762,7 +762,7 @@ where
     T: SliceLen + Clone,
 {
     trace("take_until1", move |i: I| {
-        if PARTIAL {
+        if i.is_partial() {
             streaming::take_until1_internal(i, tag.clone())
         } else {
             complete::take_until1_internal(i, tag.clone())

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -57,8 +57,8 @@ where
     I: Stream,
     I: Compare<&'static str>,
 {
-    trace("crlf", move |input| {
-        if PARTIAL {
+    trace("crlf", move |input: I| {
+        if input.is_partial() {
             streaming::crlf(input)
         } else {
             complete::crlf(input)
@@ -109,8 +109,8 @@ where
     I: Compare<&'static str>,
     <I as Stream>::Token: AsChar,
 {
-    trace("not_line_ending", move |input| {
-        if PARTIAL {
+    trace("not_line_ending", move |input: I| {
+        if input.is_partial() {
             streaming::not_line_ending(input)
         } else {
             complete::not_line_ending(input)
@@ -155,8 +155,8 @@ where
     I: Stream,
     I: Compare<&'static str>,
 {
-    trace("line_ending", move |input| {
-        if PARTIAL {
+    trace("line_ending", move |input: I| {
+        if input.is_partial() {
             streaming::line_ending(input)
         } else {
             complete::line_ending(input)
@@ -199,8 +199,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("newline", move |input| {
-        if PARTIAL {
+    trace("newline", move |input: I| {
+        if input.is_partial() {
             streaming::newline(input)
         } else {
             complete::newline(input)
@@ -243,8 +243,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("tag", move |input| {
-        if PARTIAL {
+    trace("tag", move |input: I| {
+        if input.is_partial() {
             streaming::tab(input)
         } else {
             complete::tab(input)
@@ -291,8 +291,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("alpha0", move |input| {
-        if PARTIAL {
+    trace("alpha0", move |input: I| {
+        if input.is_partial() {
             streaming::alpha0(input)
         } else {
             complete::alpha0(input)
@@ -339,8 +339,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("alpha1", move |input| {
-        if PARTIAL {
+    trace("alpha1", move |input: I| {
+        if input.is_partial() {
             streaming::alpha1(input)
         } else {
             complete::alpha1(input)
@@ -388,8 +388,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("digit0", move |input| {
-        if PARTIAL {
+    trace("digit0", move |input: I| {
+        if input.is_partial() {
             streaming::digit0(input)
         } else {
             complete::digit0(input)
@@ -452,8 +452,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("digit1", move |input| {
-        if PARTIAL {
+    trace("digit1", move |input: I| {
+        if input.is_partial() {
             streaming::digit1(input)
         } else {
             complete::digit1(input)
@@ -499,8 +499,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("hex_digit0", move |input| {
-        if PARTIAL {
+    trace("hex_digit0", move |input: I| {
+        if input.is_partial() {
             streaming::hex_digit0(input)
         } else {
             complete::hex_digit0(input)
@@ -547,8 +547,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("hex_digit1", move |input| {
-        if PARTIAL {
+    trace("hex_digit1", move |input: I| {
+        if input.is_partial() {
             streaming::hex_digit1(input)
         } else {
             complete::hex_digit1(input)
@@ -595,8 +595,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("oct_digit0", move |input| {
-        if PARTIAL {
+    trace("oct_digit0", move |input: I| {
+        if input.is_partial() {
             streaming::oct_digit0(input)
         } else {
             complete::oct_digit0(input)
@@ -643,8 +643,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("oct_digit0", move |input| {
-        if PARTIAL {
+    trace("oct_digit0", move |input: I| {
+        if input.is_partial() {
             streaming::oct_digit1(input)
         } else {
             complete::oct_digit1(input)
@@ -691,8 +691,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("alphanumeric0", move |input| {
-        if PARTIAL {
+    trace("alphanumeric0", move |input: I| {
+        if input.is_partial() {
             streaming::alphanumeric0(input)
         } else {
             complete::alphanumeric0(input)
@@ -739,8 +739,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("alphanumeric1", move |input| {
-        if PARTIAL {
+    trace("alphanumeric1", move |input: I| {
+        if input.is_partial() {
             streaming::alphanumeric1(input)
         } else {
             complete::alphanumeric1(input)
@@ -775,8 +775,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("space0", move |input| {
-        if PARTIAL {
+    trace("space0", move |input: I| {
+        if input.is_partial() {
             streaming::space0(input)
         } else {
             complete::space0(input)
@@ -823,8 +823,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("space1", move |input| {
-        if PARTIAL {
+    trace("space1", move |input: I| {
+        if input.is_partial() {
             streaming::space1(input)
         } else {
             complete::space1(input)
@@ -871,8 +871,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("multispace0", move |input| {
-        if PARTIAL {
+    trace("multispace0", move |input: I| {
+        if input.is_partial() {
             streaming::multispace0(input)
         } else {
             complete::multispace0(input)
@@ -919,8 +919,8 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("multispace1", move |input| {
-        if PARTIAL {
+    trace("multispace1", move |input: I| {
+        if input.is_partial() {
             streaming::multispace1(input)
         } else {
             complete::multispace1(input)
@@ -944,7 +944,7 @@ where
         let i = input.clone();
 
         if i.eof_offset() == 0 {
-            if PARTIAL {
+            if input.is_partial() {
                 return Err(ErrMode::Incomplete(Needed::new(1)));
             } else {
                 return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
@@ -971,7 +971,7 @@ where
             }
         }
 
-        if PARTIAL {
+        if input.is_partial() {
             Err(ErrMode::Incomplete(Needed::new(1)))
         } else {
             Ok((i.next_slice(i.eof_offset()).0, value))
@@ -1101,7 +1101,7 @@ where
             .parse_next(i)?;
 
         if i.eof_offset() == 0 {
-            if PARTIAL {
+            if input.is_partial() {
                 return Err(ErrMode::Incomplete(Needed::new(1)));
             } else {
                 return Err(ErrMode::from_error_kind(input, ErrorKind::Digit));
@@ -1132,7 +1132,7 @@ where
             }
         }
 
-        if PARTIAL {
+        if input.is_partial() {
             Err(ErrMode::Incomplete(Needed::new(1)))
         } else {
             Ok((i.next_slice(i.eof_offset()).0, value))
@@ -1242,7 +1242,7 @@ where
                 }
             }
             Err(_) => {
-                if PARTIAL && invalid_offset == input.eof_offset() {
+                if input.is_partial() && invalid_offset == input.eof_offset() {
                     // Only the next byte is guaranteed required
                     return Err(ErrMode::Incomplete(Needed::new(1)));
                 } else {
@@ -1364,7 +1364,7 @@ where
     I: AsBStr,
 {
     trace("float", move |input: I| {
-        let (i, s) = if PARTIAL {
+        let (i, s) = if input.is_partial() {
             crate::number::streaming::recognize_float_or_exceptions(input)?
         } else {
             crate::number::complete::recognize_float_or_exceptions(input)?
@@ -1425,7 +1425,7 @@ where
     Error: ParseError<I>,
 {
     trace("escaped", move |input: I| {
-        if PARTIAL {
+        if input.is_partial() {
             crate::bytes::streaming::escaped_internal(
                 input,
                 &mut normal,
@@ -1519,7 +1519,7 @@ where
     Error: ParseError<I>,
 {
     trace("escaped_transform", move |input: I| {
-        if PARTIAL {
+        if input.is_partial() {
             crate::bytes::streaming::escaped_transform_internal(
                 input,
                 &mut normal,

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -62,8 +62,8 @@ where
     I: StreamIsPartial<PARTIAL>,
     I: Stream<Token = u8>,
 {
-    trace("be_u8", move |input| {
-        if PARTIAL {
+    trace("be_u8", move |input: I| {
+        if input.is_partial() {
             streaming::be_u8(input)
         } else {
             complete::be_u8(input)
@@ -111,8 +111,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u16", move |input| {
-        if PARTIAL {
+    trace("be_u16", move |input: I| {
+        if input.is_partial() {
             streaming::be_u16(input)
         } else {
             complete::be_u16(input)
@@ -160,8 +160,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u23", move |input| {
-        if PARTIAL {
+    trace("be_u23", move |input: I| {
+        if input.is_partial() {
             streaming::be_u24(input)
         } else {
             complete::be_u24(input)
@@ -209,8 +209,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u32", move |input| {
-        if PARTIAL {
+    trace("be_u32", move |input: I| {
+        if input.is_partial() {
             streaming::be_u32(input)
         } else {
             complete::be_u32(input)
@@ -258,8 +258,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u64", move |input| {
-        if PARTIAL {
+    trace("be_u64", move |input: I| {
+        if input.is_partial() {
             streaming::be_u64(input)
         } else {
             complete::be_u64(input)
@@ -307,8 +307,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u128", move |input| {
-        if PARTIAL {
+    trace("be_u128", move |input: I| {
+        if input.is_partial() {
             streaming::be_u128(input)
         } else {
             complete::be_u128(input)
@@ -353,8 +353,8 @@ where
     I: StreamIsPartial<PARTIAL>,
     I: Stream<Token = u8>,
 {
-    trace("be_i8", move |input| {
-        if PARTIAL {
+    trace("be_i8", move |input: I| {
+        if input.is_partial() {
             streaming::be_i8(input)
         } else {
             complete::be_i8(input)
@@ -400,8 +400,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_i16", move |input| {
-        if PARTIAL {
+    trace("be_i16", move |input: I| {
+        if input.is_partial() {
             streaming::be_i16(input)
         } else {
             complete::be_i16(input)
@@ -447,8 +447,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_i24", move |input| {
-        if PARTIAL {
+    trace("be_i24", move |input: I| {
+        if input.is_partial() {
             streaming::be_i24(input)
         } else {
             complete::be_i24(input)
@@ -494,8 +494,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_i32", move |input| {
-        if PARTIAL {
+    trace("be_i32", move |input: I| {
+        if input.is_partial() {
             streaming::be_i32(input)
         } else {
             complete::be_i32(input)
@@ -541,8 +541,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_i64", move |input| {
-        if PARTIAL {
+    trace("be_i64", move |input: I| {
+        if input.is_partial() {
             streaming::be_i64(input)
         } else {
             complete::be_i64(input)
@@ -588,8 +588,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_i128", move |input| {
-        if PARTIAL {
+    trace("be_i128", move |input: I| {
+        if input.is_partial() {
             streaming::be_i128(input)
         } else {
             complete::be_i128(input)
@@ -634,8 +634,8 @@ where
     I: StreamIsPartial<PARTIAL>,
     I: Stream<Token = u8>,
 {
-    trace("le_u8", move |input| {
-        if PARTIAL {
+    trace("le_u8", move |input: I| {
+        if input.is_partial() {
             streaming::le_u8(input)
         } else {
             complete::le_u8(input)
@@ -683,8 +683,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u16", move |input| {
-        if PARTIAL {
+    trace("le_u16", move |input: I| {
+        if input.is_partial() {
             streaming::le_u16(input)
         } else {
             complete::le_u16(input)
@@ -732,8 +732,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u24", move |input| {
-        if PARTIAL {
+    trace("le_u24", move |input: I| {
+        if input.is_partial() {
             streaming::le_u24(input)
         } else {
             complete::le_u24(input)
@@ -781,8 +781,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u32", move |input| {
-        if PARTIAL {
+    trace("le_u32", move |input: I| {
+        if input.is_partial() {
             streaming::le_u32(input)
         } else {
             complete::le_u32(input)
@@ -830,8 +830,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u64", move |input| {
-        if PARTIAL {
+    trace("le_u64", move |input: I| {
+        if input.is_partial() {
             streaming::le_u64(input)
         } else {
             complete::le_u64(input)
@@ -879,8 +879,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u128", move |input| {
-        if PARTIAL {
+    trace("le_u128", move |input: I| {
+        if input.is_partial() {
             streaming::le_u128(input)
         } else {
             complete::le_u128(input)
@@ -925,8 +925,8 @@ where
     I: StreamIsPartial<PARTIAL>,
     I: Stream<Token = u8>,
 {
-    trace("le_i8", move |input| {
-        if PARTIAL {
+    trace("le_i8", move |input: I| {
+        if input.is_partial() {
             streaming::le_i8(input)
         } else {
             complete::le_i8(input)
@@ -974,8 +974,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_i16", move |input| {
-        if PARTIAL {
+    trace("le_i16", move |input: I| {
+        if input.is_partial() {
             streaming::le_i16(input)
         } else {
             complete::le_i16(input)
@@ -1023,8 +1023,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_i24", move |input| {
-        if PARTIAL {
+    trace("le_i24", move |input: I| {
+        if input.is_partial() {
             streaming::le_i24(input)
         } else {
             complete::le_i24(input)
@@ -1072,8 +1072,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_i32", move |input| {
-        if PARTIAL {
+    trace("le_i32", move |input: I| {
+        if input.is_partial() {
             streaming::le_i32(input)
         } else {
             complete::le_i32(input)
@@ -1121,8 +1121,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_i64", move |input| {
-        if PARTIAL {
+    trace("le_i64", move |input: I| {
+        if input.is_partial() {
             streaming::le_i64(input)
         } else {
             complete::le_i64(input)
@@ -1170,8 +1170,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_i128", move |input| {
-        if PARTIAL {
+    trace("le_i128", move |input: I| {
+        if input.is_partial() {
             streaming::le_i128(input)
         } else {
             complete::le_i128(input)
@@ -1221,8 +1221,8 @@ where
     I: StreamIsPartial<PARTIAL>,
     I: Stream<Token = u8>,
 {
-    trace("u8", move |input| {
-        if PARTIAL {
+    trace("u8", move |input: I| {
+        if input.is_partial() {
             streaming::u8(input)
         } else {
             complete::u8(input)
@@ -1290,13 +1290,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("u16", {
-        if PARTIAL {
+    trace("u16", move |input: I| {
+        if input.is_partial() {
             streaming::u16(endian)
         } else {
             complete::u16(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes an unsigned 3 byte integer
@@ -1359,13 +1359,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("u23", {
-        if PARTIAL {
+    trace("u23", move |input: I| {
+        if input.is_partial() {
             streaming::u24(endian)
         } else {
             complete::u24(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes an unsigned 4 byte integer
@@ -1428,13 +1428,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("u32", {
-        if PARTIAL {
+    trace("u32", move |input: I| {
+        if input.is_partial() {
             streaming::u32(endian)
         } else {
             complete::u32(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes an unsigned 8 byte integer
@@ -1497,13 +1497,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("u64", {
-        if PARTIAL {
+    trace("u64", move |input: I| {
+        if input.is_partial() {
             streaming::u64(endian)
         } else {
             complete::u64(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes an unsigned 16 byte integer
@@ -1566,13 +1566,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("u128", {
-        if PARTIAL {
+    trace("u128", move |input: I| {
+        if input.is_partial() {
             streaming::u128(endian)
         } else {
             complete::u128(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes a signed 1 byte integer
@@ -1617,8 +1617,8 @@ where
     I: StreamIsPartial<PARTIAL>,
     I: Stream<Token = u8>,
 {
-    trace("i8", move |input| {
-        if PARTIAL {
+    trace("i8", move |input: I| {
+        if input.is_partial() {
             streaming::i8(input)
         } else {
             complete::i8(input)
@@ -1686,13 +1686,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("i16", {
-        if PARTIAL {
+    trace("i16", move |input: I| {
+        if input.is_partial() {
             streaming::i16(endian)
         } else {
             complete::i16(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes a signed 3 byte integer
@@ -1755,13 +1755,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("i24", {
-        if PARTIAL {
+    trace("i24", move |input: I| {
+        if input.is_partial() {
             streaming::i24(endian)
         } else {
             complete::i24(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes a signed 4 byte integer
@@ -1824,13 +1824,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("i32", {
-        if PARTIAL {
+    trace("i32", move |input: I| {
+        if input.is_partial() {
             streaming::i32(endian)
         } else {
             complete::i32(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes a signed 8 byte integer
@@ -1893,13 +1893,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("i64", {
-        if PARTIAL {
+    trace("i64", move |input: I| {
+        if input.is_partial() {
             streaming::i64(endian)
         } else {
             complete::i64(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes a signed 16 byte integer
@@ -1962,13 +1962,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("i128", {
-        if PARTIAL {
+    trace("i128", move |input: I| {
+        if input.is_partial() {
             streaming::i128(endian)
         } else {
             complete::i128(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes a big endian 4 bytes floating point number.
@@ -2011,8 +2011,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_f32", move |input| {
-        if PARTIAL {
+    trace("be_f32", move |input: I| {
+        if input.is_partial() {
             streaming::be_f32(input)
         } else {
             complete::be_f32(input)
@@ -2060,8 +2060,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_f64", move |input| {
-        if PARTIAL {
+    trace("be_f64", move |input: I| {
+        if input.is_partial() {
             streaming::be_f64(input)
         } else {
             complete::be_f64(input)
@@ -2109,8 +2109,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_f32", move |input| {
-        if PARTIAL {
+    trace("le_f32", move |input: I| {
+        if input.is_partial() {
             streaming::le_f32(input)
         } else {
             complete::le_f32(input)
@@ -2158,8 +2158,8 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_f64", move |input| {
-        if PARTIAL {
+    trace("le_f64", move |input: I| {
+        if input.is_partial() {
             streaming::le_f64(input)
         } else {
             complete::le_f64(input)
@@ -2227,13 +2227,13 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("f32", {
-        if PARTIAL {
+    trace("f32", move |input: I| {
+        if input.is_partial() {
             streaming::f32(endian)
         } else {
             complete::f32(endian)
         }
-    })
+    }(input))
 }
 
 /// Recognizes an 8 byte floating point number
@@ -2296,11 +2296,11 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("f64", {
-        if PARTIAL {
+    trace("f64", move |input: I|{
+        if input.is_partial() {
             streaming::f64(endian)
         } else {
             complete::f64(endian)
         }
-    })
+    }(input))
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -929,190 +929,27 @@ where
 /// Marks the input as being the complete buffer or a partial buffer for streaming input
 ///
 /// See [Partial] for marking a presumed complete buffer type as a streaming buffer.
-pub trait StreamIsPartial<const YES: bool>: Sized {
-    /// Complete counterpart
-    ///
-    /// - Set to `Self` if this is a complete buffer.
-    /// - Set to [`std::convert::Infallible`] if there isn't an associated complete buffer type
-    type Complete: StreamIsPartial<false>;
-    /// Partial counterpart
-    ///
-    /// - Set to `Self` if this is a streaming buffer.
-    /// - Set to [`std::convert::Infallible`] if there isn't an associated streaming buffer type
-    type Partial: StreamIsPartial<true>;
+pub trait StreamIsPartial<const YES: bool>: Sized {}
 
-    /// Convert to complete counterpart
-    fn into_complete(self) -> Self::Complete;
-    /// Convert to partial counterpart
-    fn into_partial(self) -> Self::Partial;
-}
+impl<'a, T> StreamIsPartial<false> for &'a [T] {}
 
-impl<'a, T> StreamIsPartial<false> for &'a [T] {
-    type Complete = Self;
-    type Partial = Partial<Self>;
+impl<'a> StreamIsPartial<false> for &'a str {}
 
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        self
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        Partial(self)
-    }
-}
+impl<'a> StreamIsPartial<false> for &'a Bytes {}
 
-impl<'a> StreamIsPartial<false> for &'a str {
-    type Complete = Self;
-    type Partial = Partial<Self>;
+impl<'a> StreamIsPartial<false> for &'a BStr {}
 
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        self
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        Partial(self)
-    }
-}
+impl<const YES: bool> StreamIsPartial<YES> for crate::lib::std::convert::Infallible {}
 
-impl<'a> StreamIsPartial<false> for &'a Bytes {
-    type Complete = Self;
-    type Partial = Partial<Self>;
+impl<I> StreamIsPartial<true> for Located<I> where I: StreamIsPartial<true> {}
 
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        self
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        Partial(self)
-    }
-}
+impl<I> StreamIsPartial<false> for Located<I> where I: StreamIsPartial<false> {}
 
-impl<'a> StreamIsPartial<false> for &'a BStr {
-    type Complete = Self;
-    type Partial = Partial<Self>;
+impl<I, S> StreamIsPartial<true> for Stateful<I, S> where I: StreamIsPartial<true> {}
 
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        self
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        Partial(self)
-    }
-}
+impl<I, S> StreamIsPartial<false> for Stateful<I, S> where I: StreamIsPartial<false> {}
 
-impl<const YES: bool> StreamIsPartial<YES> for crate::lib::std::convert::Infallible {
-    type Complete = Self;
-    type Partial = Self;
-
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        self
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        self
-    }
-}
-
-impl<I> StreamIsPartial<true> for Located<I>
-where
-    I: StreamIsPartial<true>,
-{
-    type Complete = Located<<I as StreamIsPartial<true>>::Complete>;
-    type Partial = Self;
-
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        Located {
-            initial: self.initial.into_complete(),
-            input: self.input.into_complete(),
-        }
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        self
-    }
-}
-
-impl<I> StreamIsPartial<false> for Located<I>
-where
-    I: StreamIsPartial<false>,
-{
-    type Complete = Self;
-    type Partial = Located<<I as StreamIsPartial<false>>::Partial>;
-
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        self
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        Located {
-            initial: self.initial.into_partial(),
-            input: self.input.into_partial(),
-        }
-    }
-}
-
-impl<I, S> StreamIsPartial<true> for Stateful<I, S>
-where
-    I: StreamIsPartial<true>,
-{
-    type Complete = Stateful<<I as StreamIsPartial<true>>::Complete, S>;
-    type Partial = Self;
-
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        Stateful {
-            input: self.input.into_complete(),
-            state: self.state,
-        }
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        self
-    }
-}
-
-impl<I, S> StreamIsPartial<false> for Stateful<I, S>
-where
-    I: StreamIsPartial<false>,
-{
-    type Complete = Self;
-    type Partial = Stateful<<I as StreamIsPartial<false>>::Partial, S>;
-
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        self
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        Stateful {
-            input: self.input.into_partial(),
-            state: self.state,
-        }
-    }
-}
-
-impl<I> StreamIsPartial<true> for Partial<I>
-where
-    I: StreamIsPartial<false>,
-{
-    type Complete = I;
-    type Partial = Self;
-
-    #[inline(always)]
-    fn into_complete(self) -> Self::Complete {
-        self.0
-    }
-    #[inline(always)]
-    fn into_partial(self) -> Self::Partial {
-        self
-    }
-}
+impl<I> StreamIsPartial<true> for Partial<I> where I: StreamIsPartial<false> {}
 
 /// Useful functions to calculate the offset between slices and show a hexdump of a slice
 pub trait Offset {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -929,7 +929,13 @@ where
 /// Marks the input as being the complete buffer or a partial buffer for streaming input
 ///
 /// See [Partial] for marking a presumed complete buffer type as a streaming buffer.
-pub trait StreamIsPartial<const YES: bool>: Sized {}
+pub trait StreamIsPartial<const YES: bool>: Sized {
+    /// Report whether the [`Stream`] is currently incomplete
+    #[inline(always)]
+    fn is_partial(&self) -> bool {
+        YES
+    }
+}
 
 impl<'a, T> StreamIsPartial<false> for &'a [T] {}
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -941,6 +941,10 @@ impl<'a> StreamIsPartial<false> for &'a BStr {}
 
 impl<const YES: bool> StreamIsPartial<YES> for crate::lib::std::convert::Infallible {}
 
+impl<I> StreamIsPartial<true> for (I, usize) where I: StreamIsPartial<true> {}
+
+impl<I> StreamIsPartial<false> for (I, usize) where I: StreamIsPartial<false> {}
+
 impl<I> StreamIsPartial<true> for Located<I> where I: StreamIsPartial<true> {}
 
 impl<I> StreamIsPartial<false> for Located<I> where I: StreamIsPartial<false> {}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -941,17 +941,11 @@ impl<'a> StreamIsPartial<false> for &'a BStr {}
 
 impl<const YES: bool> StreamIsPartial<YES> for crate::lib::std::convert::Infallible {}
 
-impl<I> StreamIsPartial<true> for (I, usize) where I: StreamIsPartial<true> {}
+impl<I, const YES: bool> StreamIsPartial<YES> for (I, usize) where I: StreamIsPartial<YES> {}
 
-impl<I> StreamIsPartial<false> for (I, usize) where I: StreamIsPartial<false> {}
+impl<I, const YES: bool> StreamIsPartial<YES> for Located<I> where I: StreamIsPartial<YES> {}
 
-impl<I> StreamIsPartial<true> for Located<I> where I: StreamIsPartial<true> {}
-
-impl<I> StreamIsPartial<false> for Located<I> where I: StreamIsPartial<false> {}
-
-impl<I, S> StreamIsPartial<true> for Stateful<I, S> where I: StreamIsPartial<true> {}
-
-impl<I, S> StreamIsPartial<false> for Stateful<I, S> where I: StreamIsPartial<false> {}
+impl<I, S, const YES: bool> StreamIsPartial<YES> for Stateful<I, S> where I: StreamIsPartial<YES> {}
 
 impl<I> StreamIsPartial<true> for Partial<I> where I: StreamIsPartial<false> {}
 


### PR DESCRIPTION
This will be cleaned up a lot and reduce duplicate code with #97

In doing this, I removed the compile-time conversion.  We weren't using it, providing examples for it, etc and it complicated things around error reporting as it was a distinct input type.