### PR TITLE
fix!: Parsing over a slice should invoke complete parsers

### DIFF
--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -25,7 +25,7 @@ pub struct Header<'a> {
 }
 
 pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
-    let mut buf = Partial(data);
+    let mut buf = Partial::new(data);
     let mut v = Vec::new();
     loop {
         match request(buf) {

--- a/examples/json/bench.rs
+++ b/examples/json/bench.rs
@@ -41,7 +41,7 @@ fn json_bench(c: &mut criterion::Criterion) {
             |b, _| {
                 type Error<'i> = winnow::error::Error<parser_partial::Stream<'i>>;
 
-                b.iter(|| parser_partial::json::<Error>(Partial(sample)).unwrap());
+                b.iter(|| parser_partial::json::<Error>(Partial::new(sample)).unwrap());
             },
         );
     }

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -215,31 +215,34 @@ mod test {
     #[test]
     fn json_string() {
         assert_eq!(
-            string::<Error<'_>>(Partial("\"\"")),
-            Ok((Partial(""), "".to_string()))
+            string::<Error<'_>>(Partial::new("\"\"")),
+            Ok((Partial::new(""), "".to_string()))
         );
         assert_eq!(
-            string::<Error<'_>>(Partial("\"abc\"")),
-            Ok((Partial(""), "abc".to_string()))
+            string::<Error<'_>>(Partial::new("\"abc\"")),
+            Ok((Partial::new(""), "abc".to_string()))
         );
         assert_eq!(
-            string::<Error<'_>>(Partial(
+            string::<Error<'_>>(Partial::new(
                 "\"abc\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0001\\u2014\u{2014}def\""
             )),
-            Ok((Partial(""), "abc\"\\/\x08\x0C\n\r\t\x01——def".to_string())),
+            Ok((
+                Partial::new(""),
+                "abc\"\\/\x08\x0C\n\r\t\x01——def".to_string()
+            )),
         );
         assert_eq!(
-            string::<Error<'_>>(Partial("\"\\uD83D\\uDE10\"")),
-            Ok((Partial(""), "😐".to_string()))
+            string::<Error<'_>>(Partial::new("\"\\uD83D\\uDE10\"")),
+            Ok((Partial::new(""), "😐".to_string()))
         );
 
-        assert!(string::<Error<'_>>(Partial("\"")).is_err());
-        assert!(string::<Error<'_>>(Partial("\"abc")).is_err());
-        assert!(string::<Error<'_>>(Partial("\"\\\"")).is_err());
-        assert!(string::<Error<'_>>(Partial("\"\\u123\"")).is_err());
-        assert!(string::<Error<'_>>(Partial("\"\\uD800\"")).is_err());
-        assert!(string::<Error<'_>>(Partial("\"\\uD800\\uD800\"")).is_err());
-        assert!(string::<Error<'_>>(Partial("\"\\uDC00\"")).is_err());
+        assert!(string::<Error<'_>>(Partial::new("\"")).is_err());
+        assert!(string::<Error<'_>>(Partial::new("\"abc")).is_err());
+        assert!(string::<Error<'_>>(Partial::new("\"\\\"")).is_err());
+        assert!(string::<Error<'_>>(Partial::new("\"\\u123\"")).is_err());
+        assert!(string::<Error<'_>>(Partial::new("\"\\uD800\"")).is_err());
+        assert!(string::<Error<'_>>(Partial::new("\"\\uD800\\uD800\"")).is_err());
+        assert!(string::<Error<'_>>(Partial::new("\"\\uDC00\"")).is_err());
     }
 
     #[test]
@@ -258,8 +261,8 @@ mod test {
         );
 
         assert_eq!(
-            json::<Error<'_>>(Partial(input)),
-            Ok((Partial(""), expected))
+            json::<Error<'_>>(Partial::new(input)),
+            Ok((Partial::new(""), expected))
         );
     }
 
@@ -272,8 +275,8 @@ mod test {
         let expected = Array(vec![Num(42.0), Str("x".to_string())]);
 
         assert_eq!(
-            json::<Error<'_>>(Partial(input)),
-            Ok((Partial(""), expected))
+            json::<Error<'_>>(Partial::new(input)),
+            Ok((Partial::new(""), expected))
         );
     }
 
@@ -296,9 +299,9 @@ mod test {
   "#;
 
         assert_eq!(
-            json::<Error<'_>>(Partial(input)),
+            json::<Error<'_>>(Partial::new(input)),
             Ok((
-                Partial(""),
+                Partial::new(""),
                 Object(
                     vec![
                         ("null".to_string(), Null),

--- a/src/bits/tests.rs
+++ b/src/bits/tests.rs
@@ -51,7 +51,7 @@ fn test_partial_byte_consumption_bits() {
 #[cfg(feature = "std")]
 /// Ensure that in Incomplete error is thrown, if too few bytes are passed for a given parser.
 fn test_incomplete_bits() {
-    let input = Partial(&[0x12][..]);
+    let input = Partial::new(&[0x12][..]);
 
     // Take bit slices with sizes [4, 8].
     let result: IResult<_, (u8, u8)> =
@@ -103,7 +103,7 @@ fn test_take_complete_span_over_multiple_bytes() {
 
 #[test]
 fn test_take_partial_0() {
-    let input = Partial(&[][..]);
+    let input = Partial::new(&[][..]);
     let count = 0usize;
     assert_eq!(count, 0usize);
     let offset = 0usize;
@@ -115,7 +115,7 @@ fn test_take_partial_0() {
 
 #[test]
 fn test_tag_partial_ok() {
-    let input = Partial(&[0b00011111][..]);
+    let input = Partial::new(&[0b00011111][..]);
     let offset = 0usize;
     let bits_to_take = 4usize;
     let value_to_tag = 0b0001;
@@ -128,7 +128,7 @@ fn test_tag_partial_ok() {
 
 #[test]
 fn test_tag_partial_err() {
-    let input = Partial(&[0b00011111][..]);
+    let input = Partial::new(&[0b00011111][..]);
     let offset = 0usize;
     let bits_to_take = 4usize;
     let value_to_tag = 0b1111;
@@ -171,7 +171,7 @@ fn test_bool_eof_complete() {
 
 #[test]
 fn test_bool_0_partial() {
-    let input = Partial([0b10000000].as_ref());
+    let input = Partial::new([0b10000000].as_ref());
 
     let result: crate::IResult<(Partial<&[u8]>, usize), bool> = bool((input, 0));
 
@@ -180,7 +180,7 @@ fn test_bool_0_partial() {
 
 #[test]
 fn test_bool_eof_partial() {
-    let input = Partial([0b10000000].as_ref());
+    let input = Partial::new([0b10000000].as_ref());
 
     let result: crate::IResult<(Partial<&[u8]>, usize), bool> = bool((input, 8));
 

--- a/src/branch/tests.rs
+++ b/src/branch/tests.rs
@@ -102,23 +102,38 @@ fn alt_incomplete() {
     }
 
     let a = &b""[..];
-    assert_eq!(alt1(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        alt1(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
     let a = &b"b"[..];
-    assert_eq!(alt1(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        alt1(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
     let a = &b"bcd"[..];
-    assert_eq!(alt1(Partial(a)), Ok((Partial(&b"d"[..]), &b"bc"[..])));
+    assert_eq!(
+        alt1(Partial::new(a)),
+        Ok((Partial::new(&b"d"[..]), &b"bc"[..]))
+    );
     let a = &b"cde"[..];
     assert_eq!(
-        alt1(Partial(a)),
+        alt1(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(a),
+            Partial::new(a),
             ErrorKind::Tag
         )))
     );
     let a = &b"de"[..];
-    assert_eq!(alt1(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        alt1(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
     let a = &b"defg"[..];
-    assert_eq!(alt1(Partial(a)), Ok((Partial(&b"g"[..]), &b"def"[..])));
+    assert_eq!(
+        alt1(Partial::new(a)),
+        Ok((Partial::new(&b"g"[..]), &b"def"[..]))
+    );
 }
 
 #[test]
@@ -131,22 +146,34 @@ fn permutation_test() {
     let expected = (&b"abcd"[..], &b"efg"[..], &b"hi"[..]);
 
     let a = &b"abcdefghijk"[..];
-    assert_eq!(perm(Partial(a)), Ok((Partial(&b"jk"[..]), expected)));
+    assert_eq!(
+        perm(Partial::new(a)),
+        Ok((Partial::new(&b"jk"[..]), expected))
+    );
     let b = &b"efgabcdhijk"[..];
-    assert_eq!(perm(Partial(b)), Ok((Partial(&b"jk"[..]), expected)));
+    assert_eq!(
+        perm(Partial::new(b)),
+        Ok((Partial::new(&b"jk"[..]), expected))
+    );
     let c = &b"hiefgabcdjk"[..];
-    assert_eq!(perm(Partial(c)), Ok((Partial(&b"jk"[..]), expected)));
+    assert_eq!(
+        perm(Partial::new(c)),
+        Ok((Partial::new(&b"jk"[..]), expected))
+    );
 
     let d = &b"efgxyzabcdefghi"[..];
     assert_eq!(
-        perm(Partial(d)),
+        perm(Partial::new(d)),
         Err(ErrMode::Backtrack(error_node_position!(
-            Partial(&b"efgxyzabcdefghi"[..]),
+            Partial::new(&b"efgxyzabcdefghi"[..]),
             ErrorKind::Permutation,
-            error_position!(Partial(&b"xyzabcdefghi"[..]), ErrorKind::Tag)
+            error_position!(Partial::new(&b"xyzabcdefghi"[..]), ErrorKind::Tag)
         )))
     );
 
     let e = &b"efgabc"[..];
-    assert_eq!(perm(Partial(e)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        perm(Partial::new(e)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
 }

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -33,8 +33,8 @@ use crate::IResult;
 /// ```
 /// # use winnow::{bytes::any, error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
-/// assert_eq!(any::<_, Error<_>>(Partial("abc")), Ok((Partial("bc"),'a')));
-/// assert_eq!(any::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(any::<_, Error<_>>(Partial::new("abc")), Ok((Partial::new("bc"),'a')));
+/// assert_eq!(any::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Token, E>
@@ -85,10 +85,10 @@ where
 ///   tag("Hello")(s)
 /// }
 ///
-/// assert_eq!(parser(Partial("Hello, World!")), Ok((Partial(", World!"), "Hello")));
-/// assert_eq!(parser(Partial("Something")), Err(ErrMode::Backtrack(Error::new(Partial("Something"), ErrorKind::Tag))));
-/// assert_eq!(parser(Partial("S")), Err(ErrMode::Backtrack(Error::new(Partial("S"), ErrorKind::Tag))));
-/// assert_eq!(parser(Partial("H")), Err(ErrMode::Incomplete(Needed::new(4))));
+/// assert_eq!(parser(Partial::new("Hello, World!")), Ok((Partial::new(", World!"), "Hello")));
+/// assert_eq!(parser(Partial::new("Something")), Err(ErrMode::Backtrack(Error::new(Partial::new("Something"), ErrorKind::Tag))));
+/// assert_eq!(parser(Partial::new("S")), Err(ErrMode::Backtrack(Error::new(Partial::new("S"), ErrorKind::Tag))));
+/// assert_eq!(parser(Partial::new("H")), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
 pub fn tag<T, I, Error: ParseError<I>>(
@@ -140,11 +140,11 @@ where
 ///   tag_no_case("hello")(s)
 /// }
 ///
-/// assert_eq!(parser(Partial("Hello, World!")), Ok((Partial(", World!"), "Hello")));
-/// assert_eq!(parser(Partial("hello, World!")), Ok((Partial(", World!"), "hello")));
-/// assert_eq!(parser(Partial("HeLlO, World!")), Ok((Partial(", World!"), "HeLlO")));
-/// assert_eq!(parser(Partial("Something")), Err(ErrMode::Backtrack(Error::new(Partial("Something"), ErrorKind::Tag))));
-/// assert_eq!(parser(Partial("")), Err(ErrMode::Incomplete(Needed::new(5))));
+/// assert_eq!(parser(Partial::new("Hello, World!")), Ok((Partial::new(", World!"), "Hello")));
+/// assert_eq!(parser(Partial::new("hello, World!")), Ok((Partial::new(", World!"), "hello")));
+/// assert_eq!(parser(Partial::new("HeLlO, World!")), Ok((Partial::new(", World!"), "HeLlO")));
+/// assert_eq!(parser(Partial::new("Something")), Err(ErrMode::Backtrack(Error::new(Partial::new("Something"), ErrorKind::Tag))));
+/// assert_eq!(parser(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
 pub fn tag_no_case<T, I, Error: ParseError<I>>(
@@ -199,16 +199,16 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::bytes::one_of;
-/// assert_eq!(one_of::<_, _, Error<_>>("abc")(Partial("b")), Ok((Partial(""), 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>>("a")(Partial("bc")), Err(ErrMode::Backtrack(Error::new(Partial("bc"), ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, Error<_>>("a")(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(one_of::<_, _, Error<_>>("abc")(Partial::new("b")), Ok((Partial::new(""), 'b')));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")(Partial::new("bc")), Err(ErrMode::Backtrack(Error::new(Partial::new("bc"), ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, Error<_>>("a")(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn parser_fn(i: Partial<&str>) -> IResult<Partial<&str>, char> {
 ///     one_of(|c| c == 'a' || c == 'b')(i)
 /// }
-/// assert_eq!(parser_fn(Partial("abc")), Ok((Partial("bc"), 'a')));
-/// assert_eq!(parser_fn(Partial("cd")), Err(ErrMode::Backtrack(Error::new(Partial("cd"), ErrorKind::OneOf))));
-/// assert_eq!(parser_fn(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser_fn(Partial::new("abc")), Ok((Partial::new("bc"), 'a')));
+/// assert_eq!(parser_fn(Partial::new("cd")), Err(ErrMode::Backtrack(Error::new(Partial::new("cd"), ErrorKind::OneOf))));
+/// assert_eq!(parser_fn(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn one_of<I, T, Error: ParseError<I>>(
@@ -249,9 +249,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::bytes::none_of;
-/// assert_eq!(none_of::<_, _, Error<_>>("abc")(Partial("z")), Ok((Partial(""), 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>>("ab")(Partial("a")), Err(ErrMode::Backtrack(Error::new(Partial("a"), ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, Error<_>>("a")(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(none_of::<_, _, Error<_>>("abc")(Partial::new("z")), Ok((Partial::new(""), 'z')));
+/// assert_eq!(none_of::<_, _, Error<_>>("ab")(Partial::new("a")), Err(ErrMode::Backtrack(Error::new(Partial::new("a"), ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, Error<_>>("a")(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn none_of<I, T, Error: ParseError<I>>(
@@ -301,10 +301,10 @@ where
 ///   take_while0(AsChar::is_alpha)(s)
 /// }
 ///
-/// assert_eq!(alpha(Partial(b"latin123")), Ok((Partial(&b"123"[..]), &b"latin"[..])));
-/// assert_eq!(alpha(Partial(b"12345")), Ok((Partial(&b"12345"[..]), &b""[..])));
-/// assert_eq!(alpha(Partial(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(Partial(b"")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(alpha(Partial::new(b"12345")), Ok((Partial::new(&b"12345"[..]), &b""[..])));
+/// assert_eq!(alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(Partial::new(b"")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn take_while0<T, I, Error: ParseError<I>>(
@@ -365,19 +365,19 @@ where
 ///   take_while1(AsChar::is_alpha)(s)
 /// }
 ///
-/// assert_eq!(alpha(Partial(b"latin123")), Ok((Partial(&b"123"[..]), &b"latin"[..])));
-/// assert_eq!(alpha(Partial(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(Partial(b"12345")), Err(ErrMode::Backtrack(Error::new(Partial(&b"12345"[..]), ErrorKind::TakeWhile1))));
+/// assert_eq!(alpha(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha(Partial::new(b"12345")), Err(ErrMode::Backtrack(Error::new(Partial::new(&b"12345"[..]), ErrorKind::TakeWhile1))));
 ///
 /// fn hex(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
 ///   take_while1("1234567890ABCDEF")(s)
 /// }
 ///
-/// assert_eq!(hex(Partial("123 and voila")), Ok((Partial(" and voila"), "123")));
-/// assert_eq!(hex(Partial("DEADBEEF and others")), Ok((Partial(" and others"), "DEADBEEF")));
-/// assert_eq!(hex(Partial("BADBABEsomething")), Ok((Partial("something"), "BADBABE")));
-/// assert_eq!(hex(Partial("D15EA5E")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(hex(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex(Partial::new("123 and voila")), Ok((Partial::new(" and voila"), "123")));
+/// assert_eq!(hex(Partial::new("DEADBEEF and others")), Ok((Partial::new(" and others"), "DEADBEEF")));
+/// assert_eq!(hex(Partial::new("BADBABEsomething")), Ok((Partial::new("something"), "BADBABE")));
+/// assert_eq!(hex(Partial::new("D15EA5E")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn take_while1<T, I, Error: ParseError<I>>(
@@ -431,11 +431,11 @@ where
 ///   take_while_m_n(3, 6, AsChar::is_alpha)(s)
 /// }
 ///
-/// assert_eq!(short_alpha(Partial(b"latin123")), Ok((Partial(&b"123"[..]), &b"latin"[..])));
-/// assert_eq!(short_alpha(Partial(b"lengthy")), Ok((Partial(&b"y"[..]), &b"length"[..])));
-/// assert_eq!(short_alpha(Partial(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(Partial(b"ed")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(Partial(b"12345")), Err(ErrMode::Backtrack(Error::new(Partial(&b"12345"[..]), ErrorKind::TakeWhileMN))));
+/// assert_eq!(short_alpha(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(short_alpha(Partial::new(b"lengthy")), Ok((Partial::new(&b"y"[..]), &b"length"[..])));
+/// assert_eq!(short_alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(Partial::new(b"ed")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(Partial::new(b"12345")), Err(ErrMode::Backtrack(Error::new(Partial::new(&b"12345"[..]), ErrorKind::TakeWhileMN))));
 /// ```
 #[inline(always)]
 pub fn take_while_m_n<T, I, Error: ParseError<I>>(
@@ -486,10 +486,10 @@ where
 ///   take_till0(|c| c == ':')(s)
 /// }
 ///
-/// assert_eq!(till_colon(Partial("latin:123")), Ok((Partial(":123"), "latin")));
-/// assert_eq!(till_colon(Partial(":empty matched")), Ok((Partial(":empty matched"), ""))); //allowed
-/// assert_eq!(till_colon(Partial("12345")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Partial::new("latin:123")), Ok((Partial::new(":123"), "latin")));
+/// assert_eq!(till_colon(Partial::new(":empty matched")), Ok((Partial::new(":empty matched"), ""))); //allowed
+/// assert_eq!(till_colon(Partial::new("12345")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn take_till0<T, I, Error: ParseError<I>>(
@@ -550,19 +550,19 @@ where
 ///   take_till1(|c| c == ':')(s)
 /// }
 ///
-/// assert_eq!(till_colon(Partial("latin:123")), Ok((Partial(":123"), "latin")));
-/// assert_eq!(till_colon(Partial(":empty matched")), Err(ErrMode::Backtrack(Error::new(Partial(":empty matched"), ErrorKind::TakeTill1))));
-/// assert_eq!(till_colon(Partial("12345")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Partial::new("latin:123")), Ok((Partial::new(":123"), "latin")));
+/// assert_eq!(till_colon(Partial::new(":empty matched")), Err(ErrMode::Backtrack(Error::new(Partial::new(":empty matched"), ErrorKind::TakeTill1))));
+/// assert_eq!(till_colon(Partial::new("12345")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn not_space(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
 ///   take_till1(" \t\r\n")(s)
 /// }
 ///
-/// assert_eq!(not_space(Partial("Hello, World!")), Ok((Partial(" World!"), "Hello,")));
-/// assert_eq!(not_space(Partial("Sometimes\t")), Ok((Partial("\t"), "Sometimes")));
-/// assert_eq!(not_space(Partial("Nospace")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(not_space(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(not_space(Partial::new("Hello, World!")), Ok((Partial::new(" World!"), "Hello,")));
+/// assert_eq!(not_space(Partial::new("Sometimes\t")), Ok((Partial::new("\t"), "Sometimes")));
+/// assert_eq!(not_space(Partial::new("Nospace")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(not_space(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn take_till1<T, I, Error: ParseError<I>>(
@@ -629,10 +629,10 @@ where
 ///   take(6usize)(s)
 /// }
 ///
-/// assert_eq!(take6(Partial("1234567")), Ok((Partial("7"), "123456")));
-/// assert_eq!(take6(Partial("things")), Ok((Partial(""), "things")));
+/// assert_eq!(take6(Partial::new("1234567")), Ok((Partial::new("7"), "123456")));
+/// assert_eq!(take6(Partial::new("things")), Ok((Partial::new(""), "things")));
 /// // `Unknown` as we don't know the number of bytes that `count` corresponds to
-/// assert_eq!(take6(Partial("short")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(take6(Partial::new("short")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 #[inline(always)]
 pub fn take<C, I, Error: ParseError<I>>(
@@ -686,10 +686,10 @@ where
 ///   take_until0("eof")(s)
 /// }
 ///
-/// assert_eq!(until_eof(Partial("hello, worldeof")), Ok((Partial("eof"), "hello, world")));
-/// assert_eq!(until_eof(Partial("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Partial("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Partial("1eof2eof")), Ok((Partial("eof2eof"), "1")));
+/// assert_eq!(until_eof(Partial::new("hello, worldeof")), Ok((Partial::new("eof"), "hello, world")));
+/// assert_eq!(until_eof(Partial::new("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Partial::new("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Partial::new("1eof2eof")), Ok((Partial::new("eof2eof"), "1")));
 /// ```
 #[inline(always)]
 pub fn take_until0<T, I, Error: ParseError<I>>(
@@ -744,11 +744,11 @@ where
 ///   take_until1("eof")(s)
 /// }
 ///
-/// assert_eq!(until_eof(Partial("hello, worldeof")), Ok((Partial("eof"), "hello, world")));
-/// assert_eq!(until_eof(Partial("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Partial("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Partial("1eof2eof")), Ok((Partial("eof2eof"), "1")));
-/// assert_eq!(until_eof(Partial("eof")),  Err(ErrMode::Backtrack(Error::new(Partial("eof"), ErrorKind::TakeUntil))));
+/// assert_eq!(until_eof(Partial::new("hello, worldeof")), Ok((Partial::new("eof"), "hello, world")));
+/// assert_eq!(until_eof(Partial::new("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Partial::new("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof(Partial::new("1eof2eof")), Ok((Partial::new("eof2eof"), "1")));
+/// assert_eq!(until_eof(Partial::new("eof")),  Err(ErrMode::Backtrack(Error::new(Partial::new("eof"), ErrorKind::TakeUntil))));
 /// ```
 #[inline(always)]
 pub fn take_until1<T, I, Error: ParseError<I>>(

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -1305,16 +1305,19 @@ mod tests {
             length_data(le_u8)(i)
         }
         assert_eq!(
-            x(Partial(b"\x02..>>")),
-            Ok((Partial(&b">>"[..]), &b".."[..]))
+            x(Partial::new(b"\x02..>>")),
+            Ok((Partial::new(&b">>"[..]), &b".."[..]))
         );
-        assert_eq!(x(Partial(b"\x02..")), Ok((Partial(&[][..]), &b".."[..])));
         assert_eq!(
-            x(Partial(b"\x02.")),
+            x(Partial::new(b"\x02..")),
+            Ok((Partial::new(&[][..]), &b".."[..]))
+        );
+        assert_eq!(
+            x(Partial::new(b"\x02.")),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            x(Partial(b"\x02")),
+            x(Partial::new(b"\x02")),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
 
@@ -1323,19 +1326,19 @@ mod tests {
             length_data(le_u8)(i)
         }
         assert_eq!(
-            y(Partial(b"magic\x02..>>")),
-            Ok((Partial(&b">>"[..]), &b".."[..]))
+            y(Partial::new(b"magic\x02..>>")),
+            Ok((Partial::new(&b">>"[..]), &b".."[..]))
         );
         assert_eq!(
-            y(Partial(b"magic\x02..")),
-            Ok((Partial(&[][..]), &b".."[..]))
+            y(Partial::new(b"magic\x02..")),
+            Ok((Partial::new(&[][..]), &b".."[..]))
         );
         assert_eq!(
-            y(Partial(b"magic\x02.")),
+            y(Partial::new(b"magic\x02.")),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            y(Partial(b"magic\x02")),
+            y(Partial::new(b"magic\x02")),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
     }

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -66,8 +66,8 @@ proptest! {
 fn partial_any_str() {
     use super::any;
     assert_eq!(
-        any::<_, Error<Partial<&str>>>(Partial("Ә")),
-        Ok((Partial(""), 'Ә'))
+        any::<_, Error<Partial<&str>>>(Partial::new("Ә")),
+        Ok((Partial::new(""), 'Ә'))
     );
 }
 
@@ -78,13 +78,13 @@ fn partial_one_of_test() {
     }
 
     let a = &b"abcd"[..];
-    assert_eq!(f(Partial(a)), Ok((Partial(&b"bcd"[..]), b'a')));
+    assert_eq!(f(Partial::new(a)), Ok((Partial::new(&b"bcd"[..]), b'a')));
 
     let b = &b"cde"[..];
     assert_eq!(
-        f(Partial(b)),
+        f(Partial::new(b)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(b),
+            Partial::new(b),
             ErrorKind::OneOf
         )))
     );
@@ -93,8 +93,8 @@ fn partial_one_of_test() {
         one_of("+\u{FF0B}")(i)
     }
 
-    assert!(utf8(Partial("+")).is_ok());
-    assert!(utf8(Partial("\u{FF0B}")).is_ok());
+    assert!(utf8(Partial::new("+")).is_ok());
+    assert!(utf8(Partial::new("\u{FF0B}")).is_ok());
 }
 
 #[test]
@@ -105,15 +105,15 @@ fn char_byteslice() {
 
     let a = &b"abcd"[..];
     assert_eq!(
-        f(Partial(a)),
+        f(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(a),
+            Partial::new(a),
             ErrorKind::OneOf
         )))
     );
 
     let b = &b"cde"[..];
-    assert_eq!(f(Partial(b)), Ok((Partial(&b"de"[..]), b'c')));
+    assert_eq!(f(Partial::new(b)), Ok((Partial::new(&b"de"[..]), b'c')));
 }
 
 #[test]
@@ -124,15 +124,15 @@ fn char_str() {
 
     let a = "abcd";
     assert_eq!(
-        f(Partial(a)),
+        f(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(a),
+            Partial::new(a),
             ErrorKind::OneOf
         )))
     );
 
     let b = "cde";
-    assert_eq!(f(Partial(b)), Ok((Partial("de"), 'c')));
+    assert_eq!(f(Partial::new(b)), Ok((Partial::new("de"), 'c')));
 }
 
 #[test]
@@ -143,15 +143,15 @@ fn partial_none_of_test() {
 
     let a = &b"abcd"[..];
     assert_eq!(
-        f(Partial(a)),
+        f(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(a),
+            Partial::new(a),
             ErrorKind::NoneOf
         )))
     );
 
     let b = &b"cde"[..];
-    assert_eq!(f(Partial(b)), Ok((Partial(&b"de"[..]), b'c')));
+    assert_eq!(f(Partial::new(b)), Ok((Partial::new(&b"de"[..]), b'c')));
 }
 
 #[test]
@@ -160,13 +160,13 @@ fn partial_is_a() {
         take_while1("ab")(i)
     }
 
-    let a = Partial(&b"abcd"[..]);
-    assert_eq!(a_or_b(a), Ok((Partial(&b"cd"[..]), &b"ab"[..])));
+    let a = Partial::new(&b"abcd"[..]);
+    assert_eq!(a_or_b(a), Ok((Partial::new(&b"cd"[..]), &b"ab"[..])));
 
-    let b = Partial(&b"bcde"[..]);
-    assert_eq!(a_or_b(b), Ok((Partial(&b"cde"[..]), &b"b"[..])));
+    let b = Partial::new(&b"bcde"[..]);
+    assert_eq!(a_or_b(b), Ok((Partial::new(&b"cde"[..]), &b"b"[..])));
 
-    let c = Partial(&b"cdef"[..]);
+    let c = Partial::new(&b"cdef"[..]);
     assert_eq!(
         a_or_b(c),
         Err(ErrMode::Backtrack(error_position!(
@@ -175,8 +175,8 @@ fn partial_is_a() {
         )))
     );
 
-    let d = Partial(&b"bacdef"[..]);
-    assert_eq!(a_or_b(d), Ok((Partial(&b"cdef"[..]), &b"ba"[..])));
+    let d = Partial::new(&b"bacdef"[..]);
+    assert_eq!(a_or_b(d), Ok((Partial::new(&b"cdef"[..]), &b"ba"[..])));
 }
 
 #[test]
@@ -185,22 +185,22 @@ fn partial_is_not() {
         take_till1("ab")(i)
     }
 
-    let a = Partial(&b"cdab"[..]);
-    assert_eq!(a_or_b(a), Ok((Partial(&b"ab"[..]), &b"cd"[..])));
+    let a = Partial::new(&b"cdab"[..]);
+    assert_eq!(a_or_b(a), Ok((Partial::new(&b"ab"[..]), &b"cd"[..])));
 
-    let b = Partial(&b"cbde"[..]);
-    assert_eq!(a_or_b(b), Ok((Partial(&b"bde"[..]), &b"c"[..])));
+    let b = Partial::new(&b"cbde"[..]);
+    assert_eq!(a_or_b(b), Ok((Partial::new(&b"bde"[..]), &b"c"[..])));
 
-    let c = Partial(&b"abab"[..]);
+    let c = Partial::new(&b"abab"[..]);
     assert_eq!(
         a_or_b(c),
         Err(ErrMode::Backtrack(error_position!(c, ErrorKind::TakeTill1)))
     );
 
-    let d = Partial(&b"cdefba"[..]);
-    assert_eq!(a_or_b(d), Ok((Partial(&b"ba"[..]), &b"cdef"[..])));
+    let d = Partial::new(&b"cdefba"[..]);
+    assert_eq!(a_or_b(d), Ok((Partial::new(&b"ba"[..]), &b"cdef"[..])));
 
-    let e = Partial(&b"e"[..]);
+    let e = Partial::new(&b"e"[..]);
     assert_eq!(a_or_b(e), Err(ErrMode::Incomplete(Needed::new(1))));
 }
 
@@ -210,15 +210,15 @@ fn partial_take_until_incomplete() {
         take_until0("end")(i)
     }
     assert_eq!(
-        y(Partial(&b"nd"[..])),
+        y(Partial::new(&b"nd"[..])),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
     assert_eq!(
-        y(Partial(&b"123"[..])),
+        y(Partial::new(&b"123"[..])),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
     assert_eq!(
-        y(Partial(&b"123en"[..])),
+        y(Partial::new(&b"123en"[..])),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
 }
@@ -229,7 +229,7 @@ fn partial_take_until_incomplete_s() {
         take_until0("end")(i)
     }
     assert_eq!(
-        ys(Partial("123en")),
+        ys(Partial::new("123en")),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
 }
@@ -246,52 +246,52 @@ fn partial_recognize() {
             .recognize()
             .parse_next(i)
     }
-    let r = x(Partial(&b"<!-- abc --> aaa"[..]));
-    assert_eq!(r, Ok((Partial(&b" aaa"[..]), &b"<!-- abc -->"[..])));
+    let r = x(Partial::new(&b"<!-- abc --> aaa"[..]));
+    assert_eq!(r, Ok((Partial::new(&b" aaa"[..]), &b"<!-- abc -->"[..])));
 
     let semicolon = &b";"[..];
 
     fn ya(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         alpha.recognize().parse_next(i)
     }
-    let ra = ya(Partial(&b"abc;"[..]));
-    assert_eq!(ra, Ok((Partial(semicolon), &b"abc"[..])));
+    let ra = ya(Partial::new(&b"abc;"[..]));
+    assert_eq!(ra, Ok((Partial::new(semicolon), &b"abc"[..])));
 
     fn yd(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         digit.recognize().parse_next(i)
     }
-    let rd = yd(Partial(&b"123;"[..]));
-    assert_eq!(rd, Ok((Partial(semicolon), &b"123"[..])));
+    let rd = yd(Partial::new(&b"123;"[..]));
+    assert_eq!(rd, Ok((Partial::new(semicolon), &b"123"[..])));
 
     fn yhd(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         hex_digit.recognize().parse_next(i)
     }
-    let rhd = yhd(Partial(&b"123abcDEF;"[..]));
-    assert_eq!(rhd, Ok((Partial(semicolon), &b"123abcDEF"[..])));
+    let rhd = yhd(Partial::new(&b"123abcDEF;"[..]));
+    assert_eq!(rhd, Ok((Partial::new(semicolon), &b"123abcDEF"[..])));
 
     fn yod(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         oct_digit.recognize().parse_next(i)
     }
-    let rod = yod(Partial(&b"1234567;"[..]));
-    assert_eq!(rod, Ok((Partial(semicolon), &b"1234567"[..])));
+    let rod = yod(Partial::new(&b"1234567;"[..]));
+    assert_eq!(rod, Ok((Partial::new(semicolon), &b"1234567"[..])));
 
     fn yan(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         alphanumeric.recognize().parse_next(i)
     }
-    let ran = yan(Partial(&b"123abc;"[..]));
-    assert_eq!(ran, Ok((Partial(semicolon), &b"123abc"[..])));
+    let ran = yan(Partial::new(&b"123abc;"[..]));
+    assert_eq!(ran, Ok((Partial::new(semicolon), &b"123abc"[..])));
 
     fn ys(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         space.recognize().parse_next(i)
     }
-    let rs = ys(Partial(&b" \t;"[..]));
-    assert_eq!(rs, Ok((Partial(semicolon), &b" \t"[..])));
+    let rs = ys(Partial::new(&b" \t;"[..]));
+    assert_eq!(rs, Ok((Partial::new(semicolon), &b" \t"[..])));
 
     fn yms(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         multispace.recognize().parse_next(i)
     }
-    let rms = yms(Partial(&b" \t\r\n;"[..]));
-    assert_eq!(rms, Ok((Partial(semicolon), &b" \t\r\n"[..])));
+    let rms = yms(Partial::new(&b" \t\r\n;"[..]));
+    assert_eq!(rms, Ok((Partial::new(semicolon), &b" \t\r\n"[..])));
 }
 
 #[test]
@@ -304,10 +304,10 @@ fn partial_take_while0() {
     let c = &b"abcd123"[..];
     let d = &b"123"[..];
 
-    assert_eq!(f(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial(b)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial(c)), Ok((Partial(d), b)));
-    assert_eq!(f(Partial(d)), Ok((Partial(d), a)));
+    assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(Partial::new(b)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(Partial::new(c)), Ok((Partial::new(d), b)));
+    assert_eq!(f(Partial::new(d)), Ok((Partial::new(d), a)));
 }
 
 #[test]
@@ -320,13 +320,13 @@ fn partial_take_while1() {
     let c = &b"abcd123"[..];
     let d = &b"123"[..];
 
-    assert_eq!(f(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial(b)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial(c)), Ok((Partial(&b"123"[..]), b)));
+    assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(Partial::new(b)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(Partial::new(c)), Ok((Partial::new(&b"123"[..]), b)));
     assert_eq!(
-        f(Partial(d)),
+        f(Partial::new(d)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(d),
+            Partial::new(d),
             ErrorKind::TakeWhile1
         )))
     );
@@ -344,15 +344,18 @@ fn partial_take_while_m_n() {
     let e = &b"abcde"[..];
     let f = &b"123"[..];
 
-    assert_eq!(x(Partial(a)), Err(ErrMode::Incomplete(Needed::new(2))));
-    assert_eq!(x(Partial(b)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(x(Partial(c)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(x(Partial(d)), Ok((Partial(&b"123"[..]), c)));
-    assert_eq!(x(Partial(e)), Ok((Partial(&b"e"[..]), &b"abcd"[..])));
+    assert_eq!(x(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(2))));
+    assert_eq!(x(Partial::new(b)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(x(Partial::new(c)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(x(Partial::new(d)), Ok((Partial::new(&b"123"[..]), c)));
     assert_eq!(
-        x(Partial(f)),
+        x(Partial::new(e)),
+        Ok((Partial::new(&b"e"[..]), &b"abcd"[..]))
+    );
+    assert_eq!(
+        x(Partial::new(f)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(f),
+            Partial::new(f),
             ErrorKind::TakeWhileMN
         )))
     );
@@ -368,10 +371,16 @@ fn partial_take_till0() {
     let c = &b"123abcd"[..];
     let d = &b"123"[..];
 
-    assert_eq!(f(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial(b)), Ok((Partial(&b"abcd"[..]), &b""[..])));
-    assert_eq!(f(Partial(c)), Ok((Partial(&b"abcd"[..]), &b"123"[..])));
-    assert_eq!(f(Partial(d)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        f(Partial::new(b)),
+        Ok((Partial::new(&b"abcd"[..]), &b""[..]))
+    );
+    assert_eq!(
+        f(Partial::new(c)),
+        Ok((Partial::new(&b"abcd"[..]), &b"123"[..]))
+    );
+    assert_eq!(f(Partial::new(d)), Err(ErrMode::Incomplete(Needed::new(1))));
 }
 
 #[test]
@@ -384,16 +393,19 @@ fn partial_take_till1() {
     let c = &b"123abcd"[..];
     let d = &b"123"[..];
 
-    assert_eq!(f(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(
-        f(Partial(b)),
+        f(Partial::new(b)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(b),
+            Partial::new(b),
             ErrorKind::TakeTill1
         )))
     );
-    assert_eq!(f(Partial(c)), Ok((Partial(&b"abcd"[..]), &b"123"[..])));
-    assert_eq!(f(Partial(d)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        f(Partial::new(c)),
+        Ok((Partial::new(&b"abcd"[..]), &b"123"[..]))
+    );
+    assert_eq!(f(Partial::new(d)), Err(ErrMode::Incomplete(Needed::new(1))));
 }
 
 #[test]
@@ -402,18 +414,33 @@ fn partial_take_while_utf8() {
         take_while0(|c| c != '點')(i)
     }
 
-    assert_eq!(f(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial("abcd")), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial("abcd點")), Ok((Partial("點"), "abcd")));
-    assert_eq!(f(Partial("abcd點a")), Ok((Partial("點a"), "abcd")));
+    assert_eq!(
+        f(Partial::new("")),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        f(Partial::new("abcd")),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(f(Partial::new("abcd點")), Ok((Partial::new("點"), "abcd")));
+    assert_eq!(
+        f(Partial::new("abcd點a")),
+        Ok((Partial::new("點a"), "abcd"))
+    );
 
     fn g(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         take_while0(|c| c == '點')(i)
     }
 
-    assert_eq!(g(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(g(Partial("點abcd")), Ok((Partial("abcd"), "點")));
-    assert_eq!(g(Partial("點點點a")), Ok((Partial("a"), "點點點")));
+    assert_eq!(
+        g(Partial::new("")),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(g(Partial::new("點abcd")), Ok((Partial::new("abcd"), "點")));
+    assert_eq!(
+        g(Partial::new("點點點a")),
+        Ok((Partial::new("a"), "點點點"))
+    );
 }
 
 #[test]
@@ -422,18 +449,33 @@ fn partial_take_till0_utf8() {
         take_till0(|c| c == '點')(i)
     }
 
-    assert_eq!(f(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial("abcd")), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial("abcd點")), Ok((Partial("點"), "abcd")));
-    assert_eq!(f(Partial("abcd點a")), Ok((Partial("點a"), "abcd")));
+    assert_eq!(
+        f(Partial::new("")),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        f(Partial::new("abcd")),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(f(Partial::new("abcd點")), Ok((Partial::new("點"), "abcd")));
+    assert_eq!(
+        f(Partial::new("abcd點a")),
+        Ok((Partial::new("點a"), "abcd"))
+    );
 
     fn g(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         take_till0(|c| c != '點')(i)
     }
 
-    assert_eq!(g(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(g(Partial("點abcd")), Ok((Partial("abcd"), "點")));
-    assert_eq!(g(Partial("點點點a")), Ok((Partial("a"), "點點點")));
+    assert_eq!(
+        g(Partial::new("")),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(g(Partial::new("點abcd")), Ok((Partial::new("abcd"), "點")));
+    assert_eq!(
+        g(Partial::new("點點點a")),
+        Ok((Partial::new("a"), "點點點"))
+    );
 }
 
 #[test]
@@ -442,20 +484,35 @@ fn partial_take_utf8() {
         take(3_usize)(i)
     }
 
-    assert_eq!(f(Partial("")), Err(ErrMode::Incomplete(Needed::Unknown)));
-    assert_eq!(f(Partial("ab")), Err(ErrMode::Incomplete(Needed::Unknown)));
-    assert_eq!(f(Partial("點")), Err(ErrMode::Incomplete(Needed::Unknown)));
-    assert_eq!(f(Partial("ab點cd")), Ok((Partial("cd"), "ab點")));
-    assert_eq!(f(Partial("a點bcd")), Ok((Partial("cd"), "a點b")));
-    assert_eq!(f(Partial("a點b")), Ok((Partial(""), "a點b")));
+    assert_eq!(
+        f(Partial::new("")),
+        Err(ErrMode::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(
+        f(Partial::new("ab")),
+        Err(ErrMode::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(
+        f(Partial::new("點")),
+        Err(ErrMode::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(f(Partial::new("ab點cd")), Ok((Partial::new("cd"), "ab點")));
+    assert_eq!(f(Partial::new("a點bcd")), Ok((Partial::new("cd"), "a點b")));
+    assert_eq!(f(Partial::new("a點b")), Ok((Partial::new(""), "a點b")));
 
     fn g(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         take_while0(|c| c == '點')(i)
     }
 
-    assert_eq!(g(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(g(Partial("點abcd")), Ok((Partial("abcd"), "點")));
-    assert_eq!(g(Partial("點點點a")), Ok((Partial("a"), "點點點")));
+    assert_eq!(
+        g(Partial::new("")),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(g(Partial::new("點abcd")), Ok((Partial::new("abcd"), "點")));
+    assert_eq!(
+        g(Partial::new("點點點a")),
+        Ok((Partial::new("a"), "點點點"))
+    );
 }
 
 #[test]
@@ -463,8 +520,8 @@ fn partial_take_while_m_n_utf8_fixed() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         take_while_m_n(1, 1, |c| c == 'A' || c == '😃')(i)
     }
-    assert_eq!(parser(Partial("A!")), Ok((Partial("!"), "A")));
-    assert_eq!(parser(Partial("😃!")), Ok((Partial("!"), "😃")));
+    assert_eq!(parser(Partial::new("A!")), Ok((Partial::new("!"), "A")));
+    assert_eq!(parser(Partial::new("😃!")), Ok((Partial::new("!"), "😃")));
 }
 
 #[test]
@@ -472,8 +529,8 @@ fn partial_take_while_m_n_utf8_range() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         take_while_m_n(1, 2, |c| c == 'A' || c == '😃')(i)
     }
-    assert_eq!(parser(Partial("A!")), Ok((Partial("!"), "A")));
-    assert_eq!(parser(Partial("😃!")), Ok((Partial("!"), "😃")));
+    assert_eq!(parser(Partial::new("A!")), Ok((Partial::new("!"), "A")));
+    assert_eq!(parser(Partial::new("😃!")), Ok((Partial::new("!"), "😃")));
 }
 
 #[test]
@@ -481,7 +538,7 @@ fn partial_take_while_m_n_utf8_full_match_fixed() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         take_while_m_n(1, 1, |c: char| c.is_alphabetic())(i)
     }
-    assert_eq!(parser(Partial("øn")), Ok((Partial("n"), "ø")));
+    assert_eq!(parser(Partial::new("øn")), Ok((Partial::new("n"), "ø")));
 }
 
 #[test]
@@ -489,7 +546,7 @@ fn partial_take_while_m_n_utf8_full_match_range() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         take_while_m_n(1, 2, |c: char| c.is_alphabetic())(i)
     }
-    assert_eq!(parser(Partial("øn")), Ok((Partial(""), "øn")));
+    assert_eq!(parser(Partial::new("øn")), Ok((Partial::new(""), "øn")));
 }
 
 #[test]
@@ -502,12 +559,12 @@ fn partial_recognize_take_while0() {
         x.recognize().parse_next(i)
     }
     assert_eq!(
-        x(Partial(&b"ab."[..])),
-        Ok((Partial(&b"."[..]), &b"ab"[..]))
+        x(Partial::new(&b"ab."[..])),
+        Ok((Partial::new(&b"."[..]), &b"ab"[..]))
     );
     assert_eq!(
-        y(Partial(&b"ab."[..])),
-        Ok((Partial(&b"."[..]), &b"ab"[..]))
+        y(Partial::new(&b"ab."[..])),
+        Ok((Partial::new(&b"."[..]), &b"ab"[..]))
     );
 }
 
@@ -519,16 +576,19 @@ fn partial_length_bytes() {
         length_data(le_u8)(i)
     }
     assert_eq!(
-        x(Partial(b"\x02..>>")),
-        Ok((Partial(&b">>"[..]), &b".."[..]))
+        x(Partial::new(b"\x02..>>")),
+        Ok((Partial::new(&b">>"[..]), &b".."[..]))
     );
-    assert_eq!(x(Partial(b"\x02..")), Ok((Partial(&[][..]), &b".."[..])));
     assert_eq!(
-        x(Partial(b"\x02.")),
+        x(Partial::new(b"\x02..")),
+        Ok((Partial::new(&[][..]), &b".."[..]))
+    );
+    assert_eq!(
+        x(Partial::new(b"\x02.")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        x(Partial(b"\x02")),
+        x(Partial::new(b"\x02")),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
 
@@ -537,19 +597,19 @@ fn partial_length_bytes() {
         length_data(le_u8)(i)
     }
     assert_eq!(
-        y(Partial(b"magic\x02..>>")),
-        Ok((Partial(&b">>"[..]), &b".."[..]))
+        y(Partial::new(b"magic\x02..>>")),
+        Ok((Partial::new(&b">>"[..]), &b".."[..]))
     );
     assert_eq!(
-        y(Partial(b"magic\x02..")),
-        Ok((Partial(&[][..]), &b".."[..]))
+        y(Partial::new(b"magic\x02..")),
+        Ok((Partial::new(&[][..]), &b".."[..]))
     );
     assert_eq!(
-        y(Partial(b"magic\x02.")),
+        y(Partial::new(b"magic\x02.")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        y(Partial(b"magic\x02")),
+        y(Partial::new(b"magic\x02")),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
 }
@@ -561,32 +621,32 @@ fn partial_case_insensitive() {
         tag_no_case("ABcd")(i)
     }
     assert_eq!(
-        test(Partial(&b"aBCdefgh"[..])),
-        Ok((Partial(&b"efgh"[..]), &b"aBCd"[..]))
+        test(Partial::new(&b"aBCdefgh"[..])),
+        Ok((Partial::new(&b"efgh"[..]), &b"aBCd"[..]))
     );
     assert_eq!(
-        test(Partial(&b"abcdefgh"[..])),
-        Ok((Partial(&b"efgh"[..]), &b"abcd"[..]))
+        test(Partial::new(&b"abcdefgh"[..])),
+        Ok((Partial::new(&b"efgh"[..]), &b"abcd"[..]))
     );
     assert_eq!(
-        test(Partial(&b"ABCDefgh"[..])),
-        Ok((Partial(&b"efgh"[..]), &b"ABCD"[..]))
+        test(Partial::new(&b"ABCDefgh"[..])),
+        Ok((Partial::new(&b"efgh"[..]), &b"ABCD"[..]))
     );
     assert_eq!(
-        test(Partial(&b"ab"[..])),
+        test(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        test(Partial(&b"Hello"[..])),
+        test(Partial::new(&b"Hello"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"Hello"[..]),
+            Partial::new(&b"Hello"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        test(Partial(&b"Hel"[..])),
+        test(Partial::new(&b"Hel"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"Hel"[..]),
+            Partial::new(&b"Hel"[..]),
             ErrorKind::Tag
         )))
     );
@@ -594,24 +654,33 @@ fn partial_case_insensitive() {
     fn test2(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         tag_no_case("ABcd")(i)
     }
-    assert_eq!(test2(Partial("aBCdefgh")), Ok((Partial("efgh"), "aBCd")));
-    assert_eq!(test2(Partial("abcdefgh")), Ok((Partial("efgh"), "abcd")));
-    assert_eq!(test2(Partial("ABCDefgh")), Ok((Partial("efgh"), "ABCD")));
     assert_eq!(
-        test2(Partial("ab")),
+        test2(Partial::new("aBCdefgh")),
+        Ok((Partial::new("efgh"), "aBCd"))
+    );
+    assert_eq!(
+        test2(Partial::new("abcdefgh")),
+        Ok((Partial::new("efgh"), "abcd"))
+    );
+    assert_eq!(
+        test2(Partial::new("ABCDefgh")),
+        Ok((Partial::new("efgh"), "ABCD"))
+    );
+    assert_eq!(
+        test2(Partial::new("ab")),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        test2(Partial("Hello")),
+        test2(Partial::new("Hello")),
         Err(ErrMode::Backtrack(error_position!(
-            Partial("Hello"),
+            Partial::new("Hello"),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        test2(Partial("Hel")),
+        test2(Partial::new("Hel")),
         Err(ErrMode::Backtrack(error_position!(
-            Partial("Hel"),
+            Partial::new("Hel"),
             ErrorKind::Tag
         )))
     );
@@ -625,7 +694,7 @@ fn partial_tag_fixed_size_array() {
     fn test2(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         tag(&[0x42])(i)
     }
-    let input = Partial(&[0x42, 0x00][..]);
-    assert_eq!(test(input), Ok((Partial(&b"\x00"[..]), &b"\x42"[..])));
-    assert_eq!(test2(input), Ok((Partial(&b"\x00"[..]), &b"\x42"[..])));
+    let input = Partial::new(&[0x42, 0x00][..]);
+    assert_eq!(test(input), Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..])));
+    assert_eq!(test2(input), Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..])));
 }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -44,9 +44,9 @@ use crate::Parser;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::crlf;
-/// assert_eq!(crlf::<_, Error<_>>(Partial("\r\nc")), Ok((Partial("c"), "\r\n")));
-/// assert_eq!(crlf::<_, Error<_>>(Partial("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("ab\r\nc"), ErrorKind::CrLf))));
-/// assert_eq!(crlf::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(crlf::<_, Error<_>>(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
+/// assert_eq!(crlf::<_, Error<_>>(Partial::new("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(crlf::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn crlf<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -91,11 +91,11 @@ where
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::not_line_ending;
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("ab\r\nc")), Ok((Partial("\r\nc"), "ab")));
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("a\rb\nc")), Err(ErrMode::Backtrack(Error::new(Partial("a\rb\nc"), ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial("a\rbc")), Err(ErrMode::Backtrack(Error::new(Partial("a\rbc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("ab\r\nc")), Ok((Partial::new("\r\nc"), "ab")));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("a\rb\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("a\rb\nc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("a\rbc")), Err(ErrMode::Backtrack(Error::new(Partial::new("a\rbc"), ErrorKind::Tag ))));
 /// ```
 #[inline(always)]
 pub fn not_line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -138,9 +138,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::line_ending;
-/// assert_eq!(line_ending::<_, Error<_>>(Partial("\r\nc")), Ok((Partial("c"), "\r\n")));
-/// assert_eq!(line_ending::<_, Error<_>>(Partial("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("ab\r\nc"), ErrorKind::CrLf))));
-/// assert_eq!(line_ending::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(line_ending::<_, Error<_>>(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
+/// assert_eq!(line_ending::<_, Error<_>>(Partial::new("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("ab\r\nc"), ErrorKind::CrLf))));
+/// assert_eq!(line_ending::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -182,9 +182,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::newline;
-/// assert_eq!(newline::<_, Error<_>>(Partial("\nc")), Ok((Partial("c"), '\n')));
-/// assert_eq!(newline::<_, Error<_>>(Partial("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("\r\nc"), ErrorKind::Char))));
-/// assert_eq!(newline::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(newline::<_, Error<_>>(Partial::new("\nc")), Ok((Partial::new("c"), '\n')));
+/// assert_eq!(newline::<_, Error<_>>(Partial::new("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(newline::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn newline<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
@@ -226,9 +226,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::tab;
-/// assert_eq!(tab::<_, Error<_>>(Partial("\tc")), Ok((Partial("c"), '\t')));
-/// assert_eq!(tab::<_, Error<_>>(Partial("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial("\r\nc"), ErrorKind::Char))));
-/// assert_eq!(tab::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(tab::<_, Error<_>>(Partial::new("\tc")), Ok((Partial::new("c"), '\t')));
+/// assert_eq!(tab::<_, Error<_>>(Partial::new("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("\r\nc"), ErrorKind::Char))));
+/// assert_eq!(tab::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn tab<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
@@ -272,9 +272,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::alpha0;
-/// assert_eq!(alpha0::<_, Error<_>>(Partial("ab1c")), Ok((Partial("1c"), "ab")));
-/// assert_eq!(alpha0::<_, Error<_>>(Partial("1c")), Ok((Partial("1c"), "")));
-/// assert_eq!(alpha0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha0::<_, Error<_>>(Partial::new("ab1c")), Ok((Partial::new("1c"), "ab")));
+/// assert_eq!(alpha0::<_, Error<_>>(Partial::new("1c")), Ok((Partial::new("1c"), "")));
+/// assert_eq!(alpha0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alpha0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -318,9 +318,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::alpha1;
-/// assert_eq!(alpha1::<_, Error<_>>(Partial("aB1c")), Ok((Partial("1c"), "aB")));
-/// assert_eq!(alpha1::<_, Error<_>>(Partial("1c")), Err(ErrMode::Backtrack(Error::new(Partial("1c"), ErrorKind::Alpha))));
-/// assert_eq!(alpha1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha1::<_, Error<_>>(Partial::new("aB1c")), Ok((Partial::new("1c"), "aB")));
+/// assert_eq!(alpha1::<_, Error<_>>(Partial::new("1c")), Err(ErrMode::Backtrack(Error::new(Partial::new("1c"), ErrorKind::Alpha))));
+/// assert_eq!(alpha1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alpha1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -365,9 +365,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::digit0;
-/// assert_eq!(digit0::<_, Error<_>>(Partial("21c")), Ok((Partial("c"), "21")));
-/// assert_eq!(digit0::<_, Error<_>>(Partial("a21c")), Ok((Partial("a21c"), "")));
-/// assert_eq!(digit0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(digit0::<_, Error<_>>(Partial::new("21c")), Ok((Partial::new("c"), "21")));
+/// assert_eq!(digit0::<_, Error<_>>(Partial::new("a21c")), Ok((Partial::new("a21c"), "")));
+/// assert_eq!(digit0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn digit0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -411,9 +411,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::digit1;
-/// assert_eq!(digit1::<_, Error<_>>(Partial("21c")), Ok((Partial("c"), "21")));
-/// assert_eq!(digit1::<_, Error<_>>(Partial("c1")), Err(ErrMode::Backtrack(Error::new(Partial("c1"), ErrorKind::Digit))));
-/// assert_eq!(digit1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(digit1::<_, Error<_>>(Partial::new("21c")), Ok((Partial::new("c"), "21")));
+/// assert_eq!(digit1::<_, Error<_>>(Partial::new("c1")), Err(ErrMode::Backtrack(Error::new(Partial::new("c1"), ErrorKind::Digit))));
+/// assert_eq!(digit1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// ## Parsing an integer
@@ -472,9 +472,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::hex_digit0;
-/// assert_eq!(hex_digit0::<_, Error<_>>(Partial("21cZ")), Ok((Partial("Z"), "21c")));
-/// assert_eq!(hex_digit0::<_, Error<_>>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
-/// assert_eq!(hex_digit0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit0::<_, Error<_>>(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
+/// assert_eq!(hex_digit0::<_, Error<_>>(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(hex_digit0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn hex_digit0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -518,9 +518,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::hex_digit1;
-/// assert_eq!(hex_digit1::<_, Error<_>>(Partial("21cZ")), Ok((Partial("Z"), "21c")));
-/// assert_eq!(hex_digit1::<_, Error<_>>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::HexDigit))));
-/// assert_eq!(hex_digit1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit1::<_, Error<_>>(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
+/// assert_eq!(hex_digit1::<_, Error<_>>(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::HexDigit))));
+/// assert_eq!(hex_digit1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn hex_digit1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -564,9 +564,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::oct_digit0;
-/// assert_eq!(oct_digit0::<_, Error<_>>(Partial("21cZ")), Ok((Partial("cZ"), "21")));
-/// assert_eq!(oct_digit0::<_, Error<_>>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
-/// assert_eq!(oct_digit0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit0::<_, Error<_>>(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
+/// assert_eq!(oct_digit0::<_, Error<_>>(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(oct_digit0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn oct_digit0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -610,9 +610,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::oct_digit1;
-/// assert_eq!(oct_digit1::<_, Error<_>>(Partial("21cZ")), Ok((Partial("cZ"), "21")));
-/// assert_eq!(oct_digit1::<_, Error<_>>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::OctDigit))));
-/// assert_eq!(oct_digit1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit1::<_, Error<_>>(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
+/// assert_eq!(oct_digit1::<_, Error<_>>(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::OctDigit))));
+/// assert_eq!(oct_digit1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn oct_digit1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -656,9 +656,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::alphanumeric0;
-/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial("21cZ%1")), Ok((Partial("%1"), "21cZ")));
-/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial("&Z21c")), Ok((Partial("&Z21c"), "")));
-/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
+/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial::new("&Z21c")), Ok((Partial::new("&Z21c"), "")));
+/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alphanumeric0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -702,9 +702,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::alphanumeric1;
-/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial("21cZ%1")), Ok((Partial("%1"), "21cZ")));
-/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial("&H2")), Err(ErrMode::Backtrack(Error::new(Partial("&H2"), ErrorKind::AlphaNumeric))));
-/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
+/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial::new("&H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("&H2"), ErrorKind::AlphaNumeric))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alphanumeric1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -736,9 +736,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::space0;
-/// assert_eq!(space0::<_, Error<_>>(Partial(" \t21c")), Ok((Partial("21c"), " \t")));
-/// assert_eq!(space0::<_, Error<_>>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
-/// assert_eq!(space0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(space0::<_, Error<_>>(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
+/// assert_eq!(space0::<_, Error<_>>(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(space0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn space0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -782,9 +782,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::space1;
-/// assert_eq!(space1::<_, Error<_>>(Partial(" \t21c")), Ok((Partial("21c"), " \t")));
-/// assert_eq!(space1::<_, Error<_>>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::Space))));
-/// assert_eq!(space1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(space1::<_, Error<_>>(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
+/// assert_eq!(space1::<_, Error<_>>(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::Space))));
+/// assert_eq!(space1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn space1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -828,9 +828,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::multispace0;
-/// assert_eq!(multispace0::<_, Error<_>>(Partial(" \t\n\r21c")), Ok((Partial("21c"), " \t\n\r")));
-/// assert_eq!(multispace0::<_, Error<_>>(Partial("Z21c")), Ok((Partial("Z21c"), "")));
-/// assert_eq!(multispace0::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace0::<_, Error<_>>(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
+/// assert_eq!(multispace0::<_, Error<_>>(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(multispace0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn multispace0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -874,9 +874,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::character::multispace1;
-/// assert_eq!(multispace1::<_, Error<_>>(Partial(" \t\n\r21c")), Ok((Partial("21c"), " \t\n\r")));
-/// assert_eq!(multispace1::<_, Error<_>>(Partial("H2")), Err(ErrMode::Backtrack(Error::new(Partial("H2"), ErrorKind::MultiSpace))));
-/// assert_eq!(multispace1::<_, Error<_>>(Partial("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace1::<_, Error<_>>(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
+/// assert_eq!(multispace1::<_, Error<_>>(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::MultiSpace))));
+/// assert_eq!(multispace1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn multispace1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -1176,9 +1176,9 @@ impl Int for i128 {
 ///   hex_uint(s)
 /// }
 ///
-/// assert_eq!(parser(Partial(&b"01AE;"[..])), Ok((Partial(&b";"[..]), 0x01AE)));
-/// assert_eq!(parser(Partial(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Partial(&b"ggg"[..])), Err(ErrMode::Backtrack(Error::new(Partial(&b"ggg"[..]), ErrorKind::IsA))));
+/// assert_eq!(parser(Partial::new(&b"01AE;"[..])), Ok((Partial::new(&b";"[..]), 0x01AE)));
+/// assert_eq!(parser(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"ggg"[..])), Err(ErrMode::Backtrack(Error::new(Partial::new(&b"ggg"[..]), ErrorKind::IsA))));
 /// ```
 #[inline]
 pub fn hex_uint<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
@@ -1312,11 +1312,11 @@ impl HexUint for u128 {
 ///   float(s)
 /// }
 ///
-/// assert_eq!(parser(Partial("11e-1 ")), Ok((Partial(" "), 1.1)));
-/// assert_eq!(parser(Partial("11e-1")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Partial("123E-02")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Partial("123K-01")), Ok((Partial("K-01"), 123.0)));
-/// assert_eq!(parser(Partial("abc")), Err(ErrMode::Backtrack(Error::new(Partial("abc"), ErrorKind::Float))));
+/// assert_eq!(parser(Partial::new("11e-1 ")), Ok((Partial::new(" "), 1.1)));
+/// assert_eq!(parser(Partial::new("11e-1")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new("123E-02")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new("123K-01")), Ok((Partial::new("K-01"), 123.0)));
+/// assert_eq!(parser(Partial::new("abc")), Err(ErrMode::Backtrack(Error::new(Partial::new("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
 pub fn float<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
@@ -1373,8 +1373,8 @@ where
 ///   escaped(digit1, '\\', one_of("\"n\\"))(s)
 /// }
 ///
-/// assert_eq!(esc(Partial("123;")), Ok((Partial(";"), "123")));
-/// assert_eq!(esc(Partial("12\\\"34;")), Ok((Partial(";"), "12\\\"34")));
+/// assert_eq!(esc(Partial::new("123;")), Ok((Partial::new(";"), "123")));
+/// assert_eq!(esc(Partial::new("12\\\"34;")), Ok((Partial::new(";"), "12\\\"34")));
 /// ```
 #[inline(always)]
 pub fn escaped<'a, I: 'a, Error, F, G, O1, O2>(
@@ -1466,7 +1466,7 @@ where
 ///   )(input)
 /// }
 ///
-/// assert_eq!(parser(Partial("ab\\\"cd\"")), Ok((Partial("\""), String::from("ab\"cd"))));
+/// assert_eq!(parser(Partial::new("ab\\\"cd\"")), Ok((Partial::new("\""), String::from("ab\"cd"))));
 /// ```
 #[cfg(feature = "alloc")]
 #[inline(always)]

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -881,103 +881,118 @@ mod partial {
         let e: &[u8] = b" ";
         let f: &[u8] = b" ;";
         //assert_eq!(alpha1::<_, Error<_>>(a), Err(ErrMode::Incomplete(Needed::new(1))));
-        assert_parse!(alpha1(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
-        assert_eq!(
-            alpha1(Partial(b)),
-            Err(ErrMode::Backtrack(Error::new(Partial(b), ErrorKind::Alpha)))
-        );
-        assert_eq!(
-            alpha1::<_, Error<_>>(Partial(c)),
-            Ok((Partial(&c[1..]), &b"a"[..]))
-        );
-        assert_eq!(
-            alpha1::<_, Error<_>>(Partial(d)),
-            Ok((Partial("é12".as_bytes()), &b"az"[..]))
-        );
-        assert_eq!(
-            digit1(Partial(a)),
-            Err(ErrMode::Backtrack(Error::new(Partial(a), ErrorKind::Digit)))
-        );
-        assert_eq!(
-            digit1::<_, Error<_>>(Partial(b)),
+        assert_parse!(
+            alpha1(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            digit1(Partial(c)),
-            Err(ErrMode::Backtrack(Error::new(Partial(c), ErrorKind::Digit)))
-        );
-        assert_eq!(
-            digit1(Partial(d)),
-            Err(ErrMode::Backtrack(Error::new(Partial(d), ErrorKind::Digit)))
-        );
-        assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial(c)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial(d)),
-            Ok((Partial("zé12".as_bytes()), &b"a"[..]))
-        );
-        assert_eq!(
-            hex_digit1(Partial(e)),
+            alpha1(Partial::new(b)),
             Err(ErrMode::Backtrack(Error::new(
-                Partial(e),
+                Partial::new(b),
+                ErrorKind::Alpha
+            )))
+        );
+        assert_eq!(
+            alpha1::<_, Error<_>>(Partial::new(c)),
+            Ok((Partial::new(&c[1..]), &b"a"[..]))
+        );
+        assert_eq!(
+            alpha1::<_, Error<_>>(Partial::new(d)),
+            Ok((Partial::new("é12".as_bytes()), &b"az"[..]))
+        );
+        assert_eq!(
+            digit1(Partial::new(a)),
+            Err(ErrMode::Backtrack(Error::new(
+                Partial::new(a),
+                ErrorKind::Digit
+            )))
+        );
+        assert_eq!(
+            digit1::<_, Error<_>>(Partial::new(b)),
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        );
+        assert_eq!(
+            digit1(Partial::new(c)),
+            Err(ErrMode::Backtrack(Error::new(
+                Partial::new(c),
+                ErrorKind::Digit
+            )))
+        );
+        assert_eq!(
+            digit1(Partial::new(d)),
+            Err(ErrMode::Backtrack(Error::new(
+                Partial::new(d),
+                ErrorKind::Digit
+            )))
+        );
+        assert_eq!(
+            hex_digit1::<_, Error<_>>(Partial::new(a)),
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        );
+        assert_eq!(
+            hex_digit1::<_, Error<_>>(Partial::new(b)),
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        );
+        assert_eq!(
+            hex_digit1::<_, Error<_>>(Partial::new(c)),
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        );
+        assert_eq!(
+            hex_digit1::<_, Error<_>>(Partial::new(d)),
+            Ok((Partial::new("zé12".as_bytes()), &b"a"[..]))
+        );
+        assert_eq!(
+            hex_digit1(Partial::new(e)),
+            Err(ErrMode::Backtrack(Error::new(
+                Partial::new(e),
                 ErrorKind::HexDigit
             )))
         );
         assert_eq!(
-            oct_digit1(Partial(a)),
+            oct_digit1(Partial::new(a)),
             Err(ErrMode::Backtrack(Error::new(
-                Partial(a),
+                Partial::new(a),
                 ErrorKind::OctDigit
             )))
         );
         assert_eq!(
-            oct_digit1::<_, Error<_>>(Partial(b)),
+            oct_digit1::<_, Error<_>>(Partial::new(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            oct_digit1(Partial(c)),
+            oct_digit1(Partial::new(c)),
             Err(ErrMode::Backtrack(Error::new(
-                Partial(c),
+                Partial::new(c),
                 ErrorKind::OctDigit
             )))
         );
         assert_eq!(
-            oct_digit1(Partial(d)),
+            oct_digit1(Partial::new(d)),
             Err(ErrMode::Backtrack(Error::new(
-                Partial(d),
+                Partial::new(d),
                 ErrorKind::OctDigit
             )))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial(a)),
+            alphanumeric1::<_, Error<_>>(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial(c)),
+            alphanumeric1::<_, Error<_>>(Partial::new(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial(d)),
-            Ok((Partial("é12".as_bytes()), &b"az"[..]))
+            alphanumeric1::<_, Error<_>>(Partial::new(d)),
+            Ok((Partial::new("é12".as_bytes()), &b"az"[..]))
         );
         assert_eq!(
-            space1::<_, Error<_>>(Partial(e)),
+            space1::<_, Error<_>>(Partial::new(e)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            space1::<_, Error<_>>(Partial(f)),
-            Ok((Partial(&b";"[..]), &b" "[..]))
+            space1::<_, Error<_>>(Partial::new(f)),
+            Ok((Partial::new(&b";"[..]), &b" "[..]))
         );
     }
 
@@ -990,100 +1005,112 @@ mod partial {
         let d = "azé12";
         let e = " ";
         assert_eq!(
-            alpha1::<_, Error<_>>(Partial(a)),
+            alpha1::<_, Error<_>>(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            alpha1(Partial(b)),
-            Err(ErrMode::Backtrack(Error::new(Partial(b), ErrorKind::Alpha)))
-        );
-        assert_eq!(
-            alpha1::<_, Error<_>>(Partial(c)),
-            Ok((Partial(&c[1..]), "a"))
-        );
-        assert_eq!(
-            alpha1::<_, Error<_>>(Partial(d)),
-            Ok((Partial("é12"), "az"))
-        );
-        assert_eq!(
-            digit1(Partial(a)),
-            Err(ErrMode::Backtrack(Error::new(Partial(a), ErrorKind::Digit)))
-        );
-        assert_eq!(
-            digit1::<_, Error<_>>(Partial(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(
-            digit1(Partial(c)),
-            Err(ErrMode::Backtrack(Error::new(Partial(c), ErrorKind::Digit)))
-        );
-        assert_eq!(
-            digit1(Partial(d)),
-            Err(ErrMode::Backtrack(Error::new(Partial(d), ErrorKind::Digit)))
-        );
-        assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial(c)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial(d)),
-            Ok((Partial("zé12"), "a"))
-        );
-        assert_eq!(
-            hex_digit1(Partial(e)),
+            alpha1(Partial::new(b)),
             Err(ErrMode::Backtrack(Error::new(
-                Partial(e),
+                Partial::new(b),
+                ErrorKind::Alpha
+            )))
+        );
+        assert_eq!(
+            alpha1::<_, Error<_>>(Partial::new(c)),
+            Ok((Partial::new(&c[1..]), "a"))
+        );
+        assert_eq!(
+            alpha1::<_, Error<_>>(Partial::new(d)),
+            Ok((Partial::new("é12"), "az"))
+        );
+        assert_eq!(
+            digit1(Partial::new(a)),
+            Err(ErrMode::Backtrack(Error::new(
+                Partial::new(a),
+                ErrorKind::Digit
+            )))
+        );
+        assert_eq!(
+            digit1::<_, Error<_>>(Partial::new(b)),
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        );
+        assert_eq!(
+            digit1(Partial::new(c)),
+            Err(ErrMode::Backtrack(Error::new(
+                Partial::new(c),
+                ErrorKind::Digit
+            )))
+        );
+        assert_eq!(
+            digit1(Partial::new(d)),
+            Err(ErrMode::Backtrack(Error::new(
+                Partial::new(d),
+                ErrorKind::Digit
+            )))
+        );
+        assert_eq!(
+            hex_digit1::<_, Error<_>>(Partial::new(a)),
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        );
+        assert_eq!(
+            hex_digit1::<_, Error<_>>(Partial::new(b)),
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        );
+        assert_eq!(
+            hex_digit1::<_, Error<_>>(Partial::new(c)),
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        );
+        assert_eq!(
+            hex_digit1::<_, Error<_>>(Partial::new(d)),
+            Ok((Partial::new("zé12"), "a"))
+        );
+        assert_eq!(
+            hex_digit1(Partial::new(e)),
+            Err(ErrMode::Backtrack(Error::new(
+                Partial::new(e),
                 ErrorKind::HexDigit
             )))
         );
         assert_eq!(
-            oct_digit1(Partial(a)),
+            oct_digit1(Partial::new(a)),
             Err(ErrMode::Backtrack(Error::new(
-                Partial(a),
+                Partial::new(a),
                 ErrorKind::OctDigit
             )))
         );
         assert_eq!(
-            oct_digit1::<_, Error<_>>(Partial(b)),
+            oct_digit1::<_, Error<_>>(Partial::new(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            oct_digit1(Partial(c)),
+            oct_digit1(Partial::new(c)),
             Err(ErrMode::Backtrack(Error::new(
-                Partial(c),
+                Partial::new(c),
                 ErrorKind::OctDigit
             )))
         );
         assert_eq!(
-            oct_digit1(Partial(d)),
+            oct_digit1(Partial::new(d)),
             Err(ErrMode::Backtrack(Error::new(
-                Partial(d),
+                Partial::new(d),
                 ErrorKind::OctDigit
             )))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial(a)),
+            alphanumeric1::<_, Error<_>>(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial(c)),
+            alphanumeric1::<_, Error<_>>(Partial::new(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial(d)),
-            Ok((Partial("é12"), "az"))
+            alphanumeric1::<_, Error<_>>(Partial::new(d)),
+            Ok((Partial::new("é12"), "az"))
         );
         assert_eq!(
-            space1::<_, Error<_>>(Partial(e)),
+            space1::<_, Error<_>>(Partial::new(e)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -1098,44 +1125,51 @@ mod partial {
         let e = &b" \t\r\n;"[..];
         let f = &b"123abcDEF;"[..];
 
-        match alpha1::<_, Error<_>>(Partial(a)) {
-            Ok((Partial(i), _)) => {
+        match alpha1::<_, Error<_>>(Partial::new(a)) {
+            Ok((i, _)) => {
+                let i = i.into_inner();
                 assert_eq!(a.offset_to(i) + i.len(), a.len());
             }
             _ => panic!("wrong return type in offset test for alpha"),
         }
-        match digit1::<_, Error<_>>(Partial(b)) {
-            Ok((Partial(i), _)) => {
+        match digit1::<_, Error<_>>(Partial::new(b)) {
+            Ok((i, _)) => {
+                let i = i.into_inner();
                 assert_eq!(b.offset_to(i) + i.len(), b.len());
             }
             _ => panic!("wrong return type in offset test for digit"),
         }
-        match alphanumeric1::<_, Error<_>>(Partial(c)) {
-            Ok((Partial(i), _)) => {
+        match alphanumeric1::<_, Error<_>>(Partial::new(c)) {
+            Ok((i, _)) => {
+                let i = i.into_inner();
                 assert_eq!(c.offset_to(i) + i.len(), c.len());
             }
             _ => panic!("wrong return type in offset test for alphanumeric"),
         }
-        match space1::<_, Error<_>>(Partial(d)) {
-            Ok((Partial(i), _)) => {
+        match space1::<_, Error<_>>(Partial::new(d)) {
+            Ok((i, _)) => {
+                let i = i.into_inner();
                 assert_eq!(d.offset_to(i) + i.len(), d.len());
             }
             _ => panic!("wrong return type in offset test for space"),
         }
-        match multispace1::<_, Error<_>>(Partial(e)) {
-            Ok((Partial(i), _)) => {
+        match multispace1::<_, Error<_>>(Partial::new(e)) {
+            Ok((i, _)) => {
+                let i = i.into_inner();
                 assert_eq!(e.offset_to(i) + i.len(), e.len());
             }
             _ => panic!("wrong return type in offset test for multispace"),
         }
-        match hex_digit1::<_, Error<_>>(Partial(f)) {
-            Ok((Partial(i), _)) => {
+        match hex_digit1::<_, Error<_>>(Partial::new(f)) {
+            Ok((i, _)) => {
+                let i = i.into_inner();
                 assert_eq!(f.offset_to(i) + i.len(), f.len());
             }
             _ => panic!("wrong return type in offset test for hex_digit"),
         }
-        match oct_digit1::<_, Error<_>>(Partial(f)) {
-            Ok((Partial(i), _)) => {
+        match oct_digit1::<_, Error<_>>(Partial::new(f)) {
+            Ok((i, _)) => {
+                let i = i.into_inner();
                 assert_eq!(f.offset_to(i) + i.len(), f.len());
             }
             _ => panic!("wrong return type in offset test for oct_digit"),
@@ -1146,25 +1180,25 @@ mod partial {
     fn is_not_line_ending_bytes() {
         let a: &[u8] = b"ab12cd\nefgh";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial(a)),
-            Ok((Partial(&b"\nefgh"[..]), &b"ab12cd"[..]))
+            not_line_ending::<_, Error<_>>(Partial::new(a)),
+            Ok((Partial::new(&b"\nefgh"[..]), &b"ab12cd"[..]))
         );
 
         let b: &[u8] = b"ab12cd\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial(b)),
-            Ok((Partial(&b"\nefgh\nijkl"[..]), &b"ab12cd"[..]))
+            not_line_ending::<_, Error<_>>(Partial::new(b)),
+            Ok((Partial::new(&b"\nefgh\nijkl"[..]), &b"ab12cd"[..]))
         );
 
         let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial(c)),
-            Ok((Partial(&b"\r\nefgh\nijkl"[..]), &b"ab12cd"[..]))
+            not_line_ending::<_, Error<_>>(Partial::new(c)),
+            Ok((Partial::new(&b"\r\nefgh\nijkl"[..]), &b"ab12cd"[..]))
         );
 
         let d: &[u8] = b"ab12cd";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial(d)),
+            not_line_ending::<_, Error<_>>(Partial::new(d)),
             Err(ErrMode::Incomplete(Needed::Unknown))
         );
     }
@@ -1173,13 +1207,16 @@ mod partial {
     fn is_not_line_ending_str() {
         let f = "βèƒôřè\rÂßÇáƒƭèř";
         assert_eq!(
-            not_line_ending(Partial(f)),
-            Err(ErrMode::Backtrack(Error::new(Partial(f), ErrorKind::Tag)))
+            not_line_ending(Partial::new(f)),
+            Err(ErrMode::Backtrack(Error::new(
+                Partial::new(f),
+                ErrorKind::Tag
+            )))
         );
 
         let g2: &str = "ab12cd";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial(g2)),
+            not_line_ending::<_, Error<_>>(Partial::new(g2)),
             Err(ErrMode::Incomplete(Needed::Unknown))
         );
     }
@@ -1188,24 +1225,24 @@ mod partial {
     fn hex_digit_test() {
         let i = &b"0123456789abcdefABCDEF;"[..];
         assert_parse!(
-            hex_digit1(Partial(i)),
-            Ok((Partial(&b";"[..]), &i[..i.len() - 1]))
+            hex_digit1(Partial::new(i)),
+            Ok((Partial::new(&b";"[..]), &i[..i.len() - 1]))
         );
 
         let i = &b"g"[..];
         assert_parse!(
-            hex_digit1(Partial(i)),
+            hex_digit1(Partial::new(i)),
             Err(ErrMode::Backtrack(error_position!(
-                Partial(i),
+                Partial::new(i),
                 ErrorKind::HexDigit
             )))
         );
 
         let i = &b"G"[..];
         assert_parse!(
-            hex_digit1(Partial(i)),
+            hex_digit1(Partial::new(i)),
             Err(ErrMode::Backtrack(error_position!(
-                Partial(i),
+                Partial::new(i),
                 ErrorKind::HexDigit
             )))
         );
@@ -1228,15 +1265,15 @@ mod partial {
     fn oct_digit_test() {
         let i = &b"01234567;"[..];
         assert_parse!(
-            oct_digit1(Partial(i)),
-            Ok((Partial(&b";"[..]), &i[..i.len() - 1]))
+            oct_digit1(Partial::new(i)),
+            Ok((Partial::new(&b";"[..]), &i[..i.len() - 1]))
         );
 
         let i = &b"8"[..];
         assert_parse!(
-            oct_digit1(Partial(i)),
+            oct_digit1(Partial::new(i)),
             Err(ErrMode::Backtrack(error_position!(
-                Partial(i),
+                Partial::new(i),
                 ErrorKind::OctDigit
             )))
         );
@@ -1260,8 +1297,11 @@ mod partial {
             pair(not_line_ending, line_ending)(i)
         }
         let input = b"abc\r\n";
-        let output = take_full_line(Partial(input));
-        assert_eq!(output, Ok((Partial(&b""[..]), (&b"abc"[..], &b"\r\n"[..]))));
+        let output = take_full_line(Partial::new(input));
+        assert_eq!(
+            output,
+            Ok((Partial::new(&b""[..]), (&b"abc"[..], &b"\r\n"[..])))
+        );
     }
 
     #[test]
@@ -1271,51 +1311,54 @@ mod partial {
             pair(not_line_ending, line_ending)(i)
         }
         let input = b"abc\n";
-        let output = take_full_line(Partial(input));
-        assert_eq!(output, Ok((Partial(&b""[..]), (&b"abc"[..], &b"\n"[..]))));
+        let output = take_full_line(Partial::new(input));
+        assert_eq!(
+            output,
+            Ok((Partial::new(&b""[..]), (&b"abc"[..], &b"\n"[..])))
+        );
     }
 
     #[test]
     fn check_windows_lineending() {
         let input = b"\r\n";
-        let output = line_ending(Partial(&input[..]));
-        assert_parse!(output, Ok((Partial(&b""[..]), &b"\r\n"[..])));
+        let output = line_ending(Partial::new(&input[..]));
+        assert_parse!(output, Ok((Partial::new(&b""[..]), &b"\r\n"[..])));
     }
 
     #[test]
     fn check_unix_lineending() {
         let input = b"\n";
-        let output = line_ending(Partial(&input[..]));
-        assert_parse!(output, Ok((Partial(&b""[..]), &b"\n"[..])));
+        let output = line_ending(Partial::new(&input[..]));
+        assert_parse!(output, Ok((Partial::new(&b""[..]), &b"\n"[..])));
     }
 
     #[test]
     fn cr_lf() {
         assert_parse!(
-            crlf(Partial(&b"\r\na"[..])),
-            Ok((Partial(&b"a"[..]), &b"\r\n"[..]))
+            crlf(Partial::new(&b"\r\na"[..])),
+            Ok((Partial::new(&b"a"[..]), &b"\r\n"[..]))
         );
         assert_parse!(
-            crlf(Partial(&b"\r"[..])),
+            crlf(Partial::new(&b"\r"[..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            crlf(Partial(&b"\ra"[..])),
+            crlf(Partial::new(&b"\ra"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial(&b"\ra"[..]),
+                Partial::new(&b"\ra"[..]),
                 ErrorKind::CrLf
             )))
         );
 
-        assert_parse!(crlf(Partial("\r\na")), Ok((Partial("a"), "\r\n")));
+        assert_parse!(crlf(Partial::new("\r\na")), Ok((Partial::new("a"), "\r\n")));
         assert_parse!(
-            crlf(Partial("\r")),
+            crlf(Partial::new("\r")),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            crlf(Partial("\ra")),
+            crlf(Partial::new("\ra")),
             Err(ErrMode::Backtrack(error_position!(
-                Partial("\ra"),
+                Partial::new("\ra"),
                 ErrorKind::CrLf
             )))
         );
@@ -1324,35 +1367,41 @@ mod partial {
     #[test]
     fn end_of_line() {
         assert_parse!(
-            line_ending(Partial(&b"\na"[..])),
-            Ok((Partial(&b"a"[..]), &b"\n"[..]))
+            line_ending(Partial::new(&b"\na"[..])),
+            Ok((Partial::new(&b"a"[..]), &b"\n"[..]))
         );
         assert_parse!(
-            line_ending(Partial(&b"\r\na"[..])),
-            Ok((Partial(&b"a"[..]), &b"\r\n"[..]))
+            line_ending(Partial::new(&b"\r\na"[..])),
+            Ok((Partial::new(&b"a"[..]), &b"\r\n"[..]))
         );
         assert_parse!(
-            line_ending(Partial(&b"\r"[..])),
+            line_ending(Partial::new(&b"\r"[..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            line_ending(Partial(&b"\ra"[..])),
+            line_ending(Partial::new(&b"\ra"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial(&b"\ra"[..]),
+                Partial::new(&b"\ra"[..]),
                 ErrorKind::CrLf
             )))
         );
 
-        assert_parse!(line_ending(Partial("\na")), Ok((Partial("a"), "\n")));
-        assert_parse!(line_ending(Partial("\r\na")), Ok((Partial("a"), "\r\n")));
         assert_parse!(
-            line_ending(Partial("\r")),
+            line_ending(Partial::new("\na")),
+            Ok((Partial::new("a"), "\n"))
+        );
+        assert_parse!(
+            line_ending(Partial::new("\r\na")),
+            Ok((Partial::new("a"), "\r\n"))
+        );
+        assert_parse!(
+            line_ending(Partial::new("\r")),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            line_ending(Partial("\ra")),
+            line_ending(Partial::new("\ra")),
             Err(ErrMode::Backtrack(error_position!(
-                Partial("\ra"),
+                Partial::new("\ra"),
                 ErrorKind::CrLf
             )))
         );
@@ -1398,16 +1447,16 @@ mod partial {
       #[test]
       #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
       fn ints(s in "\\PC*") {
-          let res1 = digit_to_i16(Partial(&s));
-          let res2 = dec_int(Partial(s.as_str()));
+          let res1 = digit_to_i16(Partial::new(&s));
+          let res2 = dec_int(Partial::new(s.as_str()));
           assert_eq!(res1, res2);
       }
 
       #[test]
       #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
       fn uints(s in "\\PC*") {
-          let res1 = digit_to_u32(Partial(&s));
-          let res2 = dec_uint(Partial(s.as_str()));
+          let res1 = digit_to_u32(Partial::new(&s));
+          let res2 = dec_uint(Partial::new(s.as_str()));
           assert_eq!(res1, res2);
       }
     }
@@ -1419,63 +1468,66 @@ mod partial {
         }
 
         assert_parse!(
-            hex_u32(Partial(&b";"[..])),
+            hex_u32(Partial::new(&b";"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial(&b";"[..]),
-                ErrorKind::IsA
-            )))
-        );
-        assert_parse!(hex_u32(Partial(&b"ff;"[..])), Ok((Partial(&b";"[..]), 255)));
-        assert_parse!(
-            hex_u32(Partial(&b"1be2;"[..])),
-            Ok((Partial(&b";"[..]), 7138))
-        );
-        assert_parse!(
-            hex_u32(Partial(&b"c5a31be2;"[..])),
-            Ok((Partial(&b";"[..]), 3_315_801_058))
-        );
-        assert_parse!(
-            hex_u32(Partial(&b"C5A31be2;"[..])),
-            Ok((Partial(&b";"[..]), 3_315_801_058))
-        );
-        assert_parse!(
-            hex_u32(Partial(&b"00c5a31be2;"[..])), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                Partial(&b"00c5a31be2;"[..]),
+                Partial::new(&b";"[..]),
                 ErrorKind::IsA
             )))
         );
         assert_parse!(
-            hex_u32(Partial(&b"c5a31be201;"[..])), // overflow
+            hex_u32(Partial::new(&b"ff;"[..])),
+            Ok((Partial::new(&b";"[..]), 255))
+        );
+        assert_parse!(
+            hex_u32(Partial::new(&b"1be2;"[..])),
+            Ok((Partial::new(&b";"[..]), 7138))
+        );
+        assert_parse!(
+            hex_u32(Partial::new(&b"c5a31be2;"[..])),
+            Ok((Partial::new(&b";"[..]), 3_315_801_058))
+        );
+        assert_parse!(
+            hex_u32(Partial::new(&b"C5A31be2;"[..])),
+            Ok((Partial::new(&b";"[..]), 3_315_801_058))
+        );
+        assert_parse!(
+            hex_u32(Partial::new(&b"00c5a31be2;"[..])), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                Partial(&b"c5a31be201;"[..]),
+                Partial::new(&b"00c5a31be2;"[..]),
                 ErrorKind::IsA
             )))
         );
         assert_parse!(
-            hex_u32(Partial(&b"ffffffff;"[..])),
-            Ok((Partial(&b";"[..]), 4_294_967_295))
-        );
-        assert_parse!(
-            hex_u32(Partial(&b"ffffffffffffffff;"[..])), // overflow
+            hex_u32(Partial::new(&b"c5a31be201;"[..])), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                Partial(&b"ffffffffffffffff;"[..]),
+                Partial::new(&b"c5a31be201;"[..]),
                 ErrorKind::IsA
             )))
         );
         assert_parse!(
-            hex_u32(Partial(&b"ffffffffffffffff"[..])), // overflow
+            hex_u32(Partial::new(&b"ffffffff;"[..])),
+            Ok((Partial::new(&b";"[..]), 4_294_967_295))
+        );
+        assert_parse!(
+            hex_u32(Partial::new(&b"ffffffffffffffff;"[..])), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                Partial(&b"ffffffffffffffff"[..]),
+                Partial::new(&b"ffffffffffffffff;"[..]),
                 ErrorKind::IsA
             )))
         );
         assert_parse!(
-            hex_u32(Partial(&b"0x1be2;"[..])),
-            Ok((Partial(&b"x1be2;"[..]), 0))
+            hex_u32(Partial::new(&b"ffffffffffffffff"[..])), // overflow
+            Err(ErrMode::Backtrack(error_position!(
+                Partial::new(&b"ffffffffffffffff"[..]),
+                ErrorKind::IsA
+            )))
         );
         assert_parse!(
-            hex_u32(Partial(&b"12af"[..])),
+            hex_u32(Partial::new(&b"0x1be2;"[..])),
+            Ok((Partial::new(&b"x1be2;"[..]), 0))
+        );
+        assert_parse!(
+            hex_u32(Partial::new(&b"12af"[..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -160,8 +160,8 @@ use crate::error::{ContextError, ErrMode, ErrorKind, FromExternalError, Needed, 
 use crate::lib::std::borrow::Borrow;
 use crate::lib::std::convert;
 use crate::lib::std::ops::Range;
-use crate::stream::Offset;
 use crate::stream::{Location, Stream};
+use crate::stream::{Offset, StreamIsPartial};
 use crate::trace::trace;
 use crate::trace::trace_result;
 use crate::*;
@@ -482,7 +482,10 @@ pub struct AndThen<F, G, O1> {
     phantom: core::marker::PhantomData<O1>,
 }
 
-impl<F, G, O1> AndThen<F, G, O1> {
+impl<F, G, O1> AndThen<F, G, O1>
+where
+    O1: StreamIsPartial,
+{
     pub(crate) fn new(f: F, g: G) -> Self {
         Self {
             f,
@@ -492,11 +495,13 @@ impl<F, G, O1> AndThen<F, G, O1> {
     }
 }
 
-impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, E>
-    for AndThen<F, G, O1>
+impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Parser<O1, O2, E>> Parser<I, O2, E> for AndThen<F, G, O1>
+where
+    O1: StreamIsPartial,
 {
     fn parse_next(&mut self, i: I) -> IResult<I, O2, E> {
-        let (i, o1) = self.f.parse_next(i)?;
+        let (i, mut o1) = self.f.parse_next(i)?;
+        let _ = o1.complete();
         let (_, o2) = self.g.parse_next(o1)?;
         Ok((i, o2))
     }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -784,8 +784,8 @@ where
 ///
 /// let mut parser = complete(take(5u8));
 ///
-/// assert_eq!(parser(Partial("abcdefg")), Ok((Partial("fg"), "abcde")));
-/// assert_eq!(parser(Partial("abcd")), Err(ErrMode::Backtrack(Error::new(Partial("abcd"), ErrorKind::Complete))));
+/// assert_eq!(parser(Partial::new("abcdefg")), Ok((Partial::new("fg"), "abcde")));
+/// assert_eq!(parser(Partial::new("abcd")), Err(ErrMode::Backtrack(Error::new(Partial::new("abcd"), ErrorKind::Complete))));
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::complete_err")]

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -264,12 +264,15 @@ fn opt_test() {
     let b = &b"bcdefg"[..];
     let c = &b"ab"[..];
     assert_eq!(
-        opt_abcd(Partial(a)),
-        Ok((Partial(&b"ef"[..]), Some(&b"abcd"[..])))
+        opt_abcd(Partial::new(a)),
+        Ok((Partial::new(&b"ef"[..]), Some(&b"abcd"[..])))
     );
-    assert_eq!(opt_abcd(Partial(b)), Ok((Partial(&b"bcdefg"[..]), None)));
     assert_eq!(
-        opt_abcd(Partial(c)),
+        opt_abcd(Partial::new(b)),
+        Ok((Partial::new(&b"bcdefg"[..]), None))
+    );
+    assert_eq!(
+        opt_abcd(Partial::new(c)),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
 }
@@ -281,17 +284,17 @@ fn peek_test() {
     }
 
     assert_eq!(
-        peek_tag(Partial(&b"abcdef"[..])),
-        Ok((Partial(&b"abcdef"[..]), &b"abcd"[..]))
+        peek_tag(Partial::new(&b"abcdef"[..])),
+        Ok((Partial::new(&b"abcdef"[..]), &b"abcd"[..]))
     );
     assert_eq!(
-        peek_tag(Partial(&b"ab"[..])),
+        peek_tag(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        peek_tag(Partial(&b"xxx"[..])),
+        peek_tag(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -304,19 +307,19 @@ fn not_test() {
     }
 
     assert_eq!(
-        not_aaa(Partial(&b"aaa"[..])),
+        not_aaa(Partial::new(&b"aaa"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"aaa"[..]),
+            Partial::new(&b"aaa"[..]),
             ErrorKind::Not
         )))
     );
     assert_eq!(
-        not_aaa(Partial(&b"aa"[..])),
+        not_aaa(Partial::new(&b"aa"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        not_aaa(Partial(&b"abcd"[..])),
-        Ok((Partial(&b"abcd"[..]), ()))
+        not_aaa(Partial::new(&b"abcd"[..])),
+        Ok((Partial::new(&b"abcd"[..]), ()))
     );
 }
 
@@ -329,19 +332,19 @@ fn verify_test() {
         verify(take(5u8), |slice: &[u8]| slice[0] == b'a')(i)
     }
     assert_eq!(
-        test(Partial(&b"bcd"[..])),
+        test(Partial::new(&b"bcd"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        test(Partial(&b"bcdefg"[..])),
+        test(Partial::new(&b"bcdefg"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"bcdefg"[..]),
+            Partial::new(&b"bcdefg"[..]),
             ErrorKind::Verify
         )))
     );
     assert_eq!(
-        test(Partial(&b"abcdefg"[..])),
-        Ok((Partial(&b"fg"[..]), &b"abcde"[..]))
+        test(Partial::new(&b"abcdefg"[..])),
+        Ok((Partial::new(&b"fg"[..]), &b"abcde"[..]))
     );
 }
 
@@ -355,19 +358,19 @@ fn test_parser_verify() {
             .parse_next(i)
     }
     assert_eq!(
-        test(Partial(&b"bcd"[..])),
+        test(Partial::new(&b"bcd"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        test(Partial(&b"bcdefg"[..])),
+        test(Partial::new(&b"bcdefg"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"bcdefg"[..]),
+            Partial::new(&b"bcdefg"[..]),
             ErrorKind::Verify
         )))
     );
     assert_eq!(
-        test(Partial(&b"abcdefg"[..])),
-        Ok((Partial(&b"fg"[..]), &b"abcde"[..]))
+        test(Partial::new(&b"abcdefg"[..])),
+        Ok((Partial::new(&b"fg"[..]), &b"abcde"[..]))
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,15 +268,15 @@
 //! let mut tpl = (be_u16, take(3u8), tag("fg"));
 //!
 //! assert_eq!(
-//!   tpl.parse_next(Partial(&b"abcdefgh"[..])),
+//!   tpl.parse_next(Partial::new(&b"abcdefgh"[..])),
 //!   Ok((
-//!     Partial(&b"h"[..]),
+//!     Partial::new(&b"h"[..]),
 //!     (0x6162u16, &b"cde"[..], &b"fg"[..])
 //!   ))
 //! );
-//! assert_eq!(tpl.parse_next(Partial(&b"abcde"[..])), Err(winnow::error::ErrMode::Incomplete(Needed::new(2))));
+//! assert_eq!(tpl.parse_next(Partial::new(&b"abcde"[..])), Err(winnow::error::ErrMode::Incomplete(Needed::new(2))));
 //! let input = &b"abcdejk"[..];
-//! assert_eq!(tpl.parse_next(Partial(input)), Err(winnow::error::ErrMode::Backtrack(Error::new(Partial(&input[5..]), ErrorKind::Tag))));
+//! assert_eq!(tpl.parse_next(Partial::new(input)), Err(winnow::error::ErrMode::Backtrack(Error::new(Partial::new(&input[5..]), ErrorKind::Tag))));
 //! # }
 //! ```
 //!

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1119,7 +1119,8 @@ where
 {
     trace("length_value", move |i: I| {
         let (i, data) = length_data(f.by_ref()).parse_next(i)?;
-        let data = I::update_slice(i.clone(), data);
+        let mut data = I::update_slice(i.clone(), data);
+        let _ = data.complete();
         let (_, o) = g.by_ref().complete_err().parse_next(data)?;
         Ok((i, o))
     })

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1049,7 +1049,7 @@ where
 /// type Stream<'i> = Partial<&'i Bytes>;
 ///
 /// fn stream(b: &[u8]) -> Stream<'_> {
-///     Partial(Bytes::new(b))
+///     Partial::new(Bytes::new(b))
 /// }
 ///
 /// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &Bytes> {
@@ -1097,7 +1097,7 @@ where
 /// type Stream<'i> = Partial<&'i Bytes>;
 ///
 /// fn stream(b: &[u8]) -> Stream<'_> {
-///     Partial(Bytes::new(b))
+///     Partial::new(Bytes::new(b))
 /// }
 ///
 /// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &Bytes> {

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -41,21 +41,36 @@ fn separated0_test() {
     let h = &b"abcd,abc"[..];
 
     let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(Partial(a)), Ok((Partial(&b"ef"[..]), res1)));
+    assert_eq!(multi(Partial::new(a)), Ok((Partial::new(&b"ef"[..]), res1)));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-    assert_eq!(multi(Partial(b)), Ok((Partial(&b"ef"[..]), res2)));
-    assert_eq!(multi(Partial(c)), Ok((Partial(&b"azerty"[..]), Vec::new())));
-    let res3 = vec![&b""[..], &b""[..], &b""[..]];
-    assert_eq!(multi_empty(Partial(d)), Ok((Partial(&b"abc"[..]), res3)));
-    let res4 = vec![&b"abcd"[..], &b"abcd"[..]];
-    assert_eq!(multi(Partial(e)), Ok((Partial(&b",ef"[..]), res4)));
-
-    assert_eq!(multi(Partial(f)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(multi(Partial::new(b)), Ok((Partial::new(&b"ef"[..]), res2)));
     assert_eq!(
-        multi_longsep(Partial(g)),
+        multi(Partial::new(c)),
+        Ok((Partial::new(&b"azerty"[..]), Vec::new()))
+    );
+    let res3 = vec![&b""[..], &b""[..], &b""[..]];
+    assert_eq!(
+        multi_empty(Partial::new(d)),
+        Ok((Partial::new(&b"abc"[..]), res3))
+    );
+    let res4 = vec![&b"abcd"[..], &b"abcd"[..]];
+    assert_eq!(
+        multi(Partial::new(e)),
+        Ok((Partial::new(&b",ef"[..]), res4))
+    );
+
+    assert_eq!(
+        multi(Partial::new(f)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(multi(Partial(h)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        multi_longsep(Partial::new(g)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        multi(Partial::new(h)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
 }
 
 #[test]
@@ -70,9 +85,9 @@ fn separated0_empty_sep_test() {
 
     let i_err_pos = &i[3..];
     assert_eq!(
-        empty_sep(Partial(i)),
+        empty_sep(Partial::new(i)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(i_err_pos),
+            Partial::new(i_err_pos),
             ErrorKind::Assert
         )))
     );
@@ -98,25 +113,34 @@ fn separated1_test() {
     let h = &b"abcd,abc"[..];
 
     let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(Partial(a)), Ok((Partial(&b"ef"[..]), res1)));
+    assert_eq!(multi(Partial::new(a)), Ok((Partial::new(&b"ef"[..]), res1)));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-    assert_eq!(multi(Partial(b)), Ok((Partial(&b"ef"[..]), res2)));
+    assert_eq!(multi(Partial::new(b)), Ok((Partial::new(&b"ef"[..]), res2)));
     assert_eq!(
-        multi(Partial(c)),
+        multi(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(c),
+            Partial::new(c),
             ErrorKind::Tag
         )))
     );
     let res3 = vec![&b"abcd"[..], &b"abcd"[..]];
-    assert_eq!(multi(Partial(d)), Ok((Partial(&b",ef"[..]), res3)));
-
-    assert_eq!(multi(Partial(f)), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(
-        multi_longsep(Partial(g)),
+        multi(Partial::new(d)),
+        Ok((Partial::new(&b",ef"[..]), res3))
+    );
+
+    assert_eq!(
+        multi(Partial::new(f)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(multi(Partial(h)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        multi_longsep(Partial::new(g)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        multi(Partial::new(h)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
 }
 
 #[test]
@@ -127,27 +151,27 @@ fn many0_test() {
     }
 
     assert_eq!(
-        multi(Partial(&b"abcdef"[..])),
-        Ok((Partial(&b"ef"[..]), vec![&b"abcd"[..]]))
+        multi(Partial::new(&b"abcdef"[..])),
+        Ok((Partial::new(&b"ef"[..]), vec![&b"abcd"[..]]))
     );
     assert_eq!(
-        multi(Partial(&b"abcdabcdefgh"[..])),
-        Ok((Partial(&b"efgh"[..]), vec![&b"abcd"[..], &b"abcd"[..]]))
+        multi(Partial::new(&b"abcdabcdefgh"[..])),
+        Ok((Partial::new(&b"efgh"[..]), vec![&b"abcd"[..], &b"abcd"[..]]))
     );
     assert_eq!(
-        multi(Partial(&b"azerty"[..])),
-        Ok((Partial(&b"azerty"[..]), Vec::new()))
+        multi(Partial::new(&b"azerty"[..])),
+        Ok((Partial::new(&b"azerty"[..]), Vec::new()))
     );
     assert_eq!(
-        multi(Partial(&b"abcdab"[..])),
+        multi(Partial::new(&b"abcdab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        multi(Partial(&b"abcd"[..])),
+        multi(Partial::new(&b"abcd"[..])),
         Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_eq!(
-        multi(Partial(&b""[..])),
+        multi(Partial::new(&b""[..])),
         Err(ErrMode::Incomplete(Needed::new(4)))
     );
 }
@@ -161,9 +185,9 @@ fn many0_empty_test() {
     }
 
     assert_eq!(
-        multi_empty(Partial(&b"abcdef"[..])),
+        multi_empty(Partial::new(&b"abcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"abcdef"[..]),
+            Partial::new(&b"abcdef"[..]),
             ErrorKind::Assert
         )))
     );
@@ -182,17 +206,23 @@ fn many1_test() {
     let d = &b"abcdab"[..];
 
     let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(Partial(a)), Ok((Partial(&b"ef"[..]), res1)));
+    assert_eq!(multi(Partial::new(a)), Ok((Partial::new(&b"ef"[..]), res1)));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-    assert_eq!(multi(Partial(b)), Ok((Partial(&b"efgh"[..]), res2)));
     assert_eq!(
-        multi(Partial(c)),
+        multi(Partial::new(b)),
+        Ok((Partial::new(&b"efgh"[..]), res2))
+    );
+    assert_eq!(
+        multi(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(c),
+            Partial::new(c),
             ErrorKind::Tag
         )))
     );
-    assert_eq!(multi(Partial(d)), Err(ErrMode::Incomplete(Needed::new(2))));
+    assert_eq!(
+        multi(Partial::new(d)),
+        Err(ErrMode::Incomplete(Needed::new(2)))
+    );
 }
 
 #[test]
@@ -260,19 +290,31 @@ fn many_m_n_test() {
     let e = &b"AbcdAb"[..];
 
     assert_eq!(
-        multi(Partial(a)),
+        multi(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"ef"[..]),
+            Partial::new(&b"ef"[..]),
             ErrorKind::Tag
         )))
     );
     let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
-    assert_eq!(multi(Partial(b)), Ok((Partial(&b"efgh"[..]), res1)));
+    assert_eq!(
+        multi(Partial::new(b)),
+        Ok((Partial::new(&b"efgh"[..]), res1))
+    );
     let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-    assert_eq!(multi(Partial(c)), Ok((Partial(&b"efgh"[..]), res2)));
+    assert_eq!(
+        multi(Partial::new(c)),
+        Ok((Partial::new(&b"efgh"[..]), res2))
+    );
     let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-    assert_eq!(multi(Partial(d)), Ok((Partial(&b"Abcdefgh"[..]), res3)));
-    assert_eq!(multi(Partial(e)), Err(ErrMode::Incomplete(Needed::new(2))));
+    assert_eq!(
+        multi(Partial::new(d)),
+        Ok((Partial::new(&b"Abcdefgh"[..]), res3))
+    );
+    assert_eq!(
+        multi(Partial::new(e)),
+        Err(ErrMode::Incomplete(Needed::new(2)))
+    );
 }
 
 #[test]
@@ -284,35 +326,35 @@ fn count_test() {
     }
 
     assert_eq!(
-        cnt_2(Partial(&b"abcabcabcdef"[..])),
-        Ok((Partial(&b"abcdef"[..]), vec![&b"abc"[..], &b"abc"[..]]))
+        cnt_2(Partial::new(&b"abcabcabcdef"[..])),
+        Ok((Partial::new(&b"abcdef"[..]), vec![&b"abc"[..], &b"abc"[..]]))
     );
     assert_eq!(
-        cnt_2(Partial(&b"ab"[..])),
+        cnt_2(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        cnt_2(Partial(&b"abcab"[..])),
+        cnt_2(Partial::new(&b"abcab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        cnt_2(Partial(&b"xxx"[..])),
+        cnt_2(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        cnt_2(Partial(&b"xxxabcabcdef"[..])),
+        cnt_2(Partial::new(&b"xxxabcabcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxxabcabcdef"[..]),
+            Partial::new(&b"xxxabcabcdef"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        cnt_2(Partial(&b"abcxxxabcdef"[..])),
+        cnt_2(Partial::new(&b"abcxxxabcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxxabcdef"[..]),
+            Partial::new(&b"xxxabcdef"[..]),
             ErrorKind::Tag
         )))
     );
@@ -390,28 +432,28 @@ fn length_count_test() {
     }
 
     assert_eq!(
-        cnt(Partial(&b"2abcabcabcdef"[..])),
-        Ok((Partial(&b"abcdef"[..]), vec![&b"abc"[..], &b"abc"[..]]))
+        cnt(Partial::new(&b"2abcabcabcdef"[..])),
+        Ok((Partial::new(&b"abcdef"[..]), vec![&b"abc"[..], &b"abc"[..]]))
     );
     assert_eq!(
-        cnt(Partial(&b"2ab"[..])),
+        cnt(Partial::new(&b"2ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        cnt(Partial(&b"3abcab"[..])),
+        cnt(Partial::new(&b"3abcab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        cnt(Partial(&b"xxx"[..])),
+        cnt(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Digit
         )))
     );
     assert_eq!(
-        cnt(Partial(&b"2abcxxx"[..])),
+        cnt(Partial::new(&b"2abcxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -431,23 +473,23 @@ fn length_data_test() {
     }
 
     assert_eq!(
-        take(Partial(&b"6abcabcabcdef"[..])),
-        Ok((Partial(&b"abcdef"[..]), &b"abcabc"[..]))
+        take(Partial::new(&b"6abcabcabcdef"[..])),
+        Ok((Partial::new(&b"abcdef"[..]), &b"abcabc"[..]))
     );
     assert_eq!(
-        take(Partial(&b"3ab"[..])),
+        take(Partial::new(&b"3ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        take(Partial(&b"xxx"[..])),
+        take(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Digit
         )))
     );
     assert_eq!(
-        take(Partial(&b"2abcxxx"[..])),
-        Ok((Partial(&b"cxxx"[..]), &b"ab"[..]))
+        take(Partial::new(&b"2abcxxx"[..])),
+        Ok((Partial::new(&b"cxxx"[..]), &b"ab"[..]))
     );
 }
 
@@ -462,48 +504,54 @@ fn length_value_test() {
 
     let i1 = [0, 5, 6];
     assert_eq!(
-        length_value_1(Partial(&i1)),
+        length_value_1(Partial::new(&i1)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b""[..]),
+            Partial::new(&b""[..]),
             ErrorKind::Complete
         )))
     );
     assert_eq!(
-        length_value_2(Partial(&i1)),
+        length_value_2(Partial::new(&i1)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b""[..]),
+            Partial::new(&b""[..]),
             ErrorKind::Complete
         )))
     );
 
     let i2 = [1, 5, 6, 3];
     assert_eq!(
-        length_value_1(Partial(&i2)),
+        length_value_1(Partial::new(&i2)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&i2[1..2]),
+            Partial::new(&i2[1..2]),
             ErrorKind::Complete
         )))
     );
     assert_eq!(
-        length_value_2(Partial(&i2)),
+        length_value_2(Partial::new(&i2)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&i2[1..2]),
+            Partial::new(&i2[1..2]),
             ErrorKind::Complete
         )))
     );
 
     let i3 = [2, 5, 6, 3, 4, 5, 7];
-    assert_eq!(length_value_1(Partial(&i3)), Ok((Partial(&i3[3..]), 1286)));
     assert_eq!(
-        length_value_2(Partial(&i3)),
-        Ok((Partial(&i3[3..]), (5, 6)))
+        length_value_1(Partial::new(&i3)),
+        Ok((Partial::new(&i3[3..]), 1286))
+    );
+    assert_eq!(
+        length_value_2(Partial::new(&i3)),
+        Ok((Partial::new(&i3[3..]), (5, 6)))
     );
 
     let i4 = [3, 5, 6, 3, 4, 5];
-    assert_eq!(length_value_1(Partial(&i4)), Ok((Partial(&i4[4..]), 1286)));
     assert_eq!(
-        length_value_2(Partial(&i4)),
-        Ok((Partial(&i4[4..]), (5, 6)))
+        length_value_1(Partial::new(&i4)),
+        Ok((Partial::new(&i4[4..]), 1286))
+    );
+    assert_eq!(
+        length_value_2(Partial::new(&i4)),
+        Ok((Partial::new(&i4[4..]), (5, 6)))
     );
 }
 
@@ -522,33 +570,33 @@ fn fold_many0_test() {
     }
 
     assert_eq!(
-        multi(Partial(&b"abcdef"[..])),
-        Ok((Partial(&b"ef"[..]), vec![&b"abcd"[..]]))
+        multi(Partial::new(&b"abcdef"[..])),
+        Ok((Partial::new(&b"ef"[..]), vec![&b"abcd"[..]]))
     );
     assert_eq!(
-        multi(Partial(&b"abcdabcdefgh"[..])),
-        Ok((Partial(&b"efgh"[..]), vec![&b"abcd"[..], &b"abcd"[..]]))
+        multi(Partial::new(&b"abcdabcdefgh"[..])),
+        Ok((Partial::new(&b"efgh"[..]), vec![&b"abcd"[..], &b"abcd"[..]]))
     );
     assert_eq!(
-        multi(Partial(&b"azerty"[..])),
-        Ok((Partial(&b"azerty"[..]), Vec::new()))
+        multi(Partial::new(&b"azerty"[..])),
+        Ok((Partial::new(&b"azerty"[..]), Vec::new()))
     );
     assert_eq!(
-        multi(Partial(&b"abcdab"[..])),
+        multi(Partial::new(&b"abcdab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        multi(Partial(&b"abcd"[..])),
+        multi(Partial::new(&b"abcd"[..])),
         Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_eq!(
-        multi(Partial(&b""[..])),
+        multi(Partial::new(&b""[..])),
         Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_eq!(
-        multi_empty(Partial(&b"abcdef"[..])),
+        multi_empty(Partial::new(&b"abcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"abcdef"[..]),
+            Partial::new(&b"abcdef"[..]),
             ErrorKind::Many0
         )))
     );
@@ -571,17 +619,23 @@ fn fold_many1_test() {
     let d = &b"abcdab"[..];
 
     let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(Partial(a)), Ok((Partial(&b"ef"[..]), res1)));
+    assert_eq!(multi(Partial::new(a)), Ok((Partial::new(&b"ef"[..]), res1)));
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-    assert_eq!(multi(Partial(b)), Ok((Partial(&b"efgh"[..]), res2)));
     assert_eq!(
-        multi(Partial(c)),
+        multi(Partial::new(b)),
+        Ok((Partial::new(&b"efgh"[..]), res2))
+    );
+    assert_eq!(
+        multi(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(c),
+            Partial::new(c),
             ErrorKind::Many1
         )))
     );
-    assert_eq!(multi(Partial(d)), Err(ErrMode::Incomplete(Needed::new(2))));
+    assert_eq!(
+        multi(Partial::new(d)),
+        Err(ErrMode::Incomplete(Needed::new(2)))
+    );
 }
 
 #[test]
@@ -602,19 +656,31 @@ fn fold_many_m_n_test() {
     let e = &b"AbcdAb"[..];
 
     assert_eq!(
-        multi(Partial(a)),
+        multi(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"ef"[..]),
+            Partial::new(&b"ef"[..]),
             ErrorKind::Tag
         )))
     );
     let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
-    assert_eq!(multi(Partial(b)), Ok((Partial(&b"efgh"[..]), res1)));
+    assert_eq!(
+        multi(Partial::new(b)),
+        Ok((Partial::new(&b"efgh"[..]), res1))
+    );
     let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-    assert_eq!(multi(Partial(c)), Ok((Partial(&b"efgh"[..]), res2)));
+    assert_eq!(
+        multi(Partial::new(c)),
+        Ok((Partial::new(&b"efgh"[..]), res2))
+    );
     let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-    assert_eq!(multi(Partial(d)), Ok((Partial(&b"Abcdefgh"[..]), res3)));
-    assert_eq!(multi(Partial(e)), Err(ErrMode::Incomplete(Needed::new(2))));
+    assert_eq!(
+        multi(Partial::new(d)),
+        Ok((Partial::new(&b"Abcdefgh"[..]), res3))
+    );
+    assert_eq!(
+        multi(Partial::new(e)),
+        Err(ErrMode::Incomplete(Needed::new(2)))
+    );
 }
 
 #[test]

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -53,8 +53,8 @@ pub enum Endianness {
 ///   be_u8::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
@@ -101,8 +101,8 @@ where
 ///   be_u16::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0001)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
@@ -150,8 +150,8 @@ where
 ///   be_u24::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x000102)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x000102)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -199,8 +199,8 @@ where
 ///   be_u32::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x00010203)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -248,8 +248,8 @@ where
 ///   be_u64::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0001020304050607)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001020304050607)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
@@ -297,8 +297,8 @@ where
 ///   be_u128::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203040506070809101112131415)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
@@ -344,8 +344,8 @@ where
 ///
 /// let parser = be_i8::<_, Error<_>>;
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
@@ -390,8 +390,8 @@ where
 ///
 /// let parser = be_i16::<_, Error<_>>;
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0001)));
-/// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001)));
+/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
@@ -437,8 +437,8 @@ where
 ///
 /// let parser = be_i24::<_, Error<_>>;
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x000102)));
-/// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x000102)));
+/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -484,8 +484,8 @@ where
 ///
 /// let parser = be_i32::<_, Error<_>>;
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x00010203)));
-/// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203)));
+/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
 pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -531,8 +531,8 @@ where
 ///
 /// let parser = be_i64::<_, Error<_>>;
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0001020304050607)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001020304050607)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
@@ -578,8 +578,8 @@ where
 ///
 /// let parser = be_i128::<_, Error<_>>;
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203040506070809101112131415)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
@@ -625,8 +625,8 @@ where
 ///
 /// let parser = le_u8::<_, Error<_>>;
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
@@ -673,8 +673,8 @@ where
 ///   le_u16::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
@@ -722,8 +722,8 @@ where
 ///   le_u24::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x020100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -771,8 +771,8 @@ where
 ///   le_u32::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x03020100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -820,8 +820,8 @@ where
 ///   le_u64::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0706050403020100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
@@ -869,8 +869,8 @@ where
 ///   le_u128::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
@@ -916,8 +916,8 @@ where
 ///
 /// let parser = le_i8::<_, Error<_>>;
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
@@ -964,8 +964,8 @@ where
 ///   le_i16::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
@@ -1013,8 +1013,8 @@ where
 ///   le_i24::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x020100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -1062,8 +1062,8 @@ where
 ///   le_i32::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x03020100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -1111,8 +1111,8 @@ where
 ///   le_i64::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x0706050403020100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
@@ -1160,8 +1160,8 @@ where
 ///   le_i128::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial(&b"abcd"[..]), 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
+/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
@@ -1212,8 +1212,8 @@ where
 ///   u8::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"\x03abcefg"[..]), 0x00)));
-/// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"\x03abcefg"[..]), 0x00)));
+/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
@@ -1271,15 +1271,15 @@ where
 ///   u16::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_u16(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0003)));
-/// assert_eq!(be_u16(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(be_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
+/// assert_eq!(be_u16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_u16 = |s| {
 ///   u16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_u16(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0300)));
-/// assert_eq!(le_u16(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(le_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
+/// assert_eq!(le_u16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn u16<I, E: ParseError<I>>(
@@ -1340,15 +1340,15 @@ where
 ///   u24::<_,Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_u24(Partial(&b"\x00\x03\x05abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x000305)));
-/// assert_eq!(be_u24(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(be_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
+/// assert_eq!(be_u24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_u24 = |s| {
 ///   u24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_u24(Partial(&b"\x00\x03\x05abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x050300)));
-/// assert_eq!(le_u24(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(le_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
+/// assert_eq!(le_u24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn u24<I, E: ParseError<I>>(
@@ -1409,15 +1409,15 @@ where
 ///   u32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_u32(Partial(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x00030507)));
-/// assert_eq!(be_u32(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(be_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
+/// assert_eq!(be_u32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_u32 = |s| {
 ///   u32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_u32(Partial(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x07050300)));
-/// assert_eq!(le_u32(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(le_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
+/// assert_eq!(le_u32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn u32<I, E: ParseError<I>>(
@@ -1478,15 +1478,15 @@ where
 ///   u64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_u64(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0001020304050607)));
-/// assert_eq!(be_u64(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(be_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
+/// assert_eq!(be_u64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_u64 = |s| {
 ///   u64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_u64(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0706050403020100)));
-/// assert_eq!(le_u64(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(le_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
+/// assert_eq!(le_u64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn u64<I, E: ParseError<I>>(
@@ -1547,15 +1547,15 @@ where
 ///   u128::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_u128(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(be_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
+/// assert_eq!(be_u128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_u128 = |s| {
 ///   u128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_u128(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(le_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
+/// assert_eq!(le_u128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn u128<I, E: ParseError<I>>(
@@ -1608,8 +1608,8 @@ where
 ///   i8::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"\x03abcefg"[..]), 0x00)));
-/// assert_eq!(parser(Partial(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"\x03abcefg"[..]), 0x00)));
+/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
@@ -1667,15 +1667,15 @@ where
 ///   i16::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_i16(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0003)));
-/// assert_eq!(be_i16(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(be_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
+/// assert_eq!(be_i16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_i16 = |s| {
 ///   i16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_i16(Partial(&b"\x00\x03abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0300)));
-/// assert_eq!(le_i16(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(le_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
+/// assert_eq!(le_i16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn i16<I, E: ParseError<I>>(
@@ -1736,15 +1736,15 @@ where
 ///   i24::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_i24(Partial(&b"\x00\x03\x05abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x000305)));
-/// assert_eq!(be_i24(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(be_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
+/// assert_eq!(be_i24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_i24 = |s| {
 ///   i24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_i24(Partial(&b"\x00\x03\x05abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x050300)));
-/// assert_eq!(le_i24(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(le_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
+/// assert_eq!(le_i24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn i24<I, E: ParseError<I>>(
@@ -1805,15 +1805,15 @@ where
 ///   i32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_i32(Partial(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x00030507)));
-/// assert_eq!(be_i32(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(be_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
+/// assert_eq!(be_i32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_i32 = |s| {
 ///   i32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_i32(Partial(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x07050300)));
-/// assert_eq!(le_i32(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(le_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
+/// assert_eq!(le_i32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn i32<I, E: ParseError<I>>(
@@ -1874,15 +1874,15 @@ where
 ///   i64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_i64(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0001020304050607)));
-/// assert_eq!(be_i64(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(be_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
+/// assert_eq!(be_i64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_i64 = |s| {
 ///   i64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_i64(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x0706050403020100)));
-/// assert_eq!(le_i64(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(le_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
+/// assert_eq!(le_i64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn i64<I, E: ParseError<I>>(
@@ -1943,15 +1943,15 @@ where
 ///   i128::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_i128(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(be_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
+/// assert_eq!(be_i128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_i128 = |s| {
 ///   i128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_i128(Partial(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(Partial(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(le_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
+/// assert_eq!(le_i128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn i128<I, E: ParseError<I>>(
@@ -2001,8 +2001,8 @@ where
 ///   be_f32::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&[0x40, 0x29, 0x00, 0x00][..])), Ok((Partial(&b""[..]), 2.640625)));
-/// assert_eq!(parser(Partial(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Partial::new(&[0x40, 0x29, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 2.640625)));
+/// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
@@ -2050,8 +2050,8 @@ where
 ///   be_f64::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial(&b""[..]), 12.5)));
-/// assert_eq!(parser(Partial(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
@@ -2099,8 +2099,8 @@ where
 ///   le_f32::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial(&b""[..]), 12.5)));
-/// assert_eq!(parser(Partial(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
@@ -2148,8 +2148,8 @@ where
 ///   le_f64::<_, Error<_>>(s)
 /// };
 ///
-/// assert_eq!(parser(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Partial(&b""[..]), 3145728.0)));
-/// assert_eq!(parser(Partial(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 3145728.0)));
+/// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
@@ -2208,15 +2208,15 @@ where
 ///   f32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_f32(Partial(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Partial(&b""[..]), 12.5)));
-/// assert_eq!(be_f32(Partial(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(be_f32(Partial::new(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(be_f32(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_f32 = |s| {
 ///   f32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_f32(Partial(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial(&b""[..]), 12.5)));
-/// assert_eq!(le_f32(Partial(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(le_f32(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(le_f32(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn f32<I, E: ParseError<I>>(
@@ -2277,15 +2277,15 @@ where
 ///   f64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
 /// };
 ///
-/// assert_eq!(be_f64(Partial(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial(&b""[..]), 12.5)));
-/// assert_eq!(be_f64(Partial(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
+/// assert_eq!(be_f64(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(be_f64(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 ///
 /// let le_f64 = |s| {
 ///   f64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
 /// };
 ///
-/// assert_eq!(le_f64(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Partial(&b""[..]), 12.5)));
-/// assert_eq!(le_f64(Partial(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
+/// assert_eq!(le_f64(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(le_f64(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
 pub fn f64<I, E: ParseError<I>>(

--- a/src/number/tests.rs
+++ b/src/number/tests.rs
@@ -393,12 +393,24 @@ mod partial {
 
     #[test]
     fn i8_tests() {
-        assert_parse!(be_i8(Partial(&[0x00][..])), Ok((Partial(&b""[..]), 0)));
-        assert_parse!(be_i8(Partial(&[0x7f][..])), Ok((Partial(&b""[..]), 127)));
-        assert_parse!(be_i8(Partial(&[0xff][..])), Ok((Partial(&b""[..]), -1)));
-        assert_parse!(be_i8(Partial(&[0x80][..])), Ok((Partial(&b""[..]), -128)));
         assert_parse!(
-            be_i8(Partial(&[][..])),
+            be_i8(Partial::new(&[0x00][..])),
+            Ok((Partial::new(&b""[..]), 0))
+        );
+        assert_parse!(
+            be_i8(Partial::new(&[0x7f][..])),
+            Ok((Partial::new(&b""[..]), 127))
+        );
+        assert_parse!(
+            be_i8(Partial::new(&[0xff][..])),
+            Ok((Partial::new(&b""[..]), -1))
+        );
+        assert_parse!(
+            be_i8(Partial::new(&[0x80][..])),
+            Ok((Partial::new(&b""[..]), -128))
+        );
+        assert_parse!(
+            be_i8(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -406,27 +418,27 @@ mod partial {
     #[test]
     fn i16_tests() {
         assert_parse!(
-            be_i16(Partial(&[0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), 0))
+            be_i16(Partial::new(&[0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_i16(Partial(&[0x7f, 0xff][..])),
-            Ok((Partial(&b""[..]), 32_767_i16))
+            be_i16(Partial::new(&[0x7f, 0xff][..])),
+            Ok((Partial::new(&b""[..]), 32_767_i16))
         );
         assert_parse!(
-            be_i16(Partial(&[0xff, 0xff][..])),
-            Ok((Partial(&b""[..]), -1))
+            be_i16(Partial::new(&[0xff, 0xff][..])),
+            Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            be_i16(Partial(&[0x80, 0x00][..])),
-            Ok((Partial(&b""[..]), -32_768_i16))
+            be_i16(Partial::new(&[0x80, 0x00][..])),
+            Ok((Partial::new(&b""[..]), -32_768_i16))
         );
         assert_parse!(
-            be_i16(Partial(&[][..])),
+            be_i16(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i16(Partial(&[0x00][..])),
+            be_i16(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -434,27 +446,27 @@ mod partial {
     #[test]
     fn u24_tests() {
         assert_parse!(
-            be_u24(Partial(&[0x00, 0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), 0))
+            be_u24(Partial::new(&[0x00, 0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_u24(Partial(&[0x00, 0xFF, 0xFF][..])),
-            Ok((Partial(&b""[..]), 65_535_u32))
+            be_u24(Partial::new(&[0x00, 0xFF, 0xFF][..])),
+            Ok((Partial::new(&b""[..]), 65_535_u32))
         );
         assert_parse!(
-            be_u24(Partial(&[0x12, 0x34, 0x56][..])),
-            Ok((Partial(&b""[..]), 1_193_046_u32))
+            be_u24(Partial::new(&[0x12, 0x34, 0x56][..])),
+            Ok((Partial::new(&b""[..]), 1_193_046_u32))
         );
         assert_parse!(
-            be_u24(Partial(&[][..])),
+            be_u24(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_u24(Partial(&[0x00][..])),
+            be_u24(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_u24(Partial(&[0x00, 0x00][..])),
+            be_u24(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -462,27 +474,27 @@ mod partial {
     #[test]
     fn i24_tests() {
         assert_parse!(
-            be_i24(Partial(&[0xFF, 0xFF, 0xFF][..])),
-            Ok((Partial(&b""[..]), -1_i32))
+            be_i24(Partial::new(&[0xFF, 0xFF, 0xFF][..])),
+            Ok((Partial::new(&b""[..]), -1_i32))
         );
         assert_parse!(
-            be_i24(Partial(&[0xFF, 0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), -65_536_i32))
+            be_i24(Partial::new(&[0xFF, 0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), -65_536_i32))
         );
         assert_parse!(
-            be_i24(Partial(&[0xED, 0xCB, 0xAA][..])),
-            Ok((Partial(&b""[..]), -1_193_046_i32))
+            be_i24(Partial::new(&[0xED, 0xCB, 0xAA][..])),
+            Ok((Partial::new(&b""[..]), -1_193_046_i32))
         );
         assert_parse!(
-            be_i24(Partial(&[][..])),
+            be_i24(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_i24(Partial(&[0x00][..])),
+            be_i24(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i24(Partial(&[0x00, 0x00][..])),
+            be_i24(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -490,35 +502,35 @@ mod partial {
     #[test]
     fn i32_tests() {
         assert_parse!(
-            be_i32(Partial(&[0x00, 0x00, 0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), 0))
+            be_i32(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_i32(Partial(&[0x7f, 0xff, 0xff, 0xff][..])),
-            Ok((Partial(&b""[..]), 2_147_483_647_i32))
+            be_i32(Partial::new(&[0x7f, 0xff, 0xff, 0xff][..])),
+            Ok((Partial::new(&b""[..]), 2_147_483_647_i32))
         );
         assert_parse!(
-            be_i32(Partial(&[0xff, 0xff, 0xff, 0xff][..])),
-            Ok((Partial(&b""[..]), -1))
+            be_i32(Partial::new(&[0xff, 0xff, 0xff, 0xff][..])),
+            Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            be_i32(Partial(&[0x80, 0x00, 0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), -2_147_483_648_i32))
+            be_i32(Partial::new(&[0x80, 0x00, 0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), -2_147_483_648_i32))
         );
         assert_parse!(
-            be_i32(Partial(&[][..])),
+            be_i32(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(4)))
         );
         assert_parse!(
-            be_i32(Partial(&[0x00][..])),
+            be_i32(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_i32(Partial(&[0x00, 0x00][..])),
+            be_i32(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i32(Partial(&[0x00, 0x00, 0x00][..])),
+            be_i32(Partial::new(&[0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -526,59 +538,61 @@ mod partial {
     #[test]
     fn i64_tests() {
         assert_parse!(
-            be_i64(Partial(
+            be_i64(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial(&b""[..]), 0))
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_i64(Partial(
+            be_i64(Partial::new(
                 &[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
             )),
-            Ok((Partial(&b""[..]), 9_223_372_036_854_775_807_i64))
+            Ok((Partial::new(&b""[..]), 9_223_372_036_854_775_807_i64))
         );
         assert_parse!(
-            be_i64(Partial(
+            be_i64(Partial::new(
                 &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
             )),
-            Ok((Partial(&b""[..]), -1))
+            Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            be_i64(Partial(
+            be_i64(Partial::new(
                 &[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial(&b""[..]), -9_223_372_036_854_775_808_i64))
+            Ok((Partial::new(&b""[..]), -9_223_372_036_854_775_808_i64))
         );
         assert_parse!(
-            be_i64(Partial(&[][..])),
+            be_i64(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(8)))
         );
         assert_parse!(
-            be_i64(Partial(&[0x00][..])),
+            be_i64(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(7)))
         );
         assert_parse!(
-            be_i64(Partial(&[0x00, 0x00][..])),
+            be_i64(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(6)))
         );
         assert_parse!(
-            be_i64(Partial(&[0x00, 0x00, 0x00][..])),
+            be_i64(Partial::new(&[0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(5)))
         );
         assert_parse!(
-            be_i64(Partial(&[0x00, 0x00, 0x00, 0x00][..])),
+            be_i64(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(4)))
         );
         assert_parse!(
-            be_i64(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i64(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_i64(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i64(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i64(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i64(Partial::new(
+                &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+            )),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -586,117 +600,119 @@ mod partial {
     #[test]
     fn i128_tests() {
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
                 ][..]
             )),
-            Ok((Partial(&b""[..]), 0))
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[
                     0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff
                 ][..]
             )),
             Ok((
-                Partial(&b""[..]),
+                Partial::new(&b""[..]),
                 170_141_183_460_469_231_731_687_303_715_884_105_727_i128
             ))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff
                 ][..]
             )),
-            Ok((Partial(&b""[..]), -1))
+            Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[
                     0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
                 ][..]
             )),
             Ok((
-                Partial(&b""[..]),
+                Partial::new(&b""[..]),
                 -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
             ))
         );
         assert_parse!(
-            be_i128(Partial(&[][..])),
+            be_i128(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(16)))
         );
         assert_parse!(
-            be_i128(Partial(&[0x00][..])),
+            be_i128(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(15)))
         );
         assert_parse!(
-            be_i128(Partial(&[0x00, 0x00][..])),
+            be_i128(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(14)))
         );
         assert_parse!(
-            be_i128(Partial(&[0x00, 0x00, 0x00][..])),
+            be_i128(Partial::new(&[0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(13)))
         );
         assert_parse!(
-            be_i128(Partial(&[0x00, 0x00, 0x00, 0x00][..])),
+            be_i128(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(12)))
         );
         assert_parse!(
-            be_i128(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i128(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(11)))
         );
         assert_parse!(
-            be_i128(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i128(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(10)))
         );
         assert_parse!(
-            be_i128(Partial(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i128(Partial::new(
+                &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
+            )),
             Err(ErrMode::Incomplete(Needed::new(9)))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(8)))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(7)))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(6)))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(5)))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(4)))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00
@@ -705,7 +721,7 @@ mod partial {
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i128(Partial(
+            be_i128(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00
@@ -717,153 +733,165 @@ mod partial {
 
     #[test]
     fn le_i8_tests() {
-        assert_parse!(le_i8(Partial(&[0x00][..])), Ok((Partial(&b""[..]), 0)));
-        assert_parse!(le_i8(Partial(&[0x7f][..])), Ok((Partial(&b""[..]), 127)));
-        assert_parse!(le_i8(Partial(&[0xff][..])), Ok((Partial(&b""[..]), -1)));
-        assert_parse!(le_i8(Partial(&[0x80][..])), Ok((Partial(&b""[..]), -128)));
+        assert_parse!(
+            le_i8(Partial::new(&[0x00][..])),
+            Ok((Partial::new(&b""[..]), 0))
+        );
+        assert_parse!(
+            le_i8(Partial::new(&[0x7f][..])),
+            Ok((Partial::new(&b""[..]), 127))
+        );
+        assert_parse!(
+            le_i8(Partial::new(&[0xff][..])),
+            Ok((Partial::new(&b""[..]), -1))
+        );
+        assert_parse!(
+            le_i8(Partial::new(&[0x80][..])),
+            Ok((Partial::new(&b""[..]), -128))
+        );
     }
 
     #[test]
     fn le_i16_tests() {
         assert_parse!(
-            le_i16(Partial(&[0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), 0))
+            le_i16(Partial::new(&[0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_i16(Partial(&[0xff, 0x7f][..])),
-            Ok((Partial(&b""[..]), 32_767_i16))
+            le_i16(Partial::new(&[0xff, 0x7f][..])),
+            Ok((Partial::new(&b""[..]), 32_767_i16))
         );
         assert_parse!(
-            le_i16(Partial(&[0xff, 0xff][..])),
-            Ok((Partial(&b""[..]), -1))
+            le_i16(Partial::new(&[0xff, 0xff][..])),
+            Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            le_i16(Partial(&[0x00, 0x80][..])),
-            Ok((Partial(&b""[..]), -32_768_i16))
+            le_i16(Partial::new(&[0x00, 0x80][..])),
+            Ok((Partial::new(&b""[..]), -32_768_i16))
         );
     }
 
     #[test]
     fn le_u24_tests() {
         assert_parse!(
-            le_u24(Partial(&[0x00, 0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), 0))
+            le_u24(Partial::new(&[0x00, 0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_u24(Partial(&[0xFF, 0xFF, 0x00][..])),
-            Ok((Partial(&b""[..]), 65_535_u32))
+            le_u24(Partial::new(&[0xFF, 0xFF, 0x00][..])),
+            Ok((Partial::new(&b""[..]), 65_535_u32))
         );
         assert_parse!(
-            le_u24(Partial(&[0x56, 0x34, 0x12][..])),
-            Ok((Partial(&b""[..]), 1_193_046_u32))
+            le_u24(Partial::new(&[0x56, 0x34, 0x12][..])),
+            Ok((Partial::new(&b""[..]), 1_193_046_u32))
         );
     }
 
     #[test]
     fn le_i24_tests() {
         assert_parse!(
-            le_i24(Partial(&[0xFF, 0xFF, 0xFF][..])),
-            Ok((Partial(&b""[..]), -1_i32))
+            le_i24(Partial::new(&[0xFF, 0xFF, 0xFF][..])),
+            Ok((Partial::new(&b""[..]), -1_i32))
         );
         assert_parse!(
-            le_i24(Partial(&[0x00, 0x00, 0xFF][..])),
-            Ok((Partial(&b""[..]), -65_536_i32))
+            le_i24(Partial::new(&[0x00, 0x00, 0xFF][..])),
+            Ok((Partial::new(&b""[..]), -65_536_i32))
         );
         assert_parse!(
-            le_i24(Partial(&[0xAA, 0xCB, 0xED][..])),
-            Ok((Partial(&b""[..]), -1_193_046_i32))
+            le_i24(Partial::new(&[0xAA, 0xCB, 0xED][..])),
+            Ok((Partial::new(&b""[..]), -1_193_046_i32))
         );
     }
 
     #[test]
     fn le_i32_tests() {
         assert_parse!(
-            le_i32(Partial(&[0x00, 0x00, 0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), 0))
+            le_i32(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_i32(Partial(&[0xff, 0xff, 0xff, 0x7f][..])),
-            Ok((Partial(&b""[..]), 2_147_483_647_i32))
+            le_i32(Partial::new(&[0xff, 0xff, 0xff, 0x7f][..])),
+            Ok((Partial::new(&b""[..]), 2_147_483_647_i32))
         );
         assert_parse!(
-            le_i32(Partial(&[0xff, 0xff, 0xff, 0xff][..])),
-            Ok((Partial(&b""[..]), -1))
+            le_i32(Partial::new(&[0xff, 0xff, 0xff, 0xff][..])),
+            Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            le_i32(Partial(&[0x00, 0x00, 0x00, 0x80][..])),
-            Ok((Partial(&b""[..]), -2_147_483_648_i32))
+            le_i32(Partial::new(&[0x00, 0x00, 0x00, 0x80][..])),
+            Ok((Partial::new(&b""[..]), -2_147_483_648_i32))
         );
     }
 
     #[test]
     fn le_i64_tests() {
         assert_parse!(
-            le_i64(Partial(
+            le_i64(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial(&b""[..]), 0))
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_i64(Partial(
+            le_i64(Partial::new(
                 &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f][..]
             )),
-            Ok((Partial(&b""[..]), 9_223_372_036_854_775_807_i64))
+            Ok((Partial::new(&b""[..]), 9_223_372_036_854_775_807_i64))
         );
         assert_parse!(
-            le_i64(Partial(
+            le_i64(Partial::new(
                 &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
             )),
-            Ok((Partial(&b""[..]), -1))
+            Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            le_i64(Partial(
+            le_i64(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80][..]
             )),
-            Ok((Partial(&b""[..]), -9_223_372_036_854_775_808_i64))
+            Ok((Partial::new(&b""[..]), -9_223_372_036_854_775_808_i64))
         );
     }
 
     #[test]
     fn le_i128_tests() {
         assert_parse!(
-            le_i128(Partial(
+            le_i128(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
                 ][..]
             )),
-            Ok((Partial(&b""[..]), 0))
+            Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_i128(Partial(
+            le_i128(Partial::new(
                 &[
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0x7f
                 ][..]
             )),
             Ok((
-                Partial(&b""[..]),
+                Partial::new(&b""[..]),
                 170_141_183_460_469_231_731_687_303_715_884_105_727_i128
             ))
         );
         assert_parse!(
-            le_i128(Partial(
+            le_i128(Partial::new(
                 &[
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff
                 ][..]
             )),
-            Ok((Partial(&b""[..]), -1))
+            Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            le_i128(Partial(
+            le_i128(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x80
                 ][..]
             )),
             Ok((
-                Partial(&b""[..]),
+                Partial::new(&b""[..]),
                 -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
             ))
         );
@@ -872,56 +900,56 @@ mod partial {
     #[test]
     fn be_f32_tests() {
         assert_parse!(
-            be_f32(Partial(&[0x00, 0x00, 0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), 0_f32))
+            be_f32(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), 0_f32))
         );
         assert_parse!(
-            be_f32(Partial(&[0x4d, 0x31, 0x1f, 0xd8][..])),
-            Ok((Partial(&b""[..]), 185_728_380_f32))
+            be_f32(Partial::new(&[0x4d, 0x31, 0x1f, 0xd8][..])),
+            Ok((Partial::new(&b""[..]), 185_728_380_f32))
         );
     }
 
     #[test]
     fn be_f64_tests() {
         assert_parse!(
-            be_f64(Partial(
+            be_f64(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial(&b""[..]), 0_f64))
+            Ok((Partial::new(&b""[..]), 0_f64))
         );
         assert_parse!(
-            be_f64(Partial(
+            be_f64(Partial::new(
                 &[0x41, 0xa6, 0x23, 0xfb, 0x10, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial(&b""[..]), 185_728_392_f64))
+            Ok((Partial::new(&b""[..]), 185_728_392_f64))
         );
     }
 
     #[test]
     fn le_f32_tests() {
         assert_parse!(
-            le_f32(Partial(&[0x00, 0x00, 0x00, 0x00][..])),
-            Ok((Partial(&b""[..]), 0_f32))
+            le_f32(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            Ok((Partial::new(&b""[..]), 0_f32))
         );
         assert_parse!(
-            le_f32(Partial(&[0xd8, 0x1f, 0x31, 0x4d][..])),
-            Ok((Partial(&b""[..]), 185_728_380_f32))
+            le_f32(Partial::new(&[0xd8, 0x1f, 0x31, 0x4d][..])),
+            Ok((Partial::new(&b""[..]), 185_728_380_f32))
         );
     }
 
     #[test]
     fn le_f64_tests() {
         assert_parse!(
-            le_f64(Partial(
+            le_f64(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial(&b""[..]), 0_f64))
+            Ok((Partial::new(&b""[..]), 0_f64))
         );
         assert_parse!(
-            le_f64(Partial(
+            le_f64(Partial::new(
                 &[0x00, 0x00, 0x00, 0x10, 0xfb, 0x23, 0xa6, 0x41][..]
             )),
-            Ok((Partial(&b""[..]), 185_728_392_f64))
+            Ok((Partial::new(&b""[..]), 185_728_392_f64))
         );
     }
 
@@ -936,12 +964,12 @@ mod partial {
             u16(Endianness::Little)(i)
         }
         assert_eq!(
-            be_tst16(Partial(&[0x80, 0x00])),
-            Ok((Partial(&b""[..]), 32_768_u16))
+            be_tst16(Partial::new(&[0x80, 0x00])),
+            Ok((Partial::new(&b""[..]), 32_768_u16))
         );
         assert_eq!(
-            le_tst16(Partial(&[0x80, 0x00])),
-            Ok((Partial(&b""[..]), 128_u16))
+            le_tst16(Partial::new(&[0x80, 0x00])),
+            Ok((Partial::new(&b""[..]), 128_u16))
         );
 
         fn be_tst32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
@@ -951,12 +979,12 @@ mod partial {
             u32(Endianness::Little)(i)
         }
         assert_eq!(
-            be_tst32(Partial(&[0x12, 0x00, 0x60, 0x00])),
-            Ok((Partial(&b""[..]), 302_014_464_u32))
+            be_tst32(Partial::new(&[0x12, 0x00, 0x60, 0x00])),
+            Ok((Partial::new(&b""[..]), 302_014_464_u32))
         );
         assert_eq!(
-            le_tst32(Partial(&[0x12, 0x00, 0x60, 0x00])),
-            Ok((Partial(&b""[..]), 6_291_474_u32))
+            le_tst32(Partial::new(&[0x12, 0x00, 0x60, 0x00])),
+            Ok((Partial::new(&b""[..]), 6_291_474_u32))
         );
 
         fn be_tst64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
@@ -966,12 +994,16 @@ mod partial {
             u64(Endianness::Little)(i)
         }
         assert_eq!(
-            be_tst64(Partial(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00])),
-            Ok((Partial(&b""[..]), 1_297_142_246_100_992_000_u64))
+            be_tst64(Partial::new(&[
+                0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
+            ])),
+            Ok((Partial::new(&b""[..]), 1_297_142_246_100_992_000_u64))
         );
         assert_eq!(
-            le_tst64(Partial(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00])),
-            Ok((Partial(&b""[..]), 36_028_874_334_666_770_u64))
+            le_tst64(Partial::new(&[
+                0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
+            ])),
+            Ok((Partial::new(&b""[..]), 36_028_874_334_666_770_u64))
         );
 
         fn be_tsti16(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
@@ -981,12 +1013,12 @@ mod partial {
             i16(Endianness::Little)(i)
         }
         assert_eq!(
-            be_tsti16(Partial(&[0x00, 0x80])),
-            Ok((Partial(&b""[..]), 128_i16))
+            be_tsti16(Partial::new(&[0x00, 0x80])),
+            Ok((Partial::new(&b""[..]), 128_i16))
         );
         assert_eq!(
-            le_tsti16(Partial(&[0x00, 0x80])),
-            Ok((Partial(&b""[..]), -32_768_i16))
+            le_tsti16(Partial::new(&[0x00, 0x80])),
+            Ok((Partial::new(&b""[..]), -32_768_i16))
         );
 
         fn be_tsti32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
@@ -996,12 +1028,12 @@ mod partial {
             i32(Endianness::Little)(i)
         }
         assert_eq!(
-            be_tsti32(Partial(&[0x00, 0x12, 0x60, 0x00])),
-            Ok((Partial(&b""[..]), 1_204_224_i32))
+            be_tsti32(Partial::new(&[0x00, 0x12, 0x60, 0x00])),
+            Ok((Partial::new(&b""[..]), 1_204_224_i32))
         );
         assert_eq!(
-            le_tsti32(Partial(&[0x00, 0x12, 0x60, 0x00])),
-            Ok((Partial(&b""[..]), 6_296_064_i32))
+            le_tsti32(Partial::new(&[0x00, 0x12, 0x60, 0x00])),
+            Ok((Partial::new(&b""[..]), 6_296_064_i32))
         );
 
         fn be_tsti64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
@@ -1011,12 +1043,16 @@ mod partial {
             i64(Endianness::Little)(i)
         }
         assert_eq!(
-            be_tsti64(Partial(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00])),
-            Ok((Partial(&b""[..]), 71_881_672_479_506_432_i64))
+            be_tsti64(Partial::new(&[
+                0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
+            ])),
+            Ok((Partial::new(&b""[..]), 71_881_672_479_506_432_i64))
         );
         assert_eq!(
-            le_tsti64(Partial(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00])),
-            Ok((Partial(&b""[..]), 36_028_874_334_732_032_i64))
+            le_tsti64(Partial::new(&[
+                0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
+            ])),
+            Ok((Partial::new(&b""[..]), 36_028_874_334_732_032_i64))
         );
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -527,8 +527,8 @@ pub trait Parser<I, O, E> {
     ///
     /// let mut parser = take(5u8).complete_err();
     ///
-    /// assert_eq!(parser.parse_next(Partial("abcdefg")), Ok((Partial("fg"), "abcde")));
-    /// assert_eq!(parser.parse_next(Partial("abcd")), Err(ErrMode::Backtrack(Error::new(Partial("abcd"), ErrorKind::Complete))));
+    /// assert_eq!(parser.parse_next(Partial::new("abcdefg")), Ok((Partial::new("fg"), "abcde")));
+    /// assert_eq!(parser.parse_next(Partial::new("abcd")), Err(ErrMode::Backtrack(Error::new(Partial::new("abcd"), ErrorKind::Complete))));
     /// # }
     /// ```
     fn complete_err(self) -> CompleteErr<Self>
@@ -881,21 +881,24 @@ mod tests {
         }
 
         assert_eq!(
-            tuple_3(Partial(&b"abcdefgh"[..])),
-            Ok((Partial(&b"h"[..]), (0x6162u16, &b"cde"[..], &b"fg"[..])))
+            tuple_3(Partial::new(&b"abcdefgh"[..])),
+            Ok((
+                Partial::new(&b"h"[..]),
+                (0x6162u16, &b"cde"[..], &b"fg"[..])
+            ))
         );
         assert_eq!(
-            tuple_3(Partial(&b"abcd"[..])),
+            tuple_3(Partial::new(&b"abcd"[..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            tuple_3(Partial(&b"abcde"[..])),
+            tuple_3(Partial::new(&b"abcde"[..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_eq!(
-            tuple_3(Partial(&b"abcdejk"[..])),
+            tuple_3(Partial::new(&b"abcdejk"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial(&b"jk"[..]),
+                Partial::new(&b"jk"[..]),
                 ErrorKind::Tag
             )))
         );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -443,6 +443,7 @@ pub trait Parser<I, O, E> {
     /// ```
     fn and_then<G, O2>(self, g: G) -> AndThen<Self, G, O>
     where
+        O: StreamIsPartial,
         G: Parser<O, O2, E>,
         Self: core::marker::Sized,
     {

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -62,35 +62,35 @@ fn pair_test() {
     }
 
     assert_eq!(
-        pair_abc_def(Partial(&b"abcdefghijkl"[..])),
-        Ok((Partial(&b"ghijkl"[..]), (&b"abc"[..], &b"def"[..])))
+        pair_abc_def(Partial::new(&b"abcdefghijkl"[..])),
+        Ok((Partial::new(&b"ghijkl"[..]), (&b"abc"[..], &b"def"[..])))
     );
     assert_eq!(
-        pair_abc_def(Partial(&b"ab"[..])),
+        pair_abc_def(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        pair_abc_def(Partial(&b"abcd"[..])),
+        pair_abc_def(Partial::new(&b"abcd"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        pair_abc_def(Partial(&b"xxx"[..])),
+        pair_abc_def(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        pair_abc_def(Partial(&b"xxxdef"[..])),
+        pair_abc_def(Partial::new(&b"xxxdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxxdef"[..]),
+            Partial::new(&b"xxxdef"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        pair_abc_def(Partial(&b"abcxxx"[..])),
+        pair_abc_def(Partial::new(&b"abcxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -104,35 +104,35 @@ fn separated_pair_test() {
     }
 
     assert_eq!(
-        sep_pair_abc_def(Partial(&b"abc,defghijkl"[..])),
-        Ok((Partial(&b"ghijkl"[..]), (&b"abc"[..], &b"def"[..])))
+        sep_pair_abc_def(Partial::new(&b"abc,defghijkl"[..])),
+        Ok((Partial::new(&b"ghijkl"[..]), (&b"abc"[..], &b"def"[..])))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial(&b"ab"[..])),
+        sep_pair_abc_def(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial(&b"abc,d"[..])),
+        sep_pair_abc_def(Partial::new(&b"abc,d"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial(&b"xxx"[..])),
+        sep_pair_abc_def(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial(&b"xxx,def"[..])),
+        sep_pair_abc_def(Partial::new(&b"xxx,def"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx,def"[..]),
+            Partial::new(&b"xxx,def"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial(&b"abc,xxx"[..])),
+        sep_pair_abc_def(Partial::new(&b"abc,xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -145,35 +145,35 @@ fn preceded_test() {
     }
 
     assert_eq!(
-        preceded_abcd_efgh(Partial(&b"abcdefghijkl"[..])),
-        Ok((Partial(&b"ijkl"[..]), &b"efgh"[..]))
+        preceded_abcd_efgh(Partial::new(&b"abcdefghijkl"[..])),
+        Ok((Partial::new(&b"ijkl"[..]), &b"efgh"[..]))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial(&b"ab"[..])),
+        preceded_abcd_efgh(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial(&b"abcde"[..])),
+        preceded_abcd_efgh(Partial::new(&b"abcde"[..])),
         Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial(&b"xxx"[..])),
+        preceded_abcd_efgh(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial(&b"xxxxdef"[..])),
+        preceded_abcd_efgh(Partial::new(&b"xxxxdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxxxdef"[..]),
+            Partial::new(&b"xxxxdef"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial(&b"abcdxxx"[..])),
+        preceded_abcd_efgh(Partial::new(&b"abcdxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -186,35 +186,35 @@ fn terminated_test() {
     }
 
     assert_eq!(
-        terminated_abcd_efgh(Partial(&b"abcdefghijkl"[..])),
-        Ok((Partial(&b"ijkl"[..]), &b"abcd"[..]))
+        terminated_abcd_efgh(Partial::new(&b"abcdefghijkl"[..])),
+        Ok((Partial::new(&b"ijkl"[..]), &b"abcd"[..]))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial(&b"ab"[..])),
+        terminated_abcd_efgh(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial(&b"abcde"[..])),
+        terminated_abcd_efgh(Partial::new(&b"abcde"[..])),
         Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial(&b"xxx"[..])),
+        terminated_abcd_efgh(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial(&b"xxxxdef"[..])),
+        terminated_abcd_efgh(Partial::new(&b"xxxxdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxxxdef"[..]),
+            Partial::new(&b"xxxxdef"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial(&b"abcdxxxx"[..])),
+        terminated_abcd_efgh(Partial::new(&b"abcdxxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxxx"[..]),
+            Partial::new(&b"xxxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -227,46 +227,46 @@ fn delimited_test() {
     }
 
     assert_eq!(
-        delimited_abc_def_ghi(Partial(&b"abcdefghijkl"[..])),
-        Ok((Partial(&b"jkl"[..]), &b"def"[..]))
+        delimited_abc_def_ghi(Partial::new(&b"abcdefghijkl"[..])),
+        Ok((Partial::new(&b"jkl"[..]), &b"def"[..]))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial(&b"ab"[..])),
+        delimited_abc_def_ghi(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial(&b"abcde"[..])),
+        delimited_abc_def_ghi(Partial::new(&b"abcde"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial(&b"abcdefgh"[..])),
+        delimited_abc_def_ghi(Partial::new(&b"abcdefgh"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial(&b"xxx"[..])),
+        delimited_abc_def_ghi(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial(&b"xxxdefghi"[..])),
+        delimited_abc_def_ghi(Partial::new(&b"xxxdefghi"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxxdefghi"[..]),
+            Partial::new(&b"xxxdefghi"[..]),
             ErrorKind::Tag
         ),))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial(&b"abcxxxghi"[..])),
+        delimited_abc_def_ghi(Partial::new(&b"abcxxxghi"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxxghi"[..]),
+            Partial::new(&b"xxxghi"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial(&b"abcdefxxx"[..])),
+        delimited_abc_def_ghi(Partial::new(&b"abcdefxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"xxx"[..]),
+            Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -281,21 +281,24 @@ fn tuple_test() {
     }
 
     assert_eq!(
-        tuple_3(Partial(&b"abcdefgh"[..])),
-        Ok((Partial(&b"h"[..]), (0x6162u16, &b"cde"[..], &b"fg"[..])))
+        tuple_3(Partial::new(&b"abcdefgh"[..])),
+        Ok((
+            Partial::new(&b"h"[..]),
+            (0x6162u16, &b"cde"[..], &b"fg"[..])
+        ))
     );
     assert_eq!(
-        tuple_3(Partial(&b"abcd"[..])),
+        tuple_3(Partial::new(&b"abcd"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        tuple_3(Partial(&b"abcde"[..])),
+        tuple_3(Partial::new(&b"abcde"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        tuple_3(Partial(&b"abcdejk"[..])),
+        tuple_3(Partial::new(&b"abcdejk"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial(&b"jk"[..]),
+            Partial::new(&b"jk"[..]),
             ErrorKind::Tag
         )))
     );

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -299,9 +299,9 @@ impl<I, S> crate::lib::std::ops::Deref for Stateful<I, S> {
 pub struct Partial<I>(pub I);
 
 impl<I> Partial<I> {
-    /// Convert to complete counterpart
+    /// Extract the original [`Stream`]
     #[inline(always)]
-    pub fn into_complete(self) -> I {
+    pub fn into_inner(self) -> I {
         self.0
     }
 }

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -59,12 +59,12 @@ mod parse_int {
 
     #[test]
     fn issue_142() {
-        let subject = parse_ints(Partial(&b"12 34 5689a"[..]));
-        let expected = Ok((Partial(&b"a"[..]), vec![12, 34, 5689]));
+        let subject = parse_ints(Partial::new(&b"12 34 5689a"[..]));
+        let expected = Ok((Partial::new(&b"a"[..]), vec![12, 34, 5689]));
         assert_eq!(subject, expected);
 
-        let subject = parse_ints(Partial(&b"12 34 5689 "[..]));
-        let expected = Ok((Partial(&b" "[..]), vec![12, 34, 5689]));
+        let subject = parse_ints(Partial::new(&b"12 34 5689 "[..]));
+        let expected = Ok((Partial::new(&b" "[..]), vec![12, 34, 5689]));
         assert_eq!(subject, expected);
     }
 }
@@ -74,7 +74,7 @@ fn usize_length_bytes_issue() {
     use winnow::multi::length_data;
     use winnow::number::be_u16;
     #[allow(clippy::type_complexity)]
-    let _: IResult<Partial<&[u8]>, &[u8]> = length_data(be_u16)(Partial(b"012346"));
+    let _: IResult<Partial<&[u8]>, &[u8]> = length_data(be_u16)(Partial::new(b"012346"));
 }
 
 #[test]
@@ -86,12 +86,12 @@ fn take_till0_issue() {
     }
 
     assert_eq!(
-        nothing(Partial(b"")),
+        nothing(Partial::new(b"")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        nothing(Partial(b"abc")),
-        Ok((Partial(&b"abc"[..]), &b""[..]))
+        nothing(Partial::new(b"abc")),
+        Ok((Partial::new(&b"abc"[..]), &b""[..]))
     );
 }
 
@@ -108,20 +108,20 @@ fn issue_655() {
     }
 
     assert_eq!(
-        twolines(Partial("foo\nbar\n")),
-        Ok((Partial(""), ("foo", "bar")))
+        twolines(Partial::new("foo\nbar\n")),
+        Ok((Partial::new(""), ("foo", "bar")))
     );
     assert_eq!(
-        twolines(Partial("féo\nbar\n")),
-        Ok((Partial(""), ("féo", "bar")))
+        twolines(Partial::new("féo\nbar\n")),
+        Ok((Partial::new(""), ("féo", "bar")))
     );
     assert_eq!(
-        twolines(Partial("foé\nbar\n")),
-        Ok((Partial(""), ("foé", "bar")))
+        twolines(Partial::new("foé\nbar\n")),
+        Ok((Partial::new(""), ("foé", "bar")))
     );
     assert_eq!(
-        twolines(Partial("foé\r\nbar\n")),
-        Ok((Partial(""), ("foé", "bar")))
+        twolines(Partial::new("foé\r\nbar\n")),
+        Ok((Partial::new(""), ("foé", "bar")))
     );
 }
 
@@ -174,9 +174,9 @@ fn issue_848_overflow_incomplete_bits_to_bytes() {
         bits(bytes(take))(i)
     }
     assert_eq!(
-        parser(Partial(&b""[..])),
+        parser(Partial::new(&b""[..])),
         Err(ErrMode::Cut(winnow::error::Error {
-            input: Partial(&b""[..]),
+            input: Partial::new(&b""[..]),
             kind: ErrorKind::TooLarge
         }))
     );

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -21,7 +21,7 @@ fn parser02(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8])> {
 #[test]
 fn overflow_incomplete_tuple() {
     assert_eq!(
-        parser02(Partial(&b"3"[..])),
+        parser02(Partial::new(&b"3"[..])),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
     );
 }
@@ -35,7 +35,7 @@ fn overflow_incomplete_length_bytes() {
 
     // Trigger an overflow in length_data
     assert_eq!(
-        multi(Partial(
+        multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
@@ -51,7 +51,7 @@ fn overflow_incomplete_many0() {
 
     // Trigger an overflow in many0
     assert_eq!(
-        multi(Partial(
+        multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -69,7 +69,7 @@ fn overflow_incomplete_many1() {
 
     // Trigger an overflow in many1
     assert_eq!(
-        multi(Partial(
+        multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -88,7 +88,7 @@ fn overflow_incomplete_many_till0() {
 
     // Trigger an overflow in many_till0
     assert_eq!(
-        multi(Partial(
+        multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -106,7 +106,7 @@ fn overflow_incomplete_many_m_n() {
 
     // Trigger an overflow in many_m_n
     assert_eq!(
-        multi(Partial(
+        multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -123,7 +123,7 @@ fn overflow_incomplete_count() {
     }
 
     assert_eq!(
-        counter(Partial(
+        counter(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -141,7 +141,7 @@ fn overflow_incomplete_length_count() {
     }
 
     assert_eq!(
-        multi(Partial(
+        multi(Partial::new(
             &b"\x04\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xee"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551598)))
@@ -156,7 +156,7 @@ fn overflow_incomplete_length_data() {
     }
 
     assert_eq!(
-        multi(Partial(
+        multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -44,7 +44,7 @@ mod test {
         const INPUT: &str = "Hello";
         const TAG: &str = "Hello World!";
 
-        let res: IResult<_, _, error::Error<_>> = tag(TAG)(Partial(INPUT));
+        let res: IResult<_, _, error::Error<_>> = tag(TAG)(Partial::new(INPUT));
         match res {
             Err(ErrMode::Incomplete(_)) => (),
             other => {
@@ -120,7 +120,7 @@ mod test {
 
         const INPUT: &str = "βèƒôřèÂßÇá";
 
-        let res: IResult<_, _, Error<_>> = take(13_usize)(Partial(INPUT));
+        let res: IResult<_, _, Error<_>> = take(13_usize)(Partial::new(INPUT));
         match res {
             Err(ErrMode::Incomplete(_)) => (),
             other => panic!(
@@ -170,7 +170,7 @@ mod test {
         const INPUT: &str = "βèƒôřè";
         const FIND: &str = "βèƒôřèÂßÇ";
 
-        let res: IResult<_, _, Error<_>> = take_until0(FIND)(Partial(INPUT));
+        let res: IResult<_, _, Error<_>> = take_until0(FIND)(Partial::new(INPUT));
         match res {
             Err(ErrMode::Incomplete(_)) => (),
             other => panic!(
@@ -188,7 +188,7 @@ mod test {
         const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
         const FIND: &str = "Ráñδô₥";
 
-        let res: IResult<_, _, Error<_>> = take_until0(FIND)(Partial(INPUT));
+        let res: IResult<_, _, Error<_>> = take_until0(FIND)(Partial::new(INPUT));
         match res {
             Err(ErrMode::Incomplete(_)) => (),
             other => panic!(
@@ -217,10 +217,10 @@ mod test {
         let c = "abcd123";
         let d = "123";
 
-        assert_eq!(f(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
-        assert_eq!(f(Partial(b)), Err(ErrMode::Incomplete(Needed::new(1))));
-        assert_eq!(f(Partial(c)), Ok((Partial(d), b)));
-        assert_eq!(f(Partial(d)), Ok((Partial(d), a)));
+        assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+        assert_eq!(f(Partial::new(b)), Err(ErrMode::Incomplete(Needed::new(1))));
+        assert_eq!(f(Partial::new(c)), Ok((Partial::new(d), b)));
+        assert_eq!(f(Partial::new(d)), Ok((Partial::new(d), a)));
     }
 
     #[test]
@@ -305,13 +305,13 @@ mod test {
         let c = "abcd123";
         let d = "123";
 
-        assert_eq!(f(Partial(a)), Err(ErrMode::Incomplete(Needed::new(1))));
-        assert_eq!(f(Partial(b)), Err(ErrMode::Incomplete(Needed::new(1))));
-        assert_eq!(f(Partial(c)), Ok((Partial("123"), b)));
+        assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
+        assert_eq!(f(Partial::new(b)), Err(ErrMode::Incomplete(Needed::new(1))));
+        assert_eq!(f(Partial::new(c)), Ok((Partial::new("123"), b)));
         assert_eq!(
-            f(Partial(d)),
+            f(Partial::new(d)),
             Err(ErrMode::Backtrack(winnow::error::Error {
-                input: Partial(d),
+                input: Partial::new(d),
                 kind: ErrorKind::TakeWhile1
             }))
         );


### PR DESCRIPTION
Under the original `nom` design, users could mix and match complete/streaming parsers as needed.  Now, they can't.  This restores that ability by modifying the stream.  As part of that, we apply this to two existing parsers, `length_value` and `Parser::and_then`

The problem is this comes with a 30% performance hit for partial parsing because we increased the size of the Stream (I benchmarked with `is_partial` returning a static value and no change).  See #72 for fixing that.

Despite the performance degradation, I'm going to merge this as this is necessary functionality for parsers to work correctly and we have #72 for improving the performance.