### PR TITLE
Make Error clonable

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -428,7 +428,7 @@ pub trait ErrorConvert<E> {
 ///:w
 /// **Note:** [context][Parser::context] and inner errors (like from [`Parser::map_res`]) will be
 /// dropped.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Error<I> {
     /// The input stream, pointing to the location where the error occurred
     pub input: I,


### PR DESCRIPTION
> Err is clonable, but error::Error was not.

cherry-picked from rust-bakery/nom#1650
- Expanded to include `Copy`
- Note that `VerboseError` already supports `Clone`

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
