### PR TITLE
fix: Generalize `_m_n` variants into ranges

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.60.0"  # MSRV
+msrv = "1.64.0"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Default features
       run: cargo miri test --workspace
   msrv:
-    name: "Check MSRV: 1.60.0"
+    name: "Check MSRV: 1.64.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -77,7 +77,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.60.0  # MSRV
+        toolchain: 1.64.0  # MSRV
     - uses: Swatinem/rust-cache@v2
     - name: "winnow (core)"
       run: cargo check --all-targets --no-default-features
@@ -133,7 +133,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.60.0  # MSRV
+        toolchain: 1.64.0  # MSRV
         components: clippy
     - uses: Swatinem/rust-cache@v2
     - name: Install SARIF tools

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/winnow-rs/winnow"
 categories = ["parsing"]
 keywords = ["parser", "parser-combinators", "parsing", "streaming", "bit"]
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.64.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/examples/css/parser.rs
+++ b/examples/css/parser.rs
@@ -1,5 +1,5 @@
 use winnow::prelude::*;
-use winnow::token::take_while_m_n;
+use winnow::token::take_while;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Color {
@@ -25,7 +25,7 @@ pub fn hex_color(input: &str) -> IResult<&str, Color> {
 }
 
 fn hex_primary(input: &str) -> IResult<&str, u8> {
-    take_while_m_n(2, 2, |c: char| c.is_ascii_hexdigit())
+    take_while(2, |c: char| c.is_ascii_hexdigit())
         .try_map(|input| u8::from_str_radix(input, 16))
         .parse_next(input)
 }

--- a/examples/string/parser.rs
+++ b/examples/string/parser.rs
@@ -15,7 +15,7 @@ use winnow::combinator::fold_repeat0;
 use winnow::combinator::{delimited, preceded};
 use winnow::error::{FromExternalError, ParseError};
 use winnow::prelude::*;
-use winnow::token::{take_till1, take_while_m_n};
+use winnow::token::{take_till1, take_while};
 
 /// Parse a string. Use a loop of `parse_fragment` and push all of the fragments
 /// into an output string.
@@ -129,9 +129,9 @@ fn parse_unicode<'a, E>(input: &'a str) -> IResult<&'a str, char, E>
 where
     E: ParseError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
-    // `take_while_m_n` parses between `m` and `n` bytes (inclusive) that match
+    // `take_while` parses between `m` and `n` bytes (inclusive) that match
     // a predicate. `parse_hex` here parses between 1 and 6 hexadecimal numerals.
-    let parse_hex = take_while_m_n(1, 6, |c: char| c.is_ascii_hexdigit());
+    let parse_hex = take_while(1..=6, |c: char| c.is_ascii_hexdigit());
 
     // `preceded` takes a prefix parser, and if it succeeds, returns the result
     // of the body parser. In this case, it parses u{XXXX}.

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -147,7 +147,7 @@
 //! slice that is returned, which is demonstrated in the second hexadecimal number parser.
 //!
 //! If you wish to limit the number of digits in a valid integer literal, replace `repeat1` with
-//! `repeat_m_n` in the recipes.
+//! `repeat` in the recipes.
 //!
 //! #### Hexadecimal
 //!

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,4 +1,26 @@
-//! Deprecated, see [`token`][crate::token]
+//! Deprecated, see [`token`]
 #![deprecated(since = "0.4.2", note = "Replaced with `token`")]
 
+use crate::error::ParseError;
+use crate::stream::StreamIsPartial;
+use crate::stream::{ContainsToken, Stream};
+use crate::token;
+use crate::Parser;
+
 pub use crate::token::*;
