### PR TITLE
docs: Hide deprecated functionality

### DIFF
--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -1,7 +1,9 @@
 //! Bit level parsers
 //!
 
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub mod complete;
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub mod streaming;
 #[cfg(test)]
 mod tests;

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -1,6 +1,8 @@
 //! Parsers recognizing bytes streams
 
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub mod complete;
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub mod streaming;
 #[cfg(test)]
 mod tests;

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -4,7 +4,9 @@
 
 #![allow(deprecated)] // will just become `pub(crate)` later
 
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub mod complete;
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub mod streaming;
 #[cfg(test)]
 mod tests;
@@ -1522,6 +1524,7 @@ where
 #[inline]
 #[doc(hidden)]
 #[deprecated(since = "0.1.0", note = "Replaced with `AsChar::is_alpha`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn is_alphabetic(chr: u8) -> bool {
     matches!(chr, 0x41..=0x5A | 0x61..=0x7A)
 }
@@ -1529,6 +1532,7 @@ pub fn is_alphabetic(chr: u8) -> bool {
 #[inline]
 #[doc(hidden)]
 #[deprecated(since = "0.1.0", note = "Replaced with `AsChar::is_dec_digit`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn is_digit(chr: u8) -> bool {
     matches!(chr, 0x30..=0x39)
 }
@@ -1536,6 +1540,7 @@ pub fn is_digit(chr: u8) -> bool {
 #[inline]
 #[doc(hidden)]
 #[deprecated(since = "0.1.0", note = "Replaced with `AsChar::is_hex_digit`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn is_hex_digit(chr: u8) -> bool {
     matches!(chr, 0x30..=0x39 | 0x41..=0x46 | 0x61..=0x66)
 }
@@ -1543,6 +1548,7 @@ pub fn is_hex_digit(chr: u8) -> bool {
 #[inline]
 #[doc(hidden)]
 #[deprecated(since = "0.1.0", note = "Replaced with `AsChar::is_oct_digit`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn is_oct_digit(chr: u8) -> bool {
     matches!(chr, 0x30..=0x37)
 }
@@ -1550,6 +1556,7 @@ pub fn is_oct_digit(chr: u8) -> bool {
 #[inline]
 #[doc(hidden)]
 #[deprecated(since = "0.1.0", note = "Replaced with `AsChar::is_alphanum`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn is_alphanumeric(chr: u8) -> bool {
     #![allow(deprecated)]
     is_alphabetic(chr) || is_digit(chr)
@@ -1558,6 +1565,7 @@ pub fn is_alphanumeric(chr: u8) -> bool {
 #[inline]
 #[doc(hidden)]
 #[deprecated(since = "0.1.0", note = "Replaced with `AsChar::is_space`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn is_space(chr: u8) -> bool {
     chr == b' ' || chr == b'\t'
 }
@@ -1565,6 +1573,7 @@ pub fn is_space(chr: u8) -> bool {
 #[inline]
 #[doc(hidden)]
 #[deprecated(since = "0.1.0", note = "Replaced with `AsChar::is_newline`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn is_newline(chr: u8) -> bool {
     chr == b'\n'
 }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -252,6 +252,7 @@ impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P> {
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::map")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn map<I, O1, O2, E, F, G>(mut parser: F, mut f: G) -> impl FnMut(I) -> IResult<I, O2, E>
 where
     F: Parser<I, O1, E>,
@@ -313,6 +314,7 @@ impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> O2> Parser<I, O2, E> for Ma
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::map_res")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn map_res<I: Clone, O1, O2, E: FromExternalError<I, E2>, E2, F, G>(
     mut parser: F,
     mut f: G,
@@ -391,6 +393,7 @@ where
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::verify_map")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn map_opt<I: Clone, O1, O2, E: ParseError<I>, F, G>(
     mut parser: F,
     mut f: G,
@@ -465,6 +468,7 @@ where
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::and_then")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn map_parser<I, O1, O2, E: ParseError<I>, F, G>(
     mut parser: F,
     mut applied_parser: G,
@@ -567,6 +571,7 @@ where
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::flat_map")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn flat_map<I, O1, O2, E: ParseError<I>, F, G, H>(
     mut parser: F,
     mut applied_parser: G,
@@ -811,6 +816,7 @@ where
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::complete_err")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn complete<I: Clone, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
     F: Parser<I, O, E>,
@@ -877,6 +883,7 @@ where
     since = "0.1.0",
     note = "Replaced with `eof` or `FinishIResult::finish`"
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn all_consuming<I, O, E: ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
     I: Stream,
@@ -913,6 +920,7 @@ where
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::verify")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn verify<I: Clone, O1, O2, E: ParseError<I>, F, G>(
     mut first: F,
     second: G,
@@ -993,6 +1001,7 @@ where
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::value")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn value<I, O1: Clone, O2, E: ParseError<I>, F>(
     val: O1,
     mut parser: F,
@@ -1103,6 +1112,7 @@ where
 /// # }
 /// ```
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::recognize")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn recognize<I, O, E: ParseError<I>, F>(
     mut parser: F,
 ) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, E>
@@ -1200,6 +1210,7 @@ where
     since = "0.1.0",
     note = "Replaced with `Parser::with_recognized (output ordering is changed)"
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn consumed<I, O, F, E>(
     mut parser: F,
 ) -> impl FnMut(I) -> IResult<I, (<I as Stream>::Slice, O), E>
@@ -1385,6 +1396,7 @@ where
 
 /// Deprecated, see [`cut_err`]
 #[deprecated(since = "0.3.0", note = "Replaced with `cut_err`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn cut<I, O, E: ParseError<I>, F>(parser: F) -> impl FnMut(I) -> IResult<I, O, E>
 where
     I: Stream,
@@ -1462,6 +1474,7 @@ where
     since = "0.1.0",
     note = "Replaced with `Parser::output_into` and `Parser::err_into`"
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn into<I, O1, O2, E1, E2, F>(mut parser: F) -> impl FnMut(I) -> IResult<I, O2, E2>
 where
     O1: convert::Into<O2>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,11 +125,13 @@ where
     since = "0.1.0",
     note = "Replaced with `FinishIResult` which is available via `winnow::prelude`"
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub trait Finish<I, O, E> {
     #[deprecated(
         since = "0.1.0",
         note = "Replaced with `FinishIResult::finish_err` which is available via `winnow::prelude`"
     )]
