### PR TITLE
fix: Make memchr an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,15 +39,16 @@ pre-release-replacements = [
 [features]
 default = ["std"]
 alloc = []
-std = ["alloc", "memchr/std"]
+std = ["alloc", "memchr?/std"]
+simd = ["dep:memchr"]
 debug = ["dep:anstyle", "dep:is-terminal", "dep:terminal_size", "dep:concolor"]
 
-unstable-doc = ["alloc", "std"]
+unstable-doc = ["alloc", "std", "simd"]
 
 [dependencies]
 anstyle = { version = "0.2.5", optional = true }
 is-terminal = { version = "0.4.3", optional = true }
-memchr = { version = "2.3", default-features = false }
+memchr = { version = "2.3", optional = true, default-features = false }
 terminal_size = { version = "0.2.3", optional = true }
 concolor = { version = "0.0.8", optional = true, features = ["auto"] }
 


### PR DESCRIPTION
This doesn't benefit every parser, so let's not make every parser pay the cost.