### PR TITLE
perf: Undo performance regression from 0.4.0

### DIFF
--- a/benches/contains_token.rs
+++ b/benches/contains_token.rs
@@ -23,6 +23,9 @@ fn contains_token(c: &mut criterion::Criterion) {
         group.bench_with_input(criterion::BenchmarkId::new("slice", name), &len, |b, _| {
             b.iter(|| black_box(parser_slice.parse_next(black_box(sample)).unwrap()));
         });
+        group.bench_with_input(criterion::BenchmarkId::new("array", name), &len, |b, _| {
+            b.iter(|| black_box(parser_array.parse_next(black_box(sample)).unwrap()));
+        });
         group.bench_with_input(criterion::BenchmarkId::new("tuple", name), &len, |b, _| {
             b.iter(|| black_box(parser_tuple.parse_next(black_box(sample)).unwrap()));
         });
@@ -57,6 +60,11 @@ fn parser_str(input: &str) -> IResult<&str, usize> {
 
 fn parser_slice(input: &str) -> IResult<&str, usize> {
     let contains = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'][..];
+    many0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
+}
+
+fn parser_array(input: &str) -> IResult<&str, usize> {
+    let contains = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
     many0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
 }
 

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -778,7 +778,11 @@ where
     <I as Stream>::Token: AsChar + Copy,
 {
     trace("space0", move |input: I| {
-        take_while0((' ', '\t')).parse_next(input)
+        take_while0(|c: <I as Stream>::Token| {
+            let ch = c.as_char();
+            matches!(ch, ' ' | '\t')
+        })
+        .parse_next(input)
     })
     .parse_next(input)
 }
@@ -821,7 +825,11 @@ where
     <I as Stream>::Token: AsChar + Copy,
 {
     trace("space1", move |input: I| {
-        take_while1((' ', '\t')).parse_next(input)
+        take_while1(|c: <I as Stream>::Token| {
+            let ch = c.as_char();
+            matches!(ch, ' ' | '\t')
+        })
+        .parse_next(input)
     })
     .parse_next(input)
 }
@@ -864,7 +872,11 @@ where
     <I as Stream>::Token: AsChar + Copy,
 {
     trace("multispace0", move |input: I| {
-        take_while0((' ', '\t', '\r', '\n')).parse_next(input)
+        take_while0(|c: <I as Stream>::Token| {
+            let ch = c.as_char();
+            matches!(ch, ' ' | '\t' | '\r' | '\n')
+        })
+        .parse_next(input)
     })
     .parse_next(input)
 }
@@ -907,7 +919,11 @@ where
     <I as Stream>::Token: AsChar + Copy,
 {
     trace("multispace1", move |input: I| {
-        take_while1((' ', '\t', '\r', '\n')).parse_next(input)
+        take_while1(|c: <I as Stream>::Token| {
+            let ch = c.as_char();
+            matches!(ch, ' ' | '\t' | '\r' | '\n')
+        })
+        .parse_next(input)
     })
     .parse_next(input)
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2245,116 +2245,59 @@ impl<C1: AsChar> ContainsToken<C1> for RangeFull {
     }
 }
 
-impl<'a> ContainsToken<u8> for &'a [u8] {
-    #[inline(always)]
-    fn contains_token(&self, token: u8) -> bool {
-        memchr(token, self).is_some()
-    }
-}
-
-impl<'a, 'b> ContainsToken<&'a u8> for &'b [u8] {
-    #[inline(always)]
-    fn contains_token(&self, token: &u8) -> bool {
-        self.contains_token(*token)
-    }
-}
-
-impl<'a> ContainsToken<char> for &'a [u8] {
+impl<C: AsChar> ContainsToken<C> for &'_ [u8] {
     #[inline]
-    fn contains_token(&self, token: char) -> bool {
-        self.iter().any(|i| i.as_char() == token)
+    fn contains_token(&self, token: C) -> bool {
+        let token = token.as_char();
+        self.iter().any(|t| t.as_char() == token)
     }
 }
 
-impl<'a, 'b> ContainsToken<&'a char> for &'b [u8] {
-    #[inline(always)]
-    fn contains_token(&self, token: &char) -> bool {
-        self.contains_token(*token)
-    }
-}
-
-impl<const LEN: usize> ContainsToken<u8> for [u8; LEN] {
-    #[inline(always)]
-    fn contains_token(&self, token: u8) -> bool {
-        let slice = &self[..];
-        slice.contains_token(token)
-    }
-}
-
-impl<'a, const LEN: usize> ContainsToken<&'a u8> for [u8; LEN] {
-    #[inline(always)]
-    fn contains_token(&self, token: &u8) -> bool {
-        self.contains_token(*token)
-    }
-}
-
-impl<const LEN: usize> ContainsToken<char> for [u8; LEN] {
+impl<C: AsChar> ContainsToken<C> for &'_ [char] {
     #[inline]
-    fn contains_token(&self, token: char) -> bool {
-        self.iter().any(|i| i.as_char() == token)
+    fn contains_token(&self, token: C) -> bool {
+        let token = token.as_char();
+        self.iter().any(|t| *t == token)
     }
 }
 
-impl<'a, const LEN: usize> ContainsToken<&'a char> for [u8; LEN] {
-    #[inline(always)]
-    fn contains_token(&self, token: &char) -> bool {
-        self.contains_token(*token)
-    }
-}
-
-impl<'a> ContainsToken<u8> for &'a str {
-    #[inline(always)]
-    fn contains_token(&self, token: u8) -> bool {
-        self.as_bytes().contains_token(token)
-    }
-}
-
-impl<'a, 'b> ContainsToken<&'a u8> for &'b str {
-    #[inline(always)]
-    fn contains_token(&self, token: &u8) -> bool {
-        self.as_bytes().contains_token(token)
-    }
-}
-
-impl<'a> ContainsToken<char> for &'a str {
+impl<const LEN: usize, C: AsChar> ContainsToken<C> for &'_ [u8; LEN] {
     #[inline]
-    fn contains_token(&self, token: char) -> bool {
+    fn contains_token(&self, token: C) -> bool {
+        let token = token.as_char();
+        self.iter().any(|t| t.as_char() == token)
+    }
+}
+
+impl<const LEN: usize, C: AsChar> ContainsToken<C> for &'_ [char; LEN] {
+    #[inline]
+    fn contains_token(&self, token: C) -> bool {
+        let token = token.as_char();
+        self.iter().any(|t| *t == token)
+    }
+}
+
+impl<const LEN: usize, C: AsChar> ContainsToken<C> for [u8; LEN] {
+    #[inline]
+    fn contains_token(&self, token: C) -> bool {
+        let token = token.as_char();
+        self.iter().any(|t| t.as_char() == token)
+    }
+}
+
+impl<const LEN: usize, C: AsChar> ContainsToken<C> for [char; LEN] {
+    #[inline]
+    fn contains_token(&self, token: C) -> bool {
+        let token = token.as_char();
+        self.iter().any(|t| *t == token)
+    }
+}
+
+impl<C: AsChar> ContainsToken<C> for &'_ str {
+    #[inline(always)]
+    fn contains_token(&self, token: C) -> bool {
+        let token = token.as_char();
         self.chars().any(|i| i == token)
-    }
-}
-
-impl<'a, 'b> ContainsToken<&'a char> for &'b str {
-    #[inline(always)]
-    fn contains_token(&self, token: &char) -> bool {
-        self.contains_token(*token)
-    }
-}
-
-impl<'a> ContainsToken<u8> for &'a [char] {
-    #[inline]
-    fn contains_token(&self, token: u8) -> bool {
-        self.iter().any(|i| *i == token.as_char())
-    }
-}
-
-impl<'a, 'b> ContainsToken<&'a u8> for &'b [char] {
-    #[inline(always)]
-    fn contains_token(&self, token: &u8) -> bool {
-        self.contains_token(*token)
-    }
-}
-
-impl<'a> ContainsToken<char> for &'a [char] {
-    #[inline]
-    fn contains_token(&self, token: char) -> bool {
-        self.iter().any(|i| *i == token)
-    }
-}
-
-impl<'a, 'b> ContainsToken<&'a char> for &'b [char] {
-    #[inline(always)]
-    fn contains_token(&self, token: &char) -> bool {
-        self.contains_token(*token)
     }
 }
 


### PR DESCRIPTION
Updates #223. This brings the peformance of the space parsers back to pre-0.4.0 levels.  The root cause is not clear and the performance
difference shown does not align with the `contains_token` benchmark.

This only fixes half of the performance regression from https://github.com/winnow-rs/winnow/pull/210 though. There are still some other changes that negatively affect performance which I didn't figure out yet.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
