### PR TITLE
docs: Include aliases

### DIFF
--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -228,6 +228,8 @@ where
 /// );
 /// ```
 #[inline(always)]
+#[doc(alias = "literal")]
+#[doc(alias = "just")]
 pub fn tag<I, O, C, E: ParseError<(I, usize)>>(
     pattern: O,
     count: C,
@@ -270,6 +272,7 @@ where
 /// assert_eq!(parse((stream(&[0b10000000]), 0)), Ok(((stream(&[0b10000000]), 1), true)));
 /// assert_eq!(parse((stream(&[0b10000000]), 1)), Ok(((stream(&[0b10000000]), 2), false)));
 /// ```
+#[doc(alias = "any")]
 pub fn bool<I, E: ParseError<(I, usize)>>(input: (I, usize)) -> IResult<(I, usize), bool, E>
 where
     I: Stream<Token = u8> + AsBytes + StreamIsPartial,

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -51,6 +51,7 @@ pub trait Alt<I, O, E> {
 /// assert_eq!(parser(" "), Err(ErrMode::Backtrack(error_position!(" ", ErrorKind::Digit))));
 /// # }
 /// ```
+#[doc(alias = "choice")]
 pub fn alt<I: Stream, O, E: ParseError<I>, List: Alt<I, O, E>>(
     mut l: List,
 ) -> impl FnMut(I) -> IResult<I, O, E> {

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -37,6 +37,7 @@ use crate::IResult;
 /// assert_eq!(any::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
+#[doc(alias = "token")]
 pub fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Token, E>
 where
     I: StreamIsPartial,
@@ -91,6 +92,9 @@ where
 /// assert_eq!(parser(Partial::new("H")), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
+#[doc(alias = "literal")]
+#[doc(alias = "bytes")]
+#[doc(alias = "just")]
 pub fn tag<T, I, Error: ParseError<I>>(
     tag: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
@@ -149,6 +153,9 @@ where
 /// assert_eq!(parser(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
+#[doc(alias = "literal")]
+#[doc(alias = "bytes")]
+#[doc(alias = "just")]
 pub fn tag_no_case<T, I, Error: ParseError<I>>(
     tag: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
@@ -213,6 +220,9 @@ where
 /// assert_eq!(parser_fn(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
+#[doc(alias = "char")]
+#[doc(alias = "token")]
+#[doc(alias = "satisfy")]
 pub fn one_of<I, T, Error: ParseError<I>>(
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Token, Error>
@@ -389,6 +399,7 @@ where
 /// assert_eq!(hex(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
+#[doc(alias = "is_a")]
 pub fn take_while1<T, I, Error: ParseError<I>>(
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
@@ -579,6 +590,7 @@ where
 /// assert_eq!(not_space(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
+#[doc(alias = "is_not")]
 pub fn take_till1<T, I, Error: ParseError<I>>(
     list: T,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -899,6 +899,11 @@ where
 /// *Complete version*: can parse until the end of input.
 ///
 /// *Partial version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
+#[doc(alias = "u8")]
+#[doc(alias = "u16")]
+#[doc(alias = "u32")]
+#[doc(alias = "u64")]
+#[doc(alias = "u128")]
 pub fn dec_uint<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
 where
     I: StreamIsPartial,
@@ -1048,6 +1053,11 @@ impl Uint for i128 {
 /// *Complete version*: can parse until the end of input.
 ///
 /// *Partial version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data.
+#[doc(alias = "i8")]
+#[doc(alias = "i16")]
+#[doc(alias = "i32")]
+#[doc(alias = "i64")]
+#[doc(alias = "i128")]
 pub fn dec_int<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
 where
     I: StreamIsPartial,
@@ -1319,6 +1329,8 @@ impl HexUint for u128 {
 /// assert_eq!(parser(Partial::new("abc")), Err(ErrMode::Backtrack(Error::new(Partial::new("abc"), ErrorKind::Float))));
 /// ```
 #[inline(always)]
+#[doc(alias = "f32")]
+#[doc(alias = "double")]
 pub fn float<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
 where
     I: StreamIsPartial,

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -747,6 +747,8 @@ where
 /// assert_eq!(parser("123;"), Err(ErrMode::Backtrack(Error::new("123;", ErrorKind::Alpha))));
 /// # }
 /// ```
+#[doc(alias = "look_ahead")]
+#[doc(alias = "rewind")]
 pub fn peek<I: Stream, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
     F: Parser<I, O, E>,
@@ -777,6 +779,8 @@ where
 /// assert_eq!(parser(""), Ok(("", "")));
 /// # }
 /// ```
+#[doc(alias = "end")]
+#[doc(alias = "eoi")]
 pub fn eof<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
     I: Stream,
@@ -1671,6 +1675,8 @@ enum State<E> {
 /// assert_eq!(sign("10"), Ok(("10", 1)));
 /// # }
 /// ```
+#[doc(alias = "value")]
+#[doc(alias = "empty")]
 pub fn success<I: Stream, O: Clone, E: ParseError<I>>(val: O) -> impl FnMut(I) -> IResult<I, O, E> {
     trace("success", move |input: I| Ok((input, val.clone())))
 }
@@ -1689,6 +1695,7 @@ pub fn success<I: Stream, O: Clone, E: ParseError<I>>(val: O) -> impl FnMut(I) -
 /// let s = "string";
 /// assert_eq!(fail::<_, &str, _>(s), Err(ErrMode::Backtrack(Error::new(s, ErrorKind::Fail))));
 /// ```
+#[doc(alias = "unexpected")]
 pub fn fail<I: Stream, O, E: ParseError<I>>(i: I) -> IResult<I, O, E> {
     trace("fail", |i| {
         Err(ErrMode::from_error_kind(i, ErrorKind::Fail))

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -38,6 +38,9 @@ use crate::{IResult, Parser};
 /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// ```
+#[doc(alias = "skip_many")]
+#[doc(alias = "repeated")]
+#[doc(alias = "many0_count")]
 pub fn many0<I, O, C, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, C, E>
 where
     I: Stream,
@@ -98,6 +101,9 @@ where
 /// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(Error::new("123123", ErrorKind::Tag))));
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// ```
+#[doc(alias = "skip_many1")]
+#[doc(alias = "repeated")]
+#[doc(alias = "many1_count")]
 pub fn many1<I, O, C, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, C, E>
 where
     I: Stream,
@@ -232,6 +238,8 @@ where
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// assert_eq!(parser("def|abc"), Ok(("def|abc", vec![])));
 /// ```
+#[doc(alias = "sep_by")]
+#[doc(alias = "separated_list0")]
 pub fn separated0<I, O, C, O2, E, P, S>(
     mut parser: P,
     mut sep: S,
@@ -325,6 +333,8 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(Error::new("def|abc", ErrorKind::Tag))));
 /// ```
+#[doc(alias = "sep_by1")]
+#[doc(alias = "separated_list1")]
 pub fn separated1<I, O, C, O2, E, P, S>(
     mut parser: P,
     mut sep: S,
@@ -534,6 +544,7 @@ where
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
+#[doc(alias = "repeated")]
 pub fn many_m_n<I, O, C, E, F>(
     min: usize,
     max: usize,
@@ -672,7 +683,7 @@ where
 /// ```
 ///
 /// **WARNING:** Deprecated, replaced with [`many0`]
-#[deprecated(since = "0.3.0", note = "Replaced with `many0`")]
+#[deprecated(since = "0.3.0", note = "Replaced with `many1`")]
 pub fn many1_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
     I: Stream,
@@ -736,6 +747,7 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
+#[doc(alias = "skip_counskip_count")]
 pub fn count<I, O, C, E, F>(mut f: F, count: usize) -> impl FnMut(I) -> IResult<I, C, E>
 where
     I: Stream,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -118,6 +118,7 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse_next("123abcd;"), Err(ErrMode::Backtrack(Error::new("123abcd;", ErrorKind::Alpha))));
     /// # }
     /// ```
+    #[doc(alias = "to")]
     fn value<O2>(self, val: O2) -> Value<Self, O, O2>
     where
         Self: core::marker::Sized,
@@ -239,6 +240,7 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(recognize_parser.parse_next("abcd"), consumed_parser.parse_next("abcd"));
     /// # }
     /// ```
+    #[doc(alias = "consumed")]
     fn with_recognized(self) -> WithRecognized<Self, O>
     where
         Self: core::marker::Sized,
@@ -394,6 +396,9 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parse.parse_next("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::Verify))));
     /// # }
     /// ```
+    #[doc(alias = "satisfy_map")]
+    #[doc(alias = "filter_map")]
+    #[doc(alias = "map_opt")]
     fn verify_map<G, O2>(self, g: G) -> VerifyMap<Self, G, O>
     where
         Self: core::marker::Sized,
@@ -488,6 +493,7 @@ pub trait Parser<I, O, E> {
     /// // this will fail if digit1 fails
     /// assert_eq!(parser.parse_next("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Digit))));
     /// ```
+    #[doc(alias = "from_str")]
     fn parse_to<O2>(self) -> ParseTo<Self, O, O2>
     where
         Self: core::marker::Sized,
@@ -515,6 +521,8 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse_next("123abcd;"),Err(ErrMode::Backtrack(Error::new("123abcd;", ErrorKind::Alpha))));
     /// # }
     /// ```
+    #[doc(alias = "satisfy")]
+    #[doc(alias = "filter")]
     fn verify<G, O2: ?Sized>(self, second: G) -> Verify<Self, G, O2>
     where
         Self: core::marker::Sized,
@@ -527,6 +535,7 @@ pub trait Parser<I, O, E> {
     ///
     /// This is used mainly to add user friendly information
     /// to errors when backtracking through a parse tree.
+    #[doc(alias = "labelled")]
     fn context<C>(self, context: C) -> Context<Self, O, C>
     where
         Self: core::marker::Sized,

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -66,6 +66,7 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
+#[doc(alias = "ignore_then")]
 pub fn preceded<I, O1, O2, E: ParseError<I>, F, G>(
     mut first: F,
     mut second: G,
@@ -102,6 +103,7 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
+#[doc(alias = "then_ignore")]
 pub fn terminated<I, O1, O2, E: ParseError<I>, F, G>(
     mut first: F,
     mut second: G,
@@ -179,6 +181,8 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
+#[doc(alias = "between")]
+#[doc(alias = "padded")]
 pub fn delimited<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
     mut first: F,
     mut second: G,


### PR DESCRIPTION
Aliases were pulled from
- `nom`
- `chumsky`
- `combine`

This is a part of #100

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
