### PR TITLE
fix!: Switch combinators to return `impl Parser`

### DIFF
--- a/examples/arithmetic/parser.rs
+++ b/examples/arithmetic/parser.rs
@@ -25,7 +25,8 @@ pub fn expr(i: &str) -> IResult<&str, i64> {
                 acc - val
             }
         },
-    )(i)
+    )
+    .parse_next(i)
 }
 
 // We read an initial factor and for each time we find
@@ -44,7 +45,8 @@ fn term(i: &str) -> IResult<&str, i64> {
                 acc / val
             }
         },
-    )(i)
+    )
+    .parse_next(i)
 }
 
 // We transform an integer string into a i64, ignoring surrounding whitespaces
@@ -60,12 +62,13 @@ fn factor(i: &str) -> IResult<&str, i64> {
             parens,
         )),
         spaces,
-    )(i)
+    )
+    .parse_next(i)
 }
 
 // We parse any expr surrounded by parens, ignoring all whitespaces around those
 fn parens(i: &str) -> IResult<&str, i64> {
-    delimited(one_of('('), expr, one_of(')'))(i)
+    delimited(one_of('('), expr, one_of(')')).parse_next(i)
 }
 
 #[test]

--- a/examples/css/parser.rs
+++ b/examples/css/parser.rs
@@ -20,7 +20,7 @@ impl std::str::FromStr for Color {
 }
 
 pub fn hex_color(input: &str) -> IResult<&str, Color> {
-    let (input, _) = tag("#")(input)?;
+    let (input, _) = tag("#").parse_next(input)?;
     let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse_next(input)?;
 
     Ok((input, Color { red, green, blue }))

--- a/examples/http/parser.rs
+++ b/examples/http/parser.rs
@@ -2,7 +2,7 @@ use winnow::{
     bytes::{one_of, tag, take_while1},
     character::line_ending,
     multi::many1,
-    IResult,
+    IResult, Parser,
 };
 
 pub type Stream<'i> = &'i [u8];
@@ -49,17 +49,17 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
 
 fn request(input: Stream<'_>) -> IResult<Stream<'_>, (Request<'_>, Vec<Header<'_>>)> {
     let (input, req) = request_line(input)?;
-    let (input, h) = many1(message_header)(input)?;
+    let (input, h) = many1(message_header).parse_next(input)?;
     let (input, _) = line_ending(input)?;
 
     Ok((input, (req, h)))
 }
 
 fn request_line(input: Stream<'_>) -> IResult<Stream<'_>, Request<'_>> {
-    let (input, method) = take_while1(is_token)(input)?;
-    let (input, _) = take_while1(is_space)(input)?;
-    let (input, uri) = take_while1(is_not_space)(input)?;
-    let (input, _) = take_while1(is_space)(input)?;
+    let (input, method) = take_while1(is_token).parse_next(input)?;
+    let (input, _) = take_while1(is_space).parse_next(input)?;
+    let (input, uri) = take_while1(is_not_space).parse_next(input)?;
+    let (input, _) = take_while1(is_space).parse_next(input)?;
     let (input, version) = http_version(input)?;
     let (input, _) = line_ending(input)?;
 
@@ -74,24 +74,24 @@ fn request_line(input: Stream<'_>) -> IResult<Stream<'_>, Request<'_>> {
 }
 
 fn http_version(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-    let (input, _) = tag("HTTP/")(input)?;
-    let (input, version) = take_while1(is_version)(input)?;
+    let (input, _) = tag("HTTP/").parse_next(input)?;
+    let (input, version) = take_while1(is_version).parse_next(input)?;
 
     Ok((input, version))
 }
 
 fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-    let (input, _) = take_while1(is_horizontal_space)(input)?;
-    let (input, data) = take_while1(not_line_ending)(input)?;
+    let (input, _) = take_while1(is_horizontal_space).parse_next(input)?;
+    let (input, data) = take_while1(not_line_ending).parse_next(input)?;
     let (input, _) = line_ending(input)?;
 
     Ok((input, data))
 }
 
 fn message_header(input: Stream<'_>) -> IResult<Stream<'_>, Header<'_>> {
-    let (input, name) = take_while1(is_token)(input)?;
-    let (input, _) = one_of(':')(input)?;
-    let (input, value) = many1(message_header_value)(input)?;
+    let (input, name) = take_while1(is_token).parse_next(input)?;
+    let (input, _) = one_of(':').parse_next(input)?;
+    let (input, value) = many1(message_header_value).parse_next(input)?;
 
     Ok((input, Header { name, value }))
 }

--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -3,7 +3,7 @@ use winnow::{
     character::line_ending,
     multi::many1,
     stream::Partial,
-    IResult,
+    IResult, Parser,
 };
 
 pub type Stream<'i> = Partial<&'i [u8]>;
@@ -50,17 +50,17 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
 
 fn request(input: Stream<'_>) -> IResult<Stream<'_>, (Request<'_>, Vec<Header<'_>>)> {
     let (input, req) = request_line(input)?;
-    let (input, h) = many1(message_header)(input)?;
+    let (input, h) = many1(message_header).parse_next(input)?;
     let (input, _) = line_ending(input)?;
 
     Ok((input, (req, h)))
 }
 
 fn request_line(input: Stream<'_>) -> IResult<Stream<'_>, Request<'_>> {
-    let (input, method) = take_while1(is_token)(input)?;
-    let (input, _) = take_while1(is_space)(input)?;
-    let (input, uri) = take_while1(is_not_space)(input)?;
-    let (input, _) = take_while1(is_space)(input)?;
+    let (input, method) = take_while1(is_token).parse_next(input)?;
+    let (input, _) = take_while1(is_space).parse_next(input)?;
+    let (input, uri) = take_while1(is_not_space).parse_next(input)?;
+    let (input, _) = take_while1(is_space).parse_next(input)?;
     let (input, version) = http_version(input)?;
     let (input, _) = line_ending(input)?;
 
@@ -75,24 +75,24 @@ fn request_line(input: Stream<'_>) -> IResult<Stream<'_>, Request<'_>> {
 }
 
 fn http_version(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-    let (input, _) = tag("HTTP/")(input)?;
-    let (input, version) = take_while1(is_version)(input)?;
+    let (input, _) = tag("HTTP/").parse_next(input)?;
+    let (input, version) = take_while1(is_version).parse_next(input)?;
 
     Ok((input, version))
 }
 
 fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-    let (input, _) = take_while1(is_horizontal_space)(input)?;
-    let (input, data) = take_while1(not_line_ending)(input)?;
+    let (input, _) = take_while1(is_horizontal_space).parse_next(input)?;
+    let (input, data) = take_while1(not_line_ending).parse_next(input)?;
     let (input, _) = line_ending(input)?;
 
     Ok((input, data))
 }
 
 fn message_header(input: Stream<'_>) -> IResult<Stream<'_>, Header<'_>> {
-    let (input, name) = take_while1(is_token)(input)?;
-    let (input, _) = one_of(':')(input)?;
-    let (input, value) = many1(message_header_value)(input)?;
+    let (input, name) = take_while1(is_token).parse_next(input)?;
+    let (input, _) = one_of(':').parse_next(input)?;
+    let (input, value) = many1(message_header_value).parse_next(input)?;
 
     Ok((input, Header { name, value }))
 }

--- a/examples/ini/bench.rs
+++ b/examples/ini/bench.rs
@@ -32,7 +32,7 @@ file=payroll.dat
 \0";
 
     fn acc(i: parser::Stream<'_>) -> IResult<parser::Stream<'_>, Vec<(&str, &str)>> {
-        many0(parser::key_value)(i)
+        many0(parser::key_value).parse_next(i)
     }
 
     let mut group = c.benchmark_group("ini keys and values");

--- a/examples/ini/parser.rs
+++ b/examples/ini/parser.rs
@@ -33,7 +33,7 @@ pub fn key_value(i: Stream<'_>) -> IResult<Stream<'_>, (&str, &str)> {
     let (i, val) = take_while0(|c| c != b'\n' && c != b';')
         .map_res(str::from_utf8)
         .parse_next(i)?;
-    let (i, _) = opt((';', take_while0(|c| c != b'\n')))(i)?;
+    let (i, _) = opt((';', take_while0(|c| c != b'\n'))).parse_next(i)?;
     Ok((i, (key, val)))
 }
 

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -4,14 +4,14 @@ use std::iter::Iterator;
 use winnow::bytes::tag;
 use winnow::character::alphanumeric1;
 use winnow::combinator::iterator;
+use winnow::prelude::*;
 use winnow::sequence::{separated_pair, terminated};
-use winnow::IResult;
 
 fn main() {
     let mut data = "abcabcabcabc";
 
     fn parser(i: &str) -> IResult<&str, &str> {
-        tag("abc")(i)
+        tag("abc").parse_next(i)
     }
 
     // `from_fn` (available from Rust 1.34) can create an iterator

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -34,7 +34,7 @@ pub type Stream<'i> = &'i str;
 pub fn json<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, JsonValue, E> {
-    delimited(ws, json_value, ws)(input)
+    delimited(ws, json_value, ws).parse_next(input)
 }
 
 /// `alt` is a combinator that tries multiple parsers one by one, until
@@ -112,7 +112,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
 fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of("\"")(input)?;
+    let (input, c) = none_of("\"").parse_next(input)?;
     if c == '\\' {
         dispatch!(any;
           '"' => success('"'),
@@ -191,7 +191,7 @@ fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, (String, JsonValue), E> {
-    separated_pair(string, cut_err((ws, ':', ws)), json_value)(input)
+    separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
@@ -200,7 +200,7 @@ fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static s
 fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
     // Combinators like `take_while0` return a function. That function is the
     // parser,to which we can pass the input
-    take_while0(WS)(input)
+    take_while0(WS).parse_next(input)
 }
 
 const WS: &str = " \t\r\n";

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -32,7 +32,7 @@ pub type Stream<'i> = Partial<&'i str>;
 pub fn json<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, JsonValue, E> {
-    delimited(ws, json_value, ws_or_eof)(input)
+    delimited(ws, json_value, ws_or_eof).parse_next(input)
 }
 
 /// `alt` is a combinator that tries multiple parsers one by one, until
@@ -49,7 +49,8 @@ fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static 
         float.map(JsonValue::Num),
         array.map(JsonValue::Array),
         object.map(JsonValue::Object),
-    ))(input)
+    ))
+    .parse_next(input)
 }
 
 /// `tag(string)` generates a parser that recognizes the argument string.
@@ -72,7 +73,7 @@ fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'
     // an error otherwise
     let parse_false = tag("false").value(false);
 
-    alt((parse_true, parse_false))(input)
+    alt((parse_true, parse_false)).parse_next(input)
 }
 
 /// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
@@ -103,7 +104,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
 fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of("\"")(input)?;
+    let (input, c) = none_of("\"").parse_next(input)?;
     if c == '\\' {
         alt((
             any.verify_map(|c| {
@@ -118,7 +119,8 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
                 })
             }),
             preceded('u', unicode_escape),
-        ))(input)
+        ))
+        .parse_next(input)
     } else {
         Ok((input, c))
     }
@@ -183,7 +185,7 @@ fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, (String, JsonValue), E> {
-    separated_pair(string, cut_err((ws, ':', ws)), json_value)(input)
+    separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
@@ -192,7 +194,7 @@ fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static s
 fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
     // Combinators like `take_while0` return a function. That function is the
     // parser,to which we can pass the input
-    take_while0(WS)(input)
+    take_while0(WS).parse_next(input)
 }
 
 fn ws_or_eof<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {

--- a/examples/ndjson/parser.rs
+++ b/examples/ndjson/parser.rs
@@ -53,7 +53,8 @@ fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static 
         float.map(JsonValue::Num),
         array.map(JsonValue::Array),
         object.map(JsonValue::Object),
-    ))(input)
+    ))
+    .parse_next(input)
 }
 
 /// `tag(string)` generates a parser that recognizes the argument string.
@@ -76,7 +77,7 @@ fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'
     // an error otherwise
     let parse_false = tag("false").value(false);
 
-    alt((parse_true, parse_false))(input)
+    alt((parse_true, parse_false)).parse_next(input)
 }
 
 /// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
@@ -107,7 +108,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
 fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of("\"")(input)?;
+    let (input, c) = none_of("\"").parse_next(input)?;
     if c == '\\' {
         alt((
             any.verify_map(|c| {
@@ -122,7 +123,8 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
                 })
             }),
             preceded('u', unicode_escape),
-        ))(input)
+        ))
+        .parse_next(input)
     } else {
         Ok((input, c))
     }
@@ -187,7 +189,7 @@ fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, (String, JsonValue), E> {
-    separated_pair(string, cut_err((ws, ':', ws)), json_value)(input)
+    separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
@@ -196,7 +198,7 @@ fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static s
 fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
     // Combinators like `take_while0` return a function. That function is the
     // parser,to which we can pass the input
-    take_while0(WS)(input)
+    take_while0(WS).parse_next(input)
 }
 
 const WS: &str = " \t";

