### PR TITLE
refactor: Merge partial/complete implementations

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -103,7 +103,7 @@ where
     <I as Stream>::Token: AsChar,
 {
     trace("not_line_ending", move |input: I| {
-        if input.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             streaming_not_line_ending(input)
         } else {
             complete_not_line_ending(input)
@@ -943,7 +943,7 @@ where
 {
     trace("dec_uint", move |input: I| {
         if input.eof_offset() == 0 {
-            if input.is_partial() {
+            if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
                 return Err(ErrMode::Incomplete(Needed::new(1)));
             } else {
                 return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
@@ -970,7 +970,7 @@ where
             }
         }
 
-        if input.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             Err(ErrMode::Incomplete(Needed::new(1)))
         } else {
             Ok((input.next_slice(input.eof_offset()).0, value))
@@ -1104,7 +1104,7 @@ where
             .parse_next(input)?;
 
         if input.eof_offset() == 0 {
-            if input.is_partial() {
+            if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
                 return Err(ErrMode::Incomplete(Needed::new(1)));
             } else {
                 return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
@@ -1135,7 +1135,7 @@ where
             }
         }
 
-        if input.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             Err(ErrMode::Incomplete(Needed::new(1)))
         } else {
             Ok((input.next_slice(input.eof_offset()).0, value))
@@ -1246,7 +1246,10 @@ where
                 }
             }
             Err(_) => {
-                if input.is_partial() && invalid_offset == input.eof_offset() {
+                if <I as StreamIsPartial>::is_partial_supported()
+                    && input.is_partial()
+                    && invalid_offset == input.eof_offset()
+                {
                     // Only the next byte is guaranteed required
                     return Err(ErrMode::Incomplete(Needed::new(1)));
                 } else {
@@ -1477,7 +1480,7 @@ where
     Error: ParseError<I>,
 {
     trace("escaped", move |input: I| {
-        if input.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             streaming_escaped_internal(input, &mut normal, control_char, &mut escapable)
         } else {
             complete_escaped_internal(input, &mut normal, control_char, &mut escapable)
@@ -1675,7 +1678,7 @@ where
     Error: ParseError<I>,
 {
     trace("escaped_transform", move |input: I| {
-        if input.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             streaming_escaped_transform_internal(input, &mut normal, control_char, &mut transform)
         } else {
             complete_escaped_transform_internal(input, &mut normal, control_char, &mut transform)

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -112,11 +112,11 @@ where
     .parse_next(input)
 }
 
-fn streaming_not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as Stream>::Slice, E>
+fn streaming_not_line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    T: Stream + AsBStr,
-    T: Compare<&'static str>,
-    <T as Stream>::Token: AsChar,
+    I: Stream + AsBStr,
+    I: Compare<&'static str>,
+    <I as Stream>::Token: AsChar,
 {
     match input.offset_for(|item| {
         let c = item.as_char();
@@ -146,11 +146,11 @@ where
     }
 }
 
-fn complete_not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, <T as Stream>::Slice, E>
+fn complete_not_line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
-    T: Stream + AsBStr,
-    T: Compare<&'static str>,
-    <T as Stream>::Token: AsChar,
+    I: Stream + AsBStr,
+    I: Compare<&'static str>,
+    <I as Stream>::Token: AsChar,
 {
     match input.offset_for(|item| {
         let c = item.as_char();

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -114,6 +114,7 @@ where
 
 fn streaming_not_line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
+    I: StreamIsPartial,
     I: Stream + AsBStr,
     I: Compare<&'static str>,
     <I as Stream>::Token: AsChar,
@@ -148,6 +149,7 @@ where
 
 fn complete_not_line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
 where
+    I: StreamIsPartial,
     I: Stream + AsBStr,
     I: Compare<&'static str>,
     <I as Stream>::Token: AsChar,
@@ -1495,6 +1497,7 @@ fn streaming_escaped_internal<I, Error, F, G, O1, O2>(
     escapable: &mut G,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + Offset,
     <I as Stream>::Token: crate::stream::AsChar,
     F: Parser<I, O1, Error>,
@@ -1551,6 +1554,7 @@ fn complete_escaped_internal<'a, I: 'a, Error, F, G, O1, O2>(
     escapable: &mut G,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + Offset,
     <I as Stream>::Token: crate::stream::AsChar,
     F: Parser<I, O1, Error>,
@@ -1694,6 +1698,7 @@ fn streaming_escaped_transform_internal<I, Error, F, G, Output>(
     transform: &mut G,
 ) -> IResult<I, Output, Error>
 where
+    I: StreamIsPartial,
     I: Stream + Offset,
     <I as Stream>::Token: crate::stream::AsChar,
     Output: crate::stream::Accumulate<<I as Stream>::Slice>,
@@ -1752,6 +1757,7 @@ fn complete_escaped_transform_internal<I, Error, F, G, Output>(
     transform: &mut G,
 ) -> IResult<I, Output, Error>
 where
+    I: StreamIsPartial,
     I: Stream + Offset,
     <I as Stream>::Token: crate::stream::AsChar,
     Output: crate::stream::Accumulate<<I as Stream>::Slice>,

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -173,7 +173,7 @@ where
     })
 }
 
-pub(crate) fn streaming_take_internal<I, O, E: ParseError<(I, usize)>>(
+fn streaming_take_internal<I, O, E: ParseError<(I, usize)>>(
     (input, bit_offset): (I, usize),
     count: usize,
 ) -> IResult<(I, usize), O, E>
@@ -219,7 +219,7 @@ where
     }
 }
 
-pub(crate) fn complete_take_internal<I, O, E: ParseError<(I, usize)>>(
+fn complete_take_internal<I, O, E: ParseError<(I, usize)>>(
     (input, bit_offset): (I, usize),
     count: usize,
 ) -> IResult<(I, usize), O, E>

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -178,6 +178,7 @@ fn streaming_take_internal<I, O, E: ParseError<(I, usize)>>(
     count: usize,
 ) -> IResult<(I, usize), O, E>
 where
+    I: StreamIsPartial,
     I: Stream<Token = u8> + AsBytes,
     O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
@@ -224,6 +225,7 @@ fn complete_take_internal<I, O, E: ParseError<(I, usize)>>(
     count: usize,
 ) -> IResult<(I, usize), O, E>
 where
+    I: StreamIsPartial,
     I: Stream<Token = u8> + AsBytes,
     O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -165,7 +165,7 @@ where
 {
     let count = count.to_usize();
     trace("take", move |input: (I, usize)| {
-        if input.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             streaming_take_internal(input, count)
         } else {
             complete_take_internal(input, count)

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1252,7 +1252,7 @@ where
     I: Stream<Token = u8>,
 {
     trace("u8", move |input: I| {
-        if input.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             streaming_u8(input)
         } else {
             complete_u8(input)
@@ -1685,7 +1685,7 @@ where
     I: Stream<Token = u8>,
 {
     trace("i8", move |input: I| {
-        if input.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             streaming_u8(input)
         } else {
             complete_u8(input)

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1264,6 +1264,7 @@ where
 #[inline]
 fn streaming_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
 {
     input
@@ -1273,6 +1274,7 @@ where
 
 fn complete_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
+    I: StreamIsPartial,
     I: Stream<Token = u8>,
 {
     input

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1261,7 +1261,6 @@ where
     .parse_next(input)
 }
 
-#[inline]
 fn streaming_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
 where
     I: StreamIsPartial,

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1252,33 +1252,27 @@ where
     I: Stream<Token = u8>,
 {
     trace("u8", move |input: I| {
-        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-            streaming_u8(input)
+        if <I as StreamIsPartial>::is_partial_supported() {
+            u8_::<_, _, true>(input)
         } else {
-            complete_u8(input)
+            u8_::<_, _, false>(input)
         }
     })
     .parse_next(input)
 }
 
-fn streaming_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
+fn u8_<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, u8, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8>,
 {
-    input
-        .next_token()
-        .ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))
-}
-
-fn complete_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
-where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-{
-    input
-        .next_token()
-        .ok_or_else(|| ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Token)))
+    input.next_token().ok_or_else(|| {
+        if PARTIAL && input.is_partial() {
+            ErrMode::Incomplete(Needed::new(1))
+        } else {
+            ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Token))
+        }
+    })
 }
 
 /// Recognizes an unsigned 2 bytes integer
@@ -1686,10 +1680,10 @@ where
     I: Stream<Token = u8>,
 {
     trace("i8", move |input: I| {
-        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-            streaming_u8(input)
+        if <I as StreamIsPartial>::is_partial_supported() {
+            u8_::<_, _, true>(input)
         } else {
-            complete_u8(input)
+            u8_::<_, _, false>(input)
         }
         .map(|(i, n)| (i, n as i8))
     })

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -52,33 +52,27 @@ where
     I: Stream,
 {
     trace("any", move |input: I| {
-        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-            streaming_any(input)
+        if <I as StreamIsPartial>::is_partial_supported() {
+            any_::<_, _, true>(input)
         } else {
-            complete_any(input)
+            any_::<_, _, true>(input)
         }
     })
     .parse_next(input)
 }
 
-fn streaming_any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Token, E>
+fn any_<I, E: ParseError<I>, const PARTIAL: bool>(input: I) -> IResult<I, <I as Stream>::Token, E>
 where
     I: StreamIsPartial,
     I: Stream,
 {
-    input
-        .next_token()
-        .ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))
-}
-
-fn complete_any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Token, E>
-where
-    I: StreamIsPartial,
-    I: Stream,
-{
-    input
-        .next_token()
-        .ok_or_else(|| ErrMode::from_error_kind(input, ErrorKind::Token))
+    input.next_token().ok_or_else(|| {
+        if PARTIAL && input.is_partial() {
+            ErrMode::Incomplete(Needed::new(1))
+        } else {
+            ErrMode::from_error_kind(input, ErrorKind::Token)
+        }
+    })
 }
 
 /// Recognizes a literal
@@ -133,15 +127,15 @@ where
 {
     trace("tag", move |i: I| {
         let t = tag.clone();
-        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
-            streaming_tag_internal(i, t)
+        if <I as StreamIsPartial>::is_partial_supported() {
+            tag_::<_, _, _, true>(i, t)
         } else {
-            complete_tag_internal(i, t)
+            tag_::<_, _, _, false>(i, t)
         }
     })
 }
 
-fn streaming_tag_internal<T, I, Error: ParseError<I>>(
+fn tag_<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     i: I,
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
@@ -153,28 +147,9 @@ where
     let tag_len = t.slice_len();
     match i.compare(t) {
         CompareResult::Ok => Ok(i.next_slice(tag_len)),
-        CompareResult::Incomplete => {
+        CompareResult::Incomplete if PARTIAL && i.is_partial() => {
             Err(ErrMode::Incomplete(Needed::new(tag_len - i.eof_offset())))
         }
-        CompareResult::Error => {
-            let e: ErrorKind = ErrorKind::Tag;
-            Err(ErrMode::from_error_kind(i, e))
-        }
-    }
-}
-
-fn complete_tag_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    t: T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: StreamIsPartial,
-    I: Stream + Compare<T>,
-    T: SliceLen,
-{
-    let tag_len = t.slice_len();
-    match i.compare(t) {
-        CompareResult::Ok => Ok(i.next_slice(tag_len)),
         CompareResult::Incomplete | CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
             Err(ErrMode::from_error_kind(i, e))
@@ -237,15 +212,15 @@ where
 {
     trace("tag_no_case", move |i: I| {
         let t = tag.clone();
-        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
-            streaming_tag_no_case_internal(i, t)
+        if <I as StreamIsPartial>::is_partial_supported() {
+            tag_no_case_::<_, _, _, true>(i, t)
         } else {
-            complete_tag_no_case_internal(i, t)
+            tag_no_case_::<_, _, _, false>(i, t)
         }
     })
 }
 
-fn streaming_tag_no_case_internal<T, I, Error: ParseError<I>>(
+fn tag_no_case_<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     i: I,
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
@@ -258,29 +233,9 @@ where
 
     match (i).compare_no_case(t) {
         CompareResult::Ok => Ok(i.next_slice(tag_len)),
-        CompareResult::Incomplete => {
+        CompareResult::Incomplete if PARTIAL && i.is_partial() => {
             Err(ErrMode::Incomplete(Needed::new(tag_len - i.eof_offset())))
         }
-        CompareResult::Error => {
-            let e: ErrorKind = ErrorKind::Tag;
-            Err(ErrMode::from_error_kind(i, e))
-        }
-    }
-}
-
-fn complete_tag_no_case_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    t: T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: StreamIsPartial,
-    I: Stream + Compare<T>,
-    T: SliceLen,
-{
-    let tag_len = t.slice_len();
-
-    match (i).compare_no_case(t) {
-        CompareResult::Ok => Ok(i.next_slice(tag_len)),
         CompareResult::Incomplete | CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
             Err(ErrMode::from_error_kind(i, e))
@@ -468,10 +423,10 @@ where
             }
             (start, end) => {
                 let end = end.unwrap_or(usize::MAX);
-                if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
-                    streaming_take_while_m_n_internal(i, start, end, &list)
+                if <I as StreamIsPartial>::is_partial_supported() {
+                    take_while_m_n_::<_, _, _, true>(i, start, end, &list)
                 } else {
-                    complete_take_while_m_n_internal(i, start, end, &list)
+                    take_while_m_n_::<_, _, _, false>(i, start, end, &list)
                 }
             }
         }
@@ -616,7 +571,7 @@ where
     })
 }
 
-fn streaming_take_while_m_n_internal<T, I, Error: ParseError<I>>(
+fn take_while_m_n_<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     input: I,
     m: usize,
     n: usize,
@@ -646,54 +601,23 @@ where
             final_count = processed + 1;
         }
     }
-
-    if final_count == n {
-        Ok(input.next_slice(input.eof_offset()))
-    } else {
-        let needed = if m > input.eof_offset() {
-            m - input.eof_offset()
+    if PARTIAL && input.is_partial() {
+        if final_count == n {
+            Ok(input.next_slice(input.eof_offset()))
         } else {
-            1
-        };
-        Err(ErrMode::Incomplete(Needed::new(needed)))
-    }
-}
-
-fn complete_take_while_m_n_internal<T, I, Error: ParseError<I>>(
-    input: I,
-    m: usize,
-    n: usize,
-    list: &T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: StreamIsPartial,
-    I: Stream,
-    T: ContainsToken<<I as Stream>::Token>,
-{
-    if n < m {
-        return Err(ErrMode::assert(input, "`m` should be <= `n`"));
-    }
-
-    let mut final_count = 0;
-    for (processed, (offset, token)) in input.iter_offsets().enumerate() {
-        if !list.contains_token(token) {
-            if processed < m {
-                return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+            let needed = if m > input.eof_offset() {
+                m - input.eof_offset()
             } else {
-                return Ok(input.next_slice(offset));
-            }
-        } else {
-            if processed == n {
-                return Ok(input.next_slice(offset));
-            }
-            final_count = processed + 1;
+                1
+            };
+            Err(ErrMode::Incomplete(Needed::new(needed)))
         }
-    }
-
-    if m <= final_count {
-        Ok(input.next_slice(input.eof_offset()))
     } else {
-        Err(ErrMode::from_error_kind(input, ErrorKind::Slice))
+        if m <= final_count {
+            Ok(input.next_slice(input.eof_offset()))
+        } else {
+            Err(ErrMode::from_error_kind(input, ErrorKind::Slice))
+        }
     }
 }
 
@@ -895,15 +819,15 @@ where
 {
     let c = count.to_usize();
     trace("take", move |i: I| {
-        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
-            streaming_take_internal(i, c)
+        if <I as StreamIsPartial>::is_partial_supported() {
+            take_::<_, _, true>(i, c)
         } else {
-            complete_take_internal(i, c)
+            take_::<_, _, false>(i, c)
         }
     })
 }
 
-fn streaming_take_internal<I, Error: ParseError<I>>(
+fn take_<I, Error: ParseError<I>, const PARTIAL: bool>(
     i: I,
     c: usize,
 ) -> IResult<I, <I as Stream>::Slice, Error>
@@ -913,20 +837,7 @@ where
 {
     match i.offset_at(c) {
         Ok(offset) => Ok(i.next_slice(offset)),
-        Err(i) => Err(ErrMode::Incomplete(i)),
-    }
-}
-
-fn complete_take_internal<I, Error: ParseError<I>>(
-    i: I,
-    c: usize,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: StreamIsPartial,
-    I: Stream,
-{
-    match i.offset_at(c) {
-        Ok(offset) => Ok(i.next_slice(offset)),
+        Err(e) if PARTIAL && i.is_partial() => Err(ErrMode::Incomplete(e)),
         Err(_needed) => Err(ErrMode::from_error_kind(i, ErrorKind::Slice)),
     }
 }
@@ -983,15 +894,15 @@ where
     T: SliceLen + Clone,
 {
     trace("take_until0", move |i: I| {
-        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
-            streaming_take_until_internal(i, tag.clone())
+        if <I as StreamIsPartial>::is_partial_supported() {
+            take_until0_::<_, _, _, true>(i, tag.clone())
         } else {
-            complete_take_until_internal(i, tag.clone())
+            take_until0_::<_, _, _, false>(i, tag.clone())
         }
     })
 }
 
-fn streaming_take_until_internal<T, I, Error: ParseError<I>>(
+fn take_until0_<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     i: I,
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
@@ -1002,21 +913,7 @@ where
 {
     match i.find_slice(t) {
         Some(offset) => Ok(i.next_slice(offset)),
-        None => Err(ErrMode::Incomplete(Needed::Unknown)),
-    }
-}
-
-fn complete_take_until_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    t: T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: StreamIsPartial,
-    I: Stream + FindSlice<T>,
-    T: SliceLen,
-{
-    match i.find_slice(t) {
-        Some(offset) => Ok(i.next_slice(offset)),
+        None if PARTIAL && i.is_partial() => Err(ErrMode::Incomplete(Needed::Unknown)),
         None => Err(ErrMode::from_error_kind(i, ErrorKind::Slice)),
     }
 }
@@ -1075,15 +972,15 @@ where
     T: SliceLen + Clone,
 {
     trace("take_until1", move |i: I| {
-        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
-            streaming_take_until1_internal(i, tag.clone())
+        if <I as StreamIsPartial>::is_partial_supported() {
+            take_until1_::<_, _, _, true>(i, tag.clone())
         } else {
-            complete_take_until1_internal(i, tag.clone())
+            take_until1_::<_, _, _, false>(i, tag.clone())
         }
     })
 }
 
-fn streaming_take_until1_internal<T, I, Error: ParseError<I>>(
+fn take_until1_<T, I, Error: ParseError<I>, const PARTIAL: bool>(
     i: I,
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
@@ -1093,22 +990,7 @@ where
     T: SliceLen,
 {
     match i.find_slice(t) {
-        None => Err(ErrMode::Incomplete(Needed::Unknown)),
-        Some(0) => Err(ErrMode::from_error_kind(i, ErrorKind::Slice)),
-        Some(offset) => Ok(i.next_slice(offset)),
-    }
-}
-
-fn complete_take_until1_internal<T, I, Error: ParseError<I>>(
-    i: I,
-    t: T,
-) -> IResult<I, <I as Stream>::Slice, Error>
-where
-    I: StreamIsPartial,
-    I: Stream + FindSlice<T>,
-    T: SliceLen,
-{
-    match i.find_slice(t) {
+        None if PARTIAL && i.is_partial() => Err(ErrMode::Incomplete(Needed::Unknown)),
         None | Some(0) => Err(ErrMode::from_error_kind(i, ErrorKind::Slice)),
         Some(offset) => Ok(i.next_slice(offset)),
     }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -52,7 +52,7 @@ where
     I: Stream,
 {
     trace("any", move |input: I| {
-        if input.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             streaming_any(input)
         } else {
             complete_any(input)
@@ -131,7 +131,7 @@ where
 {
     trace("tag", move |i: I| {
         let t = tag.clone();
-        if i.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
             streaming_tag_internal(i, t)
         } else {
             complete_tag_internal(i, t)
@@ -233,7 +233,7 @@ where
 {
     trace("tag_no_case", move |i: I| {
         let t = tag.clone();
-        if i.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
             streaming_tag_no_case_internal(i, t)
         } else {
             complete_tag_no_case_internal(i, t)
@@ -446,7 +446,7 @@ where
     trace("take_while", move |i: I| {
         match (start_inclusive, end_inclusive) {
             (0, None) => {
-                if i.is_partial() {
+                if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
                     split_at_offset_partial(&i, |c| !list.contains_token(c))
                 } else {
                     split_at_offset_complete(&i, |c| !list.contains_token(c))
@@ -454,7 +454,7 @@ where
             }
             (1, None) => {
                 let e: ErrorKind = ErrorKind::Slice;
-                if i.is_partial() {
+                if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
                     split_at_offset1_partial(&i, |c| !list.contains_token(c), e)
                 } else {
                     split_at_offset1_complete(&i, |c| !list.contains_token(c), e)
@@ -462,7 +462,7 @@ where
             }
             (start, end) => {
                 let end = end.unwrap_or(usize::MAX);
-                if i.is_partial() {
+                if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
                     streaming_take_while_m_n_internal(i, start, end, &list)
                 } else {
                     complete_take_while_m_n_internal(i, start, end, &list)
@@ -522,7 +522,7 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("take_while0", move |i: I| {
-        if i.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
             split_at_offset_partial(&i, |c| !list.contains_token(c))
         } else {
             split_at_offset_complete(&i, |c| !list.contains_token(c))
@@ -602,7 +602,7 @@ where
 {
     trace("take_while1", move |i: I| {
         let e: ErrorKind = ErrorKind::Slice;
-        if i.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
             split_at_offset1_partial(&i, |c| !list.contains_token(c), e)
         } else {
             split_at_offset1_complete(&i, |c| !list.contains_token(c), e)
@@ -736,7 +736,7 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace("take_till0", move |i: I| {
-        if i.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
             split_at_offset_partial(&i, |c| list.contains_token(c))
         } else {
             split_at_offset_complete(&i, |c| list.contains_token(c))
@@ -814,7 +814,7 @@ where
 {
     trace("take_till1", move |i: I| {
         let e: ErrorKind = ErrorKind::Slice;
-        if i.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
             split_at_offset1_partial(&i, |c| list.contains_token(c), e)
         } else {
             split_at_offset1_complete(&i, |c| list.contains_token(c), e)
@@ -887,7 +887,7 @@ where
 {
     let c = count.to_usize();
     trace("take", move |i: I| {
-        if i.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
             streaming_take_internal(i, c)
         } else {
             complete_take_internal(i, c)
@@ -973,7 +973,7 @@ where
     T: SliceLen + Clone,
 {
     trace("take_until0", move |i: I| {
-        if i.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
             streaming_take_until_internal(i, tag.clone())
         } else {
             complete_take_until_internal(i, tag.clone())
@@ -1063,7 +1063,7 @@ where
     T: SliceLen + Clone,
 {
     trace("take_until1", move |i: I| {
-        if i.is_partial() {
+        if <I as StreamIsPartial>::is_partial_supported() && i.is_partial() {
             streaming_take_until1_internal(i, tag.clone())
         } else {
             complete_take_until1_internal(i, tag.clone())

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -63,6 +63,7 @@ where
 
 fn streaming_any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Token, E>
 where
+    I: StreamIsPartial,
     I: Stream,
 {
     input
@@ -72,6 +73,7 @@ where
 
 fn complete_any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Token, E>
 where
+    I: StreamIsPartial,
     I: Stream,
 {
     input
@@ -144,6 +146,7 @@ fn streaming_tag_internal<T, I, Error: ParseError<I>>(
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + Compare<T>,
     T: SliceLen,
 {
@@ -165,6 +168,7 @@ fn complete_tag_internal<T, I, Error: ParseError<I>>(
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + Compare<T>,
     T: SliceLen,
 {
@@ -246,6 +250,7 @@ fn streaming_tag_no_case_internal<T, I, Error: ParseError<I>>(
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + Compare<T>,
     T: SliceLen,
 {
@@ -268,6 +273,7 @@ fn complete_tag_no_case_internal<T, I, Error: ParseError<I>>(
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + Compare<T>,
     T: SliceLen,
 {
@@ -617,6 +623,7 @@ fn streaming_take_while_m_n_internal<T, I, Error: ParseError<I>>(
     list: &T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
@@ -659,6 +666,7 @@ fn complete_take_while_m_n_internal<T, I, Error: ParseError<I>>(
     list: &T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream,
     T: ContainsToken<<I as Stream>::Token>,
 {
@@ -900,6 +908,7 @@ fn streaming_take_internal<I, Error: ParseError<I>>(
     c: usize,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream,
 {
     match i.offset_at(c) {
@@ -913,6 +922,7 @@ fn complete_take_internal<I, Error: ParseError<I>>(
     c: usize,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream,
 {
     match i.offset_at(c) {
@@ -986,6 +996,7 @@ fn streaming_take_until_internal<T, I, Error: ParseError<I>>(
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + FindSlice<T>,
     T: SliceLen,
 {
@@ -1000,6 +1011,7 @@ fn complete_take_until_internal<T, I, Error: ParseError<I>>(
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + FindSlice<T>,
     T: SliceLen,
 {
@@ -1076,6 +1088,7 @@ fn streaming_take_until1_internal<T, I, Error: ParseError<I>>(
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + FindSlice<T>,
     T: SliceLen,
 {
@@ -1091,6 +1104,7 @@ fn complete_take_until1_internal<T, I, Error: ParseError<I>>(
     t: T,
 ) -> IResult<I, <I as Stream>::Slice, Error>
 where
+    I: StreamIsPartial,
     I: Stream + FindSlice<T>,
     T: SliceLen,
 {


### PR DESCRIPTION
Tried this before in #213 but it slowed down the complete cases (but
sped up the partial cases).

Not fully sure what happened before but I figured that by using
const-generics, we can effectively get the old behavior while having one
textual version of the function.  The compiler will effectively generate
the alternative version of the function for us and which ever isn't used
gets dropped.

Looks like this was successful too, maintaining performance where we
previously lost it and getting the performance gains of merging:
```
json/basic/canada       time:   [12.850 ms 12.941 ms 13.036 ms]
                        thrpt:  [164.68 MiB/s 165.89 MiB/s 167.06 MiB/s]
                 change:
                        time:   [+0.9086% +1.7638% +2.6956%] (p = 0.00 < 0.05)
                        thrpt:  [-2.6248% -1.7332% -0.9004%]
                        Change within noise threshold.
json/verbose/canada     time:   [38.102 ms 38.516 ms 39.005 ms]
                        thrpt:  [55.038 MiB/s 55.737 MiB/s 56.343 MiB/s]
                 change:
                        time:   [-1.5183% -0.3588% +0.9977%] (p = 0.58 > 0.05)
                        thrpt:  [-0.9879% +0.3601% +1.5417%]
                        No change in performance detected.
json/dispatch/canada    time:   [11.081 ms 11.151 ms 11.225 ms]
                        thrpt:  [191.25 MiB/s 192.53 MiB/s 193.73 MiB/s]
                 change:
                        time:   [+0.0911% +1.0557% +2.0514%] (p = 0.03 < 0.05)
                        thrpt:  [-2.0102% -1.0446% -0.0910%]
                        Change within noise threshold.
json/streaming/canada   time:   [26.293 ms 26.421 ms 26.556 ms]
                        thrpt:  [80.840 MiB/s 81.253 MiB/s 81.647 MiB/s]
                 change:
                        time:   [-15.627% -14.905% -14.200%] (p = 0.00 < 0.05)
                        thrpt:  [+16.550% +17.515% +18.521%]
                        Performance has improved.
```