### PR TITLE
fix!: Clarify `Parser::complete_err` is error related

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1,4 +1,4 @@
-//! # List of parsers and combinators
+//! # List of parsers and combinators]
 //!
 //! **Note**: this list is meant to provide a nicer way to find a nom parser than reading through the documentation on docs.rs. Function combinators are organized in module so they are a bit easier to find.
 //!
@@ -67,7 +67,7 @@
 //! ## Partial related
 //!
 //! - [`eof`][eof]: Returns its input if it is at the end of input data
-//! - [`Parser::complete`][Parser::complete()]: Replaces an `Incomplete` returned by the child parser with an `Backtrack`
+//! - [`Parser::complete_err`]: Replaces an `Incomplete` returned by the child parser with an `Backtrack`
 //!
 //! ## Modifiers
 //!
@@ -774,7 +774,7 @@ where
 
 /// Transforms `Incomplete` into `Backtrack`.
 ///
-/// **WARNING:** Deprecated, replaced with [`Parser::complete`]
+/// **WARNING:** Deprecated, replaced with [`Parser::complete_err`]
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, stream::Partial};
@@ -788,7 +788,7 @@ where
 /// assert_eq!(parser(Partial("abcd")), Err(ErrMode::Backtrack(Error::new(Partial("abcd"), ErrorKind::Complete))));
 /// # }
 /// ```
-#[deprecated(since = "0.1.0", note = "Replaced with `Parser::complete")]
+#[deprecated(since = "0.1.0", note = "Replaced with `Parser::complete_err")]
 pub fn complete<I: Clone, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
     F: Parser<I, O, E>,
@@ -802,26 +802,26 @@ where
     }
 }
 
-/// Implementation of [`Parser::complete`]
+/// Implementation of [`Parser::complete_err`]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
-pub struct Complete<F> {
+pub struct CompleteErr<F> {
     f: F,
 }
 
-impl<F> Complete<F> {
+impl<F> CompleteErr<F> {
     pub(crate) fn new(f: F) -> Self {
         Self { f }
     }
 }
 
-impl<F, I, O, E> Parser<I, O, E> for Complete<F>
+impl<F, I, O, E> Parser<I, O, E> for CompleteErr<F>
 where
     I: Stream,
     F: Parser<I, O, E>,
     E: ParseError<I>,
 {
     fn parse_next(&mut self, input: I) -> IResult<I, O, E> {
-        trace("complete", |input: I| {
+        trace("complete_err", |input: I| {
             let i = input.clone();
             match (self.f).parse_next(input) {
                 Err(ErrMode::Incomplete(_)) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -603,7 +603,7 @@ pub enum ErrMode<E> {
     /// This must only be set when the `Stream` is [`StreamIsPartial<true>`], like with
     /// [`Partial`][crate::Partial]
     ///
-    /// Convert this into an `Backtrack` with [`Parser::complete`][Parser::complete]
+    /// Convert this into an `Backtrack` with [`Parser::complete_err`]
     Incomplete(Needed),
     /// The parser had an error (recoverable)
     Backtrack(E),

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1125,7 +1125,7 @@ where
     trace("length_value", move |i: I| {
         let (i, data) = length_data(f.by_ref()).parse_next(i)?;
         let data = I::update_slice(i.clone(), data);
-        let (_, o) = g.by_ref().complete().parse_next(data)?;
+        let (_, o) = g.by_ref().complete_err().parse_next(data)?;
         Ok((i, o))
     })
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -58,7 +58,7 @@ pub trait Parser<I, O, E> {
     ///
     /// Because parsers are `FnMut`, they can be called multiple times.  This prevents moving `f`
     /// into [`length_data`][crate::multi::length_data] and `g` into
-    /// [`complete`][Parser::complete]:
+    /// [`Parser::complete_err`]:
     /// ```rust,compile_fail
     /// # use winnow::prelude::*;
     /// # use winnow::IResult;
@@ -90,7 +90,7 @@ pub trait Parser<I, O, E> {
     /// ) -> impl FnMut(&'i [u8]) -> IResult<&'i [u8], O, E> {
     ///   move |i: &'i [u8]| {
     ///     let (i, data) = length_data(f.by_ref()).parse_next(i)?;
-    ///     let (_, o) = g.by_ref().complete().parse_next(data)?;
+    ///     let (_, o) = g.by_ref().complete_err().parse_next(data)?;
     ///     Ok((i, o))
     ///   }
     /// }
@@ -525,17 +525,17 @@ pub trait Parser<I, O, E> {
     /// # use winnow::bytes::take;
     /// # fn main() {
     ///
-    /// let mut parser = take(5u8).complete();
+    /// let mut parser = take(5u8).complete_err();
     ///
     /// assert_eq!(parser.parse_next(Partial("abcdefg")), Ok((Partial("fg"), "abcde")));
     /// assert_eq!(parser.parse_next(Partial("abcd")), Err(ErrMode::Backtrack(Error::new(Partial("abcd"), ErrorKind::Complete))));
     /// # }
     /// ```
-    fn complete(self) -> Complete<Self>
+    fn complete_err(self) -> CompleteErr<Self>
     where
         Self: core::marker::Sized,
     {
-        Complete::new(self)
+        CompleteErr::new(self)
     }
 
     /// Convert the parser's error to another type using [`std::convert::From`]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -243,7 +243,7 @@ impl<I, S> crate::lib::std::ops::Deref for Stateful<I, S> {
 /// This can happen with some network protocol or large file parsers, where the
 /// input buffer can be full and need to be resized or refilled.
 /// - [`ErrMode::Incomplete`] will report how much more data is needed.
-/// - [`Parser::complete`][crate::Parser::complete] transform [`ErrMode::Incomplete`] to
+/// - [`Parser::complete_err`][crate::Parser::complete_err] transform [`ErrMode::Incomplete`] to
 ///   [`ErrMode::Backtrack`]
 ///
 /// See also [`StreamIsPartial`] to tell whether the input supports complete or partial parsing.

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -39,9 +39,9 @@ mod parse_int {
 
     fn spaces_or_int(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
         println!("{}", input.to_hex(8));
-        let (i, _) = opt(space.complete())(input)?;
+        let (i, _) = opt(space.complete_err())(input)?;
         let (i, res) = digit
-            .complete()
+            .complete_err()
             .map(|x| {
                 println!("x: {:?}", x);
                 let result = str::from_utf8(x).unwrap();
@@ -151,7 +151,7 @@ mod issue_647 {
         input: Stream<'a>,
         _cs: &f64,
     ) -> Result<(Stream<'a>, Vec<f64>), ErrMode<Error<Stream<'a>>>> {
-        separated0(be_f64.complete(), tag(",").complete())(input)
+        separated0(be_f64.complete_err(), tag(",").complete_err())(input)
     }
 
     fn data(input: Stream<'_>) -> IResult<Stream<'_>, Data> {


### PR DESCRIPTION
This matches `backtrack_err` and `cut_err`

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
