### PR TITLE
fix(char)!: Allow empty `escape`

### DIFF
--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -1585,9 +1585,6 @@ where
                     }
                 } else {
                     let offset = input.offset_to(&i);
-                    if offset == 0 {
-                        return Err(ErrMode::from_error_kind(input, ErrorKind::Escaped));
-                    }
                     return Ok(input.next_slice(offset));
                 }
             }
@@ -1806,12 +1803,6 @@ where
                         }
                     }
                 } else {
-                    if offset == 0 {
-                        return Err(ErrMode::from_error_kind(
-                            remainder,
-                            ErrorKind::EscapedTransform,
-                        ));
-                    }
                     return Ok((remainder, res));
                 }
             }

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -694,13 +694,7 @@ mod complete {
             escaped(digit1, '\\', one_of("\"n\\"))(s)
         }
 
-        assert_eq!(
-            esc("abcd"),
-            Err(ErrMode::Backtrack(Error {
-                input: "abcd",
-                kind: ErrorKind::Escaped
-            }))
-        );
+        assert_eq!(esc("abcd"), Ok(("abcd", "")));
     }
 
     #[cfg(feature = "alloc")]
@@ -850,13 +844,7 @@ mod complete {
             escaped_transform(digit1, '\\', "n")(s)
         }
 
-        assert_eq!(
-            esc_trans("abcd"),
-            Err(ErrMode::Backtrack(Error {
-                input: "abcd",
-                kind: ErrorKind::EscapedTransform
-            }))
-        );
+        assert_eq!(esc_trans("abcd"), Ok(("abcd", String::new())));
     }
 }
 


### PR DESCRIPTION
rust-bakery/nom#958 required at least one non-escaped value but only for `complete` and  not for `streaming`.  There was also no explanation of use case or discussion.  Generally, escaping is used for strings and strings are generally allowed to be empty.

There is the question of whether it should be renamed to `escape0`.  I'm setting that aside for  now.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
