### PR TITLE
fix(stream)!: Debug types use native slice types

### DIFF
--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -86,7 +86,7 @@ where
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parse(input: Stream<'_>) -> IResult<Stream<'_>, (u8, u8, &Bytes)> {
+/// fn parse(input: Stream<'_>) -> IResult<Stream<'_>, (u8, u8, &[u8])> {
 ///   bits::<_, _, Error<(_, usize)>, _, _>((
 ///     take(4usize),
 ///     take(8usize),
@@ -96,7 +96,7 @@ where
 ///
 /// let input = stream(&[0x12, 0x34, 0xff, 0xff]);
 ///
-/// assert_eq!(parse(input), Ok(( stream(&[]), (0x01, 0x23, Bytes::new(&[0xff, 0xff])) )));
+/// assert_eq!(parse(input), Ok(( stream(&[]), (0x01, 0x23, &[0xff, 0xff][..]) )));
 /// ```
 pub fn bytes<I, O, E1, E2, P>(mut parser: P) -> impl FnMut((I, usize)) -> IResult<(I, usize), O, E2>
 where

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1096,11 +1096,11 @@ where
 ///     Partial::new(Bytes::new(b))
 /// }
 ///
-/// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &Bytes> {
+/// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 ///   length_data(be_u16)(s)
 /// }
 ///
-/// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), Bytes::new(&b"abc"[..]))));
+/// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
 /// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 pub fn length_data<I, N, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, E>
@@ -1147,11 +1147,11 @@ where
 ///     Partial::new(Bytes::new(b))
 /// }
 ///
-/// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &Bytes> {
+/// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 ///   length_value(be_u16, tag("abc"))(s)
 /// }
 ///
-/// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), Bytes::new(&b"abc"[..]))));
+/// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
 /// assert_eq!(parser(stream(b"\x00\x03123123")), Err(ErrMode::Backtrack(Error::new(stream(&b"123"[..]), ErrorKind::Tag))));
 /// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
@@ -1197,14 +1197,14 @@ where
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, Vec<&Bytes>> {
+/// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, Vec<&[u8]>> {
 ///   length_count(u8.map(|i| {
 ///      println!("got number: {}", i);
 ///      i
 ///   }), tag("abc"))(s)
 /// }
 ///
-/// assert_eq!(parser(stream(b"\x02abcabcabc")), Ok((stream(b"abc"), vec![Bytes::new(b"abc"), Bytes::new(b"abc")])));
+/// assert_eq!(parser(stream(b"\x02abcabcabc")), Ok((stream(b"abc"), vec![&b"abc"[..], &b"abc"[..]])));
 /// assert_eq!(parser(stream(b"\x03123123123")), Err(ErrMode::Backtrack(Error::new(stream(b"123123123"), ErrorKind::Tag))));
 /// ```
 pub fn length_count<I, O, C, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, C, E>

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -543,7 +543,7 @@ impl<'i> Stream for &'i str {
 
 impl<'i> Stream for &'i Bytes {
     type Token = u8;
-    type Slice = &'i Bytes;
+    type Slice = &'i [u8];
 
     type IterOffsets = Enumerate<Cloned<Iter<'i, u8>>>;
 
@@ -588,7 +588,7 @@ impl<'i> Stream for &'i Bytes {
 
 impl<'i> Stream for &'i BStr {
     type Token = u8;
-    type Slice = &'i BStr;
+    type Slice = &'i [u8];
 
     type IterOffsets = Enumerate<Cloned<Iter<'i, u8>>>;
 
@@ -1682,14 +1682,14 @@ impl<'a> UpdateSlice for &'a str {
 impl<'a> UpdateSlice for &'a Bytes {
     #[inline(always)]
     fn update_slice(self, inner: Self::Slice) -> Self {
-        inner
+        Bytes::new(inner)
     }
 }
 
 impl<'a> UpdateSlice for &'a BStr {
     #[inline(always)]
     fn update_slice(self, inner: Self::Slice) -> Self {
-        inner
+        BStr::new(inner)
     }
 }
 


### PR DESCRIPTION
In testing out the new API, I found the custom slice types to be too much to deal with.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