--- a/examples/string/parser.rs
+++ b/examples/string/parser.rs
@@ -46,7 +46,7 @@ where
     // " character, the closing delimiter " would never match. When using
     // `delimited` with a looping parser (like fold_many0), be sure that the
     // loop won't accidentally match your closing delimiter!
-    delimited('"', build_string, '"')(input)
+    delimited('"', build_string, '"').parse_next(input)
 }
 
 /// A string fragment contains a fragment of a string being parsed: either
@@ -71,7 +71,8 @@ where
         parse_literal.map(StringFragment::Literal),
         parse_escaped_char.map(StringFragment::EscapedChar),
         parse_escaped_whitespace.value(StringFragment::EscapedWS),
-    ))(input)
+    ))
+    .parse_next(input)
 }
 
 /// Parse a non-empty block of text that doesn't include \ or "
@@ -117,7 +118,8 @@ where
             one_of('/').value('/'),
             one_of('"').value('"'),
         )),
-    )(input)
+    )
+    .parse_next(input)
 }
 
 /// Parse a unicode sequence, of the form u{XXXX}, where XXXX is 1 to 6
@@ -158,5 +160,5 @@ where
 fn parse_escaped_whitespace<'a, E: ParseError<&'a str>>(
     input: &'a str,
 ) -> IResult<&'a str, &'a str, E> {
-    preceded('\\', multispace1)(input)
+    preceded('\\', multispace1).parse_next(input)
 }

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -50,11 +50,12 @@ fn parens(i: &str) -> IResult<&str, i64> {
         space,
         delimited(terminated("(", incr), expr, tag(")").map(|_| decr())),
         space,
-    )(i)
+    )
+    .parse_next(i)
 }
 
 fn factor(i: &str) -> IResult<&str, i64> {
-    alt((delimited(space, digit, space).parse_to(), parens))(i)
+    alt((delimited(space, digit, space).parse_to(), parens)).parse_next(i)
 }
 
 fn term(i: &str) -> IResult<&str, i64> {
@@ -79,7 +80,8 @@ fn term(i: &str) -> IResult<&str, i64> {
                 }
             }
         },
-    )(i);
+    )
+    .parse_next(i);
 
     decr();
     res
@@ -102,7 +104,8 @@ fn expr(i: &str) -> IResult<&str, i64> {
                 acc.saturating_sub(val)
             }
         },
-    )(i);
+    )
+    .parse_next(i);
 
     decr();
     res

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -34,9 +34,9 @@
 //!
 //! /// A combinator that takes a parser `inner` and produces a parser that also consumes both leading and
 //! /// trailing whitespace, returning the output of `inner`.
-//! fn ws<'a, F, O, E: ParseError<&'a str>>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+//! fn ws<'a, F, O, E: ParseError<&'a str>>(inner: F) -> impl Parser<&'a str, O, E>
 //!   where
-//!   F: FnMut(&'a str) -> IResult<&'a str, O, E>,
+//!   F: Parser<&'a str, O, E>,
 //! {
 //!   delimited(
 //!     multispace0,
@@ -169,7 +169,7 @@
 //!     many1(
 //!       terminated(one_of("0123456789abcdefABCDEF"), many0('_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
-//!   )(input)
+//!   ).parse_next(input)
 //! }
 //! ```
 //!
@@ -215,7 +215,7 @@
 //!     many1(
 //!       terminated(one_of("01234567"), many0('_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
-//!   )(input)
+//!   ).parse_next(input)
 //! }
 //! ```
 //!
@@ -237,7 +237,7 @@
 //!     many1(
 //!       terminated(one_of("01"), many0('_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
-//!   )(input)
+//!   ).parse_next(input)
 //! }
 //! ```
 //!
@@ -304,7 +304,7 @@
 //!       '.',
 //!       opt(decimal)
 //!     ).recognize()
-//!   ))(input)
+//!   )).parse_next(input)
 //! }
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
@@ -313,7 +313,6 @@
 //!   ).
 //!   map(|()| ())
 //!     .recognize()
-//!
 //!     .parse_next(input)
 //! }
 //! ```

--- a/src/_topic/stream.rs
+++ b/src/_topic/stream.rs
@@ -21,7 +21,7 @@
 //! # type MyStream<'i> = &'i str;
 //! # type Output<'i> = &'i str;
 //! fn parser(i: MyStream<'_>) -> IResult<MyStream<'_>, Output<'_>> {
-//!     tag("test")(i)
+//!     tag("test").parse_next(i)
 //! }
 //! ```
 //!

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -81,10 +81,11 @@
 //! > **Aside:** [`one_of`] might look straightforward, a function returning a value that implements `Parser`.
 //! > Let's look at it more closely as its used above (resolving all generic parameters):
 //! > ```rust
-//! > # use winnow::IResult;
+//! > # use winnow::prelude::*;
+//! > # use winnow::error::Error;
 //! > pub fn one_of<'i>(
 //! >     list: &'static str
-//! > ) -> impl FnMut(&'i str) -> IResult<&'i str, char> {
+//! > ) -> impl Parser<&'i str, char, Error<&'i str>> {
 //! >     // ...
 //! > #    winnow::bytes::one_of(list)
 //! > }

