### PR TITLE
fix(parser)!: Allow literals to be parsers of partial inputs

### DIFF
--- a/benches/number.rs
+++ b/benches/number.rs
@@ -29,20 +29,20 @@ fn number(c: &mut Criterion) {
 fn float_bytes(c: &mut Criterion) {
     println!(
         "float_bytes result: {:?}",
-        float::<_, f64, Error<_>, false>(&b"-1.234E-12"[..])
+        float::<_, f64, Error<_>>(&b"-1.234E-12"[..])
     );
     c.bench_function("float bytes", |b| {
-        b.iter(|| float::<_, f64, Error<_>, false>(&b"-1.234E-12"[..]));
+        b.iter(|| float::<_, f64, Error<_>>(&b"-1.234E-12"[..]));
     });
 }
 
 fn float_str(c: &mut Criterion) {
     println!(
         "float_str result: {:?}",
-        float::<_, f64, Error<_>, false>("-1.234E-12")
+        float::<_, f64, Error<_>>("-1.234E-12")
     );
     c.bench_function("float str", |b| {
-        b.iter(|| float::<_, f64, Error<_>, false>("-1.234E-12"));
+        b.iter(|| float::<_, f64, Error<_>>("-1.234E-12"));
     });
 }
 

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -62,7 +62,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
 
     pub fn number(&self) -> Option<f64> {
         println!("number()");
-        match float::<_, _, (), false>(self.data()) {
+        match float::<_, _, ()>(self.data()) {
             Ok((i, o)) => {
                 self.offset(i);
                 println!("-> {}", o);
@@ -75,7 +75,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
     pub fn array(&self) -> Option<impl Iterator<Item = JsonValue<'a, 'b>>> {
         println!("array()");
 
-        match tag::<_, _, (), false>("[")(self.data()) {
+        match tag::<_, _, ()>("[")(self.data()) {
             Err(_) => None,
             Ok((i, _)) => {
                 println!("[");
@@ -99,7 +99,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                         }
                     }
 
-                    if let Ok((i, _)) = tag::<_, _, (), false>("]")(v.data()) {
+                    if let Ok((i, _)) = tag::<_, _, ()>("]")(v.data()) {
                         println!("]");
                         v.offset(i);
                         done = true;
@@ -109,7 +109,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                     if first {
                         first = false;
                     } else {
-                        match tag::<_, _, (), false>(",")(v.data()) {
+                        match tag::<_, _, ()>(",")(v.data()) {
                             Ok((i, _)) => {
                                 println!(",");
                                 v.offset(i);
@@ -131,7 +131,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
 
     pub fn object(&self) -> Option<impl Iterator<Item = (&'a str, JsonValue<'a, 'b>)>> {
         println!("object()");
-        match tag::<_, _, (), false>("{")(self.data()) {
+        match tag::<_, _, ()>("{")(self.data()) {
             Err(_) => None,
             Ok((i, _)) => {
                 self.offset(i);
@@ -157,7 +157,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                         }
                     }
 
-                    if let Ok((i, _)) = tag::<_, _, (), false>("}")(v.data()) {
+                    if let Ok((i, _)) = tag::<_, _, ()>("}")(v.data()) {
                         println!("}}");
                         v.offset(i);
                         done = true;
@@ -167,7 +167,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                     if first {
                         first = false;
                     } else {
-                        match tag::<_, _, (), false>(",")(v.data()) {
+                        match tag::<_, _, ()>(",")(v.data()) {
                             Ok((i, _)) => {
                                 println!(",");
                                 v.offset(i);
@@ -183,7 +183,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                         Ok((i, key)) => {
                             v.offset(i);
 
-                            match tag::<_, _, (), false>(":")(v.data()) {
+                            match tag::<_, _, ()>(":")(v.data()) {
                                 Err(_) => None,
                                 Ok((i, _)) => {
                                     v.offset(i);
@@ -258,7 +258,7 @@ fn value(i: &str) -> IResult<&str, ()> {
             hash,
             array,
             string.map(|_| ()),
-            float::<_, f64, _, false>.map(|_| ()),
+            float::<_, f64, _>.map(|_| ()),
             boolean.map(|_| ()),
         )),
     )(i)

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -158,11 +158,11 @@ where
 /// assert_eq!(parser((stream(&[0b00010010]), 0), 12), Err(winnow::error::ErrMode::Backtrack(Error{input: (stream(&[0b00010010]), 0), kind: ErrorKind::Eof })));
 /// ```
 #[inline(always)]
-pub fn take<I, O, C, E: ParseError<(I, usize)>, const PARTIAL: bool>(
+pub fn take<I, O, C, E: ParseError<(I, usize)>>(
     count: C,
 ) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E>
 where
-    I: Stream<Token = u8> + AsBytes + StreamIsPartial<PARTIAL>,
+    I: Stream<Token = u8> + AsBytes + StreamIsPartial,
     C: ToUsize,
     O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
@@ -230,12 +230,12 @@ where
 /// );
 /// ```
 #[inline(always)]
-pub fn tag<I, O, C, E: ParseError<(I, usize)>, const PARTIAL: bool>(
+pub fn tag<I, O, C, E: ParseError<(I, usize)>>(
     pattern: O,
     count: C,
 ) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E>
 where
-    I: Stream<Token = u8> + AsBytes + StreamIsPartial<PARTIAL>,
+    I: Stream<Token = u8> + AsBytes + StreamIsPartial,
     C: ToUsize,
     O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
@@ -272,11 +272,9 @@ where
 /// assert_eq!(parse((stream(&[0b10000000]), 0)), Ok(((stream(&[0b10000000]), 1), true)));
 /// assert_eq!(parse((stream(&[0b10000000]), 1)), Ok(((stream(&[0b10000000]), 2), false)));
 /// ```
-pub fn bool<I, E: ParseError<(I, usize)>, const PARTIAL: bool>(
-    input: (I, usize),
-) -> IResult<(I, usize), bool, E>
+pub fn bool<I, E: ParseError<(I, usize)>>(input: (I, usize)) -> IResult<(I, usize), bool, E>
 where
-    I: Stream<Token = u8> + AsBytes + StreamIsPartial<PARTIAL>,
+    I: Stream<Token = u8> + AsBytes + StreamIsPartial,
 {
     #![allow(deprecated)]
     trace("bool", |input: (I, usize)| {

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -33,15 +33,13 @@ use crate::IResult;
 /// ```
 /// # use winnow::{bytes::any, error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
-/// assert_eq!(any::<_, Error<_>, true>(Partial("abc")), Ok((Partial("bc"),'a')));
-/// assert_eq!(any::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(any::<_, Error<_>>(Partial("abc")), Ok((Partial("bc"),'a')));
+/// assert_eq!(any::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn any<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Token, E>
+pub fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Token, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
 {
     trace("any", move |input: I| {
@@ -93,11 +91,11 @@ where
 /// assert_eq!(parser(Partial("H")), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
-pub fn tag<T, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn tag<T, I, Error: ParseError<I>>(
     tag: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream + Compare<T>,
     T: SliceLen + Clone,
 {
@@ -149,11 +147,11 @@ where
 /// assert_eq!(parser(Partial("")), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
-pub fn tag_no_case<T, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn tag_no_case<T, I, Error: ParseError<I>>(
     tag: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream + Compare<T>,
     T: SliceLen + Clone,
 {
@@ -184,9 +182,9 @@ where
 /// # use winnow::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::bytes::one_of;
-/// assert_eq!(one_of::<_, _, Error<_>, false>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>, false>("a")("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, Error<_>, false>("a")(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("abc")("b"), Ok(("", 'b')));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::OneOf))));
 ///
 /// fn parser_fn(i: &str) -> IResult<&str, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
@@ -201,9 +199,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::bytes::one_of;
-/// assert_eq!(one_of::<_, _, Error<_>, true>("abc")(Partial("b")), Ok((Partial(""), 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Partial("bc")), Err(ErrMode::Backtrack(Error::new(Partial("bc"), ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, Error<_>, true>("a")(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(one_of::<_, _, Error<_>>("abc")(Partial("b")), Ok((Partial(""), 'b')));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")(Partial("bc")), Err(ErrMode::Backtrack(Error::new(Partial("bc"), ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn parser_fn(i: Partial<&str>) -> IResult<Partial<&str>, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
@@ -213,11 +211,11 @@ where
 /// assert_eq!(parser_fn(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn one_of<I, T, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn one_of<I, T, Error: ParseError<I>>(
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Token, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: Copy,
     T: ContainsToken<<I as Stream>::Token>,
@@ -242,25 +240,25 @@ where
 /// ```
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::bytes::none_of;
-/// assert_eq!(none_of::<_, _, Error<_>, false>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>, false>("ab")("a"), Err(ErrMode::Backtrack(Error::new("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, Error<_>, false>("a")(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("abc")("z"), Ok(("", 'z')));
+/// assert_eq!(none_of::<_, _, Error<_>>("ab")("a"), Err(ErrMode::Backtrack(Error::new("a", ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("a")(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::NoneOf))));
 /// ```
 ///
 /// ```
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::bytes::none_of;
-/// assert_eq!(none_of::<_, _, Error<_>, true>("abc")(Partial("z")), Ok((Partial(""), 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>, true>("ab")(Partial("a")), Err(ErrMode::Backtrack(Error::new(Partial("a"), ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, Error<_>, true>("a")(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(none_of::<_, _, Error<_>>("abc")(Partial("z")), Ok((Partial(""), 'z')));
+/// assert_eq!(none_of::<_, _, Error<_>>("ab")(Partial("a")), Err(ErrMode::Backtrack(Error::new(Partial("a"), ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("a")(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn none_of<I, T, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn none_of<I, T, Error: ParseError<I>>(
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Token, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: Copy,
     T: ContainsToken<<I as Stream>::Token>,
@@ -309,11 +307,11 @@ where
 /// assert_eq!(alpha(Partial(b"")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn take_while0<T, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn take_while0<T, I, Error: ParseError<I>>(
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
@@ -382,11 +380,11 @@ where
 /// assert_eq!(hex(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn take_while1<T, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn take_while1<T, I, Error: ParseError<I>>(
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
@@ -440,13 +438,13 @@ where
 /// assert_eq!(short_alpha(Partial(b"12345")), Err(ErrMode::Backtrack(Error::new(Partial(&b"12345"[..]), ErrorKind::TakeWhileMN))));
 /// ```
 #[inline(always)]
-pub fn take_while_m_n<T, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn take_while_m_n<T, I, Error: ParseError<I>>(
     m: usize,
     n: usize,
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
@@ -494,11 +492,11 @@ where
 /// assert_eq!(till_colon(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn take_till0<T, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn take_till0<T, I, Error: ParseError<I>>(
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
@@ -567,11 +565,11 @@ where
 /// assert_eq!(not_space(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn take_till1<T, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn take_till1<T, I, Error: ParseError<I>>(
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
@@ -618,8 +616,8 @@ where
 /// use winnow::error::Error;
 /// use winnow::bytes::take;
 ///
-/// assert_eq!(take::<_, _, Error<_>, false>(1usize)("💙"), Ok(("", "💙")));
-/// assert_eq!(take::<_, _, Error<_>, false>(1usize)("💙".as_bytes()), Ok((b"\x9F\x92\x99".as_ref(), b"\xF0".as_ref())));
+/// assert_eq!(take::<_, _, Error<_>>(1usize)("💙"), Ok(("", "💙")));
+/// assert_eq!(take::<_, _, Error<_>>(1usize)("💙".as_bytes()), Ok((b"\x9F\x92\x99".as_ref(), b"\xF0".as_ref())));
 /// ```
 ///
 /// ```rust
@@ -637,11 +635,11 @@ where
 /// assert_eq!(take6(Partial("short")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 #[inline(always)]
-pub fn take<C, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn take<C, I, Error: ParseError<I>>(
     count: C,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     C: ToUsize,
 {
@@ -694,11 +692,11 @@ where
 /// assert_eq!(until_eof(Partial("1eof2eof")), Ok((Partial("eof2eof"), "1")));
 /// ```
 #[inline(always)]
-pub fn take_until0<T, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn take_until0<T, I, Error: ParseError<I>>(
     tag: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream + FindSlice<T>,
     T: SliceLen + Clone,
 {
@@ -753,11 +751,11 @@ where
 /// assert_eq!(until_eof(Partial("eof")),  Err(ErrMode::Backtrack(Error::new(Partial("eof"), ErrorKind::TakeUntil))));
 /// ```
 #[inline(always)]
-pub fn take_until1<T, I, Error: ParseError<I>, const PARTIAL: bool>(
+pub fn take_until1<T, I, Error: ParseError<I>>(
     tag: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream + FindSlice<T>,
     T: SliceLen + Clone,
 {

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -66,7 +66,7 @@ proptest! {
 fn partial_any_str() {
     use super::any;
     assert_eq!(
-        any::<_, Error<Partial<&str>>, true>(Partial("Ә")),
+        any::<_, Error<Partial<&str>>>(Partial("Ә")),
         Ok((Partial(""), 'Ә'))
     );
 }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -44,16 +44,14 @@ use crate::Parser;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::crlf;
-/// assert_eq!(crlf::<_, Error<_>, true>(Partial("\r\nc")), Ok((Partial("c"), "\r\n")));
-/// assert_eq!(crlf::<_, Error<_>, true>(Partial("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("ab\r\nc"), ErrorKind::CrLf))));
-/// assert_eq!(crlf::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(crlf::<_, Error<_>>(Partial("\r\nc")), Ok((Partial("c"), "\r\n")));
+/// assert_eq!(crlf::<_, Error<_>>(Partial("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(crlf::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn crlf<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn crlf<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     I: Compare<&'static str>,
 {
@@ -93,18 +91,16 @@ where
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::not_line_ending;
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Partial("ab\r\nc")), Ok((Partial("\r\nc"), "ab")));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Partial("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Partial("a\rb\nc")), Err(ErrMode::Backtrack(Error::new(Partial("a\rb\nc"), ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, Error<_>, true>(Partial("a\rbc")), Err(ErrMode::Backtrack(Error::new(Partial("a\rbc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("ab\r\nc")), Ok((Partial("\r\nc"), "ab")));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("a\rb\nc")), Err(ErrMode::Backtrack(Error::new(Partial("a\rb\nc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("a\rbc")), Err(ErrMode::Backtrack(Error::new(Partial("a\rbc"), ErrorKind::Tag ))));
 /// ```
 #[inline(always)]
-pub fn not_line_ending<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn not_line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream + AsBStr,
     I: Compare<&'static str>,
     <I as Stream>::Token: AsChar,
@@ -142,16 +138,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::line_ending;
-/// assert_eq!(line_ending::<_, Error<_>, true>(Partial("\r\nc")), Ok((Partial("c"), "\r\n")));
-/// assert_eq!(line_ending::<_, Error<_>, true>(Partial("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("ab\r\nc"), ErrorKind::CrLf))));
-/// assert_eq!(line_ending::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(line_ending::<_, Error<_>>(Partial("\r\nc")), Ok((Partial("c"), "\r\n")));
+/// assert_eq!(line_ending::<_, Error<_>>(Partial("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn line_ending<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     I: Compare<&'static str>,
 {
@@ -188,14 +182,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::newline;
-/// assert_eq!(newline::<_, Error<_>, true>(Partial("\nc")), Ok((Partial("c"), '\n')));
-/// assert_eq!(newline::<_, Error<_>, true>(Partial("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("\r\nc"), ErrorKind::Char))));
-/// assert_eq!(newline::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(newline::<_, Error<_>>(Partial("\nc")), Ok((Partial("c"), '\n')));
+/// assert_eq!(newline::<_, Error<_>>(Partial("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(newline::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn newline<I, Error: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, char, Error>
+pub fn newline<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -232,14 +226,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::tab;
-/// assert_eq!(tab::<_, Error<_>, true>(Partial("\tc")), Ok((Partial("c"), '\t')));
-/// assert_eq!(tab::<_, Error<_>, true>(Partial("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("\r\nc"), ErrorKind::Char))));
-/// assert_eq!(tab::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(tab::<_, Error<_>>(Partial("\tc")), Ok((Partial("c"), '\t')));
+/// assert_eq!(tab::<_, Error<_>>(Partial("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(tab::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn tab<I, Error: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, char, Error>
+pub fn tab<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -278,16 +272,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::alpha0;
-/// assert_eq!(alpha0::<_, Error<_>, true>(Partial("ab1c")), Ok((Partial("1c"), "ab")));
-/// assert_eq!(alpha0::<_, Error<_>, true>(Partial("1c")), Ok((Partial("1c"), "")));
-/// assert_eq!(alpha0::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha0::<_, Error<_>>(Partial("ab1c")), Ok((Partial("1c"), "ab")));
+/// assert_eq!(alpha0::<_, Error<_>>(Partial("1c")), Ok((Partial("1c"), "")));
+/// assert_eq!(alpha0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha0<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn alpha0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -326,16 +318,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::alpha1;
-/// assert_eq!(alpha1::<_, Error<_>, true>(Partial("aB1c")), Ok((Partial("1c"), "aB")));
-/// assert_eq!(alpha1::<_, Error<_>, true>(Partial("1c")), Err(ErrMode::Backtrack(Error::new(Partial("1c"), ErrorKind::Alpha))));
-/// assert_eq!(alpha1::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha1::<_, Error<_>>(Partial("aB1c")), Ok((Partial("1c"), "aB")));
+/// assert_eq!(alpha1::<_, Error<_>>(Partial("1c")), Err(ErrMode::Backtrack(Error::new(Partial("1c"), ErrorKind::Alpha))));
+/// assert_eq!(alpha1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha1<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn alpha1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -375,16 +365,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::digit0;
-/// assert_eq!(digit0::<_, Error<_>, true>(Partial("21c")), Ok((Partial("c"), "21")));
-/// assert_eq!(digit0::<_, Error<_>, true>(Partial("a21c")), Ok((Partial("a21c"), "")));
-/// assert_eq!(digit0::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(digit0::<_, Error<_>>(Partial("21c")), Ok((Partial("c"), "21")));
+/// assert_eq!(digit0::<_, Error<_>>(Partial("a21c")), Ok((Partial("a21c"), "")));
+/// assert_eq!(digit0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn digit0<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn digit0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -423,9 +411,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::digit1;
-/// assert_eq!(digit1::<_, Error<_>, true>(Partial("21c")), Ok((Partial("c"), "21")));
-/// assert_eq!(digit1::<_, Error<_>, true>(Partial("c1")), Err(ErrMode::Backtrack(Error::new(Partial("c1"), ErrorKind::Digit))));
-/// assert_eq!(digit1::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(digit1::<_, Error<_>>(Partial("21c")), Ok((Partial("c"), "21")));
+/// assert_eq!(digit1::<_, Error<_>>(Partial("c1")), Err(ErrMode::Backtrack(Error::new(Partial("c1"), ErrorKind::Digit))));
+/// assert_eq!(digit1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// ## Parsing an integer
@@ -444,11 +432,9 @@ where
 /// assert!(parser("b").is_err());
 /// ```
 #[inline(always)]
-pub fn digit1<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn digit1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -486,16 +472,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::hex_digit0;
-/// assert_eq!(hex_digit0::<_, Error<_>, true>(Partial("21cZ")), Ok((Partial("Z"), "21c")));
-/// assert_eq!(hex_digit0::<_, Error<_>, true>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
-/// assert_eq!(hex_digit0::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit0::<_, Error<_>>(Partial("21cZ")), Ok((Partial("Z"), "21c")));
+/// assert_eq!(hex_digit0::<_, Error<_>>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
+/// assert_eq!(hex_digit0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit0<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn hex_digit0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -534,16 +518,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::hex_digit1;
-/// assert_eq!(hex_digit1::<_, Error<_>, true>(Partial("21cZ")), Ok((Partial("Z"), "21c")));
-/// assert_eq!(hex_digit1::<_, Error<_>, true>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::HexDigit))));
-/// assert_eq!(hex_digit1::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit1::<_, Error<_>>(Partial("21cZ")), Ok((Partial("Z"), "21c")));
+/// assert_eq!(hex_digit1::<_, Error<_>>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::HexDigit))));
+/// assert_eq!(hex_digit1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit1<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn hex_digit1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -582,16 +564,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::oct_digit0;
-/// assert_eq!(oct_digit0::<_, Error<_>, true>(Partial("21cZ")), Ok((Partial("cZ"), "21")));
-/// assert_eq!(oct_digit0::<_, Error<_>, true>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
-/// assert_eq!(oct_digit0::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit0::<_, Error<_>>(Partial("21cZ")), Ok((Partial("cZ"), "21")));
+/// assert_eq!(oct_digit0::<_, Error<_>>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
+/// assert_eq!(oct_digit0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit0<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn oct_digit0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -630,16 +610,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::oct_digit1;
-/// assert_eq!(oct_digit1::<_, Error<_>, true>(Partial("21cZ")), Ok((Partial("cZ"), "21")));
-/// assert_eq!(oct_digit1::<_, Error<_>, true>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::OctDigit))));
-/// assert_eq!(oct_digit1::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit1::<_, Error<_>>(Partial("21cZ")), Ok((Partial("cZ"), "21")));
+/// assert_eq!(oct_digit1::<_, Error<_>>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::OctDigit))));
+/// assert_eq!(oct_digit1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit1<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn oct_digit1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -678,16 +656,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::alphanumeric0;
-/// assert_eq!(alphanumeric0::<_, Error<_>, true>(Partial("21cZ%1")), Ok((Partial("%1"), "21cZ")));
-/// assert_eq!(alphanumeric0::<_, Error<_>, true>(Partial("&Z21c")), Ok((Partial("&Z21c"), "")));
-/// assert_eq!(alphanumeric0::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial("21cZ%1")), Ok((Partial("%1"), "21cZ")));
+/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial("&Z21c")), Ok((Partial("&Z21c"), "")));
+/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric0<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn alphanumeric0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -726,16 +702,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::alphanumeric1;
-/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Partial("21cZ%1")), Ok((Partial("%1"), "21cZ")));
-/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Partial("&H2")), Err(ErrMode::Backtrack(Error::new(Partial("&H2"), ErrorKind::AlphaNumeric))));
-/// assert_eq!(alphanumeric1::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial("21cZ%1")), Ok((Partial("%1"), "21cZ")));
+/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial("&H2")), Err(ErrMode::Backtrack(Error::new(Partial("&H2"), ErrorKind::AlphaNumeric))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric1<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn alphanumeric1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -762,16 +736,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::space0;
-/// assert_eq!(space0::<_, Error<_>, true>(Partial(" \t21c")), Ok((Partial("21c"), " \t")));
-/// assert_eq!(space0::<_, Error<_>, true>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
-/// assert_eq!(space0::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(space0::<_, Error<_>>(Partial(" \t21c")), Ok((Partial("21c"), " \t")));
+/// assert_eq!(space0::<_, Error<_>>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
+/// assert_eq!(space0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space0<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn space0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -810,16 +782,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::space1;
-/// assert_eq!(space1::<_, Error<_>, true>(Partial(" \t21c")), Ok((Partial("21c"), " \t")));
-/// assert_eq!(space1::<_, Error<_>, true>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::Space))));
-/// assert_eq!(space1::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(space1::<_, Error<_>>(Partial(" \t21c")), Ok((Partial("21c"), " \t")));
+/// assert_eq!(space1::<_, Error<_>>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::Space))));
+/// assert_eq!(space1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space1<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn space1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -858,16 +828,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::multispace0;
-/// assert_eq!(multispace0::<_, Error<_>, true>(Partial(" \t\n\r21c")), Ok((Partial("21c"), " \t\n\r")));
-/// assert_eq!(multispace0::<_, Error<_>, true>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
-/// assert_eq!(multispace0::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace0::<_, Error<_>>(Partial(" \t\n\r21c")), Ok((Partial("21c"), " \t\n\r")));
+/// assert_eq!(multispace0::<_, Error<_>>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
+/// assert_eq!(multispace0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace0<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn multispace0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -906,16 +874,14 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::multispace1;
-/// assert_eq!(multispace1::<_, Error<_>, true>(Partial(" \t\n\r21c")), Ok((Partial("21c"), " \t\n\r")));
-/// assert_eq!(multispace1::<_, Error<_>, true>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::MultiSpace))));
-/// assert_eq!(multispace1::<_, Error<_>, true>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace1::<_, Error<_>>(Partial(" \t\n\r21c")), Ok((Partial("21c"), " \t\n\r")));
+/// assert_eq!(multispace1::<_, Error<_>>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::MultiSpace))));
+/// assert_eq!(multispace1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace1<I, E: ParseError<I>, const PARTIAL: bool>(
-    input: I,
-) -> IResult<I, <I as Stream>::Slice, E>
+pub fn multispace1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
@@ -933,9 +899,9 @@ where
 /// *Complete version*: can parse until the end of input.
 ///
 /// *Partial version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
-pub fn dec_uint<I, O, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, O, E>
+pub fn dec_uint<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
     O: Uint,
@@ -1082,9 +1048,9 @@ impl Uint for i128 {
 /// *Complete version*: can parse until the end of input.
 ///
 /// *Partial version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
-pub fn dec_int<I, O, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, O, E>
+pub fn dec_int<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
     O: Int,
@@ -1215,9 +1181,9 @@ impl Int for i128 {
 /// assert_eq!(parser(Partial(&b"ggg"[..])), Err(ErrMode::Backtrack(Error::new(Partial(&b"ggg"[..]), ErrorKind::IsA))));
 /// ```
 #[inline]
-pub fn hex_uint<I, O, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, O, E>
+pub fn hex_uint<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     O: HexUint,
     <I as Stream>::Token: AsChar,
@@ -1353,9 +1319,9 @@ impl HexUint for u128 {
 /// assert_eq!(parser(Partial("abc")), Err(ErrMode::Backtrack(Error::new(Partial("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
-pub fn float<I, O, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, O, E>
+pub fn float<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     I: Offset + Compare<&'static str>,
     <I as Stream>::Slice: ParseSlice<O>,
@@ -1411,13 +1377,13 @@ where
 /// assert_eq!(esc(Partial("12\\\"34;")), Ok((Partial(";"), "12\\\"34")));
 /// ```
 #[inline(always)]
-pub fn escaped<'a, I: 'a, Error, F, G, O1, O2, const PARTIAL: bool>(
+pub fn escaped<'a, I: 'a, Error, F, G, O1, O2>(
     mut normal: F,
     control_char: char,
     mut escapable: G,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream + Offset,
     <I as Stream>::Token: crate::stream::AsChar,
     F: Parser<I, O1, Error>,
@@ -1504,13 +1470,13 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 #[inline(always)]
-pub fn escaped_transform<I, Error, F, G, Output, const PARTIAL: bool>(
+pub fn escaped_transform<I, Error, F, G, Output>(
     mut normal: F,
     control_char: char,
     mut transform: G,
 ) -> impl FnMut(I) -> IResult<I, Output, Error>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream + Offset,
     <I as Stream>::Token: crate::stream::AsChar,
     Output: crate::stream::Accumulate<<I as Stream>::Slice>,

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -36,16 +36,13 @@ mod complete {
             alpha1(b),
             Err(ErrMode::Backtrack(Error::new(b, ErrorKind::Alpha)))
         );
-        assert_eq!(alpha1::<_, Error<_>, false>(c), Ok((&c[1..], &b"a"[..])));
-        assert_eq!(
-            alpha1::<_, Error<_>, false>(d),
-            Ok(("é12".as_bytes(), &b"az"[..]))
-        );
+        assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], &b"a"[..])));
+        assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bytes(), &b"az"[..])));
         assert_eq!(
             digit1(a),
             Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Digit)))
         );
-        assert_eq!(digit1::<_, Error<_>, false>(b), Ok((empty, b)));
+        assert_eq!(digit1::<_, Error<_>>(b), Ok((empty, b)));
         assert_eq!(
             digit1(c),
             Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Digit)))
@@ -54,11 +51,11 @@ mod complete {
             digit1(d),
             Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Digit)))
         );
-        assert_eq!(hex_digit1::<_, Error<_>, false>(a), Ok((empty, a)));
-        assert_eq!(hex_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
-        assert_eq!(hex_digit1::<_, Error<_>, false>(c), Ok((empty, c)));
+        assert_eq!(hex_digit1::<_, Error<_>>(a), Ok((empty, a)));
+        assert_eq!(hex_digit1::<_, Error<_>>(b), Ok((empty, b)));
+        assert_eq!(hex_digit1::<_, Error<_>>(c), Ok((empty, c)));
         assert_eq!(
-            hex_digit1::<_, Error<_>, false>(d),
+            hex_digit1::<_, Error<_>>(d),
             Ok(("zé12".as_bytes(), &b"a"[..]))
         );
         assert_eq!(
@@ -69,7 +66,7 @@ mod complete {
             oct_digit1(a),
             Err(ErrMode::Backtrack(Error::new(a, ErrorKind::OctDigit)))
         );
-        assert_eq!(oct_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
+        assert_eq!(oct_digit1::<_, Error<_>>(b), Ok((empty, b)));
         assert_eq!(
             oct_digit1(c),
             Err(ErrMode::Backtrack(Error::new(c, ErrorKind::OctDigit)))
@@ -78,15 +75,15 @@ mod complete {
             oct_digit1(d),
             Err(ErrMode::Backtrack(Error::new(d, ErrorKind::OctDigit)))
         );
-        assert_eq!(alphanumeric1::<_, Error<_>, false>(a), Ok((empty, a)));
+        assert_eq!(alphanumeric1::<_, Error<_>>(a), Ok((empty, a)));
         //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
-        assert_eq!(alphanumeric1::<_, Error<_>, false>(c), Ok((empty, c)));
+        assert_eq!(alphanumeric1::<_, Error<_>>(c), Ok((empty, c)));
         assert_eq!(
-            alphanumeric1::<_, Error<_>, false>(d),
+            alphanumeric1::<_, Error<_>>(d),
             Ok(("é12".as_bytes(), &b"az"[..]))
         );
-        assert_eq!(space1::<_, Error<_>, false>(e), Ok((empty, e)));
-        assert_eq!(space1::<_, Error<_>, false>(f), Ok((&b";"[..], &b" "[..])));
+        assert_eq!(space1::<_, Error<_>>(e), Ok((empty, e)));
+        assert_eq!(space1::<_, Error<_>>(f), Ok((&b";"[..], &b" "[..])));
     }
 
     #[cfg(feature = "alloc")]
@@ -98,18 +95,18 @@ mod complete {
         let c = "a123";
         let d = "azé12";
         let e = " ";
-        assert_eq!(alpha1::<_, Error<_>, false>(a), Ok((empty, a)));
+        assert_eq!(alpha1::<_, Error<_>>(a), Ok((empty, a)));
         assert_eq!(
             alpha1(b),
             Err(ErrMode::Backtrack(Error::new(b, ErrorKind::Alpha)))
         );
-        assert_eq!(alpha1::<_, Error<_>, false>(c), Ok((&c[1..], "a")));
-        assert_eq!(alpha1::<_, Error<_>, false>(d), Ok(("é12", "az")));
+        assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], "a")));
+        assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12", "az")));
         assert_eq!(
             digit1(a),
             Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Digit)))
         );
-        assert_eq!(digit1::<_, Error<_>, false>(b), Ok((empty, b)));
+        assert_eq!(digit1::<_, Error<_>>(b), Ok((empty, b)));
         assert_eq!(
             digit1(c),
             Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Digit)))
@@ -118,10 +115,10 @@ mod complete {
             digit1(d),
             Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Digit)))
         );
-        assert_eq!(hex_digit1::<_, Error<_>, false>(a), Ok((empty, a)));
-        assert_eq!(hex_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
-        assert_eq!(hex_digit1::<_, Error<_>, false>(c), Ok((empty, c)));
-        assert_eq!(hex_digit1::<_, Error<_>, false>(d), Ok(("zé12", "a")));
+        assert_eq!(hex_digit1::<_, Error<_>>(a), Ok((empty, a)));
+        assert_eq!(hex_digit1::<_, Error<_>>(b), Ok((empty, b)));
+        assert_eq!(hex_digit1::<_, Error<_>>(c), Ok((empty, c)));
+        assert_eq!(hex_digit1::<_, Error<_>>(d), Ok(("zé12", "a")));
         assert_eq!(
             hex_digit1(e),
             Err(ErrMode::Backtrack(Error::new(e, ErrorKind::HexDigit)))
@@ -130,7 +127,7 @@ mod complete {
             oct_digit1(a),
             Err(ErrMode::Backtrack(Error::new(a, ErrorKind::OctDigit)))
         );
-        assert_eq!(oct_digit1::<_, Error<_>, false>(b), Ok((empty, b)));
+        assert_eq!(oct_digit1::<_, Error<_>>(b), Ok((empty, b)));
         assert_eq!(
             oct_digit1(c),
             Err(ErrMode::Backtrack(Error::new(c, ErrorKind::OctDigit)))
@@ -139,11 +136,11 @@ mod complete {
             oct_digit1(d),
             Err(ErrMode::Backtrack(Error::new(d, ErrorKind::OctDigit)))
         );
-        assert_eq!(alphanumeric1::<_, Error<_>, false>(a), Ok((empty, a)));
+        assert_eq!(alphanumeric1::<_, Error<_>>(a), Ok((empty, a)));
         //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
-        assert_eq!(alphanumeric1::<_, Error<_>, false>(c), Ok((empty, c)));
-        assert_eq!(alphanumeric1::<_, Error<_>, false>(d), Ok(("é12", "az")));
-        assert_eq!(space1::<_, Error<_>, false>(e), Ok((empty, e)));
+        assert_eq!(alphanumeric1::<_, Error<_>>(c), Ok((empty, c)));
+        assert_eq!(alphanumeric1::<_, Error<_>>(d), Ok(("é12", "az")));
+        assert_eq!(space1::<_, Error<_>>(e), Ok((empty, e)));
     }
 
     use crate::stream::Offset;
@@ -156,43 +153,43 @@ mod complete {
         let e = &b" \t\r\n;"[..];
         let f = &b"123abcDEF;"[..];
 
-        match alpha1::<_, Error<_>, false>(a) {
+        match alpha1::<_, Error<_>>(a) {
             Ok((i, _)) => {
                 assert_eq!(a.offset_to(i) + i.len(), a.len());
             }
             _ => panic!("wrong return type in offset test for alpha"),
         }
-        match digit1::<_, Error<_>, false>(b) {
+        match digit1::<_, Error<_>>(b) {
             Ok((i, _)) => {
                 assert_eq!(b.offset_to(i) + i.len(), b.len());
             }
             _ => panic!("wrong return type in offset test for digit"),
         }
-        match alphanumeric1::<_, Error<_>, false>(c) {
+        match alphanumeric1::<_, Error<_>>(c) {
             Ok((i, _)) => {
                 assert_eq!(c.offset_to(i) + i.len(), c.len());
             }
             _ => panic!("wrong return type in offset test for alphanumeric"),
         }
-        match space1::<_, Error<_>, false>(d) {
+        match space1::<_, Error<_>>(d) {
             Ok((i, _)) => {
                 assert_eq!(d.offset_to(i) + i.len(), d.len());
             }
             _ => panic!("wrong return type in offset test for space"),
         }
-        match multispace1::<_, Error<_>, false>(e) {
+        match multispace1::<_, Error<_>>(e) {
             Ok((i, _)) => {
                 assert_eq!(e.offset_to(i) + i.len(), e.len());
             }
             _ => panic!("wrong return type in offset test for multispace"),
         }
-        match hex_digit1::<_, Error<_>, false>(f) {
+        match hex_digit1::<_, Error<_>>(f) {
             Ok((i, _)) => {
                 assert_eq!(f.offset_to(i) + i.len(), f.len());
             }
             _ => panic!("wrong return type in offset test for hex_digit"),
         }
-        match oct_digit1::<_, Error<_>, false>(f) {
+        match oct_digit1::<_, Error<_>>(f) {
             Ok((i, _)) => {
                 assert_eq!(f.offset_to(i) + i.len(), f.len());
             }
@@ -204,24 +201,24 @@ mod complete {
     fn is_not_line_ending_bytes() {
         let a: &[u8] = b"ab12cd\nefgh";
         assert_eq!(
-            not_line_ending::<_, Error<_>, false>(a),
+            not_line_ending::<_, Error<_>>(a),
             Ok((&b"\nefgh"[..], &b"ab12cd"[..]))
         );
 
         let b: &[u8] = b"ab12cd\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>, false>(b),
+            not_line_ending::<_, Error<_>>(b),
             Ok((&b"\nefgh\nijkl"[..], &b"ab12cd"[..]))
         );
 
         let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>, false>(c),
+            not_line_ending::<_, Error<_>>(c),
             Ok((&b"\r\nefgh\nijkl"[..], &b"ab12cd"[..]))
         );
 
         let d: &[u8] = b"ab12cd";
-        assert_eq!(not_line_ending::<_, Error<_>, false>(d), Ok((&[][..], d)));
+        assert_eq!(not_line_ending::<_, Error<_>>(d), Ok((&[][..], d)));
     }
 
     #[test]
@@ -233,7 +230,7 @@ mod complete {
         );
 
         let g2: &str = "ab12cd";
-        assert_eq!(not_line_ending::<_, Error<_>, false>(g2), Ok(("", g2)));
+        assert_eq!(not_line_ending::<_, Error<_>>(g2), Ok(("", g2)));
     }
 
     #[test]
@@ -395,7 +392,7 @@ mod complete {
             _ => unreachable!(),
         };
 
-        let (i, s) = match digit1::<_, crate::error::Error<_>, false>(i) {
+        let (i, s) = match digit1::<_, crate::error::Error<_>>(i) {
             Ok((i, s)) => (i, s),
             Err(_) => return Err(ErrMode::from_error_kind(input, ErrorKind::Digit)),
         };
@@ -528,19 +525,19 @@ mod complete {
 
         let remaining_exponent = "-1.234E-";
         assert_parse!(
-            float::<_, f64, _, false>(remaining_exponent),
+            float::<_, f64, _>(remaining_exponent),
             Err(ErrMode::Cut(Error {
                 input: "-1.234E-",
                 kind: ErrorKind::Float
             }))
         );
 
-        let (_i, nan) = float::<_, f32, (), false>("NaN").unwrap();
+        let (_i, nan) = float::<_, f32, ()>("NaN").unwrap();
         assert!(nan.is_nan());
 
-        let (_i, inf) = float::<_, f32, (), false>("inf").unwrap();
+        let (_i, inf) = float::<_, f32, ()>("inf").unwrap();
         assert!(inf.is_infinite());
-        let (_i, inf) = float::<_, f32, (), false>("infinite").unwrap();
+        let (_i, inf) = float::<_, f32, ()>("infinite").unwrap();
         assert!(inf.is_infinite());
     }
 
@@ -568,7 +565,7 @@ mod complete {
       fn floats(s in "\\PC*") {
           println!("testing {}", s);
           let res1 = parse_f64(&s);
-          let res2 = float::<_, f64, (), false>(s.as_str());
+          let res2 = float::<_, f64, ()>(s.as_str());
           assert_eq!(res1, res2);
       }
     }
@@ -883,18 +880,18 @@ mod partial {
         let d: &[u8] = "azé12".as_bytes();
         let e: &[u8] = b" ";
         let f: &[u8] = b" ;";
-        //assert_eq!(alpha1::<_, Error<_>, true>(a), Err(ErrMode::Incomplete(Needed::new(1))));
+        //assert_eq!(alpha1::<_, Error<_>>(a), Err(ErrMode::Incomplete(Needed::new(1))));
         assert_parse!(alpha1(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
         assert_eq!(
             alpha1(Partial(b)),
             Err(ErrMode::Backtrack(Error::new(Partial(b), ErrorKind::Alpha)))
         );
         assert_eq!(
-            alpha1::<_, Error<_>, true>(Partial(c)),
+            alpha1::<_, Error<_>>(Partial(c)),
             Ok((Partial(&c[1..]), &b"a"[..]))
         );
         assert_eq!(
-            alpha1::<_, Error<_>, true>(Partial(d)),
+            alpha1::<_, Error<_>>(Partial(d)),
             Ok((Partial("é12".as_bytes()), &b"az"[..]))
         );
         assert_eq!(
@@ -902,7 +899,7 @@ mod partial {
             Err(ErrMode::Backtrack(Error::new(Partial(a), ErrorKind::Digit)))
         );
         assert_eq!(
-            digit1::<_, Error<_>, true>(Partial(b)),
+            digit1::<_, Error<_>>(Partial(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
@@ -914,19 +911,19 @@ mod partial {
             Err(ErrMode::Backtrack(Error::new(Partial(d), ErrorKind::Digit)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>, true>(Partial(a)),
+            hex_digit1::<_, Error<_>>(Partial(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>, true>(Partial(b)),
+            hex_digit1::<_, Error<_>>(Partial(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>, true>(Partial(c)),
+            hex_digit1::<_, Error<_>>(Partial(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>, true>(Partial(d)),
+            hex_digit1::<_, Error<_>>(Partial(d)),
             Ok((Partial("zé12".as_bytes()), &b"a"[..]))
         );
         assert_eq!(
@@ -944,7 +941,7 @@ mod partial {
             )))
         );
         assert_eq!(
-            oct_digit1::<_, Error<_>, true>(Partial(b)),
+            oct_digit1::<_, Error<_>>(Partial(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
@@ -962,24 +959,24 @@ mod partial {
             )))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>, true>(Partial(a)),
+            alphanumeric1::<_, Error<_>>(Partial(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
         assert_eq!(
-            alphanumeric1::<_, Error<_>, true>(Partial(c)),
+            alphanumeric1::<_, Error<_>>(Partial(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>, true>(Partial(d)),
+            alphanumeric1::<_, Error<_>>(Partial(d)),
             Ok((Partial("é12".as_bytes()), &b"az"[..]))
         );
         assert_eq!(
-            space1::<_, Error<_>, true>(Partial(e)),
+            space1::<_, Error<_>>(Partial(e)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            space1::<_, Error<_>, true>(Partial(f)),
+            space1::<_, Error<_>>(Partial(f)),
             Ok((Partial(&b";"[..]), &b" "[..]))
         );
     }
@@ -993,7 +990,7 @@ mod partial {
         let d = "azé12";
         let e = " ";
         assert_eq!(
-            alpha1::<_, Error<_>, true>(Partial(a)),
+            alpha1::<_, Error<_>>(Partial(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
@@ -1001,11 +998,11 @@ mod partial {
             Err(ErrMode::Backtrack(Error::new(Partial(b), ErrorKind::Alpha)))
         );
         assert_eq!(
-            alpha1::<_, Error<_>, true>(Partial(c)),
+            alpha1::<_, Error<_>>(Partial(c)),
             Ok((Partial(&c[1..]), "a"))
         );
         assert_eq!(
-            alpha1::<_, Error<_>, true>(Partial(d)),
+            alpha1::<_, Error<_>>(Partial(d)),
             Ok((Partial("é12"), "az"))
         );
         assert_eq!(
@@ -1013,7 +1010,7 @@ mod partial {
             Err(ErrMode::Backtrack(Error::new(Partial(a), ErrorKind::Digit)))
         );
         assert_eq!(
-            digit1::<_, Error<_>, true>(Partial(b)),
+            digit1::<_, Error<_>>(Partial(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
@@ -1025,19 +1022,19 @@ mod partial {
             Err(ErrMode::Backtrack(Error::new(Partial(d), ErrorKind::Digit)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>, true>(Partial(a)),
+            hex_digit1::<_, Error<_>>(Partial(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>, true>(Partial(b)),
+            hex_digit1::<_, Error<_>>(Partial(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>, true>(Partial(c)),
+            hex_digit1::<_, Error<_>>(Partial(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>, true>(Partial(d)),
+            hex_digit1::<_, Error<_>>(Partial(d)),
             Ok((Partial("zé12"), "a"))
         );
         assert_eq!(
@@ -1055,7 +1052,7 @@ mod partial {
             )))
         );
         assert_eq!(
-            oct_digit1::<_, Error<_>, true>(Partial(b)),
+            oct_digit1::<_, Error<_>>(Partial(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
@@ -1073,20 +1070,20 @@ mod partial {
             )))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>, true>(Partial(a)),
+            alphanumeric1::<_, Error<_>>(Partial(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
         assert_eq!(
-            alphanumeric1::<_, Error<_>, true>(Partial(c)),
+            alphanumeric1::<_, Error<_>>(Partial(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>, true>(Partial(d)),
+            alphanumeric1::<_, Error<_>>(Partial(d)),
             Ok((Partial("é12"), "az"))
         );
         assert_eq!(
-            space1::<_, Error<_>, true>(Partial(e)),
+            space1::<_, Error<_>>(Partial(e)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -1101,43 +1098,43 @@ mod partial {
         let e = &b" \t\r\n;"[..];
         let f = &b"123abcDEF;"[..];
 
-        match alpha1::<_, Error<_>, true>(Partial(a)) {
+        match alpha1::<_, Error<_>>(Partial(a)) {
             Ok((Partial(i), _)) => {
                 assert_eq!(a.offset_to(i) + i.len(), a.len());
             }
             _ => panic!("wrong return type in offset test for alpha"),
         }
-        match digit1::<_, Error<_>, true>(Partial(b)) {
+        match digit1::<_, Error<_>>(Partial(b)) {
             Ok((Partial(i), _)) => {
                 assert_eq!(b.offset_to(i) + i.len(), b.len());
             }
             _ => panic!("wrong return type in offset test for digit"),
         }
-        match alphanumeric1::<_, Error<_>, true>(Partial(c)) {
+        match alphanumeric1::<_, Error<_>>(Partial(c)) {
             Ok((Partial(i), _)) => {
                 assert_eq!(c.offset_to(i) + i.len(), c.len());
             }
             _ => panic!("wrong return type in offset test for alphanumeric"),
         }
-        match space1::<_, Error<_>, true>(Partial(d)) {
+        match space1::<_, Error<_>>(Partial(d)) {
             Ok((Partial(i), _)) => {
                 assert_eq!(d.offset_to(i) + i.len(), d.len());
             }
             _ => panic!("wrong return type in offset test for space"),
         }
-        match multispace1::<_, Error<_>, true>(Partial(e)) {
+        match multispace1::<_, Error<_>>(Partial(e)) {
             Ok((Partial(i), _)) => {
                 assert_eq!(e.offset_to(i) + i.len(), e.len());
             }
             _ => panic!("wrong return type in offset test for multispace"),
         }
-        match hex_digit1::<_, Error<_>, true>(Partial(f)) {
+        match hex_digit1::<_, Error<_>>(Partial(f)) {
             Ok((Partial(i), _)) => {
                 assert_eq!(f.offset_to(i) + i.len(), f.len());
             }
             _ => panic!("wrong return type in offset test for hex_digit"),
         }
-        match oct_digit1::<_, Error<_>, true>(Partial(f)) {
+        match oct_digit1::<_, Error<_>>(Partial(f)) {
             Ok((Partial(i), _)) => {
                 assert_eq!(f.offset_to(i) + i.len(), f.len());
             }
@@ -1149,25 +1146,25 @@ mod partial {
     fn is_not_line_ending_bytes() {
         let a: &[u8] = b"ab12cd\nefgh";
         assert_eq!(
-            not_line_ending::<_, Error<_>, true>(Partial(a)),
+            not_line_ending::<_, Error<_>>(Partial(a)),
             Ok((Partial(&b"\nefgh"[..]), &b"ab12cd"[..]))
         );
 
         let b: &[u8] = b"ab12cd\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>, true>(Partial(b)),
+            not_line_ending::<_, Error<_>>(Partial(b)),
             Ok((Partial(&b"\nefgh\nijkl"[..]), &b"ab12cd"[..]))
         );
 
         let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>, true>(Partial(c)),
+            not_line_ending::<_, Error<_>>(Partial(c)),
             Ok((Partial(&b"\r\nefgh\nijkl"[..]), &b"ab12cd"[..]))
         );
 
         let d: &[u8] = b"ab12cd";
         assert_eq!(
-            not_line_ending::<_, Error<_>, true>(Partial(d)),
+            not_line_ending::<_, Error<_>>(Partial(d)),
             Err(ErrMode::Incomplete(Needed::Unknown))
         );
     }
@@ -1182,7 +1179,7 @@ mod partial {
 
         let g2: &str = "ab12cd";
         assert_eq!(
-            not_line_ending::<_, Error<_>, true>(Partial(g2)),
+            not_line_ending::<_, Error<_>>(Partial(g2)),
             Err(ErrMode::Incomplete(Needed::Unknown))
         );
     }
@@ -1372,7 +1369,7 @@ mod partial {
             _ => unreachable!(),
         };
 
-        let (i, s) = match digit1::<_, crate::error::Error<_>, true>(i) {
+        let (i, s) = match digit1::<_, crate::error::Error<_>>(i) {
             Ok((i, s)) => (i, s),
             Err(ErrMode::Incomplete(i)) => return Err(ErrMode::Incomplete(i)),
             Err(_) => return Err(ErrMode::from_error_kind(input, ErrorKind::Digit)),

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -236,7 +236,7 @@ fn test_into() {
     use crate::bytes::take;
     use crate::error::Error;
 
-    let mut parser = into(take::<_, _, Error<_>, false>(3u8));
+    let mut parser = into(take::<_, _, Error<_>>(3u8));
     let result: IResult<&[u8], Vec<u8>> = parser(&b"abcdefg"[..]);
 
     assert_eq!(result, Ok((&b"defg"[..], vec![97, 98, 99])));
@@ -248,7 +248,7 @@ fn test_parser_into() {
     use crate::bytes::take;
     use crate::error::Error;
 
-    let mut parser = take::<_, _, Error<_>, false>(3u8).output_into();
+    let mut parser = take::<_, _, Error<_>>(3u8).output_into();
     let result: IResult<&[u8], Vec<u8>> = parser.parse_next(&b"abcdefg"[..]);
 
     assert_eq!(result, Ok((&b"defg"[..], vec![97, 98, 99])));

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1059,11 +1059,9 @@ where
 /// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), Bytes::new(&b"abc"[..]))));
 /// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
-pub fn length_data<I, N, E, F, const PARTIAL: bool>(
-    mut f: F,
-) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn length_data<I, N, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream,
     N: ToUsize,
     F: Parser<I, N, E>,
@@ -1110,12 +1108,9 @@ where
 /// assert_eq!(parser(stream(b"\x00\x03123123")), Err(ErrMode::Backtrack(Error::new(stream(&b"123"[..]), ErrorKind::Tag))));
 /// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
-pub fn length_value<I, O, N, E, F, G, const PARTIAL: bool>(
-    mut f: F,
-    mut g: G,
-) -> impl FnMut(I) -> IResult<I, O, E>
+pub fn length_value<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, O, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream + UpdateSlice,
     N: ToUsize,
     F: Parser<I, N, E>,

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -50,16 +50,16 @@ pub enum Endianness {
 /// use winnow::number::be_u8;
 ///
 /// let parser = |s| {
-///   be_u8::<_, Error<_>, true>(s)
+///   be_u8::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_u8<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u8, E>
+pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
 {
     trace("be_u8", move |input: I| {
@@ -98,16 +98,16 @@ where
 /// use winnow::number::be_u16;
 ///
 /// let parser = |s| {
-///   be_u16::<_, Error<_>, true>(s)
+///   be_u16::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0001)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_u16<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u16, E>
+pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -147,16 +147,16 @@ where
 /// use winnow::number::be_u24;
 ///
 /// let parser = |s| {
-///   be_u24::<_, Error<_>, true>(s)
+///   be_u24::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x000102)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn be_u24<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u32, E>
+pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -196,16 +196,16 @@ where
 /// use winnow::number::be_u32;
 ///
 /// let parser = |s| {
-///   be_u32::<_, Error<_>, true>(s)
+///   be_u32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x00010203)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_u32<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u32, E>
+pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -245,16 +245,16 @@ where
 /// use winnow::number::be_u64;
 ///
 /// let parser = |s| {
-///   be_u64::<_, Error<_>, true>(s)
+///   be_u64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0001020304050607)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_u64<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u64, E>
+pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -294,16 +294,16 @@ where
 /// use winnow::number::be_u128;
 ///
 /// let parser = |s| {
-///   be_u128::<_, Error<_>, true>(s)
+///   be_u128::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x00010203040506070809101112131415)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn be_u128<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u128, E>
+pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -342,15 +342,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::number::be_i8;
 ///
-/// let parser = be_i8::<_, Error<_>, true>;
+/// let parser = be_i8::<_, Error<_>>;
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_i8<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i8, E>
+pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
 {
     trace("be_i8", move |input: I| {
@@ -388,15 +388,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::number::be_i16;
 ///
-/// let parser = be_i16::<_, Error<_>, true>;
+/// let parser = be_i16::<_, Error<_>>;
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0001)));
 /// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn be_i16<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i16, E>
+pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -435,15 +435,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::number::be_i24;
 ///
-/// let parser = be_i24::<_, Error<_>, true>;
+/// let parser = be_i24::<_, Error<_>>;
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x000102)));
 /// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_i24<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i32, E>
+pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -482,15 +482,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::number::be_i32;
 ///
-/// let parser = be_i32::<_, Error<_>, true>;
+/// let parser = be_i32::<_, Error<_>>;
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x00010203)));
 /// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
-pub fn be_i32<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i32, E>
+pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -529,15 +529,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::number::be_i64;
 ///
-/// let parser = be_i64::<_, Error<_>, true>;
+/// let parser = be_i64::<_, Error<_>>;
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0001020304050607)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_i64<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i64, E>
+pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -576,15 +576,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::number::be_i128;
 ///
-/// let parser = be_i128::<_, Error<_>, true>;
+/// let parser = be_i128::<_, Error<_>>;
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x00010203040506070809101112131415)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn be_i128<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i128, E>
+pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -623,15 +623,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::number::le_u8;
 ///
-/// let parser = le_u8::<_, Error<_>, true>;
+/// let parser = le_u8::<_, Error<_>>;
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_u8<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u8, E>
+pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
 {
     trace("le_u8", move |input: I| {
@@ -670,16 +670,16 @@ where
 /// use winnow::number::le_u16;
 ///
 /// let parser = |s| {
-///   le_u16::<_, Error<_>, true>(s)
+///   le_u16::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_u16<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u16, E>
+pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -719,16 +719,16 @@ where
 /// use winnow::number::le_u24;
 ///
 /// let parser = |s| {
-///   le_u24::<_, Error<_>, true>(s)
+///   le_u24::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x020100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn le_u24<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u32, E>
+pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -768,16 +768,16 @@ where
 /// use winnow::number::le_u32;
 ///
 /// let parser = |s| {
-///   le_u32::<_, Error<_>, true>(s)
+///   le_u32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x03020100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_u32<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u32, E>
+pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -817,16 +817,16 @@ where
 /// use winnow::number::le_u64;
 ///
 /// let parser = |s| {
-///   le_u64::<_, Error<_>, true>(s)
+///   le_u64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0706050403020100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_u64<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u64, E>
+pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -866,16 +866,16 @@ where
 /// use winnow::number::le_u128;
 ///
 /// let parser = |s| {
-///   le_u128::<_, Error<_>, true>(s)
+///   le_u128::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x15141312111009080706050403020100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn le_u128<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u128, E>
+pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -914,15 +914,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::number::le_i8;
 ///
-/// let parser = le_i8::<_, Error<_>, true>;
+/// let parser = le_i8::<_, Error<_>>;
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_i8<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i8, E>
+pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
 {
     trace("le_i8", move |input: I| {
@@ -961,16 +961,16 @@ where
 /// use winnow::number::le_i16;
 ///
 /// let parser = |s| {
-///   le_i16::<_, Error<_>, true>(s)
+///   le_i16::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_i16<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i16, E>
+pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1010,16 +1010,16 @@ where
 /// use winnow::number::le_i24;
 ///
 /// let parser = |s| {
-///   le_i24::<_, Error<_>, true>(s)
+///   le_i24::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x020100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn le_i24<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i32, E>
+pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1059,16 +1059,16 @@ where
 /// use winnow::number::le_i32;
 ///
 /// let parser = |s| {
-///   le_i32::<_, Error<_>, true>(s)
+///   le_i32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x03020100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_i32<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i32, E>
+pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1108,16 +1108,16 @@ where
 /// use winnow::number::le_i64;
 ///
 /// let parser = |s| {
-///   le_i64::<_, Error<_>, true>(s)
+///   le_i64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0706050403020100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_i64<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i64, E>
+pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1157,16 +1157,16 @@ where
 /// use winnow::number::le_i128;
 ///
 /// let parser = |s| {
-///   le_i128::<_, Error<_>, true>(s)
+///   le_i128::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x15141312111009080706050403020100)));
 /// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn le_i128<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i128, E>
+pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1209,16 +1209,16 @@ where
 /// use winnow::number::u8;
 ///
 /// let parser = |s| {
-///   u8::<_, Error<_>, true>(s)
+///   u8::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"\x03abcefg"[..]), 0x00)));
 /// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn u8<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u8, E>
+pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
 {
     trace("u8", move |input: I| {
@@ -1268,25 +1268,25 @@ where
 /// use winnow::number::u16;
 ///
 /// let be_u16 = |s| {
-///   u16::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   u16::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u16(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_u16(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_u16 = |s| {
-///   u16::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   u16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u16(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0300)));
 /// assert_eq!(le_u16(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn u16<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn u16<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, u16, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1337,25 +1337,25 @@ where
 /// use winnow::number::u24;
 ///
 /// let be_u24 = |s| {
-///   u24::<_,Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   u24::<_,Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u24(Partial(&b"\x00\x03\x05abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_u24(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_u24 = |s| {
-///   u24::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   u24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u24(Partial(&b"\x00\x03\x05abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x050300)));
 /// assert_eq!(le_u24(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn u24<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn u24<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, u32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1406,25 +1406,25 @@ where
 /// use winnow::number::u32;
 ///
 /// let be_u32 = |s| {
-///   u32::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   u32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u32(Partial(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_u32(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_u32 = |s| {
-///   u32::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   u32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u32(Partial(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x07050300)));
 /// assert_eq!(le_u32(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn u32<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn u32<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, u32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1475,25 +1475,25 @@ where
 /// use winnow::number::u64;
 ///
 /// let be_u64 = |s| {
-///   u64::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   u64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u64(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_u64(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_u64 = |s| {
-///   u64::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   u64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u64(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0706050403020100)));
 /// assert_eq!(le_u64(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn u64<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn u64<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, u64, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1544,25 +1544,25 @@ where
 /// use winnow::number::u128;
 ///
 /// let be_u128 = |s| {
-///   u128::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   u128::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_u128(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_u128(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_u128 = |s| {
-///   u128::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   u128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_u128(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
 /// assert_eq!(le_u128(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn u128<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn u128<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, u128, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1605,16 +1605,16 @@ where
 /// use winnow::number::i8;
 ///
 /// let parser = |s| {
-///   i8::<_, Error<_>, true>(s)
+///   i8::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"\x03abcefg"[..]), 0x00)));
 /// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn i8<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, i8, E>
+pub fn i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
 {
     trace("i8", move |input: I| {
@@ -1664,25 +1664,25 @@ where
 /// use winnow::number::i16;
 ///
 /// let be_i16 = |s| {
-///   i16::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   i16::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i16(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_i16(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_i16 = |s| {
-///   i16::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   i16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i16(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0300)));
 /// assert_eq!(le_i16(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn i16<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn i16<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, i16, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1733,25 +1733,25 @@ where
 /// use winnow::number::i24;
 ///
 /// let be_i24 = |s| {
-///   i24::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   i24::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i24(Partial(&b"\x00\x03\x05abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_i24(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_i24 = |s| {
-///   i24::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   i24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i24(Partial(&b"\x00\x03\x05abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x050300)));
 /// assert_eq!(le_i24(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn i24<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn i24<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, i32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1802,25 +1802,25 @@ where
 /// use winnow::number::i32;
 ///
 /// let be_i32 = |s| {
-///   i32::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   i32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i32(Partial(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_i32(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_i32 = |s| {
-///   i32::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   i32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i32(Partial(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x07050300)));
 /// assert_eq!(le_i32(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn i32<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn i32<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, i32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1871,25 +1871,25 @@ where
 /// use winnow::number::i64;
 ///
 /// let be_i64 = |s| {
-///   i64::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   i64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i64(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_i64(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_i64 = |s| {
-///   i64::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   i64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i64(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0706050403020100)));
 /// assert_eq!(le_i64(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn i64<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn i64<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, i64, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1940,25 +1940,25 @@ where
 /// use winnow::number::i128;
 ///
 /// let be_i128 = |s| {
-///   i128::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   i128::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_i128(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_i128(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_i128 = |s| {
-///   i128::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   i128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_i128(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
 /// assert_eq!(le_i128(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn i128<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn i128<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, i128, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -1998,16 +1998,16 @@ where
 /// use winnow::number::be_f32;
 ///
 /// let parser = |s| {
-///   be_f32::<_, Error<_>, true>(s)
+///   be_f32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&[0x40, 0x29, 0x00, 0x00][..])), Ok((Partial(&b""[..]), 2.640625)));
 /// assert_eq!(parser(Partial(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_f32<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, f32, E>
+pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -2047,16 +2047,16 @@ where
 /// use winnow::number::be_f64;
 ///
 /// let parser = |s| {
-///   be_f64::<_, Error<_>, true>(s)
+///   be_f64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial(&b""[..]), 12.5)));
 /// assert_eq!(parser(Partial(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_f64<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, f64, E>
+pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -2096,16 +2096,16 @@ where
 /// use winnow::number::le_f32;
 ///
 /// let parser = |s| {
-///   le_f32::<_, Error<_>, true>(s)
+///   le_f32::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial(&b""[..]), 12.5)));
 /// assert_eq!(parser(Partial(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_f32<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, f32, E>
+pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -2145,16 +2145,16 @@ where
 /// use winnow::number::le_f64;
 ///
 /// let parser = |s| {
-///   le_f64::<_, Error<_>, true>(s)
+///   le_f64::<_, Error<_>>(s)
 /// };
 ///
 /// assert_eq!(parser(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Partial(&b""[..]), 3145728.0)));
 /// assert_eq!(parser(Partial(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_f64<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, f64, E>
+pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -2205,25 +2205,25 @@ where
 /// use winnow::number::f32;
 ///
 /// let be_f32 = |s| {
-///   f32::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   f32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_f32(Partial(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Partial(&b""[..]), 12.5)));
 /// assert_eq!(be_f32(Partial(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_f32 = |s| {
-///   f32::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   f32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f32(Partial(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial(&b""[..]), 12.5)));
 /// assert_eq!(le_f32(Partial(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn f32<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn f32<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, f32, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
@@ -2274,25 +2274,25 @@ where
 /// use winnow::number::f64;
 ///
 /// let be_f64 = |s| {
-///   f64::<_, Error<_>, true>(winnow::number::Endianness::Big)(s)
+///   f64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
 /// assert_eq!(be_f64(Partial(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial(&b""[..]), 12.5)));
 /// assert_eq!(be_f64(Partial(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 ///
 /// let le_f64 = |s| {
-///   f64::<_, Error<_>, true>(winnow::number::Endianness::Little)(s)
+///   f64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
 /// assert_eq!(le_f64(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Partial(&b""[..]), 12.5)));
 /// assert_eq!(le_f64(Partial(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
-pub fn f64<I, E: ParseError<I>, const PARTIAL: bool>(
+pub fn f64<I, E: ParseError<I>>(
     endian: crate::number::Endianness,
 ) -> impl FnMut(I) -> IResult<I, f64, E>
 where
-    I: StreamIsPartial<PARTIAL>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -631,7 +631,7 @@ where
 /// ```
 impl<I, E> Parser<I, u8, E> for u8
 where
-    I: StreamIsPartial<false>,
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
     E: ParseError<I>,
 {
@@ -657,7 +657,7 @@ where
 /// ```
 impl<I, E> Parser<I, <I as Stream>::Token, E> for char
 where
-    I: StreamIsPartial<false>,
+    I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
     E: ParseError<I>,
@@ -687,7 +687,7 @@ where
 /// ```
 impl<'s, I, E: ParseError<I>> Parser<I, <I as Stream>::Slice, E> for &'s [u8]
 where
-    I: Compare<&'s [u8]> + StreamIsPartial<false>,
+    I: Compare<&'s [u8]> + StreamIsPartial,
     I: Stream,
 {
     fn parse_next(&mut self, i: I) -> IResult<I, <I as Stream>::Slice, E> {
@@ -715,7 +715,7 @@ where
 /// ```
 impl<'s, I, E: ParseError<I>, const N: usize> Parser<I, <I as Stream>::Slice, E> for &'s [u8; N]
 where
-    I: Compare<&'s [u8; N]> + StreamIsPartial<false>,
+    I: Compare<&'s [u8; N]> + StreamIsPartial,
     I: Stream,
 {
     fn parse_next(&mut self, i: I) -> IResult<I, <I as Stream>::Slice, E> {
@@ -743,7 +743,7 @@ where
 /// ```
 impl<'s, I, E: ParseError<I>> Parser<I, <I as Stream>::Slice, E> for &'s str
 where
-    I: Compare<&'s str> + StreamIsPartial<false>,
+    I: Compare<&'s str> + StreamIsPartial,
     I: Stream,
 {
     fn parse_next(&mut self, i: I) -> IResult<I, <I as Stream>::Slice, E> {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -929,55 +929,99 @@ where
 /// Marks the input as being the complete buffer or a partial buffer for streaming input
 ///
 /// See [Partial] for marking a presumed complete buffer type as a streaming buffer.
-pub trait StreamIsPartial<const YES: bool>: Sized {
+pub trait StreamIsPartial: Sized {
+    /// Report whether the [`Stream`] is can ever be incomplete
+    fn is_partial_supported() -> bool;
+
     /// Report whether the [`Stream`] is currently incomplete
     #[inline(always)]
     fn is_partial(&self) -> bool {
-        YES
+        Self::is_partial_supported()
     }
 }
 
-impl<'a, T> StreamIsPartial<false> for &'a [T] {}
+impl<'a, T> StreamIsPartial for &'a [T] {
+    #[inline(always)]
+    fn is_partial_supported() -> bool {
+        false
+    }
+}
 
-impl<'a> StreamIsPartial<false> for &'a str {}
+impl<'a> StreamIsPartial for &'a str {
+    #[inline(always)]
+    fn is_partial_supported() -> bool {
+        false
+    }
+}
 
-impl<'a> StreamIsPartial<false> for &'a Bytes {}
+impl<'a> StreamIsPartial for &'a Bytes {
+    #[inline(always)]
+    fn is_partial_supported() -> bool {
+        false
+    }
+}
 
-impl<'a> StreamIsPartial<false> for &'a BStr {}
+impl<'a> StreamIsPartial for &'a BStr {
+    #[inline(always)]
+    fn is_partial_supported() -> bool {
+        false
+    }
+}
 
-impl<const YES: bool> StreamIsPartial<YES> for crate::lib::std::convert::Infallible {}
-
-impl<I, const YES: bool> StreamIsPartial<YES> for (I, usize)
+impl<I> StreamIsPartial for (I, usize)
 where
-    I: StreamIsPartial<YES>,
+    I: StreamIsPartial,
 {
+    #[inline(always)]
+    fn is_partial_supported() -> bool {
+        I::is_partial_supported()
+    }
+
     #[inline(always)]
     fn is_partial(&self) -> bool {
         self.0.is_partial()
     }
 }
 
-impl<I, const YES: bool> StreamIsPartial<YES> for Located<I>
+impl<I> StreamIsPartial for Located<I>
 where
-    I: StreamIsPartial<YES>,
+    I: StreamIsPartial,
 {
+    #[inline(always)]
+    fn is_partial_supported() -> bool {
+        I::is_partial_supported()
+    }
+
     #[inline(always)]
     fn is_partial(&self) -> bool {
         self.input.is_partial()
     }
 }
 
-impl<I, S, const YES: bool> StreamIsPartial<YES> for Stateful<I, S>
+impl<I, S> StreamIsPartial for Stateful<I, S>
 where
-    I: StreamIsPartial<YES>,
+    I: StreamIsPartial,
 {
+    #[inline(always)]
+    fn is_partial_supported() -> bool {
+        I::is_partial_supported()
+    }
+
     #[inline(always)]
     fn is_partial(&self) -> bool {
         self.input.is_partial()
     }
 }
 
-impl<I> StreamIsPartial<true> for Partial<I> where I: StreamIsPartial<false> {}
+impl<I> StreamIsPartial for Partial<I>
+where
+    I: StreamIsPartial,
+{
+    #[inline(always)]
+    fn is_partial_supported() -> bool {
+        true
+    }
+}
 
 /// Useful functions to calculate the offset between slices and show a hexdump of a slice
 pub trait Offset {

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -232,7 +232,7 @@ fn issue_1231_bits_expect_fn_closure() {
 fn issue_1282_findtoken_char() {
     use winnow::bytes::one_of;
     use winnow::error::Error;
-    let mut parser = one_of::<_, _, Error<_>, false>(&['a', 'b', 'c'][..]);
+    let mut parser = one_of::<_, _, Error<_>>(&['a', 'b', 'c'][..]);
     assert_eq!(parser("aaa"), Ok(("aa", 'a')));
 }
 
@@ -281,7 +281,7 @@ fn issue_1617_count_parser_returning_zero_size() {
     use winnow::{bytes::tag, error::Error, multi::count};
 
     // previously, `count()` panicked if the parser had type `O = ()`
-    let parser = tag::<_, _, Error<&str>, false>("abc").map(|_| ());
+    let parser = tag::<_, _, Error<&str>>("abc").map(|_| ());
     // shouldn't panic
     let result = count(parser, 3)("abcabcabcdef").expect("parsing should succeed");
     assert_eq!(result, ("def", vec![(), (), ()]));


### PR DESCRIPTION
If you used `Partial`, you couldn't use `"hello"` as a tag but had to do
`tag("hello")` because we needed to constrain the generic parameter.
Now that we've removed it, literals can be used as desired.

The downside is that for `FinishIResult`, this shifts an error from
compile time to runtime.  At least with `is_partial_support`, the user
is more likely to see it than they would have with the original `nom`
code.

BREAKING CHANGE: `StreamIsPartial` no longer takes a `const PARTIAL:
bool` generic parameter.  This was replaced with `is_partial_support`
function.

Fixes #79