### PR TITLE
fix: Make things compilable without std nor alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ required-features = ["alloc"]
 [[example]]
 name = "css"
 test = true
+required-features = ["alloc"]
 
 [[example]]
 name = "custom_error"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,9 @@
 //!
 //! Then use it to parse:
 //! ```rust
+//! # #[cfg(feature = "alloc")] {
 #![doc = include_str!("../examples/css/parser.rs")]
+//! # }
 //! ```
 //!
 //! See also the [Tutorial][_tutorial::chapter_0] and [Special Topics][_topic]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -128,8 +128,8 @@ impl<I> crate::lib::std::ops::Deref for Located<I> {
     }
 }
 
-impl<I: std::fmt::Display> std::fmt::Display for Located<I> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<I: crate::lib::std::fmt::Display> crate::lib::std::fmt::Display for Located<I> {
+    fn fmt(&self, f: &mut crate::lib::std::fmt::Formatter<'_>) -> crate::lib::std::fmt::Result {
         self.input.fmt(f)
     }
 }
@@ -196,8 +196,8 @@ impl<I, S> crate::lib::std::ops::Deref for Stateful<I, S> {
     }
 }
 
-impl<I: std::fmt::Display, S> std::fmt::Display for Stateful<I, S> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<I: crate::lib::std::fmt::Display, S> crate::lib::std::fmt::Display for Stateful<I, S> {
+    fn fmt(&self, f: &mut crate::lib::std::fmt::Formatter<'_>) -> crate::lib::std::fmt::Result {
         self.input.fmt(f)
     }
 }
@@ -310,8 +310,8 @@ impl<I> crate::lib::std::ops::Deref for Partial<I> {
     }
 }
 
-impl<I: std::fmt::Display> std::fmt::Display for Partial<I> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<I: crate::lib::std::fmt::Display> crate::lib::std::fmt::Display for Partial<I> {
+    fn fmt(&self, f: &mut crate::lib::std::fmt::Formatter<'_>) -> crate::lib::std::fmt::Result {
         self.input.fmt(f)
     }
 }


### PR DESCRIPTION
## Description
The crate (`master` branch) does not compile with nostd.

## Steps to reproduce
1. Run `cargo check --no-default-features` and/or `cargo test --no-default-features`.
2. Run `cargo check --no-default-features --features=alloc` and/or `cargo test --no-default-features --features=alloc`.

## Expected result
Both `check` and `test` pass even when `std` feature is disabled.

## Actual result
`check` and `test` fail when `std` feature is disabled.