### PR TITLE
fix(multi): Rename 'many' as 'repeat' 

### DIFF
--- a/assets/trace.svg
+++ b/assets/trace.svg
@@ -75,7 +75,7 @@
 <span class="fg2">  &lt; any                                            </span> <span class="bold">|</span> <span class="fg2">+1</span>
 <span class="fg2">  | verify                                         </span> <span class="bold">|</span> 
 <span class="fg2"> &lt; one_of                                          </span> <span class="bold">|</span> <span class="fg2">+1</span>
- &gt; fold_many0                                       <span class="bold">|</span> <span class="underline">"abc\""</span><span class="underline fg6">∅</span>
+ &gt; fold_repeat0                                     <span class="bold">|</span> <span class="underline">"abc\""</span><span class="underline fg6">∅</span>
   &gt; alt                                             <span class="bold">|</span> <span class="underline">"abc\""</span><span class="underline fg6">∅</span>
    &gt; take_till1                                     <span class="bold">|</span> <span class="underline">"abc\""</span><span class="underline fg6">∅</span>
 <span class="fg2">   &lt; take_till1                                    </span> <span class="bold">|</span> <span class="fg2">+3</span>
@@ -99,7 +99,7 @@
 <span class="fg3">    &lt; one_of                                       </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
 <span class="fg3">   &lt; preceded                                      </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
 <span class="fg3">  &lt; alt                                            </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
-<span class="fg2"> &lt; fold_many0                                      </span> <span class="bold">|</span> <span class="fg2">+3</span>
+<span class="fg2"> &lt; fold_repeat0                                    </span> <span class="bold">|</span> <span class="fg2">+3</span>
  &gt; one_of                                           <span class="bold">|</span> <span class="underline">"\""</span><span class="underline fg6">∅</span>
   &gt; any                                             <span class="bold">|</span> <span class="underline">"\""</span><span class="underline fg6">∅</span>
 <span class="fg2">  &lt; any                                            </span> <span class="bold">|</span> <span class="fg2">+1</span>

--- a/benches/contains_token.rs
+++ b/benches/contains_token.rs
@@ -1,7 +1,7 @@
 use criterion::black_box;
 
 use winnow::combinator::alt;
-use winnow::combinator::many0;
+use winnow::combinator::repeat0;
 use winnow::prelude::*;
 use winnow::token::take_till1;
 use winnow::token::take_while1;