+
+/// Deprecated, see [`token::take_while`]
+#[deprecated(since = "0.4.2", note = "Replaced with `token::take_while`")]
+#[inline(always)]
+pub fn take_while_m_n<T, I, Error: ParseError<I>>(
+    m: usize,
+    n: usize,
+    list: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    T: ContainsToken<<I as Stream>::Token>,
+{
+    token::take_while(m..=n, list)
+}

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -45,7 +45,7 @@
 //! | [`repeat_till0`][crate::combinator::repeat_till0] | `repeat_till0(tag( "ab" ), tag( "ef" ))` | `"ababefg"` | `Ok(("g", (vec!["ab", "ab"], "ef")))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
 //! | [`separated0`][crate::combinator::separated0] | `separated0("ab", ",")` | `"ab,ab,ab."` | `Ok((".", vec!["ab", "ab", "ab"]))` |`separated1` works like `separated0` but must returns at least one element|
 //! | [`fold_repeat0`][crate::combinator::fold_repeat0] | `fold_repeat0(be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([], 6))` |Applies the parser 0 or more times and folds the list of return values. The `fold_repeat1` version must apply the child parser at least one time|
-//! | [`fold_repeat_m_n`][crate::combinator::fold_repeat_m_n] | `fold_repeat_m_n(1, 2, be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([3], 3))` |Applies the parser between m and n times (n included) and folds the list of return value|
+//! | [`fold_repeat`][crate::combinator::fold_repeat] | `fold_repeat(1..=2, be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([3], 3))` |Applies the parser between m and n times (n included) and folds the list of return value|
 //!
 //! ## Partial related
 //!

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -41,7 +41,7 @@
 //! |---|---|---|---|---|
 //! | [`count`][crate::combinator::count] | `count(take(2), 3)` | `"abcdefgh"` | `Ok(("gh", vec!["ab", "cd", "ef"]))` |Applies the child parser a specified number of times|
 //! | [`repeat0`][crate::combinator::repeat0] | `repeat0("ab")` |  `"abababc"` | `Ok(("c", vec!["ab", "ab", "ab"]))` |Applies the parser 0 or more times and returns the list of results in a Vec. `repeat1` does the same operation but must return at least one element|
-//! | [`repeat_m_n`][crate::combinator::repeat_m_n] | `repeat_m_n(1, 3, "ab")` | `"ababc"` | `Ok(("c", vec!["ab", "ab"]))` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
+//! | [`repeat`][crate::combinator::repeat] | `repeat(1..=3, "ab")` | `"ababc"` | `Ok(("c", vec!["ab", "ab"]))` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
 //! | [`repeat_till0`][crate::combinator::repeat_till0] | `repeat_till0(tag( "ab" ), tag( "ef" ))` | `"ababefg"` | `Ok(("g", (vec!["ab", "ab"], "ef")))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
 //! | [`separated0`][crate::combinator::separated0] | `separated0("ab", ",")` | `"ab,ab,ab."` | `Ok((".", vec!["ab", "ab", "ab"]))` |`separated1` works like `separated0` but must returns at least one element|
 //! | [`fold_repeat0`][crate::combinator::fold_repeat0] | `fold_repeat0(be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `Ok(([], 6))` |Applies the parser 0 or more times and folds the list of return values. The `fold_repeat1` version must apply the child parser at least one time|

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -948,9 +948,9 @@ fn infinite_many() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn repeat_m_n_test() {
+fn repeat_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat_m_n(2, 4, "Abcd").parse_next(i)
+        repeat(2..=4, "Abcd").parse_next(i)
     }
 
     let a = &b"Abcdef"[..];

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -1183,13 +1183,13 @@ fn fold_repeat1_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-fn fold_repeat_m_n_test() {
+fn fold_repeat_test() {
     fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
         acc.push(item);
         acc
     }
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        fold_repeat_m_n(2, 4, "Abcd", Vec::new, fold_into_vec).parse_next(i)
+        fold_repeat(2..=4, "Abcd", Vec::new, fold_into_vec).parse_next(i)
     }
 
     let a = &b"Abcdef"[..];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! - Resilient maintainership, including
 //!   - Willing to break compatibility rather than batching up breaking changes in large releases
 //!   - Leverage feature flags to keep one active branch
-//! - We will support the last 6 months of rust releases (MSRV, currently 1.60)
+//! - We will support the last 6 months of rust releases (MSRV, currently 1.64.0)
 //!
 //! See also [Special Topic: Why winnow?][crate::_topic::why]
 //!

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -105,8 +105,8 @@ where
     combinator::separated_foldr1(parser, sep, op)
 }
 
-/// Deprecated, replaced by [`combinator::repeat_m_n`]
-#[deprecated(since = "0.4.2", note = "Replaced with `combinator::repeat_m_n`")]
+/// Deprecated, replaced by [`combinator::repeat`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::repeat`")]
 #[inline(always)]
 pub fn many_m_n<I, O, C, E, F>(min: usize, max: usize, parse: F) -> impl Parser<I, C, E>
 where
