### PR TITLE
docs: Add `hcl-edit` to the list of parsers using `winnow`

### DIFF
--- a/src/_topic/mod.rs
+++ b/src/_topic/mod.rs
@@ -19,6 +19,7 @@
 //! See also parsers written with `winnow`:
 //!
 //! - [`toml_edit`](https://crates.io/crates/toml_edit)
+//! - [`hcl-edit`](https://crates.io/crates/hcl-edit)
 
 pub mod arithmetic;
 pub mod error;


### PR DESCRIPTION
Our recent discussion in https://github.com/winnow-rs/winnow/issues/223 pushed me to finally make the initial release of `hcl-edit` which I've been holding of for too long already since I got carried away with missing details.

The crate is far from complete, but the parser implementation is functional and actually quite fast.

So I figured I'll add it to the list of parsers for others to explore real-world uses of winnow.

I hope this does not scare away people from winnow since HCL is quite a big and messy piece to parse, given the three sub-languages it has and some other quirks like the absense of keywords (for example, `true` can be an identifier or a boolean, depending on the context) :wink:.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