+    #[cfg_attr(feature = "unstable-doc", doc(hidden))]
     fn finish(self) -> Result<(I, O), E>;
 }
 
@@ -318,6 +320,7 @@ impl<T> ErrMode<Error<T>> {
 impl ErrMode<Error<&[u8]>> {
     /// Deprecated, replaced with [`Error::into_owned`]
     #[deprecated(since = "0.3.0", note = "Replaced with `Error::into_owned`")]
+    #[cfg_attr(feature = "unstable-doc", doc(hidden))]
     pub fn to_owned(self) -> ErrMode<Error<crate::lib::std::vec::Vec<u8>>> {
         self.map_input(ToOwned::to_owned)
     }
@@ -327,6 +330,7 @@ impl ErrMode<Error<&[u8]>> {
 impl ErrMode<Error<&str>> {
     /// Deprecated, replaced with [`Error::into_owned`]
     #[deprecated(since = "0.3.0", note = "Replaced with `Error::into_owned`")]
+    #[cfg_attr(feature = "unstable-doc", doc(hidden))]
     pub fn to_owned(self) -> ErrMode<Error<crate::lib::std::string::String>> {
         self.map_input(ToOwned::to_owned)
     }
@@ -376,6 +380,7 @@ pub trait ParseError<I>: Sized {
 
     /// Creates an error from an input position and an expected character
     #[deprecated(since = "0.2.0", note = "Replaced with `ContextError`")]
+    #[cfg_attr(feature = "unstable-doc", doc(hidden))]
     fn from_char(input: I, _: char) -> Self {
         Self::from_error_kind(input, ErrorKind::Char)
     }
@@ -514,6 +519,7 @@ impl ErrorConvert<()> for () {
 
 /// Creates an error from the input position and an [`ErrorKind`]
 #[deprecated(since = "0.2.0", note = "Replaced with `ParseError::from_error_kind`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn make_error<I, E: ParseError<I>>(input: I, kind: ErrorKind) -> E {
     E::from_error_kind(input, kind)
 }
@@ -522,6 +528,7 @@ pub fn make_error<I, E: ParseError<I>>(input: I, kind: ErrorKind) -> E {
 /// position and an [`ErrorKind`]. This is useful when backtracking
 /// through a parse tree, accumulating error context on the way
 #[deprecated(since = "0.2.0", note = "Replaced with `ParseError::append`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn append_error<I, E: ParseError<I>>(input: I, kind: ErrorKind, other: E) -> E {
     other.append(input, kind)
 }
@@ -638,6 +645,7 @@ impl<I: fmt::Debug + fmt::Display + Sync + Send + 'static> std::error::Error for
 ///
 /// **WARNING:** Deprecated, replaced with [`Parser::context`]
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser::context")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn context<I: Clone, E: ContextError<I, &'static str>, F, O>(
     context: &'static str,
     mut f: F,
@@ -866,6 +874,7 @@ impl ErrorKind {
     not(test),
     deprecated(since = "0.3.0", note = "Replaced with `E::from_error_kind`")
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 macro_rules! error_position(
   ($input:expr, $code:expr) => ({
     $crate::error::ParseError::from_error_kind($input, $code)
@@ -881,6 +890,7 @@ macro_rules! error_position(
     not(test),
     deprecated(since = "0.3.0", note = "Replaced with `E::append`")
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 macro_rules! error_node_position(
   ($input:expr, $code:expr, $next:expr) => ({
     $crate::error::ParseError::append($next, $input, $code)
@@ -914,6 +924,7 @@ macro_rules! error_node_position(
     since = "0.1.0",
     note = "Replaced with `trace` and the `debug` feature flag"
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 #[cfg(feature = "std")]
 pub fn dbg_dmp<'a, F, O, E: std::fmt::Debug>(
     mut f: F,

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -140,6 +140,7 @@ where
 
 /// **WARNING:** Deprecated, replaced with [`many_till0`]
 #[deprecated(since = "0.3.0", note = "Replaced with `many_till0`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn many_till<I, O, C, P, E, F, G>(f: F, g: G) -> impl FnMut(I) -> IResult<I, (C, P), E>
 where
     I: Stream,
@@ -293,6 +294,7 @@ where
     since = "0.3.0",
     note = "Replaced with `separated0` (note the parameter swap)"
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn separated_list0<I, O, C, O2, E, F, G>(sep: G, f: F) -> impl FnMut(I) -> IResult<I, C, E>
 where
     I: Stream,
@@ -388,6 +390,7 @@ where
     since = "0.3.0",
     note = "Replaced with `separated1` (note the parameter swap)"
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn separated_list1<I, O, C, O2, E, F, G>(sep: G, f: F) -> impl FnMut(I) -> IResult<I, C, E>
 where
     I: Stream,
@@ -621,6 +624,7 @@ where
 ///
 /// **WARNING:** Deprecated, replaced with [`many0`]
 #[deprecated(since = "0.3.0", note = "Replaced with `many0`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn many0_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
     I: Stream,
@@ -684,6 +688,7 @@ where
 ///
 /// **WARNING:** Deprecated, replaced with [`many0`]
 #[deprecated(since = "0.3.0", note = "Replaced with `many1`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn many1_count<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, usize, E>
 where
     I: Stream,

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -2,7 +2,9 @@
 
 #![allow(deprecated)] // will just become `pub(crate)` later
 
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub mod complete;
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub mod streaming;
 #[cfg(test)]
 mod tests;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,6 +42,7 @@ pub trait Parser<I, O, E> {
     /// A parser takes in input type, and returns a `Result` containing
     /// either the remaining input and the output value, or an error
     #[deprecated(since = "0.3.0", note = "Replaced with `Parser::parse_next`")]
+    #[cfg_attr(feature = "unstable-doc", doc(hidden))]
     fn parse(&mut self, input: I) -> IResult<I, O, E> {
         self.parse_next(input)
     }
@@ -580,6 +581,7 @@ pub trait Parser<I, O, E> {
     ///
     /// **WARNING:** Deprecated, replaced with [`winnow::sequence::tuple`][crate::sequence::tuple]
     #[deprecated(since = "0.1.0", note = "Replaced with `winnow::sequence::tuple")]
+    #[cfg_attr(feature = "unstable-doc", doc(hidden))]
     fn and<G, O2>(self, g: G) -> And<Self, G>
     where
         G: Parser<I, O2, E>,
@@ -592,6 +594,7 @@ pub trait Parser<I, O, E> {
     ///
     /// **WARNING:** Deprecated, replaced with [`winnow::branch::alt`][crate::branch::alt]
     #[deprecated(since = "0.1.0", note = "Replaced with `winnow::branch::alt")]
+    #[cfg_attr(feature = "unstable-doc", doc(hidden))]
     fn or<G>(self, g: G) -> Or<Self, G>
     where
         G: Parser<I, O, E>,

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -31,6 +31,7 @@ use crate::{IResult, Parser};
 /// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 #[deprecated(since = "0.1.0", note = "`Parser` is directly implemented for tuples")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub fn pair<I, O1, O2, E: ParseError<I>, F, G>(
     mut first: F,
     mut second: G,
@@ -205,6 +206,7 @@ where
 ///
 /// This trait is implemented for tuples of parsers of up to 21 elements.
 #[deprecated(since = "0.1.0", note = "Replaced with `Parser`")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub trait Tuple<I, O, E> {
     /// Parses the input and returns a tuple of results of each parser.
     fn parse(&mut self, input: I) -> IResult<I, O, E>;
@@ -314,6 +316,7 @@ impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
 /// assert_eq!(parser("123def"), Err(ErrMode::Backtrack(Error::new("123def", ErrorKind::Alpha))));
 /// ```
 #[deprecated(since = "0.1.0", note = "`Parser` is directly implemented for tuples")]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 #[allow(deprecated)]
 pub fn tuple<I, O, E: ParseError<I>, List: Tuple<I, O, E>>(
     mut l: List,

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1922,6 +1922,7 @@ impl ToUsize for u64 {
     since = "0.3.0",
     note = "Replaced with `Debug` (see `Bytes` and `BStr`"
 )]
+#[cfg_attr(feature = "unstable-doc", doc(hidden))]
 pub trait HexDisplay {
     /// Converts the value of `self` to a hex dump, returning the owned
     /// `String`.


### PR DESCRIPTION
I still keep the rustdoc for the sake of the doc comment examples as they are the only tests for the deprecated code.

This cleans up the API, making it clearer what we are trying to do.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
