### PR TITLE
fix!: Don't lose type information on `Parser` functions 

### DIFF
--- a/examples/arithmetic/parser.rs
+++ b/examples/arithmetic/parser.rs
@@ -58,7 +58,7 @@ fn factor(i: &str) -> IResult<&str, i64> {
         spaces,
         alt((
             digits.map_res(FromStr::from_str),
-            delimited(one_of('('), expr, one_of(')')),
+            delimited('(', expr, ')'),
             parens,
         )),
         spaces,
@@ -68,7 +68,7 @@ fn factor(i: &str) -> IResult<&str, i64> {
 
 // We parse any expr surrounded by parens, ignoring all whitespaces around those
 fn parens(i: &str) -> IResult<&str, i64> {
-    delimited(one_of('('), expr, one_of(')')).parse_next(i)
+    delimited('(', expr, ')').parse_next(i)
 }
 
 #[test]

--- a/examples/css/parser.rs
+++ b/examples/css/parser.rs
@@ -1,4 +1,4 @@
-use winnow::bytes::{tag, take_while_m_n};
+use winnow::bytes::take_while_m_n;
 use winnow::prelude::*;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -18,7 +18,7 @@ impl std::str::FromStr for Color {
 }
 
 pub fn hex_color(input: &str) -> IResult<&str, Color> {
-    let (input, _) = tag("#").parse_next(input)?;
+    let (input, _) = "#".parse_next(input)?;
     let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse_next(input)?;
 
     Ok((input, Color { red, green, blue }))

--- a/examples/http/parser.rs
+++ b/examples/http/parser.rs
@@ -1,9 +1,4 @@
-use winnow::{
-    bytes::{one_of, take_while1},
-    character::line_ending,
-    multi::many1,
-    IResult, Parser,
-};
+use winnow::{bytes::take_while1, character::line_ending, multi::many1, IResult, Parser};
 
 pub type Stream<'i> = &'i [u8];
 
@@ -90,7 +85,7 @@ fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 
 fn message_header(input: Stream<'_>) -> IResult<Stream<'_>, Header<'_>> {
     let (input, name) = take_while1(is_token).parse_next(input)?;
-    let (input, _) = one_of(':').parse_next(input)?;
+    let (input, _) = ':'.parse_next(input)?;
     let (input, value) = many1(message_header_value).parse_next(input)?;
 
     Ok((input, Header { name, value }))

--- a/examples/http/parser.rs
+++ b/examples/http/parser.rs
@@ -1,5 +1,5 @@
 use winnow::{
-    bytes::{one_of, tag, take_while1},
+    bytes::{one_of, take_while1},
     character::line_ending,
     multi::many1,
     IResult, Parser,
@@ -74,7 +74,7 @@ fn request_line(input: Stream<'_>) -> IResult<Stream<'_>, Request<'_>> {
 }
 
 fn http_version(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-    let (input, _) = tag("HTTP/").parse_next(input)?;
+    let (input, _) = "HTTP/".parse_next(input)?;
     let (input, version) = take_while1(is_version).parse_next(input)?;
 
     Ok((input, version))

--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -1,5 +1,5 @@
 use winnow::{
-    bytes::{one_of, tag, take_while1},
+    bytes::{one_of, take_while1},
     character::line_ending,
     multi::many1,
     stream::Partial,
@@ -75,7 +75,7 @@ fn request_line(input: Stream<'_>) -> IResult<Stream<'_>, Request<'_>> {
 }
 
 fn http_version(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-    let (input, _) = tag("HTTP/").parse_next(input)?;
+    let (input, _) = "HTTP/".parse_next(input)?;
     let (input, version) = take_while1(is_version).parse_next(input)?;
 
     Ok((input, version))

--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -1,9 +1,5 @@
 use winnow::{
-    bytes::{one_of, take_while1},
-    character::line_ending,
-    multi::many1,
-    stream::Partial,
-    IResult, Parser,
+    bytes::take_while1, character::line_ending, multi::many1, stream::Partial, IResult, Parser,
 };
 
 pub type Stream<'i> = Partial<&'i [u8]>;
@@ -91,7 +87,7 @@ fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 
 fn message_header(input: Stream<'_>) -> IResult<Stream<'_>, Header<'_>> {
     let (input, name) = take_while1(is_token).parse_next(input)?;
-    let (input, _) = one_of(':').parse_next(input)?;
+    let (input, _) = ':'.parse_next(input)?;
     let (input, value) = many1(message_header_value).parse_next(input)?;
 
     Ok((input, Header { name, value }))

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::iter::Iterator;
 
-use winnow::bytes::tag;
 use winnow::character::alphanumeric1;
 use winnow::combinator::iterator;
 use winnow::prelude::*;
@@ -11,7 +10,7 @@ fn main() {
     let mut data = "abcabcabcabc";
 
     fn parser(i: &str) -> IResult<&str, &str> {
-        tag("abc").parse_next(i)
+        "abc".parse_next(i)
     }
 
     // `from_fn` (available from Rust 1.34) can create an iterator

--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -4,7 +4,7 @@ use std::str;
 use winnow::prelude::*;
 use winnow::{
     branch::alt,
-    bytes::{any, none_of, tag, take, take_while0},
+    bytes::{any, none_of, take, take_while0},
     character::float,
     combinator::cut_err,
     error::{ContextError, ParseError},
@@ -58,7 +58,7 @@ fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static 
 fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
-    tag("null").parse_next(input)
+    "null".parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
@@ -66,11 +66,11 @@ fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>,
 fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
-    let parse_true = tag("true").value(true);
+    let parse_true = "true".value(true);
 
     // This is a parser that returns `false` if it sees the string "false", and
     // an error otherwise
-    let parse_false = tag("false").value(false);
+    let parse_false = "false".value(false);
 
     alt((parse_true, parse_false)).parse_next(input)
 }

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -4,7 +4,7 @@ use std::str;
 use winnow::prelude::*;
 use winnow::{
     branch::{alt, dispatch},
-    bytes::{any, none_of, tag, take, take_while0},
+    bytes::{any, none_of, take, take_while0},
     character::float,
     combinator::cut_err,
     combinator::fail,
@@ -65,7 +65,7 @@ fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static 
 fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
-    tag("null").parse_next(input)
+    "null".parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
@@ -73,7 +73,7 @@ fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>,
 fn true_<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
-    tag("true").value(true).parse_next(input)
+    "true".value(true).parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
@@ -81,7 +81,7 @@ fn true_<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>
 fn false_<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
     // This is a parser that returns `false` if it sees the string "false", and
     // an error otherwise
-    tag("false").value(false).parse_next(input)
+    "false".value(false).parse_next(input)
 }
 
 /// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -4,7 +4,7 @@ use std::str;
 use winnow::prelude::*;
 use winnow::{
     branch::alt,
-    bytes::{any, none_of, tag, take, take_while0},
+    bytes::{any, none_of, take, take_while0},
     character::float,
     combinator::{cut_err, rest},
     error::{ContextError, ParseError},
@@ -59,7 +59,7 @@ fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static 
 fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
-    tag("null").parse_next(input)
+    "null".parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
@@ -67,11 +67,11 @@ fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>,
 fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
-    let parse_true = tag("true").value(true);
+    let parse_true = "true".value(true);
 
     // This is a parser that returns `false` if it sees the string "false", and
     // an error otherwise
-    let parse_false = tag("false").value(false);
+    let parse_false = "false".value(false);
 
     alt((parse_true, parse_false)).parse_next(input)
 }

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -220,7 +220,7 @@ fn string(i: &str) -> IResult<&str, &str> {
 }
 
 fn boolean(input: &str) -> IResult<&str, bool> {
-    alt((tag("false").map(|_| false), tag("true").map(|_| true))).parse_next(input)
+    alt(("false".map(|_| false), "true".map(|_| true))).parse_next(input)
 }
 
 fn array(i: &str) -> IResult<&str, ()> {

--- a/examples/ndjson/parser.rs
+++ b/examples/ndjson/parser.rs
@@ -4,7 +4,7 @@ use std::str;
 use winnow::prelude::*;
 use winnow::{
     branch::alt,
-    bytes::{any, none_of, tag, take, take_while0},
+    bytes::{any, none_of, take, take_while0},
     character::float,
     character::line_ending,
     combinator::cut_err,
@@ -63,7 +63,7 @@ fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static 
 fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
-    tag("null").parse_next(input)
+    "null".parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
@@ -71,11 +71,11 @@ fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>,
 fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
-    let parse_true = tag("true").value(true);
+    let parse_true = "true".value(true);
 
     // This is a parser that returns `false` if it sees the string "false", and
     // an error otherwise
-    let parse_false = tag("false").value(false);
+    let parse_false = "false".value(false);
 
     alt((parse_true, parse_false)).parse_next(input)
 }

--- a/examples/s_expression/parser.rs
+++ b/examples/s_expression/parser.rs
@@ -5,7 +5,6 @@
 use winnow::{
     branch::alt,
     bytes::one_of,
-    bytes::tag,
     character::{alpha1, digit1, multispace0, multispace1},
     combinator::{cut_err, opt},
     error::VerboseError,
@@ -107,8 +106,8 @@ fn parse_num(i: &str) -> IResult<&str, Atom, VerboseError<&str>> {
 /// Our boolean values are also constant, so we can do it the same way
 fn parse_bool(i: &str) -> IResult<&str, Atom, VerboseError<&str>> {
     alt((
-        tag("#t").map(|_| Atom::Boolean(true)),
-        tag("#f").map(|_| Atom::Boolean(false)),
+        "#t".map(|_| Atom::Boolean(true)),
+        "#f".map(|_| Atom::Boolean(false)),
     ))
     .parse_next(i)
 }
@@ -120,7 +119,7 @@ fn parse_builtin(i: &str) -> IResult<&str, BuiltIn, VerboseError<&str>> {
         parse_builtin_op,
         // map lets us process the parsed output, in this case we know what we parsed,
         // so we ignore the input and return the BuiltIn directly
-        tag("not").map(|_| BuiltIn::Not),
+        "not".map(|_| BuiltIn::Not),
     ))
     .parse_next(i)
 }

--- a/examples/string/parser.rs
+++ b/examples/string/parser.rs
@@ -10,7 +10,7 @@
 //!   escape and the next non-whitespace character
 
 use winnow::branch::alt;
-use winnow::bytes::{one_of, take_till1, take_while_m_n};
+use winnow::bytes::{take_till1, take_while_m_n};
 use winnow::character::multispace1;
 use winnow::error::{FromExternalError, ParseError};
 use winnow::multi::fold_many0;
@@ -109,14 +109,14 @@ where
             // parser (the second argument) succeeds. In these cases, it looks for
             // the marker characters (n, r, t, etc) and returns the matching
             // character (\n, \r, \t, etc).
-            one_of('n').value('\n'),
-            one_of('r').value('\r'),
-            one_of('t').value('\t'),
-            one_of('b').value('\u{08}'),
-            one_of('f').value('\u{0C}'),
-            one_of('\\').value('\\'),
-            one_of('/').value('/'),
-            one_of('"').value('"'),
+            'n'.value('\n'),
+            'r'.value('\r'),
+            't'.value('\t'),
+            'b'.value('\u{08}'),
+            'f'.value('\u{0C}'),
+            '\\'.value('\\'),
+            '/'.value('/'),
+            '"'.value('"'),
         )),
     )
     .parse_next(input)

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -48,7 +48,7 @@ fn decr() {
 fn parens(i: &str) -> IResult<&str, i64> {
     delimited(
         space,
-        delimited(terminated("(", incr), expr, tag(")").map(|_| decr())),
+        delimited(terminated("(", incr), expr, ")".map(|_| decr())),
         space,
     )
     .parse_next(i)

--- a/src/_topic/stream.rs
+++ b/src/_topic/stream.rs
@@ -21,7 +21,7 @@
 //! # type MyStream<'i> = &'i str;
 //! # type Output<'i> = &'i str;
 //! fn parser(i: MyStream<'_>) -> IResult<MyStream<'_>, Output<'_>> {
-//!     tag("test").parse_next(i)
+//!     "test".parse_next(i)
 //! }
 //! ```
 //!

--- a/src/branch/tests.rs
+++ b/src/branch/tests.rs
@@ -1,5 +1,5 @@
 use crate::branch::{alt, permutation};
-use crate::bytes::tag;
+
 use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::Needed;
@@ -89,7 +89,7 @@ fn alt_test() {
     assert_eq!(alt3(a), Ok((a, &b""[..])));
 
     fn alt4(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        alt((tag("abcd"), tag("efgh"))).parse_next(i)
+        alt(("abcd", "efgh")).parse_next(i)
     }
     let b = &b"efgh"[..];
     assert_eq!(alt4(a), Ok((&b""[..], a)));
@@ -99,7 +99,7 @@ fn alt_test() {
 #[test]
 fn alt_incomplete() {
     fn alt1(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        alt((tag("a"), tag("bc"), tag("def"))).parse_next(i)
+        alt(("a", "bc", "def")).parse_next(i)
     }
 
     let a = &b""[..];
@@ -141,7 +141,7 @@ fn alt_incomplete() {
 fn permutation_test() {
     #[allow(clippy::type_complexity)]
     fn perm(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8], &[u8])> {
-        permutation((tag("abcd"), tag("efg"), tag("hi"))).parse_next(i)
+        permutation(("abcd", "efg", "hi")).parse_next(i)
     }
 
     let expected = (&b"abcd"[..], &b"efg"[..], &b"hi"[..]);

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -95,7 +95,7 @@ where
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
-///   tag("Hello").parse_next(s)
+///   "Hello".parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
@@ -110,7 +110,7 @@ where
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   tag("Hello").parse_next(s)
+///   "Hello".parse_next(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new("Hello, World!")), Ok((Partial::new(", World!"), "Hello")));

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -104,7 +104,7 @@ fn partial_one_of_test() {
 #[test]
 fn char_byteslice() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-        one_of('c').parse_next(i)
+        'c'.parse_next(i)
     }
 
     let a = &b"abcd"[..];
@@ -123,7 +123,7 @@ fn char_byteslice() {
 #[test]
 fn char_str() {
     fn f(i: Partial<&str>) -> IResult<Partial<&str>, char> {
-        one_of('c').parse_next(i)
+        'c'.parse_next(i)
     }
 
     let a = "abcd";

--- a/src/bytes/tests.rs
+++ b/src/bytes/tests.rs
@@ -243,7 +243,7 @@ fn partial_recognize() {
     };
 
     fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        delimited(tag("<!--"), take(5_usize), tag("-->"))
+        delimited("<!--", take(5_usize), "-->")
             .recognize()
             .parse_next(i)
     }
@@ -594,7 +594,7 @@ fn partial_length_bytes() {
     );
 
     fn y(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        let (i, _) = tag("magic").parse_next(i)?;
+        let (i, _) = "magic".parse_next(i)?;
         length_data(le_u8).parse_next(i)
     }
     assert_eq!(

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -258,8 +258,7 @@ where
     <I as Stream>::Token: AsChar + Copy,
 {
     trace("newline", move |input: I| {
-        one_of('\n')
-            .map(|c: <I as Stream>::Token| c.as_char())
+        '\n'.map(|c: <I as Stream>::Token| c.as_char())
             .parse_next(input)
     })
     .parse_next(input)
@@ -301,8 +300,7 @@ where
     <I as Stream>::Token: AsChar + Copy,
 {
     trace("tab", move |input: I| {
-        one_of('\t')
-            .map(|c: <I as Stream>::Token| c.as_char())
+        '\t'.map(|c: <I as Stream>::Token| c.as_char())
             .parse_next(input)
     })
     .parse_next(input)

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -9,7 +9,7 @@ use crate::lib::std::ops::{Add, Shl};
 
 use crate::branch::alt;
 use crate::bytes::one_of;
-use crate::bytes::tag;
+
 use crate::bytes::take_while0;
 use crate::bytes::take_while1;
 use crate::combinator::cut_err;
@@ -58,7 +58,7 @@ where
     I: Stream,
     I: Compare<&'static str>,
 {
-    trace("crlf", move |input: I| tag("\r\n").parse_next(input)).parse_next(input)
+    trace("crlf", move |input: I| "\r\n".parse_next(input)).parse_next(input)
 }
 
 /// Recognizes a string of any char except '\r\n' or '\n'.
@@ -1613,9 +1613,9 @@ where
 ///     alpha1,
 ///     '\\',
 ///     alt((
-///       tag("\\").value("\\"),
-///       tag("\"").value("\""),
-///       tag("n").value("\n"),
+///       "\\".value("\\"),
+///       "\"".value("\""),
+///       "n".value("\n"),
 ///     ))
 ///   ).parse_next(input)
 /// }
@@ -1639,9 +1639,9 @@ where
 ///     alpha1,
 ///     '\\',
 ///     alt((
-///       tag("\\").value("\\"),
-///       tag("\"").value("\""),
-///       tag("n").value("\n"),
+///       "\\".value("\\"),
+///       "\"".value("\""),
+///       "n".value("\n"),
 ///     ))
 ///   ).parse_next(input)
 /// }

--- a/src/character/tests.rs
+++ b/src/character/tests.rs
@@ -685,7 +685,6 @@ mod complete {
     #[cfg(feature = "alloc")]
     #[test]
     fn complete_escape_transform() {
-        use crate::bytes::tag;
         use crate::character::alpha1 as alpha;
 
         #[cfg(feature = "alloc")]
@@ -698,9 +697,9 @@ mod complete {
                 alpha,
                 '\\',
                 alt((
-                    tag("\\").value(&b"\\"[..]),
-                    tag("\"").value(&b"\""[..]),
-                    tag("n").value(&b"\n"[..]),
+                    "\\".value(&b"\\"[..]),
+                    "\"".value(&b"\""[..]),
+                    "n".value(&b"\n"[..]),
                 )),
             )
             .map(to_s)
@@ -742,8 +741,8 @@ mod complete {
                 alpha,
                 '&',
                 alt((
-                    tag("egrave;").value("è".as_bytes()),
-                    tag("agrave;").value("à".as_bytes()),
+                    "egrave;".value("è".as_bytes()),
+                    "agrave;".value("à".as_bytes()),
                 )),
             )
             .map(to_s)
@@ -762,18 +761,13 @@ mod complete {
     #[cfg(feature = "std")]
     #[test]
     fn complete_escape_transform_str() {
-        use crate::bytes::tag;
         use crate::character::alpha1 as alpha;
 
         fn esc(i: &str) -> IResult<&str, String> {
             escaped_transform(
                 alpha,
                 '\\',
-                alt((
-                    tag("\\").value("\\"),
-                    tag("\"").value("\""),
-                    tag("n").value("\n"),
-                )),
+                alt(("\\".value("\\"), "\"".value("\""), "n".value("\n"))),
             )
             .parse_next(i)
         }
@@ -800,7 +794,7 @@ mod complete {
             escaped_transform(
                 alpha,
                 '&',
-                alt((tag("egrave;").value("è"), tag("agrave;").value("à"))),
+                alt(("egrave;".value("è"), "agrave;".value("à"))),
             )
             .parse_next(i)
         }
@@ -811,12 +805,7 @@ mod complete {
         );
 
         fn esc3(i: &str) -> IResult<&str, String> {
-            escaped_transform(
-                alpha,
-                '␛',
-                alt((tag("0").value("\0"), tag("n").value("\n"))),
-            )
-            .parse_next(i)
+            escaped_transform(alpha, '␛', alt(("0".value("\0"), "n".value("\n")))).parse_next(i)
         }
         assert_eq!(esc3("a␛0bc␛n"), Ok(("", String::from("a\0bc\n"))));
     }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -10,7 +10,7 @@
 //! |---|---|---|---|---|
 //! | [`one_of`][crate::bytes::one_of] | `one_of("abc")` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one of the provided characters (works with non ASCII characters too)|
 //! | [`none_of`][crate::bytes::none_of] | `none_of("abc")` |  `"xyab"` | `Ok(("yab", 'x'))` |Matches anything but the provided characters|
-//! | [`tag`][crate::bytes::tag] | `tag("hello")` |  `"hello world"` | `Ok((" world", "hello"))` |Recognizes a specific suite of characters or bytes|
+//! | [`tag`][crate::bytes::tag] | `"hello"` |  `"hello world"` | `Ok((" world", "hello"))` |Recognizes a specific suite of characters or bytes|
 //! | [`tag_no_case`][crate::bytes::tag_no_case] | `tag_no_case("hello")` |  `"HeLLo World"` | `Ok((" World", "HeLLo"))` |Case insensitive comparison. Note that case insensitive comparison is not well defined for unicode, and that you might have bad surprises|
 //! | [`take`][crate::bytes::take] | `take(4)` |  `"hello"` | `Ok(("o", "hell"))` |Takes a specific number of bytes or characters|
 //! | [`take_while0`][crate::bytes::take_while0] | `take_while0(is_alphabetic)` |  `"abc123"` | `Ok(("123", "abc"))` |Returns the longest list of bytes for which the provided pattern matches. `take_while1` does the same, but must return at least one character|
@@ -21,32 +21,32 @@
 //!
 //! | combinator | usage | input | output | comment |
 //! |---|---|---|---|---|
-//! | [`alt`][crate::branch::alt] | `alt((tag("ab"), tag("cd")))` |  `"cdef"` | `Ok(("ef", "cd"))` |Try a list of parsers and return the result of the first successful one|
+//! | [`alt`][crate::branch::alt] | `alt(("ab", "cd"))` |  `"cdef"` | `Ok(("ef", "cd"))` |Try a list of parsers and return the result of the first successful one|
 //! | [`dispatch`][crate::branch::dispatch] | \- | \- | \- | `match` for parsers |
-//! | [`permutation`][crate::branch::permutation] | `permutation((tag("ab"), tag("cd"), tag("12")))` | `"cd12abc"` | `Ok(("c", ("ab", "cd", "12"))` |Succeeds when all its child parser have succeeded, whatever the order|
+//! | [`permutation`][crate::branch::permutation] | `permutation(("ab", "cd", "12"))` | `"cd12abc"` | `Ok(("c", ("ab", "cd", "12"))` |Succeeds when all its child parser have succeeded, whatever the order|
 //!
 //! ## Sequence combinators
 //!
 //! | combinator | usage | input | output | comment |
 //! |---|---|---|---|---|
-//! | [`(...)` (tuples)][crate::Parser] | `(tag("ab"), tag("XY"), take(1))` | `"abXYZ!"` | `Ok(("!", ("ab", "XY", "Z")))` |Chains parsers and assemble the sub results in a tuple. You can use as many child parsers as you can put elements in a tuple|
+//! | [`(...)` (tuples)][crate::Parser] | `("ab", "XY", take(1))` | `"abXYZ!"` | `Ok(("!", ("ab", "XY", "Z")))` |Chains parsers and assemble the sub results in a tuple. You can use as many child parsers as you can put elements in a tuple|
 //! | [`delimited`][crate::sequence::delimited] | `delimited(char('('), take(2), char(')'))` | `"(ab)cd"` | `Ok(("cd", "ab"))` ||
-//! | [`preceded`][crate::sequence::preceded] | `preceded(tag("ab"), tag("XY"))` | `"abXYZ"` | `Ok(("Z", "XY"))` ||
-//! | [`terminated`][crate::sequence::terminated] | `terminated(tag("ab"), tag("XY"))` | `"abXYZ"` | `Ok(("Z", "ab"))` ||
-//! | [`separated_pair`][crate::sequence::separated_pair] | `separated_pair(tag("hello"), char(','), tag("world"))` | `"hello,world!"` | `Ok(("!", ("hello", "world")))` ||
+//! | [`preceded`][crate::sequence::preceded] | `preceded("ab", "XY")` | `"abXYZ"` | `Ok(("Z", "XY"))` ||
+//! | [`terminated`][crate::sequence::terminated] | `terminated("ab", "XY")` | `"abXYZ"` | `Ok(("Z", "ab"))` ||
+//! | [`separated_pair`][crate::sequence::separated_pair] | `separated_pair("hello", char(','), "world")` | `"hello,world!"` | `Ok(("!", ("hello", "world")))` ||
 //!
 //! ## Applying a parser multiple times
 //!
 //! | combinator | usage | input | output | comment |
 //! |---|---|---|---|---|
 //! | [`count`][crate::multi::count] | `count(take(2), 3)` | `"abcdefgh"` | `Ok(("gh", vec!["ab", "cd", "ef"]))` |Applies the child parser a specified number of times|
-//! | [`many0`][crate::multi::many0] | `many0(tag("ab"))` |  `"abababc"` | `Ok(("c", vec!["ab", "ab", "ab"]))` |Applies the parser 0 or more times and returns the list of results in a Vec. `many1` does the same operation but must return at least one element|
-//! | [`many_m_n`][crate::multi::many_m_n] | `many_m_n(1, 3, tag("ab"))` | `"ababc"` | `Ok(("c", vec!["ab", "ab"]))` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
+//! | [`many0`][crate::multi::many0] | `many0("ab")` |  `"abababc"` | `Ok(("c", vec!["ab", "ab", "ab"]))` |Applies the parser 0 or more times and returns the list of results in a Vec. `many1` does the same operation but must return at least one element|
+//! | [`many_m_n`][crate::multi::many_m_n] | `many_m_n(1, 3, "ab")` | `"ababc"` | `Ok(("c", vec!["ab", "ab"]))` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
 //! | [`many_till0`][crate::multi::many_till0] | `many_till0(tag( "ab" ), tag( "ef" ))` | `"ababefg"` | `Ok(("g", (vec!["ab", "ab"], "ef")))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
-//! | [`separated0`][crate::multi::separated0] | `separated0(tag("ab"), tag(","))` | `"ab,ab,ab."` | `Ok((".", vec!["ab", "ab", "ab"]))` |`separated1` works like `separated0` but must returns at least one element|
+//! | [`separated0`][crate::multi::separated0] | `separated0("ab", ",")` | `"ab,ab,ab."` | `Ok((".", vec!["ab", "ab", "ab"]))` |`separated1` works like `separated0` but must returns at least one element|
 //! | [`fold_many0`][crate::multi::fold_many0] | `fold_many0(be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([], 6))` |Applies the parser 0 or more times and folds the list of return values. The `fold_many1` version must apply the child parser at least one time|
 //! | [`fold_many_m_n`][crate::multi::fold_many_m_n] | `fold_many_m_n(1, 2, be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([3], 3))` |Applies the parser between m and n times (n included) and folds the list of return value|
-//! | [`length_count`][crate::multi::length_count] | `length_count(number, tag("ab"))` | `"2ababab"` | `Ok(("ab", vec!["ab", "ab"]))` |Gets a number from the first parser, then applies the second parser that many times|
+//! | [`length_count`][crate::multi::length_count] | `length_count(number, "ab")` | `"2ababab"` | `Ok(("ab", vec!["ab", "ab"]))` |Gets a number from the first parser, then applies the second parser that many times|
 //!
 //! ## Partial related
 //!
@@ -1266,7 +1266,7 @@ where
 /// use std::collections::HashMap;
 ///
 /// let data = "abc|defg|hijkl|mnopqr|123";
-/// let mut it = iterator(data, terminated(alpha1, tag("|")));
+/// let mut it = iterator(data, terminated(alpha1, "|"));
 ///
 /// let parsed = it.map(|v| (v, v.len())).collect::<HashMap<_,_>>();
 /// let res: IResult<_,_> = it.finish();

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1371,7 +1371,6 @@ enum State<E> {
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::prelude::*;
 /// use winnow::branch::alt;
-/// use winnow::bytes::one_of;
 /// use winnow::combinator::success;
 ///
 /// let mut parser = success::<_,_,Error<_>>(10);
@@ -1379,8 +1378,8 @@ enum State<E> {
 ///
 /// fn sign(input: &str) -> IResult<&str, isize> {
 ///     alt((
-///         one_of('-').value(-1),
-///         one_of('+').value(1),
+///         '-'.value(-1),
+///         '+'.value(1),
 ///         success::<_,_,Error<_>>(1)
 ///     )).parse_next(input)
 /// }

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::bytes::tag;
+
 use crate::bytes::take;
 use crate::error::ErrMode;
 use crate::error::Error;
@@ -158,7 +158,7 @@ fn test_parser_into() {
 #[test]
 fn opt_test() {
     fn opt_abcd(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Option<&[u8]>> {
-        opt(tag("abcd")).parse_next(i)
+        opt("abcd").parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -181,7 +181,7 @@ fn opt_test() {
 #[test]
 fn peek_test() {
     fn peek_tag(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        peek(tag("abcd")).parse_next(i)
+        peek("abcd").parse_next(i)
     }
 
     assert_eq!(
@@ -204,7 +204,7 @@ fn peek_test() {
 #[test]
 fn not_test() {
     fn not_aaa(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, ()> {
-        not(tag("aaa")).parse_next(i)
+        not("aaa").parse_next(i)
     }
 
     assert_eq!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -711,12 +711,11 @@ macro_rules! error_node_position(
 #[cfg(feature = "alloc")]
 mod tests {
     use super::*;
-    use crate::bytes::one_of;
 
     #[test]
     fn convert_error_panic() {
         let input = "";
 
-        let _result: IResult<_, _, VerboseError<&str>> = one_of('x').parse_next(input);
+        let _result: IResult<_, _, VerboseError<&str>> = 'x'.parse_next(input);
     }
 }

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -31,7 +31,7 @@ use crate::Parser;
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many0(tag("abc")).parse_next(s)
+///   many0("abc").parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -95,7 +95,7 @@ where
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many1(tag("abc")).parse_next(s)
+///   many1("abc").parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -158,7 +158,7 @@ where
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, (Vec<&str>, &str)> {
-///   many_till0(tag("abc"), tag("end")).parse_next(s)
+///   many_till0("abc", "end").parse_next(s)
 /// };
 ///
 /// assert_eq!(parser("abcabcend"), Ok(("", (vec!["abc", "abc"], "end"))));
@@ -220,7 +220,7 @@ where
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated0(tag("abc"), tag("|")).parse_next(s)
+///   separated0("abc", "|").parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
@@ -297,7 +297,7 @@ where
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated1(tag("abc"), tag("|")).parse_next(s)
+///   separated1("abc", "|").parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
@@ -492,7 +492,7 @@ where
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many_m_n(0, 2, tag("abc")).parse_next(s)
+///   many_m_n(0, 2, "abc").parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -562,7 +562,7 @@ where
 /// use winnow::bytes::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   count(tag("abc"), 2).parse_next(s)
+///   count("abc", 2).parse_next(s)
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
@@ -618,7 +618,7 @@ where
 ///
 /// fn parser(s: &str) -> IResult<&str, [&str; 2]> {
 ///   let mut buf = ["", ""];
-///   let (rest, ()) = fill(tag("abc"), &mut buf).parse_next(s)?;
+///   let (rest, ()) = fill("abc", &mut buf).parse_next(s)?;
 ///   Ok((rest, buf))
 /// }
 ///
@@ -678,7 +678,7 @@ where
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   fold_many0(
-///     tag("abc"),
+///     "abc",
 ///     Vec::new,
 ///     |mut acc: Vec<_>, item| {
 ///       acc.push(item);
@@ -753,7 +753,7 @@ where
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   fold_many1(
-///     tag("abc"),
+///     "abc",
 ///     Vec::new,
 ///     |mut acc: Vec<_>, item| {
 ///       acc.push(item);
@@ -840,7 +840,7 @@ where
 ///   fold_many_m_n(
 ///     0,
 ///     2,
-///     tag("abc"),
+///     "abc",
 ///     Vec::new,
 ///     |mut acc: Vec<_>, item| {
 ///       acc.push(item);
@@ -988,7 +988,7 @@ where
 /// }
 ///
 /// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-///   length_value(be_u16, tag("abc")).parse_next(s)
+///   length_value(be_u16, "abc").parse_next(s)
 /// }
 ///
 /// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
@@ -1042,7 +1042,7 @@ where
 ///   length_count(u8.map(|i| {
 ///      println!("got number: {}", i);
 ///      i
-///   }), tag("abc")).parse_next(s)
+///   }), "abc").parse_next(s)
 /// }
 ///
 /// assert_eq!(parser(stream(b"\x02abcabcabc")), Ok((stream(b"abc"), vec![&b"abc"[..], &b"abc"[..]])));

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -2,7 +2,6 @@ use super::{length_data, length_value, many0, many1};
 use crate::Parser;
 use crate::Partial;
 use crate::{
-    bytes::tag,
     character::digit1 as digit,
     error::{ErrMode, ErrorKind, Needed, ParseError},
     lib::std::str::{self, FromStr},
@@ -22,13 +21,13 @@ use crate::{
 #[cfg(feature = "alloc")]
 fn separated0_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0(tag("abcd"), tag(",")).parse_next(i)
+        separated0("abcd", ",").parse_next(i)
     }
     fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0(tag(""), tag(",")).parse_next(i)
+        separated0("", ",").parse_next(i)
     }
     fn multi_longsep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0(tag("abcd"), tag("..")).parse_next(i)
+        separated0("abcd", "..").parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -78,7 +77,7 @@ fn separated0_test() {
 #[cfg_attr(debug_assertions, should_panic)]
 fn separated0_empty_sep_test() {
     fn empty_sep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0(tag("abc"), tag("")).parse_next(i)
+        separated0("abc", "").parse_next(i)
     }
 
     let i = &b"abcabc"[..];
@@ -97,10 +96,10 @@ fn separated0_empty_sep_test() {
 #[cfg(feature = "alloc")]
 fn separated1_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated1(tag("abcd"), tag(",")).parse_next(i)
+        separated1("abcd", ",").parse_next(i)
     }
     fn multi_longsep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated1(tag("abcd"), tag("..")).parse_next(i)
+        separated1("abcd", "..").parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -147,7 +146,7 @@ fn separated1_test() {
 #[cfg(feature = "alloc")]
 fn many0_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(tag("abcd")).parse_next(i)
+        many0("abcd").parse_next(i)
     }
 
     assert_eq!(
@@ -181,7 +180,7 @@ fn many0_test() {
 #[cfg_attr(debug_assertions, should_panic)]
 fn many0_empty_test() {
     fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(tag("")).parse_next(i)
+        many0("").parse_next(i)
     }
 
     assert_eq!(
@@ -197,7 +196,7 @@ fn many0_empty_test() {
 #[cfg(feature = "alloc")]
 fn many1_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many1(tag("abcd")).parse_next(i)
+        many1("abcd").parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -230,7 +229,7 @@ fn many1_test() {
 fn many_till_test() {
     #[allow(clippy::type_complexity)]
     fn multi(i: &[u8]) -> IResult<&[u8], (Vec<&[u8]>, &[u8])> {
-        many_till0(tag("abcd"), tag("efgh")).parse_next(i)
+        many_till0("abcd", "efgh").parse_next(i)
     }
 
     let a = b"abcdabcdefghabcd";
@@ -280,7 +279,7 @@ fn infinite_many() {
 #[cfg(feature = "alloc")]
 fn many_m_n_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many_m_n(2, 4, tag("Abcd")).parse_next(i)
+        many_m_n(2, 4, "Abcd").parse_next(i)
     }
 
     let a = &b"Abcdef"[..];
@@ -322,7 +321,7 @@ fn many_m_n_test() {
 fn count_test() {
     const TIMES: usize = 2;
     fn cnt_2(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        count(tag("abc"), TIMES).parse_next(i)
+        count("abc", TIMES).parse_next(i)
     }
 
     assert_eq!(
@@ -365,7 +364,7 @@ fn count_test() {
 fn count_zero() {
     const TIMES: usize = 0;
     fn counter_2(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        count(tag("abc"), TIMES).parse_next(i)
+        count("abc", TIMES).parse_next(i)
     }
 
     let done = &b"abcabcabcdef"[..];
@@ -428,7 +427,7 @@ fn length_count_test() {
     }
 
     fn cnt(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        length_count(number, tag("abc")).parse_next(i)
+        length_count(number, "abc").parse_next(i)
     }
 
     assert_eq!(
@@ -572,7 +571,7 @@ fn fold_many0_test() {
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many0(tag("abcd"), Vec::new, fold_into_vec).parse_next(i)
+        fold_many0("abcd", Vec::new, fold_into_vec).parse_next(i)
     }
 
     assert_eq!(
@@ -610,7 +609,7 @@ fn fold_many0_empty_test() {
         acc
     }
     fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many0(tag(""), Vec::new, fold_into_vec).parse_next(i)
+        fold_many0("", Vec::new, fold_into_vec).parse_next(i)
     }
 
     assert_eq!(
@@ -630,7 +629,7 @@ fn fold_many1_test() {
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many1(tag("abcd"), Vec::new, fold_into_vec).parse_next(i)
+        fold_many1("abcd", Vec::new, fold_into_vec).parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -666,7 +665,7 @@ fn fold_many_m_n_test() {
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many_m_n(2, 4, tag("Abcd"), Vec::new, fold_into_vec).parse_next(i)
+        fold_many_m_n(2, 4, "Abcd", Vec::new, fold_into_vec).parse_next(i)
     }
 
     let a = &b"Abcdef"[..];
@@ -706,7 +705,7 @@ fn fold_many_m_n_test() {
 #[test]
 fn many0_count_test() {
     fn count0_nums(i: &[u8]) -> IResult<&[u8], usize> {
-        many0((digit, tag(","))).parse_next(i)
+        many0((digit, ",")).parse_next(i)
     }
 
     assert_eq!(count0_nums(&b"123,junk"[..]), Ok((&b"junk"[..], 1)));
@@ -724,7 +723,7 @@ fn many0_count_test() {
 #[test]
 fn many1_count_test() {
     fn count1_nums(i: &[u8]) -> IResult<&[u8], usize> {
-        many1((digit, tag(","))).parse_next(i)
+        many1((digit, ",")).parse_next(i)
     }
 
     assert_eq!(count1_nums(&b"123,45,junk"[..]), Ok((&b"junk"[..], 2)));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,8 @@
 //! Basic types to build the parsers
 
 use crate::combinator::*;
-use crate::error::{ContextError, IResult, ParseError};
-use crate::stream::{AsChar, Compare, Location, Stream, StreamIsPartial};
+use crate::error::{ContextError, FromExternalError, IResult, ParseError};
+use crate::stream::{AsChar, Compare, Location, Offset, ParseSlice, Stream, StreamIsPartial};
 
 /// Core trait for parsing
 ///
@@ -126,7 +126,7 @@ pub trait Parser<I, O, E> {
     /// # }
     /// ```
     #[doc(alias = "to")]
-    fn value<O2>(self, val: O2) -> Value<Self, O, O2>
+    fn value<O2>(self, val: O2) -> Value<Self, I, O, O2, E>
     where
         Self: core::marker::Sized,
         O2: Clone,
@@ -149,7 +149,7 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse_next("123abcd;"), Err(ErrMode::Backtrack(Error::new("123abcd;", ErrorKind::Slice))));
     /// # }
     /// ```
-    fn void(self) -> Void<Self, O>
+    fn void(self) -> Void<Self, I, O, E>
     where
         Self: core::marker::Sized,
     {
@@ -177,7 +177,7 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
     /// # }
     /// ```
-    fn output_into<O2>(self) -> OutputInto<Self, O, O2>
+    fn output_into<O2>(self) -> OutputInto<Self, I, O, O2, E>
     where
         Self: core::marker::Sized,
         O: Into<O2>,
@@ -202,9 +202,10 @@ pub trait Parser<I, O, E> {
     /// # }
     /// ```
     #[doc(alias = "concat")]
-    fn recognize(self) -> Recognize<Self, O>
+    fn recognize(self) -> Recognize<Self, I, O, E>
     where
         Self: core::marker::Sized,
+        I: Stream + Offset,
     {
         Recognize::new(self)
     }
@@ -249,9 +250,10 @@ pub trait Parser<I, O, E> {
     /// # }
     /// ```
     #[doc(alias = "consumed")]
-    fn with_recognized(self) -> WithRecognized<Self, O>
+    fn with_recognized(self) -> WithRecognized<Self, I, O, E>
     where
         Self: core::marker::Sized,
+        I: Stream + Offset,
     {
         WithRecognized::new(self)
     }
@@ -272,10 +274,10 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse(Located::new("abcd,efgh")), Ok((0..4, 5..9)));
     /// assert_eq!(parser.parse_next(Located::new("abcd;")),Err(ErrMode::Backtrack(Error::new(Located::new("abcd;").next_slice(4).0, ErrorKind::Verify))));
     /// ```
-    fn span(self) -> Span<Self, O>
+    fn span(self) -> Span<Self, I, O, E>
     where
         Self: core::marker::Sized,
-        I: Location + Clone,
+        I: Stream + Location,
     {
         Span::new(self)
     }
@@ -320,10 +322,10 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(recognize_parser.parse_next(Located::new("abcd")), consumed_parser.parse_next(Located::new("abcd")));
     /// # }
     /// ```
-    fn with_span(self) -> WithSpan<Self, O>
+    fn with_span(self) -> WithSpan<Self, I, O, E>
     where
         Self: core::marker::Sized,
-        I: Location + Clone,
+        I: Stream + Location,
     {
         WithSpan::new(self)
     }
@@ -346,12 +348,12 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse_next("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Slice))));
     /// # }
     /// ```
-    fn map<G, O2>(self, g: G) -> Map<Self, G, O>
+    fn map<G, O2>(self, map: G) -> Map<Self, G, I, O, O2, E>
     where
         G: Fn(O) -> O2,
         Self: core::marker::Sized,
     {
-        Map::new(self, g)
+        Map::new(self, map)
     }
 
     /// Applies a function returning a `Result` over the output of a parser.
@@ -375,12 +377,14 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parse.parse_next("123456"), Err(ErrMode::Backtrack(Error::new("123456", ErrorKind::Verify))));
     /// # }
     /// ```
-    fn map_res<G, O2, E2>(self, g: G) -> MapRes<Self, G, O>
+    fn map_res<G, O2, E2>(self, map: G) -> MapRes<Self, G, I, O, O2, E, E2>
     where
         Self: core::marker::Sized,
         G: FnMut(O) -> Result<O2, E2>,
+        I: Clone,
+        E: FromExternalError<I, E2>,
     {
-        MapRes::new(self, g)
+        MapRes::new(self, map)
     }
 
     /// Apply both [`Parser::verify`] and [`Parser::map`].
@@ -407,12 +411,14 @@ pub trait Parser<I, O, E> {
     #[doc(alias = "satisfy_map")]
     #[doc(alias = "filter_map")]
     #[doc(alias = "map_opt")]
-    fn verify_map<G, O2>(self, g: G) -> VerifyMap<Self, G, O>
+    fn verify_map<G, O2>(self, map: G) -> VerifyMap<Self, G, I, O, O2, E>
     where
         Self: core::marker::Sized,
         G: FnMut(O) -> Option<O2>,
+        I: Clone,
+        E: ParseError<I>,
     {
-        VerifyMap::new(self, g)
+        VerifyMap::new(self, map)
     }
 
     /// Creates a parser from the output of this one
@@ -447,13 +453,13 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(length_data.parse_next(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
     /// assert_eq!(length_data.parse_next(&[4, 0, 1, 2][..]), Err(ErrMode::Backtrack(Error::new(&[0, 1, 2][..], ErrorKind::Slice))));
     /// ```
-    fn flat_map<G, H, O2>(self, g: G) -> FlatMap<Self, G, O>
+    fn flat_map<G, H, O2>(self, map: G) -> FlatMap<Self, G, H, I, O, O2, E>
     where
+        Self: core::marker::Sized,
         G: FnMut(O) -> H,
         H: Parser<I, O2, E>,
-        Self: core::marker::Sized,
     {
-        FlatMap::new(self, g)
+        FlatMap::new(self, map)
     }
 
     /// Applies a second parser over the output of the first one
@@ -473,13 +479,13 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(digits.parse_next("123"), Err(ErrMode::Backtrack(Error::new("123", ErrorKind::Slice))));
     /// # }
     /// ```
-    fn and_then<G, O2>(self, g: G) -> AndThen<Self, G, O>
+    fn and_then<G, O2>(self, inner: G) -> AndThen<Self, G, I, O, O2, E>
     where
-        O: StreamIsPartial,
-        G: Parser<O, O2, E>,
         Self: core::marker::Sized,
+        G: Parser<O, O2, E>,
+        O: StreamIsPartial,
     {
-        AndThen::new(self, g)
+        AndThen::new(self, inner)
     }
 
     /// Apply [`std::str::FromStr`] to the output of the parser
@@ -502,10 +508,12 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse_next("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Slice))));
     /// ```
     #[doc(alias = "from_str")]
-    fn parse_to<O2>(self) -> ParseTo<Self, O, O2>
+    fn parse_to<O2>(self) -> ParseTo<Self, I, O, O2, E>
     where
         Self: core::marker::Sized,
-        O: crate::stream::ParseSlice<O2>,
+        I: Stream,
+        O: ParseSlice<O2>,
+        E: ParseError<I>,
     {
         ParseTo::new(self)
     }
@@ -531,12 +539,16 @@ pub trait Parser<I, O, E> {
     /// ```
     #[doc(alias = "satisfy")]
     #[doc(alias = "filter")]
-    fn verify<G, O2: ?Sized>(self, second: G) -> Verify<Self, G, O2>
+    fn verify<G, O2>(self, filter: G) -> Verify<Self, G, I, O, O2, E>
     where
         Self: core::marker::Sized,
         G: Fn(&O2) -> bool,
+        I: Clone,
+        O: crate::lib::std::borrow::Borrow<O2>,
+        O2: ?Sized,
+        E: ParseError<I>,
     {
-        Verify::new(self, second)
+        Verify::new(self, filter)
     }
 
     /// If parsing fails, add context to the error
@@ -544,11 +556,12 @@ pub trait Parser<I, O, E> {
     /// This is used mainly to add user friendly information
     /// to errors when backtracking through a parse tree.
     #[doc(alias = "labelled")]
-    fn context<C>(self, context: C) -> Context<Self, O, C>
+    fn context<C>(self, context: C) -> Context<Self, I, O, E, C>
     where
         Self: core::marker::Sized,
-        C: Clone + crate::lib::std::fmt::Debug,
+        I: Stream,
         E: ContextError<I, C>,
+        C: Clone + crate::lib::std::fmt::Debug,
     {
         Context::new(self, context)
     }
@@ -576,7 +589,7 @@ pub trait Parser<I, O, E> {
     }
 
     /// Convert the parser's error to another type using [`std::convert::From`]
-    fn err_into<E2>(self) -> ErrInto<Self, E, E2>
+    fn err_into<E2>(self) -> ErrInto<Self, I, O, E, E2>
     where
         Self: core::marker::Sized,
         E: Into<E2>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -230,7 +230,7 @@ pub trait Parser<I, O, E> {
     /// use winnow::sequence::separated_pair;
     ///
     /// fn inner_parser(input: &str) -> IResult<&str, bool> {
-    ///     tag("1234").value(true).parse_next(input)
+    ///     "1234".value(true).parse_next(input)
     /// }
     ///
     /// # fn main() {
@@ -303,7 +303,7 @@ pub trait Parser<I, O, E> {
     /// use winnow::sequence::separated_pair;
     ///
     /// fn inner_parser(input: Located<&str>) -> IResult<Located<&str>, bool> {
-    ///     tag("1234").value(true).parse_next(input)
+    ///     "1234".value(true).parse_next(input)
     /// }
     ///
     /// # fn main() {
@@ -818,7 +818,7 @@ impl<'a, I, O, E> Parser<I, O, E> for Box<dyn Parser<I, O, E> + 'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bytes::{tag, take};
+    use crate::bytes::take;
     use crate::error::ErrMode;
     use crate::error::Error;
     use crate::error::ErrorKind;
@@ -870,7 +870,7 @@ mod tests {
     fn tuple_test() {
         #[allow(clippy::type_complexity)]
         fn tuple_3(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (u16, &[u8], &[u8])> {
-            (be_u16, take(3u8), tag("fg")).parse_next(i)
+            (be_u16, take(3u8), "fg").parse_next(i)
         }
 
         assert_eq!(

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -23,7 +23,7 @@ use crate::Parser;
 /// use winnow::sequence::preceded;
 /// use winnow::bytes::tag;
 ///
-/// let mut parser = preceded(tag("abc"), tag("efg"));
+/// let mut parser = preceded("abc", "efg");
 ///
 /// assert_eq!(parser.parse_next("abcefg"), Ok(("", "efg")));
 /// assert_eq!(parser.parse_next("abcefghij"), Ok(("hij", "efg")));
@@ -61,7 +61,7 @@ where
 /// use winnow::sequence::terminated;
 /// use winnow::bytes::tag;
 ///
-/// let mut parser = terminated(tag("abc"), tag("efg"));
+/// let mut parser = terminated("abc", "efg");
 ///
 /// assert_eq!(parser.parse_next("abcefg"), Ok(("", "abc")));
 /// assert_eq!(parser.parse_next("abcefghij"), Ok(("hij", "abc")));
@@ -100,7 +100,7 @@ where
 /// use winnow::sequence::separated_pair;
 /// use winnow::bytes::tag;
 ///
-/// let mut parser = separated_pair(tag("abc"), tag("|"), tag("efg"));
+/// let mut parser = separated_pair("abc", "|", "efg");
 ///
 /// assert_eq!(parser.parse_next("abc|efg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser.parse_next("abc|efghij"), Ok(("hij", ("abc", "efg"))));
@@ -141,7 +141,7 @@ where
 /// use winnow::sequence::delimited;
 /// use winnow::bytes::tag;
 ///
-/// let mut parser = delimited(tag("("), tag("abc"), tag(")"));
+/// let mut parser = delimited("(", "abc", ")");
 ///
 /// assert_eq!(parser.parse_next("(abc)"), Ok(("", "abc")));
 /// assert_eq!(parser.parse_next("(abc)def"), Ok(("def", "abc")));

--- a/src/sequence/tests.rs
+++ b/src/sequence/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::bytes::tag;
+
 use crate::error::{ErrMode, ErrorKind, Needed};
 use crate::IResult;
 use crate::Partial;
@@ -18,10 +18,9 @@ struct C {
 
 #[test]
 fn complete() {
-    use crate::bytes::tag;
     fn err_test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        let (i, _) = tag("ijkl").parse_next(i)?;
-        tag("mnop").parse_next(i)
+        let (i, _) = "ijkl".parse_next(i)?;
+        "mnop".parse_next(i)
     }
     let a = &b"ijklmn"[..];
 
@@ -39,7 +38,7 @@ fn complete() {
 fn separated_pair_test() {
     #[allow(clippy::type_complexity)]
     fn sep_pair_abc_def(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8])> {
-        separated_pair(tag("abc"), tag(","), tag("def")).parse_next(i)
+        separated_pair("abc", ",", "def").parse_next(i)
     }
 
     assert_eq!(
@@ -80,7 +79,7 @@ fn separated_pair_test() {
 #[test]
 fn preceded_test() {
     fn preceded_abcd_efgh(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        preceded(tag("abcd"), tag("efgh")).parse_next(i)
+        preceded("abcd", "efgh").parse_next(i)
     }
 
     assert_eq!(
@@ -121,7 +120,7 @@ fn preceded_test() {
 #[test]
 fn terminated_test() {
     fn terminated_abcd_efgh(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        terminated(tag("abcd"), tag("efgh")).parse_next(i)
+        terminated("abcd", "efgh").parse_next(i)
     }
 
     assert_eq!(
@@ -162,7 +161,7 @@ fn terminated_test() {
 #[test]
 fn delimited_test() {
     fn delimited_abc_def_ghi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        delimited(tag("abc"), tag("def"), tag("ghi")).parse_next(i)
+        delimited("abc", "def", "ghi").parse_next(i)
     }
 
     assert_eq!(

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -45,6 +45,7 @@ compile_error!("`debug` requires `std`");
 /// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::Slice))));
 /// ```
 #[cfg_attr(not(feature = "debug"), allow(unused_variables))]
+#[cfg_attr(not(feature = "debug"), allow(unused_mut))]
 pub fn trace<I: Stream, O, E>(
     name: impl crate::lib::std::fmt::Display,
     mut parser: impl Parser<I, O, E>,

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use winnow::bytes::tag;
 use winnow::character::digit1 as digit;
 use winnow::error::{ErrorKind, ParseError};
 #[cfg(feature = "alloc")]
@@ -31,7 +30,7 @@ impl<'a> ParseError<Partial<&'a str>> for CustomError {
 
 fn test1(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
     //fix_error!(input, CustomError, tag!("abcd"))
-    tag("abcd").parse_next(input)
+    "abcd".parse_next(input)
 }
 
 fn test2(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {

--- a/tests/testsuite/fnmut.rs
+++ b/tests/testsuite/fnmut.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "alloc")]
 
-use winnow::bytes::tag;
 use winnow::multi::many0;
 use winnow::Parser;
 
@@ -12,7 +11,7 @@ fn parse() {
     let res = {
         let mut parser = many0::<_, _, Vec<_>, (), _>(|i| {
             counter += 1;
-            tag("abc").parse_next(i)
+            "abc".parse_next(i)
         });
 
         parser.parse_next("abcabcabcabc").unwrap()
@@ -28,7 +27,7 @@ fn accumulate() {
 
     let (_, count) = {
         let mut parser = many0::<_, _, usize, (), _>(|i| {
-            let (i, o) = tag("abc").parse_next(i)?;
+            let (i, o) = "abc".parse_next(i)?;
             v.push(o);
             Ok((i, ()))
         });

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -187,8 +187,8 @@ fn issue_942() {
     pub fn parser<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
         i: &'a str,
     ) -> IResult<&'a str, usize, E> {
-        use winnow::{bytes::one_of, multi::many0};
-        many0(one_of('a').context("char_a")).parse_next(i)
+        use winnow::multi::many0;
+        many0('a'.context("char_a")).parse_next(i)
     }
     assert_eq!(parser::<()>("aaa"), Ok(("", 3)));
 }

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -154,7 +154,7 @@ mod issue_647 {
 
     fn data(input: Stream<'_>) -> IResult<Stream<'_>, Data> {
         let (i, c) = be_f64(input)?;
-        let (i, _) = tag("\n").parse_next(i)?;
+        let (i, _) = "\n".parse_next(i)?;
         let (i, v) = list(i, &c)?;
         Ok((i, Data { c, v }))
     }
@@ -237,11 +237,11 @@ fn issue_1282_findtoken_char() {
 
 #[test]
 fn issue_x_looser_fill_bounds() {
-    use winnow::{bytes::tag, character::digit1, multi::fill, sequence::terminated};
+    use winnow::{character::digit1, multi::fill, sequence::terminated};
 
     fn fill_pair(i: &[u8]) -> IResult<&[u8], [&[u8]; 2]> {
         let mut buf = [&[][..], &[][..]];
-        let (i, _) = fill(terminated(digit1, tag(",")), &mut buf).parse_next(i)?;
+        let (i, _) = fill(terminated(digit1, ","), &mut buf).parse_next(i)?;
         Ok((i, buf))
     }
 

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -79,11 +79,11 @@ fn overflow_incomplete_many1() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many_till0() {
-    use winnow::{bytes::tag, multi::many_till0};
+    use winnow::multi::many_till0;
 
     #[allow(clippy::type_complexity)]
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (Vec<&[u8]>, &[u8])> {
-        many_till0(length_data(be_u64), tag("abc")).parse_next(i)
+        many_till0(length_data(be_u64), "abc").parse_next(i)
     }
 
     // Trigger an overflow in many_till0

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -5,7 +5,7 @@ mod test {
     #[cfg(feature = "alloc")]
     use winnow::{branch::alt, bytes::tag_no_case, multi::many1};
     use winnow::{
-        bytes::{tag, take, take_till0, take_till1, take_until0, take_while1},
+        bytes::{take, take_till0, take_till1, take_until0, take_while1},
         error::ErrMode,
         error::{self, Error, ErrorKind},
         IResult,
@@ -14,19 +14,18 @@ mod test {
     #[test]
     fn tag_succeed_str() {
         const INPUT: &str = "Hello World!";
-        const TAG: &str = "Hello";
         fn test(input: &str) -> IResult<&str, &str> {
-            tag(TAG).parse_next(input)
+            "Hello".parse_next(input)
         }
 
         match test(INPUT) {
             Ok((extra, output)) => {
                 assert!(extra == " World!", "Parser `tag` consumed leftover input.");
                 assert!(
-                    output == TAG,
+                    output == "Hello",
                     "Parser `tag` doesn't return the tag it matched on success. \
            Expected `{}`, got `{}`.",
-                    TAG,
+                    "Hello",
                     output
                 );
             }
@@ -40,12 +39,9 @@ mod test {
 
     #[test]
     fn tag_incomplete_str() {
-        use winnow::bytes::tag;
-
         const INPUT: &str = "Hello";
-        const TAG: &str = "Hello World!";
 
-        let res: IResult<_, _, error::Error<_>> = tag(TAG).parse_next(Partial::new(INPUT));
+        let res: IResult<_, _, error::Error<_>> = "Hello World!".parse_next(Partial::new(INPUT));
         match res {
             Err(ErrMode::Incomplete(_)) => (),
             other => {
@@ -61,9 +57,8 @@ mod test {
     #[test]
     fn tag_error_str() {
         const INPUT: &str = "Hello World!";
-        const TAG: &str = "Random"; // TAG must be closer than INPUT.
 
-        let res: IResult<_, _, error::Error<_>> = tag(TAG).parse_next(INPUT);
+        let res: IResult<_, _, error::Error<_>> = "Random".parse_next(INPUT);
         match res {
             Err(ErrMode::Backtrack(_)) => (),
             other => {
@@ -510,7 +505,7 @@ mod test {
         let b = "ababcd";
 
         fn f(i: &str) -> IResult<&str, &str> {
-            many1::<_, _, (), _, _>(alt((tag("a"), tag("b"))))
+            many1::<_, _, (), _, _>(alt(("a", "b")))
                 .recognize()
                 .parse_next(i)
         }
@@ -522,7 +517,7 @@ mod test {
     #[test]
     fn utf8_indexing_str() {
         fn dot(i: &str) -> IResult<&str, &str> {
-            tag(".").parse_next(i)
+            ".".parse_next(i)
         }
 
         let _ = dot("點");


### PR DESCRIPTION
When playing around with #163, I found that carrying more type
information along in `Parser`s, type inference works better, offering an
alternative to solving the core problem that associated types was
looking to solve.