@@ -115,7 +115,7 @@ where
     F: Parser<I, O, E>,
     E: ParseError<I>,
 {
-    combinator::repeat_m_n(min, max, parse)
+    combinator::repeat(min..=max, parse)
 }
 
 /// Deprecated, replaced by [`combinator::count`]

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -171,8 +171,8 @@ where
     combinator::fold_repeat1(f, init, g)
 }
 
-/// Deprecated, replaced by [`combinator::fold_repeat_m_n`]
-#[deprecated(since = "0.4.2", note = "Replaced with `combinator::fold_repeat_m_n`")]
+/// Deprecated, replaced by [`combinator::fold_repeat`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::fold_repeat`")]
 #[inline(always)]
 pub fn fold_many_m_n<I, O, E, F, G, H, R>(
     min: usize,
@@ -188,7 +188,7 @@ where
     H: FnMut() -> R,
     E: ParseError<I>,
 {
-    combinator::fold_repeat_m_n(min, max, parse, init, fold)
+    combinator::fold_repeat(min..=max, parse, init, fold)
 }
 
 /// Deprecated, replaced by [`binary::length_data`]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1744,6 +1744,121 @@ where
     }
 }
 
+/// A range bounded inclusively for counting parses performed
+#[derive(PartialEq, Eq)]
+pub struct Range {
+    pub(crate) start_inclusive: usize,
+    pub(crate) end_inclusive: Option<usize>,
+}
+
+impl Range {
+    #[inline(always)]
+    fn raw(start_inclusive: usize, end_inclusive: Option<usize>) -> Self {
+        Self {
+            start_inclusive,
+            end_inclusive,
+        }
+    }
+}
+
+impl crate::lib::std::ops::RangeBounds<usize> for Range {
+    fn start_bound(&self) -> crate::lib::std::ops::Bound<&usize> {
+        crate::lib::std::ops::Bound::Included(&self.start_inclusive)
+    }
+
+    fn end_bound(&self) -> crate::lib::std::ops::Bound<&usize> {
+        if let Some(end_inclusive) = &self.end_inclusive {
+            crate::lib::std::ops::Bound::Included(end_inclusive)
+        } else {
+            crate::lib::std::ops::Bound::Unbounded
+        }
+    }
+}
+
+impl From<usize> for Range {
+    #[inline(always)]
+    fn from(fixed: usize) -> Self {
+        (fixed..=fixed).into()
+    }
+}
+
+impl From<crate::lib::std::ops::Range<usize>> for Range {
+    #[inline(always)]
+    fn from(range: crate::lib::std::ops::Range<usize>) -> Self {
+        let start_inclusive = range.start;
+        let end_inclusive = Some(range.end.saturating_sub(1));
+        Self::raw(start_inclusive, end_inclusive)
+    }
+}
+
+impl From<crate::lib::std::ops::RangeFull> for Range {
+    #[inline(always)]
+    fn from(_: crate::lib::std::ops::RangeFull) -> Self {
+        let start_inclusive = 0;
+        let end_inclusive = None;
+        Self::raw(start_inclusive, end_inclusive)
+    }
+}
+
+impl From<crate::lib::std::ops::RangeFrom<usize>> for Range {
+    #[inline(always)]
+    fn from(range: crate::lib::std::ops::RangeFrom<usize>) -> Self {
+        let start_inclusive = range.start;
+        let end_inclusive = None;
+        Self::raw(start_inclusive, end_inclusive)
+    }
+}
+
+impl From<crate::lib::std::ops::RangeTo<usize>> for Range {
+    #[inline(always)]
+    fn from(range: crate::lib::std::ops::RangeTo<usize>) -> Self {
+        let start_inclusive = 0;
+        let end_inclusive = Some(range.end.saturating_sub(1));
+        Self::raw(start_inclusive, end_inclusive)
+    }
+}
+
+impl From<crate::lib::std::ops::RangeInclusive<usize>> for Range {
+    #[inline(always)]
+    fn from(range: crate::lib::std::ops::RangeInclusive<usize>) -> Self {
+        let start_inclusive = *range.start();
+        let end_inclusive = Some(*range.end());
+        Self::raw(start_inclusive, end_inclusive)
+    }
+}
+
+impl From<crate::lib::std::ops::RangeToInclusive<usize>> for Range {
+    #[inline(always)]
+    fn from(range: crate::lib::std::ops::RangeToInclusive<usize>) -> Self {
+        let start_inclusive = 0;
+        let end_inclusive = Some(range.end);
+        Self::raw(start_inclusive, end_inclusive)
+    }
+}
+
+impl crate::lib::std::fmt::Display for Range {
+    fn fmt(&self, f: &mut crate::lib::std::fmt::Formatter<'_>) -> crate::lib::std::fmt::Result {
+        self.start_inclusive.fmt(f)?;
+        match self.end_inclusive {
+            Some(e) if e == self.start_inclusive => {}
+            Some(e) => {
+                "..=".fmt(f)?;
+                e.fmt(f)?;
+            }
+            None => {
+                "..".fmt(f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl crate::lib::std::fmt::Debug for Range {
+    fn fmt(&self, f: &mut crate::lib::std::fmt::Formatter<'_>) -> crate::lib::std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
 /// Abstracts something which can extend an `Extend`.
 /// Used to build modified input slices in `escaped_transform`
 pub trait Accumulate<T>: Sized {

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -573,7 +573,7 @@ where
 ///
 /// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
 ///
-/// To recognize a series of tokens, use [`repeat_m_n`][crate::combinator::repeat_m_n] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
+/// To recognize a series of tokens, use [`repeat`][crate::combinator::repeat] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
 ///
 /// # Example
 ///

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -8,6 +8,7 @@ use crate::error::ErrorKind;
 use crate::error::Needed;
 use crate::error::ParseError;
 use crate::lib::std::result::Result::Ok;
+use crate::stream::Range;
 use crate::stream::{
     split_at_offset1_complete, split_at_offset1_partial, split_at_offset_complete,
     split_at_offset_partial, Compare, CompareResult, ContainsToken, FindSlice, SliceLen, Stream,
@@ -383,6 +384,93 @@ where
     )
 }
 
+/// Recognize the longest (m <= len <= n) input slice that matches the [pattern][ContainsToken]
+///
+/// It will return an `ErrMode::Backtrack(Error::new(_, ErrorKind::Slice))` if the pattern wasn't met or is out
+/// of range (m <= len <= n).
+///
+/// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
+///
+/// To recognize a series of tokens, use [`repeat`][crate::combinator::repeat] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
+///
+/// # Example
+///
+/// ```rust
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
+/// use winnow::token::take_while;
+/// use winnow::stream::AsChar;
+///
+/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+///   take_while(3..=6, AsChar::is_alpha).parse_next(s)
+/// }
+///
+/// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
+/// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Backtrack(Error::new(&b"ed"[..], ErrorKind::Slice))));
+/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::Slice))));
+/// ```
+///
+/// ```rust
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::Partial;
+/// use winnow::token::take_while;
+/// use winnow::stream::AsChar;
+///
+/// fn short_alpha(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
+///   take_while(3..=6, AsChar::is_alpha).parse_next(s)
+/// }
+///
+/// assert_eq!(short_alpha(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(short_alpha(Partial::new(b"lengthy")), Ok((Partial::new(&b"y"[..]), &b"length"[..])));
+/// assert_eq!(short_alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(Partial::new(b"ed")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha(Partial::new(b"12345")), Err(ErrMode::Backtrack(Error::new(Partial::new(&b"12345"[..]), ErrorKind::Slice))));
+/// ```
+#[inline(always)]
+pub fn take_while<T, I, Error: ParseError<I>>(
+    range: impl Into<Range>,
+    list: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    T: ContainsToken<<I as Stream>::Token>,
+{
+    let Range {
+        start_inclusive,
+        end_inclusive,
+    } = range.into();
+    trace("take_while", move |i: I| {
+        match (start_inclusive, end_inclusive) {
+            (0, None) => {
+                if i.is_partial() {
+                    streaming_take_while_internal(i, &list)
+                } else {
+                    complete_take_while_internal(i, &list)
+                }
+            }
+            (1, None) => {
+                if i.is_partial() {
+                    streaming_take_while1_internal(i, &list)
+                } else {
+                    complete_take_while1_internal(i, &list)
+                }
+            }
+            (start, end) => {
+                let end = end.unwrap_or(usize::MAX);
+                if i.is_partial() {
+                    streaming_take_while_m_n_internal(i, start, end, &list)
+                } else {
+                    complete_take_while_m_n_internal(i, start, end, &list)
+                }
+            }
+        }
+    })
+}
+
 /// Recognize the longest input slice (if any) that matches the [pattern][ContainsToken]
 ///
 /// *Partial version*: will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
@@ -564,71 +652,6 @@ where
 {
     let e: ErrorKind = ErrorKind::Slice;
     split_at_offset1_complete(&i, |c| !list.contains_token(c), e)
-}
-
-/// Recognize the longest (m <= len <= n) input slice that matches the [pattern][ContainsToken]
-///
-/// It will return an `ErrMode::Backtrack(Error::new(_, ErrorKind::Slice))` if the pattern wasn't met or is out
-/// of range (m <= len <= n).
-///
-/// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
-///
-/// To recognize a series of tokens, use [`repeat`][crate::combinator::repeat] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`][crate::Parser::recognize].
-///
-/// # Example
-///
-/// ```rust
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
-/// # use winnow::prelude::*;
-/// use winnow::token::take_while_m_n;
-/// use winnow::stream::AsChar;
-///
-/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while_m_n(3, 6, AsChar::is_alpha).parse_next(s)
-/// }
-///
-/// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
-/// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Backtrack(Error::new(&b"ed"[..], ErrorKind::Slice))));
-/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::Slice))));
-/// ```
-///
-/// ```rust
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
-/// # use winnow::prelude::*;
-/// # use winnow::Partial;
-/// use winnow::token::take_while_m_n;
-/// use winnow::stream::AsChar;
-///
-/// fn short_alpha(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-///   take_while_m_n(3, 6, AsChar::is_alpha).parse_next(s)
-/// }
-///
-/// assert_eq!(short_alpha(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
-/// assert_eq!(short_alpha(Partial::new(b"lengthy")), Ok((Partial::new(&b"y"[..]), &b"length"[..])));
-/// assert_eq!(short_alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(Partial::new(b"ed")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(Partial::new(b"12345")), Err(ErrMode::Backtrack(Error::new(Partial::new(&b"12345"[..]), ErrorKind::Slice))));
-/// ```
-#[inline(always)]
-pub fn take_while_m_n<T, I, Error: ParseError<I>>(
-    m: usize,
-    n: usize,
-    list: T,
-) -> impl Parser<I, <I as Stream>::Slice, Error>
-where
-    I: StreamIsPartial,
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    trace("take_while_m_n", move |i: I| {
-        if i.is_partial() {
-            streaming_take_while_m_n_internal(i, m, n, &list)
-        } else {
-            complete_take_while_m_n_internal(i, m, n, &list)
-        }
-    })
 }
 
 pub(crate) fn streaming_take_while_m_n_internal<T, I, Error: ParseError<I>>(

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -18,14 +18,13 @@ use crate::Partial;
 #[test]
 fn complete_take_while_m_n_utf8_all_matching() {
     let result: IResult<&str, &str> =
-        take_while_m_n(1, 4, |c: char| c.is_alphabetic()).parse_next("øn");
+        take_while(1..=4, |c: char| c.is_alphabetic()).parse_next("øn");
     assert_eq!(result, Ok(("", "øn")));
 }
 
 #[test]
 fn complete_take_while_m_n_utf8_all_matching_substring() {
-    let result: IResult<&str, &str> =
-        take_while_m_n(1, 1, |c: char| c.is_alphabetic()).parse_next("øn");
+    let result: IResult<&str, &str> = take_while(1, |c: char| c.is_alphabetic()).parse_next("øn");
     assert_eq!(result, Ok(("n", "ø")));
 }
 
@@ -60,7 +59,7 @@ proptest! {
       let input = format!("{:a<valid$}{:b<invalid$}", "", "", valid=valid, invalid=invalid);
       let expected = model_complete_take_while_m_n(m, n, valid, &input);
       if m <= n {
-          let actual = take_while_m_n(m, n, |c: char| c == 'a').parse_next(input.as_str());
+          let actual = take_while(m..=n, |c: char| c == 'a').parse_next(input.as_str());
           assert_eq!(expected, actual);
       }
   }
@@ -336,7 +335,7 @@ fn partial_take_while1() {
 #[test]
 fn partial_take_while_m_n() {
     fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while_m_n(2, 4, AsChar::is_alpha).parse_next(i)
+        take_while(2..=4, AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"a"[..];
@@ -519,7 +518,7 @@ fn partial_take_utf8() {
 #[test]
 fn partial_take_while_m_n_utf8_fixed() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while_m_n(1, 1, |c| c == 'A' || c == '😃').parse_next(i)
+        take_while(1, |c| c == 'A' || c == '😃').parse_next(i)
     }
     assert_eq!(parser(Partial::new("A!")), Ok((Partial::new("!"), "A")));
     assert_eq!(parser(Partial::new("😃!")), Ok((Partial::new("!"), "😃")));
@@ -528,7 +527,7 @@ fn partial_take_while_m_n_utf8_fixed() {
 #[test]
 fn partial_take_while_m_n_utf8_range() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while_m_n(1, 2, |c| c == 'A' || c == '😃').parse_next(i)
+        take_while(1..=2, |c| c == 'A' || c == '😃').parse_next(i)
     }
     assert_eq!(parser(Partial::new("A!")), Ok((Partial::new("!"), "A")));
     assert_eq!(parser(Partial::new("😃!")), Ok((Partial::new("!"), "😃")));
@@ -537,7 +536,7 @@ fn partial_take_while_m_n_utf8_range() {
 #[test]
 fn partial_take_while_m_n_utf8_full_match_fixed() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while_m_n(1, 1, |c: char| c.is_alphabetic()).parse_next(i)
+        take_while(1, |c: char| c.is_alphabetic()).parse_next(i)
     }
     assert_eq!(parser(Partial::new("øn")), Ok((Partial::new("n"), "ø")));
 }
@@ -545,7 +544,7 @@ fn partial_take_while_m_n_utf8_full_match_fixed() {
 #[test]
 fn partial_take_while_m_n_utf8_full_match_range() {
     fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while_m_n(1, 2, |c: char| c.is_alphabetic()).parse_next(i)
+        take_while(1..=2, |c: char| c.is_alphabetic()).parse_next(i)
     }
     assert_eq!(parser(Partial::new("øn")), Ok((Partial::new(""), "øn")));
 }

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -27,14 +27,14 @@ compile_error!("`debug` requires `std`");
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
-/// # use winnow::token::take_while_m_n;
+/// # use winnow::token::take_while;
 /// # use winnow::stream::AsChar;
 /// # use winnow::prelude::*;
 /// use winnow::trace::trace;
 ///
 /// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
 ///   trace("short_alpha",
-///     take_while_m_n(3, 6, AsChar::is_alpha)
+///     take_while(3..=6, AsChar::is_alpha)
 ///   ).parse_next(s)
 /// }
 ///

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -196,8 +196,8 @@ fn issue_942() {
 #[test]
 #[cfg(feature = "std")]
 fn issue_many_m_n_with_zeros() {
-    use winnow::combinator::repeat_m_n;
-    let mut parser = repeat_m_n::<_, _, Vec<_>, (), _>(0, 0, 'a');
+    use winnow::combinator::repeat;
+    let mut parser = repeat::<_, _, Vec<_>, (), _>(0, 'a');
     assert_eq!(parser.parse_next("aaa"), Ok(("aaa", vec![])));
 }
 
@@ -265,8 +265,8 @@ fn issue_x_looser_fill_bounds() {
 #[cfg(feature = "std")]
 fn issue_1459_clamp_capacity() {
     // shouldn't panic
-    use winnow::combinator::repeat_m_n;
-    let mut parser = repeat_m_n::<_, _, Vec<_>, (), _>(usize::MAX, usize::MAX, 'a');
+    use winnow::combinator::repeat;
+    let mut parser = repeat::<_, _, Vec<_>, (), _>(usize::MAX..=usize::MAX, 'a');
     assert_eq!(
         parser.parse_next("a"),
         Err(winnow::error::ErrMode::Backtrack(()))

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -99,13 +99,13 @@ fn overflow_incomplete_many_till0() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many_m_n() {
-    use winnow::combinator::repeat_m_n;
+    use winnow::combinator::repeat;
 
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat_m_n(2, 4, length_data(be_u64)).parse_next(i)
+        repeat(2..=4, length_data(be_u64)).parse_next(i)
     }
 
-    // Trigger an overflow in repeat_m_n
+    // Trigger an overflow in repeat
     assert_eq!(
         multi(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]


### PR DESCRIPTION
This hits the highest priorities among #98.

Unlike rust-bakery/nom#1608 which created a `NomRange` trait and generalized the functions based on that, we mirrored the `StreamingIsPartial` approach and normalize the ranges in `#[inline(always)]` code dispatch to the optimized variants.  This means the user only pays for up to 3 implementations rather than paying for an implementation per range type.

This is also taking a conservative approach and not touching the existing `0` or `1` suffixed functions.  No benchmarks touch what we changed