### PR TITLE
feat: Replace `FinishIResult::finish` with `Parser::parse`

### DIFF
--- a/examples/arithmetic/main.rs
+++ b/examples/arithmetic/main.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), lexopt::Error> {
 
     println!("{} =", input);
     match args.implementation {
-        Impl::Eval => match parser::expr.parse_next(input).finish() {
+        Impl::Eval => match parser::expr.parse(input) {
             Ok(result) => {
                 println!("  {}", result);
             }
@@ -18,7 +18,7 @@ fn main() -> Result<(), lexopt::Error> {
                 println!("  {}", err);
             }
         },
-        Impl::Ast => match parser_ast::expr.parse_next(input).finish() {
+        Impl::Ast => match parser_ast::expr.parse(input) {
             Ok(result) => {
                 println!("  {:#?}", result);
             }

--- a/examples/css/main.rs
+++ b/examples/css/main.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), lexopt::Error> {
     let input = args.input.as_deref().unwrap_or("#AAAAAA");
 
     println!("{} =", input);
-    match hex_color.parse_next(input).finish() {
+    match hex_color.parse(input) {
         Ok(result) => {
             println!("  {:?}", result);
         }

--- a/examples/css/parser.rs
+++ b/examples/css/parser.rs
@@ -13,9 +13,7 @@ impl std::str::FromStr for Color {
     type Err = winnow::error::Error<String>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        hex_color(s)
-            .finish()
-            .map_err(winnow::error::Error::into_owned)
+        hex_color.parse(s).map_err(winnow::error::Error::into_owned)
     }
 }
 

--- a/examples/ini/main.rs
+++ b/examples/ini/main.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), lexopt::Error> {
     let input = args.input.as_deref().unwrap_or("1 + 1");
 
     if args.binary {
-        match parser::categories.parse_next(input.as_bytes()).finish() {
+        match parser::categories.parse(input.as_bytes()) {
             Ok(result) => {
                 println!("  {:?}", result);
             }
@@ -18,7 +18,7 @@ fn main() -> Result<(), lexopt::Error> {
             }
         }
     } else {
-        match parser_str::categories.parse_next(input).finish() {
+        match parser_str::categories.parse(input) {
             Ok(result) => {
                 println!("  {:?}", result);
             }

--- a/examples/json/main.rs
+++ b/examples/json/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), lexopt::Error> {
     });
 
     if args.verbose {
-        match parser::json::<VerboseError<&str>>(data).finish() {
+        match parser::json::<VerboseError<&str>>.parse(data) {
             Ok(json) => {
                 println!("{:#?}", json);
             }
@@ -41,8 +41,8 @@ fn main() -> Result<(), lexopt::Error> {
         }
     } else {
         let result = match args.implementation {
-            Impl::Naive => parser::json::<Error<&str>>(data).finish(),
-            Impl::Dispatch => parser_dispatch::json::<Error<&str>>(data).finish(),
+            Impl::Naive => parser::json::<Error<&str>>.parse(data),
+            Impl::Dispatch => parser_dispatch::json::<Error<&str>>.parse(data),
         };
         match result {
             Ok(json) => {

--- a/examples/string/main.rs
+++ b/examples/string/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), lexopt::Error> {
     let args = Args::parse()?;
 
     let data = args.input.as_deref().unwrap_or("\"abc\"");
-    let result = parser::parse_string::<()>(data).finish();
+    let result = parser::parse_string::<()>.parse(data);
     match result {
         Ok(data) => println!("{}", data),
         Err(err) => println!("{:?}", err),
@@ -55,14 +55,14 @@ impl Args {
 #[test]
 fn simple() {
     let data = "\"abc\"";
-    let result = parser::parse_string::<()>(data).finish();
+    let result = parser::parse_string::<()>.parse(data);
     assert_eq!(result, Ok(String::from("abc")));
 }
 
 #[test]
 fn escaped() {
     let data = "\"tab:\\tafter tab, newline:\\nnew line, quote: \\\", emoji: \\u{1F602}, newline:\\nescaped whitespace: \\    abc\"";
-    let result = parser::parse_string::<()>(data).finish();
+    let result = parser::parse_string::<()>.parse(data);
     assert_eq!(
         result,
         Ok(String::from("tab:\tafter tab, newline:\nnew line, quote: \", emoji: 😂, newline:\nescaped whitespace: abc"))

--- a/src/_tutorial/chapter_6.rs
+++ b/src/_tutorial/chapter_6.rs
@@ -150,7 +150,6 @@ use crate::combinator::cut_err;
 use crate::error::ErrMode;
 use crate::error::Error;
 use crate::error::VerboseError;
-use crate::FinishIResult;
 use crate::IResult;
 use crate::Parser;
 use crate::_topic;

--- a/src/_tutorial/chapter_7.rs
+++ b/src/_tutorial/chapter_7.rs
@@ -24,15 +24,14 @@
 //! - They are safe to be referenced across threads
 //! - They do not borrow
 //!
-//! winnow provides some helpers for this like [`FinishIResult`]:
+//! winnow provides some helpers for this:
 //! ```rust
 //! # use winnow::IResult;
-//! # use winnow::Parser;
 //! # use winnow::bytes::take_while1;
 //! # use winnow::branch::dispatch;
 //! # use winnow::bytes::take;
 //! # use winnow::combinator::fail;
-//! use winnow::FinishIResult;
+//! use winnow::Parser;
 //! use winnow::error::Error;
 //!
 //! #[derive(Debug, PartialEq, Eq)]
@@ -44,8 +43,7 @@
 //!     fn from_str(input: &str) -> Result<Self, Self::Err> {
 //!         parse_digits
 //!             .map(Hex)
-//!             .parse_next(input)
-//!             .finish()
+//!             .parse(input)
 //!             .map_err(|e| e.into_owned())
 //!     }
 //! }
@@ -97,7 +95,6 @@
 //!     assert!(input.parse::<Hex>().is_err());
 //! }
 //! ```
-//! [`FinishIResult::finish`]:
 //! - Ensures we hit [`eof`]
 //! - Removes the [`ErrMode`] wrapper
 //!
@@ -109,7 +106,6 @@ use super::chapter_1;
 use crate::combinator::eof;
 use crate::error::ErrMode;
 use crate::error::Error;
-use crate::FinishIResult;
 use crate::IResult;
 
 pub use super::chapter_6 as previous;

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,7 @@ use crate::Parser;
 pub type IResult<I, O, E = Error<I>> = Result<(I, O), ErrMode<E>>;
 
 /// Extension trait to convert a parser's [`IResult`] to a more manageable type
+#[deprecated(since = "0.4.0", note = "Replaced with `Parser::parse`")]
 pub trait FinishIResult<I, O, E> {
     /// Converts the parser's [`IResult`] to a type that is more consumable by callers.
     ///
@@ -69,6 +70,7 @@ pub trait FinishIResult<I, O, E> {
     ///     hex_uint.map(Hex).parse_next(value).finish().map_err(Error::into_owned)
     /// }
     /// ```
+    #[deprecated(since = "0.4.0", note = "Replaced with `Parser::parse`")]
     fn finish(self) -> Result<O, E>;
 
     /// Converts the parser's [`IResult`] to a type that is more consumable by errors.
@@ -81,9 +83,11 @@ pub trait FinishIResult<I, O, E> {
     /// If the result is `Err(ErrMode::Incomplete(_))`, this method will panic as [`ErrMode::Incomplete`]
     /// should only be set when the input is [`StreamIsPartial<false>`] which this isn't implemented
     /// for.
+    #[deprecated(since = "0.4.0", note = "Replaced with `Parser::parse`")]
     fn finish_err(self) -> Result<(I, O), E>;
 }
 
+#[allow(deprecated)]
 impl<I, O, E> FinishIResult<I, O, E> for IResult<I, O, E>
 where
     I: Stream,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ pub mod _tutorial;
 /// }
 ///
 /// fn main() {
-///   let result = parse_data.parse_next("100").finish();
+///   let result = parse_data.parse("100");
 ///   assert_eq!(result, Ok(100));
 /// }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,11 +237,13 @@ pub mod _tutorial;
 /// ```
 pub mod prelude {
     pub use crate::stream::StreamIsPartial as _;
+    #[allow(deprecated)]
     pub use crate::FinishIResult as _;
     pub use crate::IResult;
     pub use crate::Parser;
 }
 
+#[allow(deprecated)]
 pub use error::FinishIResult;
 pub use error::IResult;
 pub use parser::*;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -268,7 +268,7 @@ pub trait Parser<I, O, E> {
     ///
     /// let mut parser = separated_pair(alpha1.span(), ',', alpha1.span());
     ///
-    /// assert_eq!(parser.parse_next(Located::new("abcd,efgh")).finish(), Ok((0..4, 5..9)));
+    /// assert_eq!(parser.parse(Located::new("abcd,efgh")), Ok((0..4, 5..9)));
     /// assert_eq!(parser.parse_next(Located::new("abcd;")),Err(ErrMode::Backtrack(Error::new(Located::new("abcd;").next_slice(4).0, ErrorKind::Verify))));
     /// ```
     fn span(self) -> Span<Self, O>
@@ -307,7 +307,7 @@ pub trait Parser<I, O, E> {
     ///
     /// let mut consumed_parser = separated_pair(alpha1.value(1).with_span(), ',', alpha1.value(2).with_span());
     ///
-    /// assert_eq!(consumed_parser.parse_next(Located::new("abcd,efgh")).finish(), Ok(((1, 0..4), (2, 5..9))));
+    /// assert_eq!(consumed_parser.parse(Located::new("abcd,efgh")), Ok(((1, 0..4), (2, 5..9))));
     /// assert_eq!(consumed_parser.parse_next(Located::new("abcd;")),Err(ErrMode::Backtrack(Error::new(Located::new("abcd;").next_slice(4).0, ErrorKind::Verify))));
     ///
     /// // the second output (representing the consumed input)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -48,6 +48,7 @@ pub trait Parser<I, O, E> {
         I: Clone,
         E: ParseError<I>,
     {
+        #![allow(deprecated)]
         use crate::error::FinishIResult;
         self.parse_next(input).finish()
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,6 +39,19 @@ use crate::stream::{AsChar, Compare, Location, Stream, StreamIsPartial};
 /// - `u8` and `char`, see [`winnow::bytes::one_of`][crate::bytes::one_of]
 /// - `&[u8]` and `&str`, see [`winnow::bytes::tag`][crate::bytes::tag]
 pub trait Parser<I, O, E> {
+    /// Parse all of `input`, generating `O` from it
+    fn parse(&mut self, input: I) -> Result<O, E>
+    where
+        I: Stream,
+        // Force users to deal with `Incomplete` when `StreamIsPartial<true>`
+        I: StreamIsPartial,
+        I: Clone,
+        E: ParseError<I>,
+    {
+        use crate::error::FinishIResult;
+        self.parse_next(input).finish()
+    }
+
     /// Take tokens from the [`Stream`], turning it into the output
     ///
     /// This includes advancing the [`Stream`] to the next location.

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -167,7 +167,7 @@ impl<I: crate::lib::std::fmt::Display> crate::lib::std::fmt::Display for Located
 /// let data = "Hello";
 /// let state = Cell::new(0);
 /// let input = Stream { input: data, state: State(&state) };
-/// let output = word.parse_next(input).finish().unwrap();
+/// let output = word.parse(input).unwrap();
 /// assert_eq!(state.get(), 1);
 /// ```
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This was made possible be renaming `Parser::parse` to `Parser::parse_next`

Fixes #80