### PR TITLE
refactor: Flatten partial/complete combinators

### DIFF
--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -503,33 +503,11 @@ where
 {
     trace("take_while0", move |i: I| {
         if i.is_partial() {
-            streaming_take_while_internal(i, &list)
+            split_at_offset_partial(&i, |c| !list.contains_token(c))
         } else {
-            complete_take_while_internal(i, &list)
+            split_at_offset_complete(&i, |c| !list.contains_token(c))
         }
     })
-}
-
-pub(crate) fn streaming_take_while_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    list: &T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    split_at_offset_partial(&i, |c| !list.contains_token(c))
-}
-
-pub(crate) fn complete_take_while_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    list: &T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    split_at_offset_complete(&i, |c| !list.contains_token(c))
 }
 
 /// Recognize the longest (at least 1) input slice that matches the [pattern][ContainsToken]
@@ -601,36 +579,13 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("take_while1", move |i: I| {
+        let e: ErrorKind = ErrorKind::TakeWhile1;
         if i.is_partial() {
-            streaming_take_while1_internal(i, &list)
+            split_at_offset1_partial(&i, |c| !list.contains_token(c), e)
         } else {
-            complete_take_while1_internal(i, &list)
+            split_at_offset1_complete(&i, |c| !list.contains_token(c), e)
         }
     })
-}
-
-pub(crate) fn streaming_take_while1_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    list: &T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    let e: ErrorKind = ErrorKind::TakeWhile1;
-    split_at_offset1_partial(&i, |c| !list.contains_token(c), e)
-}
-
-pub(crate) fn complete_take_while1_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    list: &T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    let e: ErrorKind = ErrorKind::TakeWhile1;
-    split_at_offset1_complete(&i, |c| !list.contains_token(c), e)
 }
 
 /// Recognize the longest (m <= len <= n) input slice that matches the [pattern][ContainsToken]
@@ -821,33 +776,11 @@ where
 {
     trace("take_till0", move |i: I| {
         if i.is_partial() {
-            streaming_take_till_internal(i, &list)
+            split_at_offset_partial(&i, |c| list.contains_token(c))
         } else {
-            complete_take_till_internal(i, &list)
+            split_at_offset_complete(&i, |c| list.contains_token(c))
         }
     })
-}
-
-pub(crate) fn streaming_take_till_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    list: &T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    split_at_offset_partial(&i, |c| list.contains_token(c))
-}
-
-pub(crate) fn complete_take_till_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    list: &T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    split_at_offset_complete(&i, |c| list.contains_token(c))
 }
 
 /// Recognize the longest (at least 1) input slice till a [pattern][ContainsToken] is met.
@@ -917,36 +850,13 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("take_till1", move |i: I| {
+        let e: ErrorKind = ErrorKind::TakeTill1;
         if i.is_partial() {
-            streaming_take_till1_internal(i, &list)
+            split_at_offset1_partial(&i, |c| list.contains_token(c), e)
         } else {
-            complete_take_till1_internal(i, &list)
+            split_at_offset1_complete(&i, |c| list.contains_token(c), e)
         }
     })
-}
-
-pub(crate) fn streaming_take_till1_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    list: &T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    let e: ErrorKind = ErrorKind::TakeTill1;
-    split_at_offset1_partial(&i, |c| list.contains_token(c), e)
-}
-
-pub(crate) fn complete_take_till1_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    list: &T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    let e: ErrorKind = ErrorKind::TakeTill1;
-    split_at_offset1_complete(&i, |c| list.contains_token(c), e)
 }
 
 /// Recognize an input slice containing the first N input elements (I[..N]).


### PR DESCRIPTION
This is a follow up to #209

Not sure how I feel about these numbers (mostly looking at `canada`)
- Streaming speed up is good
- Verbose error slow down is bad
- Dispatch slowed down?
```
json/basic/small        time:   [888.82 ns 892.90 ns 897.36 ns]
json/verbose/small      time:   [2.3590 µs 2.3744 µs 2.3904 µs]
json/dispatch/small     time:   [878.03 ns 882.46 ns 887.66 ns]
json/streaming/small    time:   [1.6785 µs 1.6851 µs 1.6919 µs]
json/basic/canada       time:   [12.282 ms 12.379 ms 12.484 ms]
json/verbose/canada     time:   [36.598 ms 36.807 ms 37.028 ms]
json/dispatch/canada    time:   [9.7343 ms 9.7769 ms 9.8228 ms]
json/streaming/canada   time:   [21.357 ms 21.484 ms 21.635 ms]  
```
After:
```
json/basic/small        time:   [944.81 ns 951.53 ns 958.13 ns]
json/verbose/small      time:   [2.4752 µs 2.4926 µs 2.5112 µs]
json/dispatch/small     time:   [817.42 ns 823.53 ns 829.89 ns] 
json/streaming/small    time:   [1.3763 µs 1.3825 µs 1.3896 µs]
json/basic/canada       time:   [12.313 ms 12.402 ms 12.500 ms]
json/verbose/canada     time:   [41.466 ms 41.729 ms 42.006 ms]
json/dispatch/canada    time:   [9.9793 ms 10.043 ms 10.114 ms] 
json/streaming/canada   time:   [17.590 ms 17.671 ms 17.761 ms]
```

Not noticing a compilation slow down