--- a/src/bits/tests.rs
+++ b/src/bits/tests.rs
@@ -10,9 +10,8 @@ fn test_complete_byte_consumption_bits() {
 
     // Take 3 bit slices with sizes [4, 8, 4].
     let result: IResult<&[u8], (u8, u8, u8)> =
-        bits::<_, _, Error<(&[u8], usize)>, _, _>((take(4usize), take(8usize), take(4usize)))(
-            input,
-        );
+        bits::<_, _, Error<(&[u8], usize)>, _, _>((take(4usize), take(8usize), take(4usize)))
+            .parse_next(input);
 
     let output = result.expect("We take 2 bytes and the input is longer than 2 bytes");
 
@@ -35,7 +34,7 @@ fn test_partial_byte_consumption_bits() {
 
     // Take bit slices with sizes [4, 8].
     let result: IResult<&[u8], (u8, u8)> =
-        bits::<_, _, Error<(&[u8], usize)>, _, _>((take(4usize), take(8usize)))(input);
+        bits::<_, _, Error<(&[u8], usize)>, _, _>((take(4usize), take(8usize))).parse_next(input);
 
     let output = result.expect("We take 1.5 bytes and the input is longer than 2 bytes");
 
@@ -55,7 +54,7 @@ fn test_incomplete_bits() {
 
     // Take bit slices with sizes [4, 8].
     let result: IResult<_, (u8, u8)> =
-        bits::<_, _, Error<(_, usize)>, _, _>((take(4usize), take(8usize)))(input);
+        bits::<_, _, Error<(_, usize)>, _, _>((take(4usize), take(8usize))).parse_next(input);
 
     assert!(result.is_err());
     let error = result.err().unwrap();
@@ -69,7 +68,7 @@ fn test_take_complete_0() {
     assert_eq!(count, 0usize);
     let offset = 0usize;
 
-    let result: crate::IResult<(&[u8], usize), usize> = take(count)((input, offset));
+    let result: crate::IResult<(&[u8], usize), usize> = take(count).parse_next((input, offset));
 
     assert_eq!(result, Ok(((input, offset), 0)));
 }
@@ -78,7 +77,7 @@ fn test_take_complete_0() {
 fn test_take_complete_eof() {
     let input = &[0b00010010][..];
 
-    let result: crate::IResult<(&[u8], usize), usize> = take(1usize)((input, 8));
+    let result: crate::IResult<(&[u8], usize), usize> = take(1usize).parse_next((input, 8));
 
     assert_eq!(
         result,
@@ -93,7 +92,7 @@ fn test_take_complete_eof() {
 fn test_take_complete_span_over_multiple_bytes() {
     let input = &[0b00010010, 0b00110100, 0b11111111, 0b11111111][..];
 
-    let result: crate::IResult<(&[u8], usize), usize> = take(24usize)((input, 4));
+    let result: crate::IResult<(&[u8], usize), usize> = take(24usize).parse_next((input, 4));
 
     assert_eq!(
         result,
@@ -108,7 +107,7 @@ fn test_take_partial_0() {
     assert_eq!(count, 0usize);
     let offset = 0usize;
 
-    let result: crate::IResult<(_, usize), usize> = take(count)((input, offset));
+    let result: crate::IResult<(_, usize), usize> = take(count).parse_next((input, offset));
 
     assert_eq!(result, Ok(((input, offset), 0)));
 }
@@ -121,7 +120,7 @@ fn test_tag_partial_ok() {
     let value_to_tag = 0b0001;
 
     let result: crate::IResult<(_, usize), usize> =
-        tag(value_to_tag, bits_to_take)((input, offset));
+        tag(value_to_tag, bits_to_take).parse_next((input, offset));
 
     assert_eq!(result, Ok(((input, bits_to_take), value_to_tag)));
 }
@@ -134,7 +133,7 @@ fn test_tag_partial_err() {
     let value_to_tag = 0b1111;
 
     let result: crate::IResult<(_, usize), usize> =
-        tag(value_to_tag, bits_to_take)((input, offset));
+        tag(value_to_tag, bits_to_take).parse_next((input, offset));
 
     assert_eq!(
         result,
@@ -182,7 +181,7 @@ fn test_bool_0_partial() {
 fn test_bool_eof_partial() {
     let input = Partial::new([0b10000000].as_ref());
 
-    let result: crate::IResult<(Partial<&[u8]>, usize), bool> = bool((input, 8));
+    let result: crate::IResult<(Partial<&[u8]>, usize), bool> = bool.parse_next((input, 8));
 
     assert_eq!(
         result,

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -32,12 +32,13 @@ pub trait Alt<I, O, E> {
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::Error,error::ErrorKind, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::Error,error::ErrorKind, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::character::{alpha1, digit1};
 /// use winnow::branch::alt;
 /// # fn main() {
 /// fn parser(input: &str) -> IResult<&str, &str> {
-///   alt((alpha1, digit1))(input)
+///   alt((alpha1, digit1)).parse_next(input)
 /// };
 ///
 /// // the first parser, alpha1, recognizes the input
@@ -53,7 +54,7 @@ pub trait Alt<I, O, E> {
 #[doc(alias = "choice")]
 pub fn alt<I: Stream, O, E: ParseError<I>, List: Alt<I, O, E>>(
     mut l: List,
-) -> impl FnMut(I) -> IResult<I, O, E> {
+) -> impl Parser<I, O, E> {
     trace("alt", move |i: I| l.choice(i))
 }
 
@@ -72,12 +73,13 @@ pub trait Permutation<I, O, E> {
 /// tuple of the parser results.
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode,error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode,error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::character::{alpha1, digit1};
 /// use winnow::branch::permutation;
 /// # fn main() {
 /// fn parser(input: &str) -> IResult<&str, (&str, &str)> {
-///   permutation((alpha1, digit1))(input)
+///   permutation((alpha1, digit1)).parse_next(input)
 /// }
 ///
 /// // permutation recognizes alphabetic characters then digit
@@ -94,12 +96,13 @@ pub trait Permutation<I, O, E> {
 /// The parsers are applied greedily: if there are multiple unapplied parsers
 /// that could parse the next slice of input, the first one is used.
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}};
+/// # use winnow::prelude::*;
 /// use winnow::branch::permutation;
 /// use winnow::bytes::any;
 ///
 /// fn parser(input: &str) -> IResult<&str, (char, char)> {
-///   permutation((any, 'a'))(input)
+///   permutation((any, 'a')).parse_next(input)
 /// }
 ///
 /// // any parses 'b', then char('a') parses 'a'
@@ -112,7 +115,7 @@ pub trait Permutation<I, O, E> {
 ///
 pub fn permutation<I: Stream, O, E: ParseError<I>, List: Permutation<I, O, E>>(
     mut l: List,
-) -> impl FnMut(I) -> IResult<I, O, E> {
+) -> impl Parser<I, O, E> {
     trace("permutation", move |i: I| l.permutation(i))
 }
 

--- a/src/branch/tests.rs
+++ b/src/branch/tests.rs
@@ -4,6 +4,7 @@ use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::Needed;
 use crate::IResult;
+use crate::Parser;
 use crate::Partial;
 #[cfg(feature = "alloc")]
 use crate::{
@@ -63,13 +64,13 @@ fn alt_test() {
     }
 
     fn alt1(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        alt((dont_work, dont_work))(i)
+        alt((dont_work, dont_work)).parse_next(i)
     }
     fn alt2(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        alt((dont_work, work))(i)
+        alt((dont_work, work)).parse_next(i)
     }
     fn alt3(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        alt((dont_work, dont_work, work2, dont_work))(i)
+        alt((dont_work, dont_work, work2, dont_work)).parse_next(i)
     }
     //named!(alt1, alt!(dont_work | dont_work));
     //named!(alt2, alt!(dont_work | work));
@@ -88,7 +89,7 @@ fn alt_test() {
     assert_eq!(alt3(a), Ok((a, &b""[..])));
 
     fn alt4(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        alt((tag("abcd"), tag("efgh")))(i)
+        alt((tag("abcd"), tag("efgh"))).parse_next(i)
     }
     let b = &b"efgh"[..];
     assert_eq!(alt4(a), Ok((&b""[..], a)));
@@ -98,7 +99,7 @@ fn alt_test() {
 #[test]
 fn alt_incomplete() {
     fn alt1(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        alt((tag("a"), tag("bc"), tag("def")))(i)
+        alt((tag("a"), tag("bc"), tag("def"))).parse_next(i)
     }
 
     let a = &b""[..];
@@ -140,7 +141,7 @@ fn alt_incomplete() {
 fn permutation_test() {
     #[allow(clippy::type_complexity)]
     fn perm(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8], &[u8])> {
-        permutation((tag("abcd"), tag("efg"), tag("hi")))(i)
+        permutation((tag("abcd"), tag("efg"), tag("hi"))).parse_next(i)
     }
 
     let expected = (&b"abcd"[..], &b"efg"[..], &b"hi"[..]);

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -17,13 +17,15 @@ use crate::Partial;
 
 #[test]
 fn complete_take_while_m_n_utf8_all_matching() {
-    let result: IResult<&str, &str> = take_while_m_n(1, 4, |c: char| c.is_alphabetic())("øn");
+    let result: IResult<&str, &str> =
+        take_while_m_n(1, 4, |c: char| c.is_alphabetic()).parse_next("øn");
     assert_eq!(result, Ok(("", "øn")));
 }
 
 #[test]
 fn complete_take_while_m_n_utf8_all_matching_substring() {
-    let result: IResult<&str, &str> = take_while_m_n(1, 1, |c: char| c.is_alphabetic())("øn");
+    let result: IResult<&str, &str> =
+        take_while_m_n(1, 1, |c: char| c.is_alphabetic()).parse_next("øn");
     assert_eq!(result, Ok(("n", "ø")));
 }
 
@@ -58,7 +60,7 @@ proptest! {
       let input = format!("{:a<valid$}{:b<invalid$}", "", "", valid=valid, invalid=invalid);
       let expected = model_complete_take_while_m_n(m, n, valid, &input);
       if m <= n {
-          let actual = take_while_m_n(m, n, |c: char| c == 'a')(input.as_str());
+          let actual = take_while_m_n(m, n, |c: char| c == 'a').parse_next(input.as_str());
           assert_eq!(expected, actual);
       }
   }
@@ -76,7 +78,7 @@ fn partial_any_str() {
 #[test]
 fn partial_one_of_test() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-        one_of("ab")(i)
+        one_of("ab").parse_next(i)
     }
 
     let a = &b"abcd"[..];
@@ -92,7 +94,7 @@ fn partial_one_of_test() {
     );
 
     fn utf8(i: Partial<&str>) -> IResult<Partial<&str>, char> {
-        one_of("+\u{FF0B}")(i)
+        one_of("+\u{FF0B}").parse_next(i)
     }
 
     assert!(utf8(Partial::new("+")).is_ok());
@@ -102,7 +104,7 @@ fn partial_one_of_test() {
 #[test]
 fn char_byteslice() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-        one_of('c')(i)
+        one_of('c').parse_next(i)
     }
 
     let a = &b"abcd"[..];
@@ -121,7 +123,7 @@ fn char_byteslice() {
 #[test]
 fn char_str() {
     fn f(i: Partial<&str>) -> IResult<Partial<&str>, char> {
-        one_of('c')(i)
+        one_of('c').parse_next(i)
     }
 
     let a = "abcd";
@@ -140,7 +142,7 @@ fn char_str() {
 #[test]
 fn partial_none_of_test() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-        none_of("ab")(i)
+        none_of("ab").parse_next(i)
     }
 
     let a = &b"abcd"[..];
@@ -159,7 +161,7 @@ fn partial_none_of_test() {
 #[test]
 fn partial_is_a() {
     fn a_or_b(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while1("ab")(i)
+        take_while1("ab").parse_next(i)
     }
 
     let a = Partial::new(&b"abcd"[..]);
@@ -181,7 +183,7 @@ fn partial_is_a() {
 #[test]
 fn partial_is_not() {
     fn a_or_b(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_till1("ab")(i)
+        take_till1("ab").parse_next(i)
     }
 
     let a = Partial::new(&b"cdab"[..]);
@@ -206,7 +208,7 @@ fn partial_is_not() {
 #[test]
 fn partial_take_until_incomplete() {
     fn y(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_until0("end")(i)
+        take_until0("end").parse_next(i)
     }
     assert_eq!(
         y(Partial::new(&b"nd"[..])),
@@ -225,7 +227,7 @@ fn partial_take_until_incomplete() {
 #[test]
 fn partial_take_until_incomplete_s() {
     fn ys(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_until0("end")(i)
+        take_until0("end").parse_next(i)
     }
     assert_eq!(
         ys(Partial::new("123en")),
@@ -296,7 +298,7 @@ fn partial_recognize() {
 #[test]
 fn partial_take_while0() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while0(AsChar::is_alpha)(i)
+        take_while0(AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"abcd"[..];
@@ -312,7 +314,7 @@ fn partial_take_while0() {
 #[test]
 fn partial_take_while1() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while1(AsChar::is_alpha)(i)
+        take_while1(AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"abcd"[..];
@@ -334,7 +336,7 @@ fn partial_take_while1() {
 #[test]
 fn partial_take_while_m_n() {
     fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while_m_n(2, 4, AsChar::is_alpha)(i)
+        take_while_m_n(2, 4, AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"a"[..];
@@ -363,7 +365,7 @@ fn partial_take_while_m_n() {
 #[test]
 fn partial_take_till0() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_till0(AsChar::is_alpha)(i)
+        take_till0(AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"abcd"[..];
@@ -385,7 +387,7 @@ fn partial_take_till0() {
 #[test]
 fn partial_take_till1() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_till1(AsChar::is_alpha)(i)
+        take_till1(AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"abcd"[..];
@@ -410,7 +412,7 @@ fn partial_take_till1() {
 #[test]
 fn partial_take_while_utf8() {
     fn f(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while0(|c| c != '點')(i)
+        take_while0(|c| c != '點').parse_next(i)
     }
 
     assert_eq!(
@@ -428,7 +430,7 @@ fn partial_take_while_utf8() {
     );
 
     fn g(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while0(|c| c == '點')(i)
+        take_while0(|c| c == '點').parse_next(i)
     }
 
     assert_eq!(
@@ -445,7 +447,7 @@ fn partial_take_while_utf8() {
 #[test]
 fn partial_take_till0_utf8() {
     fn f(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_till0(|c| c == '點')(i)
+        take_till0(|c| c == '點').parse_next(i)
     }
 
     assert_eq!(
@@ -463,7 +465,7 @@ fn partial_take_till0_utf8() {
     );
 
     fn g(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_till0(|c| c != '點')(i)
+        take_till0(|c| c != '點').parse_next(i)
     }
 
     assert_eq!(
@@ -480,7 +482,7 @@ fn partial_take_till0_utf8() {
 #[test]
 fn partial_take_utf8() {
     fn f(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take(3_usize)(i)
+        take(3_usize).parse_next(i)
     }
 
     assert_eq!(
@@ -500,7 +502,7 @@ fn partial_take_utf8() {
     assert_eq!(f(Partial::new("a點b")), Ok((Partial::new(""), "a點b")));
 
     fn g(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while0(|c| c == '點')(i)
+        take_while0(|c| c == '點').parse_next(i)
     }
 
     assert_eq!(
@@ -517,7 +519,7 @@ fn partial_take_utf8() {
 #[test]
 fn partial_take_while_m_n_utf8_fixed() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while_m_n(1, 1, |c| c == 'A' || c == '😃')(i)
+        take_while_m_n(1, 1, |c| c == 'A' || c == '😃').parse_next(i)
     }
     assert_eq!(parser(Partial::new("A!")), Ok((Partial::new("!"), "A")));
     assert_eq!(parser(Partial::new("😃!")), Ok((Partial::new("!"), "😃")));
@@ -526,7 +528,7 @@ fn partial_take_while_m_n_utf8_fixed() {
 #[test]
 fn partial_take_while_m_n_utf8_range() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while_m_n(1, 2, |c| c == 'A' || c == '😃')(i)
+        take_while_m_n(1, 2, |c| c == 'A' || c == '😃').parse_next(i)
     }
     assert_eq!(parser(Partial::new("A!")), Ok((Partial::new("!"), "A")));
     assert_eq!(parser(Partial::new("😃!")), Ok((Partial::new("!"), "😃")));
@@ -535,7 +537,7 @@ fn partial_take_while_m_n_utf8_range() {
 #[test]
 fn partial_take_while_m_n_utf8_full_match_fixed() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while_m_n(1, 1, |c: char| c.is_alphabetic())(i)
+        take_while_m_n(1, 1, |c: char| c.is_alphabetic()).parse_next(i)
     }
     assert_eq!(parser(Partial::new("øn")), Ok((Partial::new("n"), "ø")));
 }
@@ -543,7 +545,7 @@ fn partial_take_while_m_n_utf8_full_match_fixed() {
 #[test]
 fn partial_take_while_m_n_utf8_full_match_range() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while_m_n(1, 2, |c: char| c.is_alphabetic())(i)
+        take_while_m_n(1, 2, |c: char| c.is_alphabetic()).parse_next(i)
     }
     assert_eq!(parser(Partial::new("øn")), Ok((Partial::new(""), "øn")));
 }
@@ -552,7 +554,7 @@ fn partial_take_while_m_n_utf8_full_match_range() {
 #[cfg(feature = "std")]
 fn partial_recognize_take_while0() {
     fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while0(AsChar::is_alphanum)(i)
+        take_while0(AsChar::is_alphanum).parse_next(i)
     }
     fn y(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         x.recognize().parse_next(i)
@@ -572,7 +574,7 @@ fn partial_length_bytes() {
     use crate::number::le_u8;
 
     fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        length_data(le_u8)(i)
+        length_data(le_u8).parse_next(i)
     }
     assert_eq!(
         x(Partial::new(b"\x02..>>")),
@@ -592,8 +594,8 @@ fn partial_length_bytes() {
     );
 
     fn y(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        let (i, _) = tag("magic")(i)?;
-        length_data(le_u8)(i)
+        let (i, _) = tag("magic").parse_next(i)?;
+        length_data(le_u8).parse_next(i)
     }
     assert_eq!(
         y(Partial::new(b"magic\x02..>>")),
@@ -617,7 +619,7 @@ fn partial_length_bytes() {
 #[test]
 fn partial_case_insensitive() {
     fn test(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        tag_no_case("ABcd")(i)
+        tag_no_case("ABcd").parse_next(i)
     }
     assert_eq!(
         test(Partial::new(&b"aBCdefgh"[..])),
@@ -651,7 +653,7 @@ fn partial_case_insensitive() {
     );
 
     fn test2(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        tag_no_case("ABcd")(i)
+        tag_no_case("ABcd").parse_next(i)
     }
     assert_eq!(
         test2(Partial::new("aBCdefgh")),
@@ -688,10 +690,10 @@ fn partial_case_insensitive() {
 #[test]
 fn partial_tag_fixed_size_array() {
     fn test(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        tag([0x42])(i)
+        tag([0x42]).parse_next(i)
     }
     fn test2(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        tag(&[0x42])(i)
+        tag(&[0x42]).parse_next(i)
     }
     let input = Partial::new(&[0x42, 0x00][..]);
     assert_eq!(test(input), Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..])));

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -58,7 +58,7 @@ where
     I: Stream,
     I: Compare<&'static str>,
 {
-    trace("crlf", move |input: I| tag("\r\n").parse_next(input))(input)
+    trace("crlf", move |input: I| tag("\r\n").parse_next(input)).parse_next(input)
 }
 
 /// Recognizes a string of any char except '\r\n' or '\n'.
@@ -108,7 +108,8 @@ where
         } else {
             complete_not_line_ending(input)
         }
-    })(input)
+    })
+    .parse_next(input)
 }
 
 pub(crate) fn streaming_not_line_ending<T, E: ParseError<T>>(
@@ -217,7 +218,8 @@ where
 {
     trace("line_ending", move |input: I| {
         alt(("\n", "\r\n")).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Matches a newline character '\n'.
@@ -259,7 +261,8 @@ where
         one_of('\n')
             .map(|c: <I as Stream>::Token| c.as_char())
             .parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Matches a tab character '\t'.
@@ -301,7 +304,8 @@ where
         one_of('\t')
             .map(|c: <I as Stream>::Token| c.as_char())
             .parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
@@ -343,7 +347,8 @@ where
 {
     trace("alpha0", move |input: I| {
         take_while0(|c: <I as Stream>::Token| c.is_alpha()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes one or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
@@ -385,7 +390,8 @@ where
 {
     trace("alpha1", move |input: I| {
         take_while1(|c: <I as Stream>::Token| c.is_alpha()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes zero or more ASCII numerical characters: 0-9
@@ -428,7 +434,8 @@ where
 {
     trace("digit0", move |input: I| {
         take_while0(|c: <I as Stream>::Token| c.is_dec_digit()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes one or more ASCII numerical characters: 0-9
@@ -486,7 +493,8 @@ where
 {
     trace("digit1", move |input: I| {
         take_while1(|c: <I as Stream>::Token| c.is_dec_digit()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes zero or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -527,7 +535,8 @@ where
 {
     trace("hex_digit0", move |input: I| {
         take_while0(|c: <I as Stream>::Token| c.is_hex_digit()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes one or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -569,7 +578,8 @@ where
 {
     trace("hex_digit1", move |input: I| {
         take_while1(|c: <I as Stream>::Token| c.is_hex_digit()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes zero or more octal characters: 0-7
@@ -611,7 +621,8 @@ where
 {
     trace("oct_digit0", move |input: I| {
         take_while0(|c: <I as Stream>::Token| c.is_oct_digit()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes one or more octal characters: 0-7
@@ -653,7 +664,8 @@ where
 {
     trace("oct_digit0", move |input: I| {
         take_while1(|c: <I as Stream>::Token| c.is_oct_digit()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes zero or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -695,7 +707,8 @@ where
 {
     trace("alphanumeric0", move |input: I| {
         take_while0(|c: <I as Stream>::Token| c.is_alphanum()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes one or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -737,7 +750,8 @@ where
 {
     trace("alphanumeric1", move |input: I| {
         take_while1(|c: <I as Stream>::Token| c.is_alphanum()).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes zero or more spaces and tabs.
@@ -767,7 +781,8 @@ where
 {
     trace("space0", move |input: I| {
         take_while0((' ', '\t')).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes one or more spaces and tabs.
@@ -809,7 +824,8 @@ where
 {
     trace("space1", move |input: I| {
         take_while1((' ', '\t')).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes zero or more spaces, tabs, carriage returns and line feeds.
@@ -851,7 +867,8 @@ where
 {
     trace("multispace0", move |input: I| {
         take_while0((' ', '\t', '\r', '\n')).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes one or more spaces, tabs, carriage returns and line feeds.
@@ -893,7 +910,8 @@ where
 {
     trace("multispace1", move |input: I| {
         take_while1((' ', '\t', '\r', '\n')).parse_next(input)
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Decode a decimal unsigned integer
@@ -947,7 +965,8 @@ where
         } else {
             Ok((input.next_slice(input.eof_offset()).0, value))
         }
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Metadata for parsing unsigned integers, see [`dec_uint`]
@@ -1111,7 +1130,8 @@ where
         } else {
             Ok((input.next_slice(input.eof_offset()).0, value))
         }
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Metadata for parsing signed integers, see [`dec_int`]
@@ -1239,7 +1259,8 @@ where
         }
 
         Ok((remaining, res))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Metadata for parsing hex numbers, see [`hex_uint`]
@@ -1346,7 +1367,8 @@ where
             Some(f) => Ok((i, f)),
             None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
         }
-    })(input)
+    })
+    .parse_next(input)
 }
 
 fn recognize_float_or_exceptions<I, E: ParseError<I>>(
@@ -1366,7 +1388,8 @@ where
         crate::bytes::tag_no_case("nan"),
         crate::bytes::tag_no_case("inf"),
         crate::bytes::tag_no_case("infinity"),
-    ))(input)
+    ))
+    .parse_next(input)
 }
 
 fn recognize_float<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -1399,29 +1422,31 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::character::digit1;
+/// # use winnow::prelude::*;
 /// use winnow::character::escaped;
 /// use winnow::bytes::one_of;
 ///
 /// fn esc(s: &str) -> IResult<&str, &str> {
-///   escaped(digit1, '\\', one_of(r#""n\"#))(s)
+///   escaped(digit1, '\\', one_of(r#""n\"#)).parse_next(s)
 /// }
 ///
 /// assert_eq!(esc("123;"), Ok((";", "123")));
 /// assert_eq!(esc(r#"12\"34;"#), Ok((";", r#"12\"34"#)));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::character::digit1;
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::character::escaped;
 /// use winnow::bytes::one_of;
 ///
 /// fn esc(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   escaped(digit1, '\\', one_of("\"n\\"))(s)
+///   escaped(digit1, '\\', one_of("\"n\\")).parse_next(s)
 /// }
 ///
 /// assert_eq!(esc(Partial::new("123;")), Ok((Partial::new(";"), "123")));
@@ -1432,7 +1457,7 @@ pub fn escaped<'a, I: 'a, Error, F, G, O1, O2>(
     mut normal: F,
     control_char: char,
     mut escapable: G,
-) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, Error>
+) -> impl Parser<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + Offset,
@@ -1574,7 +1599,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use std::str::from_utf8;
@@ -1592,7 +1617,7 @@ where
 ///       tag("\"").value("\""),
 ///       tag("n").value("\n"),
 ///     ))
-///   )(input)
+///   ).parse_next(input)
 /// }
 ///
 /// assert_eq!(parser("ab\\\"cd"), Ok(("", String::from("ab\"cd"))));
@@ -1618,7 +1643,7 @@ where
 ///       tag("\"").value("\""),
 ///       tag("n").value("\n"),
 ///     ))
-///   )(input)
+///   ).parse_next(input)
 /// }
 ///
 /// assert_eq!(parser(Partial::new("ab\\\"cd\"")), Ok((Partial::new("\""), String::from("ab\"cd"))));
@@ -1629,7 +1654,7 @@ pub fn escaped_transform<I, Error, F, G, Output>(
     mut normal: F,
     control_char: char,
     mut transform: G,
-) -> impl FnMut(I) -> IResult<I, Output, Error>
+) -> impl Parser<I, Output, Error>
 where
     I: StreamIsPartial,
     I: Stream + Offset,

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -158,7 +158,7 @@ fn test_parser_into() {
 #[test]
 fn opt_test() {
     fn opt_abcd(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Option<&[u8]>> {
-        opt(tag("abcd"))(i)
+        opt(tag("abcd")).parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -181,7 +181,7 @@ fn opt_test() {
 #[test]
 fn peek_test() {
     fn peek_tag(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        peek(tag("abcd"))(i)
+        peek(tag("abcd")).parse_next(i)
     }
 
     assert_eq!(
@@ -204,7 +204,7 @@ fn peek_test() {
 #[test]
 fn not_test() {
     fn not_aaa(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, ()> {
-        not(tag("aaa"))(i)
+        not(tag("aaa")).parse_next(i)
     }
 
     assert_eq!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -713,6 +713,6 @@ mod tests {
     fn convert_error_panic() {
         let input = "";
 
-        let _result: IResult<_, _, VerboseError<&str>> = one_of('x')(input);
+        let _result: IResult<_, _, VerboseError<&str>> = one_of('x').parse_next(input);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ pub mod prelude {
     pub use crate::stream::StreamIsPartial as _;
     pub use crate::FinishIResult as _;
     pub use crate::IResult;
-    pub use crate::Parser as _;
+    pub use crate::Parser;
 }
 
 pub use error::FinishIResult;

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -9,7 +9,7 @@ use crate::error::ParseError;
 use crate::stream::Accumulate;
 use crate::stream::{Stream, StreamIsPartial, ToUsize, UpdateSlice};
 use crate::trace::trace;
-use crate::{IResult, Parser};
+use crate::Parser;
 
 /// [`Accumulate`] the output of a parser into a container, like `Vec`
 ///
@@ -25,12 +25,13 @@ use crate::{IResult, Parser};
 ///
 #[cfg_attr(not(feature = "std"), doc = "```ignore")]
 #[cfg_attr(feature = "std", doc = "```")]
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::many0;
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many0(tag("abc"))(s)
+///   many0(tag("abc")).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -41,7 +42,7 @@ use crate::{IResult, Parser};
 #[doc(alias = "skip_many")]
 #[doc(alias = "repeated")]
 #[doc(alias = "many0_count")]
-pub fn many0<I, O, C, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, C, E>
+pub fn many0<I, O, C, E, F>(mut f: F) -> impl Parser<I, C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -88,12 +89,13 @@ where
 ///
 #[cfg_attr(not(feature = "std"), doc = "```ignore")]
 #[cfg_attr(feature = "std", doc = "```")]
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::many1;
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many1(tag("abc"))(s)
+///   many1(tag("abc")).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -104,7 +106,7 @@ where
 #[doc(alias = "skip_many1")]
 #[doc(alias = "repeated")]
 #[doc(alias = "many1_count")]
-pub fn many1<I, O, C, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, C, E>
+pub fn many1<I, O, C, E, F>(mut f: F) -> impl Parser<I, C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -150,12 +152,13 @@ where
 ///
 #[cfg_attr(not(feature = "std"), doc = "```ignore")]
 #[cfg_attr(feature = "std", doc = "```")]
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::many_till0;
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, (Vec<&str>, &str)> {
-///   many_till0(tag("abc"), tag("end"))(s)
+///   many_till0(tag("abc"), tag("end")).parse_next(s)
 /// };
 ///
 /// assert_eq!(parser("abcabcend"), Ok(("", (vec!["abc", "abc"], "end"))));
@@ -164,7 +167,7 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
 /// ```
-pub fn many_till0<I, O, C, P, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, (C, P), E>
+pub fn many_till0<I, O, C, P, E, F, G>(mut f: F, mut g: G) -> impl Parser<I, (C, P), E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -211,12 +214,13 @@ where
 ///
 #[cfg_attr(not(feature = "std"), doc = "```ignore")]
 #[cfg_attr(feature = "std", doc = "```")]
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::separated0;
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated0(tag("abc"), tag("|"))(s)
+///   separated0(tag("abc"), tag("|")).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
@@ -227,10 +231,7 @@ where
 /// ```
 #[doc(alias = "sep_by")]
 #[doc(alias = "separated_list0")]
-pub fn separated0<I, O, C, O2, E, P, S>(
-    mut parser: P,
-    mut sep: S,
-) -> impl FnMut(I) -> IResult<I, C, E>
+pub fn separated0<I, O, C, O2, E, P, S>(mut parser: P, mut sep: S) -> impl Parser<I, C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -290,12 +291,13 @@ where
 ///
 #[cfg_attr(not(feature = "std"), doc = "```ignore")]
 #[cfg_attr(feature = "std", doc = "```")]
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::separated1;
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated1(tag("abc"), tag("|"))(s)
+///   separated1(tag("abc"), tag("|")).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
@@ -306,10 +308,7 @@ where
 /// ```
 #[doc(alias = "sep_by1")]
 #[doc(alias = "separated_list1")]
-pub fn separated1<I, O, C, O2, E, P, S>(
-    mut parser: P,
-    mut sep: S,
-) -> impl FnMut(I) -> IResult<I, C, E>
+pub fn separated1<I, O, C, O2, E, P, S>(mut parser: P, mut sep: S) -> impl Parser<I, C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -361,13 +360,14 @@ where
 ///
 /// # Example
 ///
-/// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// ```rust
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::separated_foldl1;
 /// use winnow::character::dec_int;
 ///
 /// fn parser(s: &str) -> IResult<&str, i32> {
-///   separated_foldl1(dec_int, "-", |l, _, r| l - r)(s)
+///   separated_foldl1(dec_int, "-", |l, _, r| l - r).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("9-3-5"), Ok(("", 1)));
@@ -378,7 +378,7 @@ pub fn separated_foldl1<I, O, O2, E, P, S, Op>(
     mut parser: P,
     mut sep: S,
     op: Op,
-) -> impl FnMut(I) -> IResult<I, O, E>
+) -> impl Parser<I, O, E>
 where
     I: Stream,
     P: Parser<I, O, E>,
@@ -422,12 +422,13 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::separated_foldr1;
 /// use winnow::character::dec_uint;
 ///
 /// fn parser(s: &str) -> IResult<&str, u32> {
-///   separated_foldr1(dec_uint, "^", |l: u32, _, r: u32| l.pow(r))(s)
+///   separated_foldr1(dec_uint, "^", |l: u32, _, r: u32| l.pow(r)).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("2^3^2"), Ok(("", 512)));
@@ -440,7 +441,7 @@ pub fn separated_foldr1<I, O, O2, E, P, S, Op>(
     mut parser: P,
     mut sep: S,
     op: Op,
-) -> impl FnMut(I) -> IResult<I, O, E>
+) -> impl Parser<I, O, E>
 where
     I: Stream,
     P: Parser<I, O, E>,
@@ -485,12 +486,13 @@ where
 ///
 #[cfg_attr(not(feature = "std"), doc = "```ignore")]
 #[cfg_attr(feature = "std", doc = "```")]
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::many_m_n;
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many_m_n(0, 2, tag("abc"))(s)
+///   many_m_n(0, 2, tag("abc")).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -500,11 +502,7 @@ where
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
 #[doc(alias = "repeated")]
-pub fn many_m_n<I, O, C, E, F>(
-    min: usize,
-    max: usize,
-    mut parse: F,
-) -> impl FnMut(I) -> IResult<I, C, E>
+pub fn many_m_n<I, O, C, E, F>(min: usize, max: usize, mut parse: F) -> impl Parser<I, C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -558,12 +556,13 @@ where
 ///
 #[cfg_attr(not(feature = "std"), doc = "```ignore")]
 #[cfg_attr(feature = "std", doc = "```")]
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::count;
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   count(tag("abc"), 2)(s)
+///   count(tag("abc"), 2).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -573,7 +572,7 @@ where
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
 #[doc(alias = "skip_counskip_count")]
-pub fn count<I, O, C, E, F>(mut f: F, count: usize) -> impl FnMut(I) -> IResult<I, C, E>
+pub fn count<I, O, C, E, F>(mut f: F, count: usize) -> impl Parser<I, C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -612,13 +611,14 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::fill;
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, [&str; 2]> {
 ///   let mut buf = ["", ""];
-///   let (rest, ()) = fill(tag("abc"), &mut buf)(s)?;
+///   let (rest, ()) = fill(tag("abc"), &mut buf).parse_next(s)?;
 ///   Ok((rest, buf))
 /// }
 ///
@@ -628,7 +628,7 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", ["abc", "abc"])));
 /// ```
-pub fn fill<'a, I, O, E, F>(mut f: F, buf: &'a mut [O]) -> impl FnMut(I) -> IResult<I, (), E> + 'a
+pub fn fill<'a, I, O, E, F>(mut f: F, buf: &'a mut [O]) -> impl Parser<I, (), E> + 'a
 where
     I: Stream + 'a,
     F: Parser<I, O, E> + 'a,
@@ -671,7 +671,8 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::fold_many0;
 /// use winnow::bytes::tag;
 ///
@@ -683,7 +684,7 @@ where
 ///       acc.push(item);
 ///       acc
 ///     }
-///   )(s)
+///   ).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -691,11 +692,7 @@ where
 /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// ```
-pub fn fold_many0<I, O, E, F, G, H, R>(
-    mut f: F,
-    mut init: H,
-    mut g: G,
-) -> impl FnMut(I) -> IResult<I, R, E>
+pub fn fold_many0<I, O, E, F, G, H, R>(mut f: F, mut init: H, mut g: G) -> impl Parser<I, R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -749,7 +746,8 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::fold_many1;
 /// use winnow::bytes::tag;
 ///
@@ -761,7 +759,7 @@ where
 ///       acc.push(item);
 ///       acc
 ///     }
-///   )(s)
+///   ).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -769,11 +767,7 @@ where
 /// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(Error::new("123123", ErrorKind::Many))));
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Many))));
 /// ```
-pub fn fold_many1<I, O, E, F, G, H, R>(
-    mut f: F,
-    mut init: H,
-    mut g: G,
-) -> impl FnMut(I) -> IResult<I, R, E>
+pub fn fold_many1<I, O, E, F, G, H, R>(mut f: F, mut init: H, mut g: G) -> impl Parser<I, R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -837,7 +831,8 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::multi::fold_many_m_n;
 /// use winnow::bytes::tag;
 ///
@@ -851,7 +846,7 @@ where
 ///       acc.push(item);
 ///       acc
 ///     }
-///   )(s)
+///   ).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -866,7 +861,7 @@ pub fn fold_many_m_n<I, O, E, F, G, H, R>(
     mut parse: F,
     mut init: H,
     mut fold: G,
-) -> impl FnMut(I) -> IResult<I, R, E>
+) -> impl Parser<I, R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -921,7 +916,8 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult, stream::Partial};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, stream::Partial};
+/// # use winnow::prelude::*;
 /// use winnow::Bytes;
 /// use winnow::number::be_u16;
 /// use winnow::multi::length_data;
@@ -934,13 +930,13 @@ where
 /// }
 ///
 /// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-///   length_data(be_u16)(s)
+///   length_data(be_u16).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
 /// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
-pub fn length_data<I, N, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn length_data<I, N, E, F>(mut f: F) -> impl Parser<I, <I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -972,7 +968,8 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult, stream::{Partial, StreamIsPartial}};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, stream::{Partial, StreamIsPartial}};
+/// # use winnow::prelude::*;
 /// use winnow::Bytes;
 /// use winnow::number::be_u16;
 /// use winnow::multi::length_value;
@@ -991,14 +988,14 @@ where
 /// }
 ///
 /// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-///   length_value(be_u16, tag("abc"))(s)
+///   length_value(be_u16, tag("abc")).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
 /// assert_eq!(parser(stream(b"\x00\x03123123")), Err(ErrMode::Backtrack(Error::new(complete_stream(&b"123"[..]), ErrorKind::Tag))));
 /// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
-pub fn length_value<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, O, E>
+pub fn length_value<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl Parser<I, O, E>
 where
     I: StreamIsPartial,
     I: Stream + UpdateSlice,
@@ -1028,7 +1025,8 @@ where
 #[cfg_attr(not(feature = "std"), doc = "```ignore")]
 #[cfg_attr(feature = "std", doc = "```")]
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
 /// use winnow::Bytes;
 /// use winnow::number::u8;
 /// use winnow::multi::length_count;
@@ -1044,13 +1042,13 @@ where
 ///   length_count(u8.map(|i| {
 ///      println!("got number: {}", i);
 ///      i
-///   }), tag("abc"))(s)
+///   }), tag("abc")).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser(stream(b"\x02abcabcabc")), Ok((stream(b"abc"), vec![&b"abc"[..], &b"abc"[..]])));
 /// assert_eq!(parser(stream(b"\x03123123123")), Err(ErrMode::Backtrack(Error::new(stream(b"123123123"), ErrorKind::Tag))));
 /// ```
-pub fn length_count<I, O, C, N, E, F, G>(mut f: F, mut g: G) -> impl FnMut(I) -> IResult<I, C, E>
+pub fn length_count<I, O, C, N, E, F, G>(mut f: F, mut g: G) -> impl Parser<I, C, E>
 where
     I: Stream,
     N: ToUsize,

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -22,13 +22,13 @@ use crate::{
 #[cfg(feature = "alloc")]
 fn separated0_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0(tag("abcd"), tag(","))(i)
+        separated0(tag("abcd"), tag(",")).parse_next(i)
     }
     fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0(tag(""), tag(","))(i)
+        separated0(tag(""), tag(",")).parse_next(i)
     }
     fn multi_longsep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0(tag("abcd"), tag(".."))(i)
+        separated0(tag("abcd"), tag("..")).parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -78,7 +78,7 @@ fn separated0_test() {
 #[cfg_attr(debug_assertions, should_panic)]
 fn separated0_empty_sep_test() {
     fn empty_sep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0(tag("abc"), tag(""))(i)
+        separated0(tag("abc"), tag("")).parse_next(i)
     }
 
     let i = &b"abcabc"[..];
@@ -97,10 +97,10 @@ fn separated0_empty_sep_test() {
 #[cfg(feature = "alloc")]
 fn separated1_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated1(tag("abcd"), tag(","))(i)
+        separated1(tag("abcd"), tag(",")).parse_next(i)
     }
     fn multi_longsep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated1(tag("abcd"), tag(".."))(i)
+        separated1(tag("abcd"), tag("..")).parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -147,7 +147,7 @@ fn separated1_test() {
 #[cfg(feature = "alloc")]
 fn many0_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(tag("abcd"))(i)
+        many0(tag("abcd")).parse_next(i)
     }
 
     assert_eq!(
@@ -181,7 +181,7 @@ fn many0_test() {
 #[cfg_attr(debug_assertions, should_panic)]
 fn many0_empty_test() {
     fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(tag(""))(i)
+        many0(tag("")).parse_next(i)
     }
 
     assert_eq!(
@@ -197,7 +197,7 @@ fn many0_empty_test() {
 #[cfg(feature = "alloc")]
 fn many1_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many1(tag("abcd"))(i)
+        many1(tag("abcd")).parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -230,7 +230,7 @@ fn many1_test() {
 fn many_till_test() {
     #[allow(clippy::type_complexity)]
     fn multi(i: &[u8]) -> IResult<&[u8], (Vec<&[u8]>, &[u8])> {
-        many_till0(tag("abcd"), tag("efgh"))(i)
+        many_till0(tag("abcd"), tag("efgh")).parse_next(i)
     }
 
     let a = b"abcdabcdefghabcd";
@@ -261,13 +261,13 @@ fn infinite_many() {
 
     // should not go into an infinite loop
     fn multi0(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        many0(tst)(i)
+        many0(tst).parse_next(i)
     }
     let a = &b"abcdef"[..];
     assert_eq!(multi0(a), Ok((a, Vec::new())));
 
     fn multi1(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        many1(tst)(i)
+        many1(tst).parse_next(i)
     }
     let a = &b"abcdef"[..];
     assert_eq!(
@@ -280,7 +280,7 @@ fn infinite_many() {
 #[cfg(feature = "alloc")]
 fn many_m_n_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many_m_n(2, 4, tag("Abcd"))(i)
+        many_m_n(2, 4, tag("Abcd")).parse_next(i)
     }
 
     let a = &b"Abcdef"[..];
@@ -322,7 +322,7 @@ fn many_m_n_test() {
 fn count_test() {
     const TIMES: usize = 2;
     fn cnt_2(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        count(tag("abc"), TIMES)(i)
+        count(tag("abc"), TIMES).parse_next(i)
     }
 
     assert_eq!(
@@ -365,7 +365,7 @@ fn count_test() {
 fn count_zero() {
     const TIMES: usize = 0;
     fn counter_2(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        count(tag("abc"), TIMES)(i)
+        count(tag("abc"), TIMES).parse_next(i)
     }
 
     let done = &b"abcabcabcdef"[..];
@@ -428,7 +428,7 @@ fn length_count_test() {
     }
 
     fn cnt(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        length_count(number, tag("abc"))(i)
+        length_count(number, tag("abc")).parse_next(i)
     }
 
     assert_eq!(
@@ -469,7 +469,7 @@ fn length_data_test() {
     }
 
     fn take(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        length_data(number)(i)
+        length_data(number).parse_next(i)
     }
 
     assert_eq!(
@@ -498,10 +498,10 @@ fn length_value_test() {
     use crate::stream::StreamIsPartial;
 
     fn length_value_1(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-        length_value(be_u8, be_u16)(i)
+        length_value(be_u8, be_u16).parse_next(i)
     }
     fn length_value_2(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (u8, u8)> {
-        length_value(be_u8, (be_u8, be_u8))(i)
+        length_value(be_u8, (be_u8, be_u8)).parse_next(i)
     }
 
     let mut empty_complete = Partial::new(&b""[..]);
@@ -572,7 +572,7 @@ fn fold_many0_test() {
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many0(tag("abcd"), Vec::new, fold_into_vec)(i)
+        fold_many0(tag("abcd"), Vec::new, fold_into_vec).parse_next(i)
     }
 
     assert_eq!(
@@ -610,7 +610,7 @@ fn fold_many0_empty_test() {
         acc
     }
     fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many0(tag(""), Vec::new, fold_into_vec)(i)
+        fold_many0(tag(""), Vec::new, fold_into_vec).parse_next(i)
     }
 
     assert_eq!(
@@ -630,7 +630,7 @@ fn fold_many1_test() {
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many1(tag("abcd"), Vec::new, fold_into_vec)(i)
+        fold_many1(tag("abcd"), Vec::new, fold_into_vec).parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -666,7 +666,7 @@ fn fold_many_m_n_test() {
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many_m_n(2, 4, tag("Abcd"), Vec::new, fold_into_vec)(i)
+        fold_many_m_n(2, 4, tag("Abcd"), Vec::new, fold_into_vec).parse_next(i)
     }
 
     let a = &b"Abcdef"[..];
@@ -706,7 +706,7 @@ fn fold_many_m_n_test() {
 #[test]
 fn many0_count_test() {
     fn count0_nums(i: &[u8]) -> IResult<&[u8], usize> {
-        many0((digit, tag(",")))(i)
+        many0((digit, tag(","))).parse_next(i)
     }
 
     assert_eq!(count0_nums(&b"123,junk"[..]), Ok((&b"junk"[..], 1)));
@@ -724,7 +724,7 @@ fn many0_count_test() {
 #[test]
 fn many1_count_test() {
     fn count1_nums(i: &[u8]) -> IResult<&[u8], usize> {
-        many1((digit, tag(",")))(i)
+        many1((digit, tag(","))).parse_next(i)
     }
 
     assert_eq!(count1_nums(&b"123,45,junk"[..]), Ok((&b"junk"[..], 2)));

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -37,12 +37,13 @@ pub enum Endianness {
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u8;
 ///
-/// let parser = |s| {
-///   be_u8(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u8> {
+///     be_u8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
 /// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Token))));
@@ -50,12 +51,13 @@ pub enum Endianness {
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_u8;
 ///
-/// let parser = |s| {
-///   be_u8::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
+///     be_u8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -79,12 +81,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u16;
 ///
-/// let parser = |s| {
-///   be_u16(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u16> {
+///     be_u16.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -92,12 +95,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_u16;
 ///
-/// let parser = |s| {
-///   be_u16::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
+///     be_u16.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -109,7 +113,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u16", move |input: I| be_uint(input, 2))(input)
+    trace("be_u16", move |input: I| be_uint(input, 2)).parse_next(input)
 }
 
 /// Recognizes a big endian unsigned 3 byte integer.
@@ -122,12 +126,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u24;
 ///
-/// let parser = |s| {
-///   be_u24(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u32> {
+///     be_u24.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -135,12 +140,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_u24;
 ///
-/// let parser = |s| {
-///   be_u24::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+///     be_u24.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x000102)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
@@ -152,7 +158,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u23", move |input: I| be_uint(input, 3))(input)
+    trace("be_u23", move |input: I| be_uint(input, 3)).parse_next(input)
 }
 
 /// Recognizes a big endian unsigned 4 bytes integer.
@@ -165,12 +171,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u32;
 ///
-/// let parser = |s| {
-///   be_u32(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u32> {
+///     be_u32.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -178,12 +185,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_u32;
 ///
-/// let parser = |s| {
-///   be_u32::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+///     be_u32.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
@@ -195,7 +203,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u32", move |input: I| be_uint(input, 4))(input)
+    trace("be_u32", move |input: I| be_uint(input, 4)).parse_next(input)
 }
 
 /// Recognizes a big endian unsigned 8 bytes integer.
@@ -208,12 +216,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u64;
 ///
-/// let parser = |s| {
-///   be_u64(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u64> {
+///     be_u64.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -221,12 +230,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_u64;
 ///
-/// let parser = |s| {
-///   be_u64::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
+///     be_u64.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001020304050607)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
@@ -238,7 +248,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u64", move |input: I| be_uint(input, 8))(input)
+    trace("be_u64", move |input: I| be_uint(input, 8)).parse_next(input)
 }
 
 /// Recognizes a big endian unsigned 16 bytes integer.
@@ -251,12 +261,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_u128;
 ///
-/// let parser = |s| {
-///   be_u128(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u128> {
+///     be_u128.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -264,12 +275,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_u128;
 ///
-/// let parser = |s| {
-///   be_u128::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
+///     be_u128.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203040506070809101112131415)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
@@ -281,7 +293,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("be_u128", move |input: I| be_uint(input, 16))(input)
+    trace("be_u128", move |input: I| be_uint(input, 16)).parse_next(input)
 }
 
 #[inline]
@@ -321,12 +333,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i8;
 ///
-/// let parser = |s| {
-///   be_i8(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i8> {
+///     be_i8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
 /// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Token))));
@@ -334,10 +347,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_i8;
 ///
-/// let parser = be_i8::<_, Error<_>>;
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i8> {
+///       be_i8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -361,12 +377,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i16;
 ///
-/// let parser = |s| {
-///   be_i16(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i16> {
+///     be_i16.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -374,10 +391,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_i16;
 ///
-/// let parser = be_i16::<_, Error<_>>;
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
+///       be_i16.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001)));
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
@@ -391,7 +411,8 @@ where
 {
     trace("be_i16", move |input: I| {
         be_uint::<_, u16, _>(input, 2).map(|(i, n)| (i, n as i16))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a big endian signed 3 bytes integer.
@@ -404,12 +425,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i24;
 ///
-/// let parser = |s| {
-///   be_i24(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i32> {
+///     be_i24.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -417,10 +439,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_i24;
 ///
-/// let parser = be_i24::<_, Error<_>>;
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
+///       be_i24.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x000102)));
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
@@ -442,7 +467,8 @@ where
             };
             (i, n)
         })
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a big endian signed 4 bytes integer.
@@ -455,12 +481,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i32;
 ///
-/// let parser = |s| {
-///   be_i32(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i32> {
+///       be_i32.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -468,10 +495,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_i32;
 ///
-/// let parser = be_i32::<_, Error<_>>;
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
+///       be_i32.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203)));
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
@@ -485,7 +515,8 @@ where
 {
     trace("be_i32", move |input: I| {
         be_uint::<_, u32, _>(input, 4).map(|(i, n)| (i, n as i32))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a big endian signed 8 bytes integer.
@@ -498,12 +529,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i64;
 ///
-/// let parser = |s| {
-///   be_i64(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i64> {
+///       be_i64.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -511,10 +543,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_i64;
 ///
-/// let parser = be_i64::<_, Error<_>>;
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
+///       be_i64.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001020304050607)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
@@ -528,7 +563,8 @@ where
 {
     trace("be_i64", move |input: I| {
         be_uint::<_, u64, _>(input, 8).map(|(i, n)| (i, n as i64))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a big endian signed 16 bytes integer.
@@ -541,12 +577,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_i128;
 ///
-/// let parser = |s| {
-///   be_i128(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i128> {
+///       be_i128.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -554,10 +591,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_i128;
 ///
-/// let parser = be_i128::<_, Error<_>>;
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
+///       be_i128.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203040506070809101112131415)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
@@ -571,7 +611,8 @@ where
 {
     trace("be_i128", move |input: I| {
         be_uint::<_, u128, _>(input, 16).map(|(i, n)| (i, n as i128))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes an unsigned 1 byte integer.
@@ -584,12 +625,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u8;
 ///
-/// let parser = |s| {
-///   le_u8(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u8> {
+///       le_u8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
 /// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Token))));
@@ -597,10 +639,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_u8;
 ///
-/// let parser = le_u8::<_, Error<_>>;
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
+///       le_u8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -624,12 +669,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u16;
 ///
-/// let parser = |s| {
-///   le_u16(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u16> {
+///       le_u16.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -637,12 +683,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_u16;
 ///
-/// let parser = |s| {
-///   le_u16::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
+///       le_u16::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -654,7 +701,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u16", move |input: I| le_uint(input, 2))(input)
+    trace("le_u16", move |input: I| le_uint(input, 2)).parse_next(input)
 }
 
 /// Recognizes a little endian unsigned 3 byte integer.
@@ -667,12 +714,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u24;
 ///
-/// let parser = |s| {
-///   le_u24(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u32> {
+///       le_u24.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -680,12 +728,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_u24;
 ///
-/// let parser = |s| {
-///   le_u24::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+///       le_u24::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
@@ -697,7 +746,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u24", move |input: I| le_uint(input, 3))(input)
+    trace("le_u24", move |input: I| le_uint(input, 3)).parse_next(input)
 }
 
 /// Recognizes a little endian unsigned 4 bytes integer.
@@ -710,12 +759,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u32;
 ///
-/// let parser = |s| {
-///   le_u32(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u32> {
+///       le_u32.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -723,12 +773,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_u32;
 ///
-/// let parser = |s| {
-///   le_u32::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+///       le_u32::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
@@ -740,7 +791,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u32", move |input: I| le_uint(input, 4))(input)
+    trace("le_u32", move |input: I| le_uint(input, 4)).parse_next(input)
 }
 
 /// Recognizes a little endian unsigned 8 bytes integer.
@@ -753,12 +804,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u64;
 ///
-/// let parser = |s| {
-///   le_u64(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u64> {
+///       le_u64.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -766,12 +818,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_u64;
 ///
-/// let parser = |s| {
-///   le_u64::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
+///       le_u64::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
@@ -783,7 +836,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u64", move |input: I| le_uint(input, 8))(input)
+    trace("le_u64", move |input: I| le_uint(input, 8)).parse_next(input)
 }
 
 /// Recognizes a little endian unsigned 16 bytes integer.
@@ -796,12 +849,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_u128;
 ///
-/// let parser = |s| {
-///   le_u128(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u128> {
+///       le_u128.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -809,12 +863,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_u128;
 ///
-/// let parser = |s| {
-///   le_u128::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
+///       le_u128::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
@@ -826,7 +881,7 @@ where
     I: Stream<Token = u8>,
     <I as Stream>::Slice: AsBytes,
 {
-    trace("le_u128", move |input: I| le_uint(input, 16))(input)
+    trace("le_u128", move |input: I| le_uint(input, 16)).parse_next(input)
 }
 
 #[inline]
@@ -865,12 +920,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i8;
 ///
-/// let parser = |s| {
-///   le_i8(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i8> {
+///       le_i8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
 /// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Token))));
@@ -878,10 +934,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_i8;
 ///
-/// let parser = le_i8::<_, Error<_>>;
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i8> {
+///       le_i8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -905,12 +964,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i16;
 ///
-/// let parser = |s| {
-///   le_i16(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i16> {
+///       le_i16.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -918,12 +978,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_i16;
 ///
-/// let parser = |s| {
-///   le_i16::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
+///       le_i16::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -937,7 +998,8 @@ where
 {
     trace("le_i16", move |input: I| {
         le_uint::<_, u16, _>(input, 2).map(|(i, n)| (i, n as i16))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a little endian signed 3 bytes integer.
@@ -950,12 +1012,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i24;
 ///
-/// let parser = |s| {
-///   le_i24(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i32> {
+///       le_i24.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -963,12 +1026,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_i24;
 ///
-/// let parser = |s| {
-///   le_i24::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
+///       le_i24::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
@@ -990,7 +1054,8 @@ where
             };
             (i, n)
         })
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a little endian signed 4 bytes integer.
@@ -1003,12 +1068,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i32;
 ///
-/// let parser = |s| {
-///   le_i32(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i32> {
+///       le_i32.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -1016,12 +1082,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_i32;
 ///
-/// let parser = |s| {
-///   le_i32::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
+///       le_i32::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
@@ -1035,7 +1102,8 @@ where
 {
     trace("le_i32", move |input: I| {
         le_uint::<_, u32, _>(input, 4).map(|(i, n)| (i, n as i32))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a little endian signed 8 bytes integer.
@@ -1048,12 +1116,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i64;
 ///
-/// let parser = |s| {
-///   le_i64(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i64> {
+///       le_i64.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -1061,12 +1130,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_i64;
 ///
-/// let parser = |s| {
-///   le_i64::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
+///       le_i64::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
@@ -1080,7 +1150,8 @@ where
 {
     trace("le_i64", move |input: I| {
         le_uint::<_, u64, _>(input, 8).map(|(i, n)| (i, n as i64))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a little endian signed 16 bytes integer.
@@ -1093,12 +1164,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_i128;
 ///
-/// let parser = |s| {
-///   le_i128(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i128> {
+///       le_i128.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
 /// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
@@ -1106,12 +1178,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_i128;
 ///
-/// let parser = |s| {
-///   le_i128::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
+///       le_i128::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
@@ -1125,7 +1198,8 @@ where
 {
     trace("le_i128", move |input: I| {
         le_uint::<_, u128, _>(input, 16).map(|(i, n)| (i, n as i128))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes an unsigned 1 byte integer
@@ -1140,12 +1214,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::u8;
 ///
-/// let parser = |s| {
-///   u8(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], u8> {
+///       u8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
 /// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Token))));
@@ -1153,13 +1228,14 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::u8;
 ///
-/// let parser = |s| {
-///   u8::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
+///       u8::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"\x03abcefg"[..]), 0x00)));
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -1176,7 +1252,8 @@ where
         } else {
             complete_u8(input)
         }
-    })(input)
+    })
+    .parse_next(input)
 }
 
 #[inline]
@@ -1211,18 +1288,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::u16;
 ///
 /// let be_u16 = |s| {
-///   u16(winnow::number::Endianness::Big)(s)
+///     u16(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_u16 = |s| {
-///   u16(winnow::number::Endianness::Little)(s)
+///     u16(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
@@ -1231,28 +1309,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::u16;
 ///
 /// let be_u16 = |s| {
-///   u16::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     u16::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_u16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_u16 = |s| {
-///   u16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     u16::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
 /// assert_eq!(le_u16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn u16<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, u16, E>
+pub fn u16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, u16, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1283,18 +1360,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::u24;
 ///
 /// let be_u24 = |s| {
-///   u24(winnow::number::Endianness::Big)(s)
+///     u24(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_u24 = |s| {
-///   u24(winnow::number::Endianness::Little)(s)
+///     u24(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
@@ -1303,28 +1381,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::u24;
 ///
 /// let be_u24 = |s| {
-///   u24::<_,Error<_>>(winnow::number::Endianness::Big)(s)
+///     u24::<_,Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_u24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_u24 = |s| {
-///   u24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     u24::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
 /// assert_eq!(le_u24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn u24<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, u32, E>
+pub fn u24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, u32, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1355,18 +1432,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::u32;
 ///
 /// let be_u32 = |s| {
-///   u32(winnow::number::Endianness::Big)(s)
+///     u32(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_u32 = |s| {
-///   u32(winnow::number::Endianness::Little)(s)
+///     u32(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
@@ -1375,28 +1453,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::u32;
 ///
 /// let be_u32 = |s| {
-///   u32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     u32::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_u32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_u32 = |s| {
-///   u32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     u32::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
 /// assert_eq!(le_u32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn u32<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, u32, E>
+pub fn u32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, u32, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1427,18 +1504,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::u64;
 ///
 /// let be_u64 = |s| {
-///   u64(winnow::number::Endianness::Big)(s)
+///     u64(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_u64 = |s| {
-///   u64(winnow::number::Endianness::Little)(s)
+///     u64(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
@@ -1447,28 +1525,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::u64;
 ///
 /// let be_u64 = |s| {
-///   u64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     u64::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_u64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_u64 = |s| {
-///   u64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     u64::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
 /// assert_eq!(le_u64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn u64<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, u64, E>
+pub fn u64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, u64, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1499,18 +1576,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::u128;
 ///
 /// let be_u128 = |s| {
-///   u128(winnow::number::Endianness::Big)(s)
+///     u128(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_u128 = |s| {
-///   u128(winnow::number::Endianness::Little)(s)
+///     u128(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
@@ -1519,28 +1597,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::u128;
 ///
 /// let be_u128 = |s| {
-///   u128::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     u128::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_u128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_u128 = |s| {
-///   u128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     u128::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
 /// assert_eq!(le_u128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn u128<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, u128, E>
+pub fn u128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, u128, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1570,12 +1647,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::i8;
 ///
-/// let parser = |s| {
-///   i8(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], i8> {
+///       i8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
 /// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(Error::new(&[][..], ErrorKind::Token))));
@@ -1583,13 +1661,14 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::i8;
 ///
-/// let parser = |s| {
-///   i8::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i8> {
+///       i8.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"\x03abcefg"[..]), 0x00)));
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -1607,7 +1686,8 @@ where
             complete_u8(input)
         }
         .map(|(i, n)| (i, n as i8))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a signed 2 byte integer
@@ -1623,18 +1703,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::i16;
 ///
 /// let be_i16 = |s| {
-///   i16(winnow::number::Endianness::Big)(s)
+///     i16(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_i16 = |s| {
-///   i16(winnow::number::Endianness::Little)(s)
+///     i16(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
@@ -1643,28 +1724,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::i16;
 ///
 /// let be_i16 = |s| {
-///   i16::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     i16::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_i16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_i16 = |s| {
-///   i16::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     i16::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
 /// assert_eq!(le_i16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn i16<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, i16, E>
+pub fn i16<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, i16, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1695,18 +1775,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::i24;
 ///
 /// let be_i24 = |s| {
-///   i24(winnow::number::Endianness::Big)(s)
+///     i24(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_i24 = |s| {
-///   i24(winnow::number::Endianness::Little)(s)
+///     i24(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
@@ -1715,28 +1796,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::i24;
 ///
 /// let be_i24 = |s| {
-///   i24::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     i24::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_i24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// let le_i24 = |s| {
-///   i24::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     i24::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
 /// assert_eq!(le_i24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn i24<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, i32, E>
+pub fn i24<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, i32, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1767,18 +1847,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::i32;
 ///
 /// let be_i32 = |s| {
-///   i32(winnow::number::Endianness::Big)(s)
+///     i32(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_i32 = |s| {
-///   i32(winnow::number::Endianness::Little)(s)
+///     i32(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
@@ -1787,28 +1868,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::i32;
 ///
 /// let be_i32 = |s| {
-///   i32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     i32::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_i32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// let le_i32 = |s| {
-///   i32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     i32::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
 /// assert_eq!(le_i32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn i32<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, i32, E>
+pub fn i32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, i32, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1839,18 +1919,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::i64;
 ///
 /// let be_i64 = |s| {
-///   i64(winnow::number::Endianness::Big)(s)
+///     i64(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_i64 = |s| {
-///   i64(winnow::number::Endianness::Little)(s)
+///     i64(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
@@ -1859,28 +1940,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::i64;
 ///
 /// let be_i64 = |s| {
-///   i64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     i64::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_i64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// let le_i64 = |s| {
-///   i64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     i64::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
 /// assert_eq!(le_i64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn i64<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, i64, E>
+pub fn i64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, i64, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1911,18 +1991,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::i128;
 ///
 /// let be_i128 = |s| {
-///   i128(winnow::number::Endianness::Big)(s)
+///     i128(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Backtrack(Error::new(&[0x01][..], ErrorKind::Slice))));
 ///
 /// let le_i128 = |s| {
-///   i128(winnow::number::Endianness::Little)(s)
+///     i128(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
@@ -1931,28 +2012,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::i128;
 ///
 /// let be_i128 = |s| {
-///   i128::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     i128::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_i128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// let le_i128 = |s| {
-///   i128::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     i128::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
 /// assert_eq!(le_i128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn i128<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, i128, E>
+pub fn i128<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, i128, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -1980,12 +2060,14 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_f32;
 ///
-/// let parser = |s| {
-///   be_f32(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], f32> {
+///       be_f32.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Slice))));
@@ -1993,12 +2075,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_f32;
 ///
-/// let parser = |s| {
-///   be_f32::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
+///       be_f32.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&[0x40, 0x29, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 2.640625)));
 /// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
@@ -2012,7 +2095,8 @@ where
 {
     trace("be_f32", move |input: I| {
         be_uint::<_, u32, _>(input, 4).map(|(i, n)| (i, f32::from_bits(n)))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a big endian 8 bytes floating point number.
@@ -2025,12 +2109,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::be_f64;
 ///
-/// let parser = |s| {
-///   be_f64(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], f64> {
+///       be_f64.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Slice))));
@@ -2038,12 +2123,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::be_f64;
 ///
-/// let parser = |s| {
-///   be_f64::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
+///       be_f64::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
@@ -2057,7 +2143,8 @@ where
 {
     trace("be_f64", move |input: I| {
         be_uint::<_, u64, _>(input, 8).map(|(i, n)| (i, f64::from_bits(n)))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a little endian 4 bytes floating point number.
@@ -2070,12 +2157,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_f32;
 ///
-/// let parser = |s| {
-///   le_f32(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], f32> {
+///       le_f32.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Slice))));
@@ -2083,12 +2171,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_f32;
 ///
-/// let parser = |s| {
-///   le_f32::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
+///       le_f32::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
@@ -2102,7 +2191,8 @@ where
 {
     trace("le_f32", move |input: I| {
         le_uint::<_, u32, _>(input, 4).map(|(i, n)| (i, f32::from_bits(n)))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a little endian 8 bytes floating point number.
@@ -2115,12 +2205,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::le_f64;
 ///
-/// let parser = |s| {
-///   le_f64(s)
-/// };
+/// fn parser(s: &[u8]) -> IResult<&[u8], f64> {
+///       le_f64.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Slice))));
@@ -2128,12 +2219,13 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::number::le_f64;
 ///
-/// let parser = |s| {
-///   le_f64::<_, Error<_>>(s)
-/// };
+/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
+///       le_f64::<_, Error<_>>.parse_next(s)
+/// }
 ///
 /// assert_eq!(parser(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 3145728.0)));
 /// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
@@ -2147,7 +2239,8 @@ where
 {
     trace("be_f64", move |input: I| {
         le_uint::<_, u64, _>(input, 8).map(|(i, n)| (i, f64::from_bits(n)))
-    })(input)
+    })
+    .parse_next(input)
 }
 
 /// Recognizes a 4 byte floating point number
@@ -2163,18 +2256,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::f32;
 ///
 /// let be_f32 = |s| {
-///   f32(winnow::number::Endianness::Big)(s)
+///     f32(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Slice))));
 ///
 /// let le_f32 = |s| {
-///   f32(winnow::number::Endianness::Little)(s)
+///     f32(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
@@ -2183,28 +2277,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::f32;
 ///
 /// let be_f32 = |s| {
-///   f32::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     f32::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_f32(Partial::new(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(be_f32(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// let le_f32 = |s| {
-///   f32::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     f32::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_f32(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(le_f32(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn f32<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, f32, E>
+pub fn f32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, f32, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
@@ -2235,18 +2328,19 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::number::f64;
 ///
 /// let be_f64 = |s| {
-///   f64(winnow::number::Endianness::Big)(s)
+///     f64(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Backtrack(Error::new(&b"abc"[..], ErrorKind::Slice))));
 ///
 /// let le_f64 = |s| {
-///   f64(winnow::number::Endianness::Little)(s)
+///     f64(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
@@ -2255,28 +2349,27 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::number::f64;
 ///
 /// let be_f64 = |s| {
-///   f64::<_, Error<_>>(winnow::number::Endianness::Big)(s)
+///     f64::<_, Error<_>>(winnow::number::Endianness::Big).parse_next(s)
 /// };
 ///
 /// assert_eq!(be_f64(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(be_f64(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 ///
 /// let le_f64 = |s| {
-///   f64::<_, Error<_>>(winnow::number::Endianness::Little)(s)
+///     f64::<_, Error<_>>(winnow::number::Endianness::Little).parse_next(s)
 /// };
 ///
 /// assert_eq!(le_f64(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(le_f64(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
-pub fn f64<I, E: ParseError<I>>(
-    endian: crate::number::Endianness,
-) -> impl FnMut(I) -> IResult<I, f64, E>
+pub fn f64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> impl Parser<I, f64, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,

--- a/src/number/tests.rs
+++ b/src/number/tests.rs
@@ -298,19 +298,19 @@ mod complete {
         use crate::number::Endianness;
 
         fn be_tst16(i: &[u8]) -> IResult<&[u8], u16> {
-            u16(Endianness::Big)(i)
+            u16(Endianness::Big).parse_next(i)
         }
         fn le_tst16(i: &[u8]) -> IResult<&[u8], u16> {
-            u16(Endianness::Little)(i)
+            u16(Endianness::Little).parse_next(i)
         }
         assert_eq!(be_tst16(&[0x80, 0x00]), Ok((&b""[..], 32_768_u16)));
         assert_eq!(le_tst16(&[0x80, 0x00]), Ok((&b""[..], 128_u16)));
 
         fn be_tst32(i: &[u8]) -> IResult<&[u8], u32> {
-            u32(Endianness::Big)(i)
+            u32(Endianness::Big).parse_next(i)
         }
         fn le_tst32(i: &[u8]) -> IResult<&[u8], u32> {
-            u32(Endianness::Little)(i)
+            u32(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tst32(&[0x12, 0x00, 0x60, 0x00]),
@@ -322,10 +322,10 @@ mod complete {
         );
 
         fn be_tst64(i: &[u8]) -> IResult<&[u8], u64> {
-            u64(Endianness::Big)(i)
+            u64(Endianness::Big).parse_next(i)
         }
         fn le_tst64(i: &[u8]) -> IResult<&[u8], u64> {
-            u64(Endianness::Little)(i)
+            u64(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tst64(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
@@ -337,19 +337,19 @@ mod complete {
         );
 
         fn be_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
-            i16(Endianness::Big)(i)
+            i16(Endianness::Big).parse_next(i)
         }
         fn le_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
-            i16(Endianness::Little)(i)
+            i16(Endianness::Little).parse_next(i)
         }
         assert_eq!(be_tsti16(&[0x00, 0x80]), Ok((&b""[..], 128_i16)));
         assert_eq!(le_tsti16(&[0x00, 0x80]), Ok((&b""[..], -32_768_i16)));
 
         fn be_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
-            i32(Endianness::Big)(i)
+            i32(Endianness::Big).parse_next(i)
         }
         fn le_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
-            i32(Endianness::Little)(i)
+            i32(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tsti32(&[0x00, 0x12, 0x60, 0x00]),
@@ -361,10 +361,10 @@ mod complete {
         );
 
         fn be_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
-            i64(Endianness::Big)(i)
+            i64(Endianness::Big).parse_next(i)
         }
         fn le_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
-            i64(Endianness::Little)(i)
+            i64(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tsti64(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
@@ -958,10 +958,10 @@ mod partial {
         use crate::number::Endianness;
 
         fn be_tst16(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-            u16(Endianness::Big)(i)
+            u16(Endianness::Big).parse_next(i)
         }
         fn le_tst16(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-            u16(Endianness::Little)(i)
+            u16(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tst16(Partial::new(&[0x80, 0x00])),
@@ -973,10 +973,10 @@ mod partial {
         );
 
         fn be_tst32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-            u32(Endianness::Big)(i)
+            u32(Endianness::Big).parse_next(i)
         }
         fn le_tst32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-            u32(Endianness::Little)(i)
+            u32(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tst32(Partial::new(&[0x12, 0x00, 0x60, 0x00])),
@@ -988,10 +988,10 @@ mod partial {
         );
 
         fn be_tst64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-            u64(Endianness::Big)(i)
+            u64(Endianness::Big).parse_next(i)
         }
         fn le_tst64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-            u64(Endianness::Little)(i)
+            u64(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tst64(Partial::new(&[
@@ -1007,10 +1007,10 @@ mod partial {
         );
 
         fn be_tsti16(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-            i16(Endianness::Big)(i)
+            i16(Endianness::Big).parse_next(i)
         }
         fn le_tsti16(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-            i16(Endianness::Little)(i)
+            i16(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tsti16(Partial::new(&[0x00, 0x80])),
@@ -1022,10 +1022,10 @@ mod partial {
         );
 
         fn be_tsti32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-            i32(Endianness::Big)(i)
+            i32(Endianness::Big).parse_next(i)
         }
         fn le_tsti32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-            i32(Endianness::Little)(i)
+            i32(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tsti32(Partial::new(&[0x00, 0x12, 0x60, 0x00])),
@@ -1037,10 +1037,10 @@ mod partial {
         );
 
         fn be_tsti64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-            i64(Endianness::Big)(i)
+            i64(Endianness::Big).parse_next(i)
         }
         fn le_tsti64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-            i64(Endianness::Little)(i)
+            i64(Endianness::Little).parse_next(i)
         }
         assert_eq!(
             be_tsti64(Partial::new(&[

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -6,7 +6,7 @@ mod tests;
 use crate::error::ParseError;
 use crate::stream::Stream;
 use crate::trace::trace;
-use crate::{IResult, Parser};
+use crate::Parser;
 
 /// Apply two parsers, only returning the output from the second.
 ///
@@ -18,22 +18,23 @@ use crate::{IResult, Parser};
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::sequence::preceded;
 /// use winnow::bytes::tag;
 ///
 /// let mut parser = preceded(tag("abc"), tag("efg"));
 ///
-/// assert_eq!(parser("abcefg"), Ok(("", "efg")));
-/// assert_eq!(parser("abcefghij"), Ok(("hij", "efg")));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_next("abcefg"), Ok(("", "efg")));
+/// assert_eq!(parser.parse_next("abcefghij"), Ok(("hij", "efg")));
+/// assert_eq!(parser.parse_next(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_next("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 #[doc(alias = "ignore_then")]
 pub fn preceded<I, O1, O2, E: ParseError<I>, F, G>(
     mut first: F,
     mut second: G,
-) -> impl FnMut(I) -> IResult<I, O2, E>
+) -> impl Parser<I, O2, E>
 where
     I: Stream,
     F: Parser<I, O1, E>,
@@ -55,22 +56,23 @@ where
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
+/// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::sequence::terminated;
 /// use winnow::bytes::tag;
 ///
 /// let mut parser = terminated(tag("abc"), tag("efg"));
 ///
-/// assert_eq!(parser("abcefg"), Ok(("", "abc")));
-/// assert_eq!(parser("abcefghij"), Ok(("hij", "abc")));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_next("abcefg"), Ok(("", "abc")));
+/// assert_eq!(parser.parse_next("abcefghij"), Ok(("hij", "abc")));
+/// assert_eq!(parser.parse_next(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_next("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 #[doc(alias = "then_ignore")]
 pub fn terminated<I, O1, O2, E: ParseError<I>, F, G>(
     mut first: F,
     mut second: G,
-) -> impl FnMut(I) -> IResult<I, O1, E>
+) -> impl Parser<I, O1, E>
 where
     I: Stream,
     F: Parser<I, O1, E>,
@@ -94,21 +96,22 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::error::Needed::Size;
+/// # use winnow::prelude::*;
 /// use winnow::sequence::separated_pair;
 /// use winnow::bytes::tag;
 ///
 /// let mut parser = separated_pair(tag("abc"), tag("|"), tag("efg"));
 ///
-/// assert_eq!(parser("abc|efg"), Ok(("", ("abc", "efg"))));
-/// assert_eq!(parser("abc|efghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_next("abc|efg"), Ok(("", ("abc", "efg"))));
+/// assert_eq!(parser.parse_next("abc|efghij"), Ok(("hij", ("abc", "efg"))));
+/// assert_eq!(parser.parse_next(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_next("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 pub fn separated_pair<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
     mut first: F,
     mut sep: G,
     mut second: H,
-) -> impl FnMut(I) -> IResult<I, (O1, O3), E>
+) -> impl Parser<I, (O1, O3), E>
 where
     I: Stream,
     F: Parser<I, O1, E>,
@@ -134,15 +137,16 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::error::Needed::Size;
+/// # use winnow::prelude::*;
 /// use winnow::sequence::delimited;
 /// use winnow::bytes::tag;
 ///
 /// let mut parser = delimited(tag("("), tag("abc"), tag(")"));
 ///
-/// assert_eq!(parser("(abc)"), Ok(("", "abc")));
-/// assert_eq!(parser("(abc)def"), Ok(("def", "abc")));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_next("(abc)"), Ok(("", "abc")));
+/// assert_eq!(parser.parse_next("(abc)def"), Ok(("def", "abc")));
+/// assert_eq!(parser.parse_next(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_next("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Tag))));
 /// ```
 #[doc(alias = "between")]
 #[doc(alias = "padded")]
@@ -150,7 +154,7 @@ pub fn delimited<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
     mut first: F,
     mut second: G,
     mut third: H,
-) -> impl FnMut(I) -> IResult<I, O2, E>
+) -> impl Parser<I, O2, E>
 where
     I: Stream,
     F: Parser<I, O1, E>,

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -20,8 +20,8 @@ struct C {
 fn complete() {
     use crate::bytes::tag;
     fn err_test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        let (i, _) = tag("ijkl")(i)?;
-        tag("mnop")(i)
+        let (i, _) = tag("ijkl").parse_next(i)?;
+        tag("mnop").parse_next(i)
     }
     let a = &b"ijklmn"[..];
 
@@ -39,7 +39,7 @@ fn complete() {
 fn separated_pair_test() {
     #[allow(clippy::type_complexity)]
     fn sep_pair_abc_def(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8])> {
-        separated_pair(tag("abc"), tag(","), tag("def"))(i)
+        separated_pair(tag("abc"), tag(","), tag("def")).parse_next(i)
     }
 
     assert_eq!(
@@ -80,7 +80,7 @@ fn separated_pair_test() {
 #[test]
 fn preceded_test() {
     fn preceded_abcd_efgh(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        preceded(tag("abcd"), tag("efgh"))(i)
+        preceded(tag("abcd"), tag("efgh")).parse_next(i)
     }
 
     assert_eq!(
@@ -121,7 +121,7 @@ fn preceded_test() {
 #[test]
 fn terminated_test() {
     fn terminated_abcd_efgh(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        terminated(tag("abcd"), tag("efgh"))(i)
+        terminated(tag("abcd"), tag("efgh")).parse_next(i)
     }
 
     assert_eq!(
@@ -162,7 +162,7 @@ fn terminated_test() {
 #[test]
 fn delimited_test() {
     fn delimited_abc_def_ghi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        delimited(tag("abc"), tag("def"), tag("ghi"))(i)
+        delimited(tag("abc"), tag("def"), tag("ghi")).parse_next(i)
     }
 
     assert_eq!(

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -221,14 +221,15 @@ impl<I: crate::lib::std::fmt::Display, S> crate::lib::std::fmt::Display for Stat
 /// Here is how it works in practice:
 ///
 /// ```rust
-/// use winnow::{IResult, error::ErrMode, error::Needed, error::{Error, ErrorKind}, bytes, character, stream::Partial};
+/// # use winnow::{IResult, error::ErrMode, error::Needed, error::{Error, ErrorKind}, bytes, character, stream::Partial};
+/// # use winnow::prelude::*;
 ///
 /// fn take_partial(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-///   bytes::take(4u8)(i)
+///   bytes::take(4u8).parse_next(i)
 /// }
 ///
 /// fn take_complete(i: &[u8]) -> IResult<&[u8], &[u8]> {
-///   bytes::take(4u8)(i)
+///   bytes::take(4u8).parse_next(i)
 /// }
 ///
 /// // both parsers will take 4 bytes as expected

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -31,12 +31,12 @@ impl<'a> ParseError<Partial<&'a str>> for CustomError {
 
 fn test1(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
     //fix_error!(input, CustomError, tag!("abcd"))
-    tag("abcd")(input)
+    tag("abcd").parse_next(input)
 }
 
 fn test2(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
     //terminated!(input, test1, fix_error!(CustomError, digit))
-    terminated(test1, digit)(input)
+    terminated(test1, digit).parse_next(input)
 }
 
 fn test3(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
@@ -47,5 +47,5 @@ fn test3(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
 
 #[cfg(feature = "alloc")]
 fn test4(input: Partial<&str>) -> IResult<Partial<&str>, Vec<&str>, CustomError> {
-    count(test1, 4)(input)
+    count(test1, 4).parse_next(input)
 }

--- a/tests/testsuite/fnmut.rs
+++ b/tests/testsuite/fnmut.rs
@@ -2,6 +2,7 @@
 
 use winnow::bytes::tag;
 use winnow::multi::many0;
+use winnow::Parser;
 
 #[test]
 #[cfg(feature = "std")]
@@ -11,10 +12,10 @@ fn parse() {
     let res = {
         let mut parser = many0::<_, _, Vec<_>, (), _>(|i| {
             counter += 1;
-            tag("abc")(i)
+            tag("abc").parse_next(i)
         });
 
-        parser("abcabcabcabc").unwrap()
+        parser.parse_next("abcabcabcabc").unwrap()
     };
 
     println!("res: {:?}", res);
@@ -27,11 +28,11 @@ fn accumulate() {
 
     let (_, count) = {
         let mut parser = many0::<_, _, usize, (), _>(|i| {
-            let (i, o) = tag("abc")(i)?;
+            let (i, o) = tag("abc").parse_next(i)?;
             v.push(o);
             Ok((i, ()))
         });
-        parser("abcabcabcabc").unwrap()
+        parser.parse_next("abcabcabcabc").unwrap()
     };
 
     println!("v: {:?}", v);

--- a/tests/testsuite/multiline.rs
+++ b/tests/testsuite/multiline.rs
@@ -4,7 +4,7 @@ use winnow::{
     character::{alphanumeric1 as alphanumeric, line_ending as eol},
     multi::many0,
     sequence::terminated,
-    IResult,
+    IResult, Parser,
 };
 
 pub fn end_of_line(input: &str) -> IResult<&str, &str> {
@@ -16,11 +16,11 @@ pub fn end_of_line(input: &str) -> IResult<&str, &str> {
 }
 
 pub fn read_line(input: &str) -> IResult<&str, &str> {
-    terminated(alphanumeric, end_of_line)(input)
+    terminated(alphanumeric, end_of_line).parse_next(input)
 }
 
 pub fn read_lines(input: &str) -> IResult<&str, Vec<&str>> {
-    many0(read_line)(input)
+    many0(read_line).parse_next(input)
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -30,7 +30,7 @@ fn overflow_incomplete_tuple() {
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_bytes() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(length_data(be_u64))(i)
+        many0(length_data(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in length_data
@@ -46,7 +46,7 @@ fn overflow_incomplete_length_bytes() {
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many0() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(length_data(be_u64))(i)
+        many0(length_data(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in many0
@@ -64,7 +64,7 @@ fn overflow_incomplete_many1() {
     use winnow::multi::many1;
 
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many1(length_data(be_u64))(i)
+        many1(length_data(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in many1
@@ -83,7 +83,7 @@ fn overflow_incomplete_many_till0() {
 
     #[allow(clippy::type_complexity)]
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (Vec<&[u8]>, &[u8])> {
-        many_till0(length_data(be_u64), tag("abc"))(i)
+        many_till0(length_data(be_u64), tag("abc")).parse_next(i)
     }
 
     // Trigger an overflow in many_till0
@@ -101,7 +101,7 @@ fn overflow_incomplete_many_m_n() {
     use winnow::multi::many_m_n;
 
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many_m_n(2, 4, length_data(be_u64))(i)
+        many_m_n(2, 4, length_data(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in many_m_n
@@ -119,7 +119,7 @@ fn overflow_incomplete_count() {
     use winnow::multi::count;
 
     fn counter(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        count(length_data(be_u64), 2)(i)
+        count(length_data(be_u64), 2).parse_next(i)
     }
 
     assert_eq!(
@@ -137,7 +137,7 @@ fn overflow_incomplete_length_count() {
     use winnow::number::be_u8;
 
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        length_count(be_u8, length_data(be_u64))(i)
+        length_count(be_u8, length_data(be_u64)).parse_next(i)
     }
 
     assert_eq!(
@@ -152,7 +152,7 @@ fn overflow_incomplete_length_count() {
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_data() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(length_data(be_u64))(i)
+        many0(length_data(be_u64)).parse_next(i)
     }
 
     assert_eq!(

--- a/tests/testsuite/reborrow_fold.rs
+++ b/tests/testsuite/reborrow_fold.rs
@@ -27,5 +27,6 @@ fn list<'a>(i: &'a [u8], tomb: &mut ()) -> IResult<&'a [u8], String> {
             acc
         }),
         ')',
-    )(i)
+    )
+    .parse_next(i)
 }


### PR DESCRIPTION
This doesn't help with functions that don't return a parser.  I'm somewhat tempted to make them do so, for consistency if nothing else.

Fixes #162

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