@@ -55,22 +55,22 @@ fn contains_token(c: &mut criterion::Criterion) {
 
 fn parser_str(input: &str) -> IResult<&str, usize> {
     let contains = "0123456789";
-    many0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
+    repeat0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
 }
 
 fn parser_slice(input: &str) -> IResult<&str, usize> {
     let contains = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'][..];
-    many0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
+    repeat0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
 }
 
 fn parser_array(input: &str) -> IResult<&str, usize> {
     let contains = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-    many0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
+    repeat0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
 }
 
 fn parser_tuple(input: &str) -> IResult<&str, usize> {
     let contains = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9');
-    many0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
+    repeat0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
 }
 
 fn parser_closure_or(input: &str) -> IResult<&str, usize> {
@@ -86,12 +86,12 @@ fn parser_closure_or(input: &str) -> IResult<&str, usize> {
             || c == '8'
             || c == '9'
     };
-    many0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
+    repeat0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
 }
 
 fn parser_closure_matches(input: &str) -> IResult<&str, usize> {
     let contains = |c: char| matches!(c, '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9');
-    many0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
+    repeat0(alt((take_while1(contains), take_till1(contains)))).parse_next(input)
 }
 
 const CONTIGUOUS: &str = "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";

--- a/examples/arithmetic/parser.rs
+++ b/examples/arithmetic/parser.rs
@@ -5,7 +5,7 @@ use winnow::{
     ascii::{digit1 as digits, space0 as spaces},
     combinator::alt,
     combinator::delimited,
-    combinator::fold_many0,
+    combinator::fold_repeat0,
     token::one_of,
     IResult,
 };
@@ -15,7 +15,7 @@ use winnow::{
 pub fn expr(i: &str) -> IResult<&str, i64> {
     let (i, init) = term(i)?;
 
-    fold_many0(
+    fold_repeat0(
         (one_of("+-"), term),
         move || init,
         |acc, (op, val): (char, i64)| {
@@ -35,7 +35,7 @@ pub fn expr(i: &str) -> IResult<&str, i64> {
 fn term(i: &str) -> IResult<&str, i64> {
     let (i, init) = factor(i)?;
 
-    fold_many0(
+    fold_repeat0(
         (one_of("*/"), factor),
         move || init,
         |acc, (op, val): (char, i64)| {

--- a/examples/arithmetic/parser_ast.rs
+++ b/examples/arithmetic/parser_ast.rs
@@ -7,7 +7,7 @@ use winnow::prelude::*;
 use winnow::{
     ascii::{digit1 as digit, multispace0 as multispace},
     combinator::alt,
-    combinator::many0,
+    combinator::repeat0,
     combinator::{delimited, preceded},
     IResult,
 };
@@ -46,7 +46,7 @@ impl Display for Expr {
 
 pub fn expr(i: &str) -> IResult<&str, Expr> {
     let (i, initial) = term(i)?;
-    let (i, remainder) = many0(alt((
+    let (i, remainder) = repeat0(alt((
         |i| {
             let (i, add) = preceded("+", term).parse_next(i)?;
             Ok((i, (Oper::Add, add)))
@@ -63,7 +63,7 @@ pub fn expr(i: &str) -> IResult<&str, Expr> {
 
 fn term(i: &str) -> IResult<&str, Expr> {
     let (i, initial) = factor(i)?;
-    let (i, remainder) = many0(alt((
+    let (i, remainder) = repeat0(alt((
         |i| {
             let (i, mul) = preceded("*", factor).parse_next(i)?;
             Ok((i, (Oper::Mul, mul)))

--- a/examples/http/parser.rs
+++ b/examples/http/parser.rs
@@ -1,4 +1,4 @@
-use winnow::{ascii::line_ending, combinator::many1, token::take_while1, IResult, Parser};
+use winnow::{ascii::line_ending, combinator::repeat1, token::take_while1, IResult, Parser};
 
 pub type Stream<'i> = &'i [u8];
 
@@ -44,7 +44,7 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
 
 fn request(input: Stream<'_>) -> IResult<Stream<'_>, (Request<'_>, Vec<Header<'_>>)> {
     let (input, req) = request_line(input)?;
-    let (input, h) = many1(message_header).parse_next(input)?;
+    let (input, h) = repeat1(message_header).parse_next(input)?;
     let (input, _) = line_ending(input)?;
 
     Ok((input, (req, h)))
@@ -86,7 +86,7 @@ fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 fn message_header(input: Stream<'_>) -> IResult<Stream<'_>, Header<'_>> {
     let (input, name) = take_while1(is_token).parse_next(input)?;
     let (input, _) = ':'.parse_next(input)?;
-    let (input, value) = many1(message_header_value).parse_next(input)?;
+    let (input, value) = repeat1(message_header_value).parse_next(input)?;
 
     Ok((input, Header { name, value }))
 }

--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -1,5 +1,5 @@
 use winnow::{
-    ascii::line_ending, combinator::many1, stream::Partial, token::take_while1, IResult, Parser,
+    ascii::line_ending, combinator::repeat1, stream::Partial, token::take_while1, IResult, Parser,
 };
 
 pub type Stream<'i> = Partial<&'i [u8]>;
@@ -46,7 +46,7 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
 
 fn request(input: Stream<'_>) -> IResult<Stream<'_>, (Request<'_>, Vec<Header<'_>>)> {
     let (input, req) = request_line(input)?;
-    let (input, h) = many1(message_header).parse_next(input)?;
+    let (input, h) = repeat1(message_header).parse_next(input)?;
     let (input, _) = line_ending(input)?;
 
     Ok((input, (req, h)))
@@ -88,7 +88,7 @@ fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 fn message_header(input: Stream<'_>) -> IResult<Stream<'_>, Header<'_>> {
     let (input, name) = take_while1(is_token).parse_next(input)?;
     let (input, _) = ':'.parse_next(input)?;
-    let (input, value) = many1(message_header_value).parse_next(input)?;
+    let (input, value) = repeat1(message_header_value).parse_next(input)?;
 
     Ok((input, Header { name, value }))
 }

--- a/examples/ini/bench.rs
+++ b/examples/ini/bench.rs
@@ -1,4 +1,4 @@
-use winnow::combinator::many0;
+use winnow::combinator::repeat0;
 use winnow::prelude::*;
 
 mod parser;
@@ -32,7 +32,7 @@ file=payroll.dat
 \0";
 
     fn acc(i: parser::Stream<'_>) -> IResult<parser::Stream<'_>, Vec<(&str, &str)>> {
-        many0(parser::key_value).parse_next(i)
+        repeat0(parser::key_value).parse_next(i)
     }
 
     let mut group = c.benchmark_group("ini keys and values");

--- a/examples/ini/parser.rs
+++ b/examples/ini/parser.rs
@@ -4,8 +4,8 @@ use std::str;
 use winnow::prelude::*;
 use winnow::{
     ascii::{alphanumeric1 as alphanumeric, multispace0 as multispace, space0 as space},
-    combinator::many0,
     combinator::opt,
+    combinator::repeat0,
     combinator::{delimited, separated_pair, terminated},
     token::take_while0,
 };
@@ -13,10 +13,10 @@ use winnow::{
 pub type Stream<'i> = &'i [u8];
 
 pub fn categories(i: Stream<'_>) -> IResult<Stream<'_>, HashMap<&str, HashMap<&str, &str>>> {
-    many0(separated_pair(
+    repeat0(separated_pair(
         category,
         opt(multispace),
-        many0(terminated(key_value, opt(multispace))),
+        repeat0(terminated(key_value, opt(multispace))),
     ))
     .parse_next(i)
 }

--- a/examples/ini/parser_str.rs
+++ b/examples/ini/parser_str.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use winnow::prelude::*;
 use winnow::{
     ascii::{alphanumeric1 as alphanumeric, space0 as space},
-    combinator::many0,
     combinator::opt,
+    combinator::repeat0,
     combinator::{delimited, terminated},
     token::{take_till0, take_while0, take_while1},
 };
@@ -12,7 +12,7 @@ use winnow::{
 pub type Stream<'i> = &'i str;
 
 pub fn categories(input: Stream<'_>) -> IResult<Stream<'_>, HashMap<&str, HashMap<&str, &str>>> {
-    many0(category_and_keys).parse_next(input)
+    repeat0(category_and_keys).parse_next(input)
 }
 
 fn category_and_keys(i: Stream<'_>) -> IResult<Stream<'_>, (&str, HashMap<&str, &str>)> {
@@ -28,7 +28,7 @@ fn category(i: Stream<'_>) -> IResult<Stream<'_>, &str> {
 }
 
 fn keys_and_values(input: Stream<'_>) -> IResult<Stream<'_>, HashMap<&str, &str>> {
-    many0(key_value).parse_next(input)
+    repeat0(key_value).parse_next(input)
 }
 
 fn key_value(i: Stream<'_>) -> IResult<Stream<'_>, (&str, &str)> {

--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -7,7 +7,7 @@ use winnow::{
     combinator::alt,
     combinator::cut_err,
     combinator::{delimited, preceded, separated_pair, terminated},
-    combinator::{fold_many0, separated0},
+    combinator::{fold_repeat0, separated0},
     error::{ContextError, ParseError},
     token::{any, none_of, take, take_while0},
 };
@@ -87,7 +87,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_many0(character, String::new, |mut string, c| {
+            fold_repeat0(character, String::new, |mut string, c| {
                 string.push(c);
                 string
             }),

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -10,7 +10,7 @@ use winnow::{
     combinator::success,
     combinator::{alt, dispatch},
     combinator::{delimited, preceded, separated_pair, terminated},
-    combinator::{fold_many0, separated0},
+    combinator::{fold_repeat0, separated0},
     error::{ContextError, ParseError},
     token::{any, none_of, take, take_while0},
 };
@@ -96,7 +96,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_many0(character, String::new, |mut string, c| {
+            fold_repeat0(character, String::new, |mut string, c| {
                 string.push(c);
                 string
             }),

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -7,7 +7,7 @@ use winnow::{
     combinator::alt,
     combinator::{cut_err, rest},
     combinator::{delimited, preceded, separated_pair, terminated},
-    combinator::{fold_many0, separated0},
+    combinator::{fold_repeat0, separated0},
     error::{ContextError, ParseError},
     stream::Partial,
     token::{any, none_of, take, take_while0},
@@ -88,7 +88,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_many0(character, String::new, |mut string, c| {
+            fold_repeat0(character, String::new, |mut string, c| {
                 string.push(c);
                 string
             }),

--- a/examples/ndjson/parser.rs
+++ b/examples/ndjson/parser.rs
@@ -8,7 +8,7 @@ use winnow::{
     combinator::alt,
     combinator::cut_err,
     combinator::{delimited, preceded, separated_pair, terminated},
-    combinator::{fold_many0, separated0},
+    combinator::{fold_repeat0, separated0},
     error::{ContextError, ParseError},
     stream::Partial,
     token::{any, none_of, take, take_while0},
@@ -92,7 +92,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_many0(character, String::new, |mut string, c| {
+            fold_repeat0(character, String::new, |mut string, c| {
                 string.push(c);
                 string
             }),

--- a/examples/s_expression/parser.rs
+++ b/examples/s_expression/parser.rs
@@ -5,7 +5,7 @@
 use winnow::{
     ascii::{alpha1, digit1, multispace0, multispace1},
     combinator::alt,
-    combinator::many0,
+    combinator::repeat0,
     combinator::{cut_err, opt},
     combinator::{delimited, preceded, terminated},
     error::VerboseError,
@@ -168,8 +168,8 @@ fn parse_keyword(i: &str) -> IResult<&str, Atom, VerboseError<&str>> {
 /// tuples are themselves a parser, used to sequence parsers together, so we can translate this
 /// directly and then map over it to transform the output into an `Expr::Application`
 fn parse_application(i: &str) -> IResult<&str, Expr, VerboseError<&str>> {
-    let application_inner =
-        (parse_expr, many0(parse_expr)).map(|(head, tail)| Expr::Application(Box::new(head), tail));
+    let application_inner = (parse_expr, repeat0(parse_expr))
+        .map(|(head, tail)| Expr::Application(Box::new(head), tail));
     // finally, we wrap it in an s-expression
     s_exp(application_inner).parse_next(i)
 }
@@ -212,7 +212,7 @@ fn parse_quote(i: &str) -> IResult<&str, Expr, VerboseError<&str>> {
     // this should look very straight-forward after all we've done:
     // we find the `'` (quote) character, use cut_err to say that we're unambiguously
     // looking for an s-expression of 0 or more expressions, and then parse them
-    preceded("'", cut_err(s_exp(many0(parse_expr))))
+    preceded("'", cut_err(s_exp(repeat0(parse_expr))))
         .context("quote")
         .map(Expr::Quote)
         .parse_next(i)

--- a/examples/string/parser.rs
+++ b/examples/string/parser.rs
@@ -11,7 +11,7 @@
 
 use winnow::ascii::multispace1;
 use winnow::combinator::alt;
-use winnow::combinator::fold_many0;
+use winnow::combinator::fold_repeat0;
 use winnow::combinator::{delimited, preceded};
 use winnow::error::{FromExternalError, ParseError};
 use winnow::prelude::*;
@@ -23,9 +23,9 @@ pub fn parse_string<'a, E>(input: &'a str) -> IResult<&'a str, String, E>
 where
     E: ParseError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
-    // fold_many0 is the equivalent of iterator::fold. It runs a parser in a loop,
+    // fold_repeat0 is the equivalent of iterator::fold. It runs a parser in a loop,
     // and for each output value, calls a folding function on each output value.
-    let build_string = fold_many0(
+    let build_string = fold_repeat0(
         // Our parser function – parses a single string fragment
         parse_fragment,
         // Our init value, an empty string
@@ -44,7 +44,7 @@ where
 
     // Finally, parse the string. Note that, if `build_string` could accept a raw
     // " character, the closing delimiter " would never match. When using
-    // `delimited` with a looping parser (like fold_many0), be sure that the
+    // `delimited` with a looping parser (like fold_repeat0), be sure that the
     // loop won't accidentally match your closing delimiter!
     delimited('"', build_string, '"').parse_next(input)
 }

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -6,7 +6,7 @@ use winnow::prelude::*;
 use winnow::{
     ascii::{digit1 as digit, space0 as space},
     combinator::alt,
-    combinator::fold_many0,
+    combinator::fold_repeat0,
     combinator::{delimited, terminated},
 };
 
@@ -64,7 +64,7 @@ fn term(i: &str) -> IResult<&str, i64> {
         e
     })?;
 
-    let res = fold_many0(
+    let res = fold_repeat0(
         alt((('*', factor), ('/', factor.verify(|i| *i != 0)))),
         || init,
         |acc, (op, val): (char, i64)| {
@@ -93,7 +93,7 @@ fn expr(i: &str) -> IResult<&str, i64> {
         e
     })?;
 
-    let res = fold_many0(
+    let res = fold_repeat0(
         (alt(('+', '-')), term),
         || init,
         |acc, (op, val): (char, i64)| {

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -146,8 +146,8 @@
 //! string slice to an integer value is slightly simpler. You can also strip the `_` from the string
 //! slice that is returned, which is demonstrated in the second hexadecimal number parser.
 //!
-//! If you wish to limit the number of digits in a valid integer literal, replace `many1` with
-//! `many_m_n` in the recipes.
+//! If you wish to limit the number of digits in a valid integer literal, replace `repeat1` with
+//! `repeat_m_n` in the recipes.
 //!
 //! #### Hexadecimal
 //!
@@ -157,7 +157,7 @@
 //! use winnow::prelude::*;
 //! use winnow::{
 //!   combinator::alt,
-//!   combinator::{many0, many1},
+//!   combinator::{repeat0, repeat1},
 //!   combinator::{preceded, terminated},
 //!   token::one_of,
 //!   token::tag,
@@ -166,8 +166,8 @@
 //! fn hexadecimal(input: &str) -> IResult<&str, &str> { // <'a, E: ParseError<&'a str>>
 //!   preceded(
 //!     alt(("0x", "0X")),
-//!     many1(
-//!       terminated(one_of("0123456789abcdefABCDEF"), many0('_').map(|()| ()))
+//!     repeat1(
+//!       terminated(one_of("0123456789abcdefABCDEF"), repeat0('_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
 //!   ).parse_next(input)
 //! }
@@ -179,7 +179,7 @@
 //! use winnow::prelude::*;
 //! use winnow::{
 //!   combinator::alt,
-//!   combinator::{many0, many1},
+//!   combinator::{repeat0, repeat1},
 //!   combinator::{preceded, terminated},
 //!   token::one_of,
 //!   token::tag,
@@ -188,8 +188,8 @@
 //! fn hexadecimal_value(input: &str) -> IResult<&str, i64> {
 //!   preceded(
 //!     alt(("0x", "0X")),
-//!     many1(
-//!       terminated(one_of("0123456789abcdefABCDEF"), many0('_').map(|()| ()))
+//!     repeat1(
+//!       terminated(one_of("0123456789abcdefABCDEF"), repeat0('_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
 //!   ).try_map(
 //!     |out: &str| i64::from_str_radix(&str::replace(&out, "_", ""), 16)
@@ -203,7 +203,7 @@
 //! use winnow::prelude::*;
 //! use winnow::{
 //!   combinator::alt,
-//!   combinator::{many0, many1},
+//!   combinator::{repeat0, repeat1},
 //!   combinator::{preceded, terminated},
 //!   token::one_of,
 //!   token::tag,
@@ -212,8 +212,8 @@
 //! fn octal(input: &str) -> IResult<&str, &str> {
 //!   preceded(
 //!     alt(("0o", "0O")),
-//!     many1(
-//!       terminated(one_of("01234567"), many0('_').map(|()| ()))
+//!     repeat1(
+//!       terminated(one_of("01234567"), repeat0('_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
 //!   ).parse_next(input)
 //! }
@@ -225,7 +225,7 @@
 //! use winnow::prelude::*;
 //! use winnow::{
 //!   combinator::alt,
-//!   combinator::{many0, many1},
+//!   combinator::{repeat0, repeat1},
 //!   combinator::{preceded, terminated},
 //!   token::one_of,
 //!   token::tag,
@@ -234,8 +234,8 @@
 //! fn binary(input: &str) -> IResult<&str, &str> {
 //!   preceded(
 //!     alt(("0b", "0B")),
-//!     many1(
-//!       terminated(one_of("01"), many0('_').map(|()| ()))
+//!     repeat1(
+//!       terminated(one_of("01"), repeat0('_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
 //!   ).parse_next(input)
 //! }
@@ -247,14 +247,14 @@
 //! use winnow::prelude::*;
 //! use winnow::{
 //!   IResult,
-//!   combinator::{many0, many1},
+//!   combinator::{repeat0, repeat1},
 //!   combinator::terminated,
 //!   token::one_of,
 //! };
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
-//!   many1(
-//!     terminated(one_of("0123456789"), many0('_').map(|()| ()))
+//!   repeat1(
+//!     terminated(one_of("0123456789"), repeat0('_').map(|()| ()))
 //!   ).map(|()| ())
 //!     .recognize()
 //!     .parse_next(input)
@@ -269,7 +269,7 @@
 //! use winnow::prelude::*;
 //! use winnow::{
 //!   combinator::alt,
-//!   combinator::{many0, many1},
+//!   combinator::{repeat0, repeat1},
 //!   combinator::opt,
 //!   combinator::{preceded, terminated},
 //!   token::one_of,
@@ -308,8 +308,8 @@
 //! }
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
-//!   many1(
-//!     terminated(one_of("0123456789"), many0('_').map(|()| ()))
+//!   repeat1(
+//!     terminated(one_of("0123456789"), repeat0('_').map(|()| ()))
 //!   ).
 //!   map(|()| ())
 //!     .recognize()

--- a/src/_topic/partial.rs
+++ b/src/_topic/partial.rs
@@ -21,7 +21,7 @@
 //! Caveats:
 //! - `winnow` takes the approach of re-parsing from scratch.  Chunks should be relatively small to
 //!   prevent the re-parsing overhead from dominating.
-//! - Parsers like [`many0`] do not know when an `eof` is from insufficient data or the end of the
+//! - Parsers like [`repeat0`] do not know when an `eof` is from insufficient data or the end of the
 //!   stream, causing them to always report [`Incomplete`].
 //!
 //! # Example
@@ -39,7 +39,7 @@
 #![allow(unused_imports)] // Used for intra-doc links
 
 use crate::binary::length_value;
-use crate::combinator::many0;
+use crate::combinator::repeat0;
 use crate::error::ErrMode::Incomplete;
 use crate::error::Needed;
 use crate::stream::Partial;

--- a/src/_tutorial/chapter_5.rs
+++ b/src/_tutorial/chapter_5.rs
@@ -1,9 +1,9 @@
 //! # Chapter 5: Repetition
 //!
 //! In [`chapter_3`], we covered how to sequence different parsers into a tuple but sometimes you need to run a
-//! single parser many times into a [`Vec`].
+//! single parser multiple times, collecting the result into a [`Vec`].
 //!
-//! Let's take our `parse_digits` and collect a list of them with [`many0`]:
+//! Let's take our `parse_digits` and collect a list of them with [`repeat0`]:
 //! ```rust
 //! # use winnow::IResult;
 //! # use winnow::Parser;
@@ -12,11 +12,11 @@
 //! # use winnow::token::take;
 //! # use winnow::combinator::fail;
 //! use winnow::combinator::opt;
-//! use winnow::combinator::many0;
+//! use winnow::combinator::repeat0;
 //! use winnow::combinator::terminated;
 //!
 //! fn parse_list(input: &str) -> IResult<&str, Vec<usize>> {
-//!     many0(terminated(parse_digits, opt(','))).parse_next(input)
+//!     repeat0(terminated(parse_digits, opt(','))).parse_next(input)
 //! }
 //!
 //! // ...
@@ -132,7 +132,7 @@
 //! }
 //! ```
 //!
-//! If you look closely at [`many0`], it isn't collecting directly into a [`Vec`] but
+//! If you look closely at [`repeat0`], it isn't collecting directly into a [`Vec`] but
 //! [`Accumulate`] to gather the results.  This let's us make more complex parsers than we did in
 //! [`chapter_2`] by accumulating the results into a `()` and [`recognize`][Parser::recognize]-ing the captured input:
 //! ```rust
@@ -204,7 +204,7 @@
 #![allow(unused_imports)]
 use super::chapter_2;
 use super::chapter_3;
-use crate::combinator::many0;
+use crate::combinator::repeat0;
 use crate::combinator::separated0;
 use crate::stream::Accumulate;
 use crate::Parser;

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -40,12 +40,12 @@
 //! | combinator | usage | input | output | comment |
 //! |---|---|---|---|---|
 //! | [`count`][crate::combinator::count] | `count(take(2), 3)` | `"abcdefgh"` | `Ok(("gh", vec!["ab", "cd", "ef"]))` |Applies the child parser a specified number of times|
-//! | [`many0`][crate::combinator::many0] | `many0("ab")` |  `"abababc"` | `Ok(("c", vec!["ab", "ab", "ab"]))` |Applies the parser 0 or more times and returns the list of results in a Vec. `many1` does the same operation but must return at least one element|
-//! | [`many_m_n`][crate::combinator::many_m_n] | `many_m_n(1, 3, "ab")` | `"ababc"` | `Ok(("c", vec!["ab", "ab"]))` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
-//! | [`many_till0`][crate::combinator::many_till0] | `many_till0(tag( "ab" ), tag( "ef" ))` | `"ababefg"` | `Ok(("g", (vec!["ab", "ab"], "ef")))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
+//! | [`repeat0`][crate::combinator::repeat0] | `repeat0("ab")` |  `"abababc"` | `Ok(("c", vec!["ab", "ab", "ab"]))` |Applies the parser 0 or more times and returns the list of results in a Vec. `repeat1` does the same operation but must return at least one element|
+//! | [`repeat_m_n`][crate::combinator::repeat_m_n] | `repeat_m_n(1, 3, "ab")` | `"ababc"` | `Ok(("c", vec!["ab", "ab"]))` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
+//! | [`repeat_till0`][crate::combinator::repeat_till0] | `repeat_till0(tag( "ab" ), tag( "ef" ))` | `"ababefg"` | `Ok(("g", (vec!["ab", "ab"], "ef")))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
 //! | [`separated0`][crate::combinator::separated0] | `separated0("ab", ",")` | `"ab,ab,ab."` | `Ok((".", vec!["ab", "ab", "ab"]))` |`separated1` works like `separated0` but must returns at least one element|
-//! | [`fold_many0`][crate::combinator::fold_many0] | `fold_many0(be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([], 6))` |Applies the parser 0 or more times and folds the list of return values. The `fold_many1` version must apply the child parser at least one time|
-//! | [`fold_many_m_n`][crate::combinator::fold_many_m_n] | `fold_many_m_n(1, 2, be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([3], 3))` |Applies the parser between m and n times (n included) and folds the list of return value|
+//! | [`fold_repeat0`][crate::combinator::fold_repeat0] | `fold_repeat0(be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([], 6))` |Applies the parser 0 or more times and folds the list of return values. The `fold_repeat1` version must apply the child parser at least one time|
+//! | [`fold_repeat_m_n`][crate::combinator::fold_repeat_m_n] | `fold_repeat_m_n(1, 2, be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([3], 3))` |Applies the parser between m and n times (n included) and folds the list of return value|
 //!
 //! ## Partial related
 //!

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -815,9 +815,9 @@ fn separated1_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn many0_test() {
+fn repeat0_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0("abcd").parse_next(i)
+        repeat0("abcd").parse_next(i)
     }
 
     assert_eq!(
@@ -849,9 +849,9 @@ fn many0_test() {
 #[test]
 #[cfg(feature = "alloc")]
 #[cfg_attr(debug_assertions, should_panic)]
-fn many0_empty_test() {
+fn repeat0_empty_test() {
     fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0("").parse_next(i)
+        repeat0("").parse_next(i)
     }
 
     assert_eq!(
@@ -865,9 +865,9 @@ fn many0_empty_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn many1_test() {
+fn repeat1_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many1("abcd").parse_next(i)
+        repeat1("abcd").parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -897,10 +897,10 @@ fn many1_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn many_till_test() {
+fn repeat_till_test() {
     #[allow(clippy::type_complexity)]
     fn multi(i: &[u8]) -> IResult<&[u8], (Vec<&[u8]>, &[u8])> {
-        many_till0("abcd", "efgh").parse_next(i)
+        repeat_till0("abcd", "efgh").parse_next(i)
     }
 
     let a = b"abcdabcdefghabcd";
@@ -931,13 +931,13 @@ fn infinite_many() {
 
     // should not go into an infinite loop
     fn multi0(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        many0(tst).parse_next(i)
+        repeat0(tst).parse_next(i)
     }
     let a = &b"abcdef"[..];
     assert_eq!(multi0(a), Ok((a, Vec::new())));
 
     fn multi1(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        many1(tst).parse_next(i)
+        repeat1(tst).parse_next(i)
     }
     let a = &b"abcdef"[..];
     assert_eq!(
@@ -948,9 +948,9 @@ fn infinite_many() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn many_m_n_test() {
+fn repeat_m_n_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many_m_n(2, 4, "Abcd").parse_next(i)
+        repeat_m_n(2, 4, "Abcd").parse_next(i)
     }
 
     let a = &b"Abcdef"[..];
@@ -1089,13 +1089,13 @@ impl<I> ParseError<I> for NilError {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn fold_many0_test() {
+fn fold_repeat0_test() {
     fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
         acc.push(item);
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many0("abcd", Vec::new, fold_into_vec).parse_next(i)
+        fold_repeat0("abcd", Vec::new, fold_into_vec).parse_next(i)
     }
 
     assert_eq!(
@@ -1127,13 +1127,13 @@ fn fold_many0_test() {
 #[test]
 #[cfg(feature = "alloc")]
 #[cfg_attr(debug_assertions, should_panic)]
-fn fold_many0_empty_test() {
+fn fold_repeat0_empty_test() {
     fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
         acc.push(item);
         acc
     }
     fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many0("", Vec::new, fold_into_vec).parse_next(i)
+        fold_repeat0("", Vec::new, fold_into_vec).parse_next(i)
     }
 
     assert_eq!(
@@ -1147,13 +1147,13 @@ fn fold_many0_empty_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn fold_many1_test() {
+fn fold_repeat1_test() {
     fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
         acc.push(item);
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many1("abcd", Vec::new, fold_into_vec).parse_next(i)
+        fold_repeat1("abcd", Vec::new, fold_into_vec).parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -1183,13 +1183,13 @@ fn fold_many1_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn fold_many_m_n_test() {
+fn fold_repeat_m_n_test() {
     fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
         acc.push(item);
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_many_m_n(2, 4, "Abcd", Vec::new, fold_into_vec).parse_next(i)
+        fold_repeat_m_n(2, 4, "Abcd", Vec::new, fold_into_vec).parse_next(i)
     }
 
     let a = &b"Abcdef"[..];
@@ -1227,9 +1227,9 @@ fn fold_many_m_n_test() {
 }
 
 #[test]
-fn many0_count_test() {
+fn repeat0_count_test() {
     fn count0_nums(i: &[u8]) -> IResult<&[u8], usize> {
-        many0((digit, ",")).parse_next(i)
+        repeat0((digit, ",")).parse_next(i)
     }
 
     assert_eq!(count0_nums(&b"123,junk"[..]), Ok((&b"junk"[..], 1)));
@@ -1245,9 +1245,9 @@ fn many0_count_test() {
 }
 
 #[test]
-fn many1_count_test() {
+fn repeat1_count_test() {
     fn count1_nums(i: &[u8]) -> IResult<&[u8], usize> {
-        many1((digit, ",")).parse_next(i)
+        repeat1((digit, ",")).parse_next(i)
     }
 
     assert_eq!(count1_nums(&b"123,45,junk"[..]), Ok((&b"junk"[..], 2)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(extended_key_value_attributes))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 // BEGIN - Embark standard lints v6 for Rust 1.55+
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -8,8 +8,8 @@ use crate::stream::Accumulate;
 use crate::stream::{Stream, StreamIsPartial, ToUsize, UpdateSlice};
 use crate::Parser;
 
-/// Deprecated, replaced by [`combinator::many0`]
-#[deprecated(since = "0.4.2", note = "Replaced with `combinator::many0`")]
+/// Deprecated, replaced by [`combinator::repeat0`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::repeat0`")]
 #[inline(always)]
 pub fn many0<I, O, C, E, F>(f: F) -> impl Parser<I, C, E>
 where
@@ -18,11 +18,11 @@ where
     F: Parser<I, O, E>,
     E: ParseError<I>,
 {
-    combinator::many0(f)
+    combinator::repeat0(f)
 }
 
-/// Deprecated, replaced by [`combinator::many1`]
-#[deprecated(since = "0.4.2", note = "Replaced with `combinator::many1`")]
+/// Deprecated, replaced by [`combinator::repeat1`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::repeat1`")]
 #[inline(always)]
 pub fn many1<I, O, C, E, F>(f: F) -> impl Parser<I, C, E>
 where
@@ -31,11 +31,11 @@ where
     F: Parser<I, O, E>,
     E: ParseError<I>,
 {
-    combinator::many1(f)
+    combinator::repeat1(f)
 }
 
-/// Deprecated, replaced by [`combinator::many_till0`]
-#[deprecated(since = "0.4.2", note = "Replaced with `combinator::many_till0`")]
+/// Deprecated, replaced by [`combinator::repeat_till0`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::repeat_till0`")]
 #[inline(always)]
 pub fn many_till0<I, O, C, P, E, F, G>(f: F, g: G) -> impl Parser<I, (C, P), E>
 where
@@ -45,7 +45,7 @@ where
     G: Parser<I, P, E>,
     E: ParseError<I>,
 {
-    combinator::many_till0(f, g)
+    combinator::repeat_till0(f, g)
 }
 
 /// Deprecated, replaced by [`combinator::separated0`]
@@ -105,8 +105,8 @@ where
     combinator::separated_foldr1(parser, sep, op)
 }
 
-/// Deprecated, replaced by [`combinator::many_m_n`]
-#[deprecated(since = "0.4.2", note = "Replaced with `combinator::many_m_n`")]
+/// Deprecated, replaced by [`combinator::repeat_m_n`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::repeat_m_n`")]
 #[inline(always)]
 pub fn many_m_n<I, O, C, E, F>(min: usize, max: usize, parse: F) -> impl Parser<I, C, E>
 where
@@ -115,7 +115,7 @@ where
     F: Parser<I, O, E>,
     E: ParseError<I>,
 {
-    combinator::many_m_n(min, max, parse)
+    combinator::repeat_m_n(min, max, parse)
 }
 
 /// Deprecated, replaced by [`combinator::count`]
@@ -143,8 +143,8 @@ where
     combinator::fill(f, buf)
 }
 
-/// Deprecated, replaced by [`combinator::fold_many0`]
-#[deprecated(since = "0.4.2", note = "Replaced with `combinator::fold_many0`")]
+/// Deprecated, replaced by [`combinator::fold_repeat0`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::fold_repeat0`")]
 #[inline(always)]
 pub fn fold_many0<I, O, E, F, G, H, R>(f: F, init: H, g: G) -> impl Parser<I, R, E>
 where
@@ -154,11 +154,11 @@ where
     H: FnMut() -> R,
     E: ParseError<I>,
 {
-    combinator::fold_many0(f, init, g)
+    combinator::fold_repeat0(f, init, g)
 }
 
-/// Deprecated, replaced by [`combinator::fold_many1`]
-#[deprecated(since = "0.4.2", note = "Replaced with `combinator::fold_many1`")]
+/// Deprecated, replaced by [`combinator::fold_repeat1`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::fold_repeat1`")]
 #[inline(always)]
 pub fn fold_many1<I, O, E, F, G, H, R>(f: F, init: H, g: G) -> impl Parser<I, R, E>
 where
@@ -168,11 +168,11 @@ where
     H: FnMut() -> R,
     E: ParseError<I>,
 {
-    combinator::fold_many1(f, init, g)
+    combinator::fold_repeat1(f, init, g)
 }
 
-/// Deprecated, replaced by [`combinator::fold_many_m_n`]
-#[deprecated(since = "0.4.2", note = "Replaced with `combinator::fold_many_m_n`")]
+/// Deprecated, replaced by [`combinator::fold_repeat_m_n`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::fold_repeat_m_n`")]
 #[inline(always)]
 pub fn fold_many_m_n<I, O, E, F, G, H, R>(
     min: usize,
@@ -188,7 +188,7 @@ where
     H: FnMut() -> R,
     E: ParseError<I>,
 {
-    combinator::fold_many_m_n(min, max, parse, init, fold)
+    combinator::fold_repeat_m_n(min, max, parse, init, fold)
 }
 
 /// Deprecated, replaced by [`binary::length_data`]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -13,9 +13,6 @@ use core::num::NonZeroUsize;
 
 use crate::error::{ErrMode, ErrorKind, Needed, ParseError};
 use crate::lib::std::iter::{Cloned, Enumerate};
-use crate::lib::std::ops::{
-    Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
-};
 use crate::lib::std::slice::Iter;
 use crate::lib::std::str::from_utf8;
 use crate::lib::std::str::CharIndices;
@@ -2196,7 +2193,7 @@ impl<C: AsChar, F: Fn(C) -> bool> ContainsToken<C> for F {
     }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for Range<C2> {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for crate::lib::std::ops::Range<C2> {
     #[inline(always)]
     fn contains_token(&self, token: C1) -> bool {
         let start = self.start.clone().as_char();
@@ -2205,7 +2202,9 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for Range<C2> {
     }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeInclusive<C2> {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1>
+    for crate::lib::std::ops::RangeInclusive<C2>
+{
     #[inline(always)]
     fn contains_token(&self, token: C1) -> bool {
         let start = self.start().clone().as_char();
@@ -2214,7 +2213,7 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeInclusive<C2> {
     }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeFrom<C2> {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for crate::lib::std::ops::RangeFrom<C2> {
     #[inline(always)]
     fn contains_token(&self, token: C1) -> bool {
         let start = self.start.clone().as_char();
@@ -2222,7 +2221,7 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeFrom<C2> {
     }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeTo<C2> {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for crate::lib::std::ops::RangeTo<C2> {
     #[inline(always)]
     fn contains_token(&self, token: C1) -> bool {
         let end = self.end.clone().as_char();
@@ -2230,7 +2229,9 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeTo<C2> {
     }
 }
 
-impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeToInclusive<C2> {
+impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1>
+    for crate::lib::std::ops::RangeToInclusive<C2>
+{
     #[inline(always)]
     fn contains_token(&self, token: C1) -> bool {
         let end = self.end.clone().as_char();
@@ -2238,7 +2239,7 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for RangeToInclusive<C2> 
     }
 }
 
-impl<C1: AsChar> ContainsToken<C1> for RangeFull {
+impl<C1: AsChar> ContainsToken<C1> for crate::lib::std::ops::RangeFull {
     #[inline(always)]
     fn contains_token(&self, _token: C1) -> bool {
         true

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -387,7 +387,7 @@ where
 ///
 /// *Partial version*: will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
 ///
-/// To recognize a series of tokens, use [`many0`][crate::combinator::many0] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
+/// To recognize a series of tokens, use [`repeat0`][crate::combinator::repeat0] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
 ///
 /// # Example
 ///
@@ -469,7 +469,7 @@ where
 ///
 /// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
 ///
-/// To recognize a series of tokens, use [`many1`][crate::combinator::many1] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
+/// To recognize a series of tokens, use [`repeat1`][crate::combinator::repeat1] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
 ///
 /// # Example
 ///
@@ -573,7 +573,7 @@ where
 ///
 /// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
 ///
-/// To recognize a series of tokens, use [`many_m_n`][crate::combinator::many_m_n] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
+/// To recognize a series of tokens, use [`repeat_m_n`][crate::combinator::repeat_m_n] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
 ///
 /// # Example
 ///

--- a/tests/testsuite/fnmut.rs
+++ b/tests/testsuite/fnmut.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "alloc")]
 
-use winnow::combinator::many0;
+use winnow::combinator::repeat0;
 use winnow::Parser;
 
 #[test]
@@ -9,7 +9,7 @@ fn parse() {
     let mut counter = 0;
 
     let res = {
-        let mut parser = many0::<_, _, Vec<_>, (), _>(|i| {
+        let mut parser = repeat0::<_, _, Vec<_>, (), _>(|i| {
             counter += 1;
             "abc".parse_next(i)
         });
@@ -26,7 +26,7 @@ fn accumulate() {
     let mut v = Vec::new();
 
     let (_, count) = {
-        let mut parser = many0::<_, _, usize, (), _>(|i| {
+        let mut parser = repeat0::<_, _, usize, (), _>(|i| {
             let (i, o) = "abc".parse_next(i)?;
             v.push(o);
             Ok((i, ()))

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -27,13 +27,13 @@ mod parse_int {
     use winnow::Partial;
     use winnow::{
         ascii::{digit1 as digit, space1 as space},
-        combinator::many0,
         combinator::opt,
+        combinator::repeat0,
         IResult,
     };
 
     fn parse_ints(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<i32>> {
-        many0(spaces_or_int).parse_next(input)
+        repeat0(spaces_or_int).parse_next(input)
     }
 
     fn spaces_or_int(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
@@ -187,8 +187,8 @@ fn issue_942() {
     pub fn parser<'a, E: ParseError<&'a str> + ContextError<&'a str, &'static str>>(
         i: &'a str,
     ) -> IResult<&'a str, usize, E> {
-        use winnow::combinator::many0;
-        many0('a'.context("char_a")).parse_next(i)
+        use winnow::combinator::repeat0;
+        repeat0('a'.context("char_a")).parse_next(i)
     }
     assert_eq!(parser::<()>("aaa"), Ok(("", 3)));
 }
@@ -196,8 +196,8 @@ fn issue_942() {
 #[test]
 #[cfg(feature = "std")]
 fn issue_many_m_n_with_zeros() {
-    use winnow::combinator::many_m_n;
-    let mut parser = many_m_n::<_, _, Vec<_>, (), _>(0, 0, 'a');
+    use winnow::combinator::repeat_m_n;
+    let mut parser = repeat_m_n::<_, _, Vec<_>, (), _>(0, 0, 'a');
     assert_eq!(parser.parse_next("aaa"), Ok(("aaa", vec![])));
 }
 
@@ -265,8 +265,8 @@ fn issue_x_looser_fill_bounds() {
 #[cfg(feature = "std")]
 fn issue_1459_clamp_capacity() {
     // shouldn't panic
-    use winnow::combinator::many_m_n;
-    let mut parser = many_m_n::<_, _, Vec<_>, (), _>(usize::MAX, usize::MAX, 'a');
+    use winnow::combinator::repeat_m_n;
+    let mut parser = repeat_m_n::<_, _, Vec<_>, (), _>(usize::MAX, usize::MAX, 'a');
     assert_eq!(
         parser.parse_next("a"),
         Err(winnow::error::ErrMode::Backtrack(()))

--- a/tests/testsuite/multiline.rs
+++ b/tests/testsuite/multiline.rs
@@ -2,7 +2,7 @@
 
 use winnow::{
     ascii::{alphanumeric1 as alphanumeric, line_ending as eol},
-    combinator::many0,
+    combinator::repeat0,
     combinator::terminated,
     IResult, Parser,
 };
@@ -20,7 +20,7 @@ pub fn read_line(input: &str) -> IResult<&str, &str> {
 }
 
 pub fn read_lines(input: &str) -> IResult<&str, Vec<&str>> {
-    many0(read_line).parse_next(input)
+    repeat0(read_line).parse_next(input)
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -5,7 +5,7 @@
 use winnow::binary::be_u64;
 use winnow::binary::length_data;
 #[cfg(feature = "alloc")]
-use winnow::combinator::many0;
+use winnow::combinator::repeat0;
 use winnow::error::{ErrMode, Needed};
 use winnow::prelude::*;
 use winnow::token::take;
@@ -31,7 +31,7 @@ fn overflow_incomplete_tuple() {
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_bytes() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(length_data(be_u64)).parse_next(i)
+        repeat0(length_data(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in length_data
@@ -47,10 +47,10 @@ fn overflow_incomplete_length_bytes() {
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many0() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(length_data(be_u64)).parse_next(i)
+        repeat0(length_data(be_u64)).parse_next(i)
     }
 
-    // Trigger an overflow in many0
+    // Trigger an overflow in repeat0
     assert_eq!(
         multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
@@ -62,13 +62,13 @@ fn overflow_incomplete_many0() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many1() {
-    use winnow::combinator::many1;
+    use winnow::combinator::repeat1;
 
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many1(length_data(be_u64)).parse_next(i)
+        repeat1(length_data(be_u64)).parse_next(i)
     }
 
-    // Trigger an overflow in many1
+    // Trigger an overflow in repeat1
     assert_eq!(
         multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
@@ -80,14 +80,14 @@ fn overflow_incomplete_many1() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many_till0() {
-    use winnow::combinator::many_till0;
+    use winnow::combinator::repeat_till0;
 
     #[allow(clippy::type_complexity)]
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (Vec<&[u8]>, &[u8])> {
-        many_till0(length_data(be_u64), "abc").parse_next(i)
+        repeat_till0(length_data(be_u64), "abc").parse_next(i)
     }
 
-    // Trigger an overflow in many_till0
+    // Trigger an overflow in repeat_till0
     assert_eq!(
         multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
@@ -99,13 +99,13 @@ fn overflow_incomplete_many_till0() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many_m_n() {
-    use winnow::combinator::many_m_n;
+    use winnow::combinator::repeat_m_n;
 
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many_m_n(2, 4, length_data(be_u64)).parse_next(i)
+        repeat_m_n(2, 4, length_data(be_u64)).parse_next(i)
     }
 
-    // Trigger an overflow in many_m_n
+    // Trigger an overflow in repeat_m_n
     assert_eq!(
         multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
@@ -153,7 +153,7 @@ fn overflow_incomplete_length_count() {
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_data() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        many0(length_data(be_u64)).parse_next(i)
+        repeat0(length_data(be_u64)).parse_next(i)
     }
 
     assert_eq!(

--- a/tests/testsuite/reborrow_fold.rs
+++ b/tests/testsuite/reborrow_fold.rs
@@ -4,7 +4,7 @@
 use std::str;
 
 use winnow::combinator::delimited;
-use winnow::combinator::fold_many0;
+use winnow::combinator::fold_repeat0;
 use winnow::prelude::*;
 use winnow::token::take_till1;
 use winnow::IResult;
@@ -22,7 +22,7 @@ fn atom(_tomb: &mut ()) -> impl for<'a> FnMut(&'a [u8]) -> IResult<&'a [u8], Str
 fn list<'a>(i: &'a [u8], tomb: &mut ()) -> IResult<&'a [u8], String> {
     delimited(
         '(',
-        fold_many0(atom(tomb), String::new, |mut acc: String, next: String| {
+        fold_repeat0(atom(tomb), String::new, |mut acc: String, next: String| {
             acc.push_str(next.as_str());
             acc
         }),

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -3,7 +3,7 @@ mod test {
     use winnow::Parser;
     use winnow::Partial;
     #[cfg(feature = "alloc")]
-    use winnow::{combinator::alt, combinator::many1, token::tag_no_case};
+    use winnow::{combinator::alt, combinator::repeat1, token::tag_no_case};
     use winnow::{
         error::ErrMode,
         error::{self, Error, ErrorKind},
@@ -505,7 +505,7 @@ mod test {
         let b = "ababcd";
 
         fn f(i: &str) -> IResult<&str, &str> {
-            many1::<_, _, (), _, _>(alt(("a", "b")))
+            repeat1::<_, _, (), _, _>(alt(("a", "b")))
                 .recognize()
                 .parse_next(i)
         }


### PR DESCRIPTION
When working on #98, I realized `repeat` makes the intent a lot
clearer.  Thanks `chumsky`!

This is a part of #95