### PR TITLE
fix(comb): Relax flat_map's trait bound

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -605,7 +605,7 @@ impl<F, G, O1> FlatMap<F, G, O1> {
     }
 }
 
-impl<I, O1, O2, E, F: Parser<I, O1, E>, G: Fn(O1) -> H, H: Parser<I, O2, E>> Parser<I, O2, E>
+impl<I, O1, O2, E, F: Parser<I, O1, E>, G: FnMut(O1) -> H, H: Parser<I, O2, E>> Parser<I, O2, E>
     for FlatMap<F, G, O1>
 {
     fn parse_next(&mut self, i: I) -> IResult<I, O2, E> {

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -6,7 +6,10 @@ use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::error::Needed;
 use crate::error::ParseError;
+use crate::multi::count;
+use crate::number::u16;
 use crate::number::u8;
+use crate::number::Endianness;
 use crate::IResult;
 use crate::Parser;
 use crate::Partial;
@@ -115,6 +118,12 @@ fn test_parser_flat_map() {
         u8.flat_map(take).parse_next(input),
         Ok((&[103, 104][..], &[100, 101, 102][..]))
     );
+}
+
+#[allow(dead_code)]
+fn test_closure_compiles_195(input: &[u8]) -> IResult<&[u8], ()> {
+    u8.flat_map(|num| count(u16(Endianness::Big), num as usize))
+        .parse_next(input)
 }
 
 #[test]


### PR DESCRIPTION
So `Parser::flat_map` had the right bound but not the `Parser` impl for `FlatMap`.  Changing the bound should not be a breaking change.

Fixes #195

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
