### PR TITLE
perf(parser): Restore pre-consolidation performance

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -40,6 +40,7 @@ use crate::stream::{AsChar, Compare, Location, Offset, ParseSlice, Stream, Strea
 /// - `&[u8]` and `&str`, see [`winnow::token::tag`][crate::token::tag]
 pub trait Parser<I, O, E> {
     /// Parse all of `input`, generating `O` from it
+    #[inline]
     fn parse(&mut self, input: I) -> Result<O, E>
     where
         I: Stream,
@@ -614,6 +615,7 @@ impl<'a, I, O, E, F> Parser<I, O, E> for F
 where
     F: FnMut(I) -> IResult<I, O, E> + 'a,
 {
+    #[inline(always)]
     fn parse_next(&mut self, i: I) -> IResult<I, O, E> {
         self(i)
     }
@@ -640,6 +642,7 @@ where
     I: Stream<Token = u8>,
     E: ParseError<I>,
 {
+    #[inline(always)]
     fn parse_next(&mut self, i: I) -> IResult<I, u8, E> {
         crate::token::one_of(*self).parse_next(i)
     }
@@ -667,6 +670,7 @@ where
     <I as Stream>::Token: AsChar + Copy,
     E: ParseError<I>,
 {
+    #[inline(always)]
     fn parse_next(&mut self, i: I) -> IResult<I, <I as Stream>::Token, E> {
         crate::token::one_of(*self).parse_next(i)
     }
@@ -695,6 +699,7 @@ where
     I: Compare<&'s [u8]> + StreamIsPartial,
     I: Stream,
 {
+    #[inline(always)]
     fn parse_next(&mut self, i: I) -> IResult<I, <I as Stream>::Slice, E> {
         crate::token::tag(*self).parse_next(i)
     }
@@ -723,6 +728,7 @@ where
     I: Compare<&'s [u8; N]> + StreamIsPartial,
     I: Stream,
 {
+    #[inline(always)]
     fn parse_next(&mut self, i: I) -> IResult<I, <I as Stream>::Slice, E> {
         crate::token::tag(*self).parse_next(i)
     }
@@ -751,12 +757,14 @@ where
     I: Compare<&'s str> + StreamIsPartial,
     I: Stream,
 {
+    #[inline(always)]
     fn parse_next(&mut self, i: I) -> IResult<I, <I as Stream>::Slice, E> {
         crate::token::tag(*self).parse_next(i)
     }
 }
 
 impl<I, E: ParseError<I>> Parser<I, (), E> for () {
+    #[inline(always)]
     fn parse_next(&mut self, i: I) -> IResult<I, (), E> {
         Ok((i, ()))
     }
@@ -769,6 +777,7 @@ macro_rules! impl_parser_for_tuple {
     where
       $($parser: Parser<I, $output, E>),+
     {
+      #[inline(always)]
       fn parse_next(&mut self, i: I) -> IResult<I, ($($output),+,), E> {
         let ($(ref mut $parser),+,) = *self;
 
@@ -822,6 +831,7 @@ use alloc::boxed::Box;
 
 #[cfg(feature = "alloc")]
 impl<'a, I, O, E> Parser<I, O, E> for Box<dyn Parser<I, O, E> + 'a> {
+    #[inline(always)]
     fn parse_next(&mut self, input: I) -> IResult<I, O, E> {
         (**self).parse_next(input)
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2118,6 +2118,7 @@ impl AsChar for u8 {
     fn is_space(self) -> bool {
         self == b' ' || self == b'\t'
     }
+    #[inline]
     fn is_newline(self) -> bool {
         self == b'\n'
     }
@@ -2155,6 +2156,7 @@ impl<'a> AsChar for &'a u8 {
     fn is_space(self) -> bool {
         *self == b' ' || *self == b'\t'
     }
+    #[inline]
     fn is_newline(self) -> bool {
         *self == b'\n'
     }
@@ -2193,6 +2195,7 @@ impl AsChar for char {
     fn is_space(self) -> bool {
         self == ' ' || self == '\t'
     }
+    #[inline]
     fn is_newline(self) -> bool {
         self == '\n'
     }
@@ -2231,6 +2234,7 @@ impl<'a> AsChar for &'a char {
     fn is_space(self) -> bool {
         *self == ' ' || *self == '\t'
     }
+    #[inline]
     fn is_newline(self) -> bool {
         *self == '\n'
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1762,10 +1762,12 @@ impl Range {
 }
 
 impl crate::lib::std::ops::RangeBounds<usize> for Range {
+    #[inline(always)]
     fn start_bound(&self) -> crate::lib::std::ops::Bound<&usize> {
         crate::lib::std::ops::Bound::Included(&self.start_inclusive)
     }
 
+    #[inline(always)]
     fn end_bound(&self) -> crate::lib::std::ops::Bound<&usize> {
         if let Some(end_inclusive) = &self.end_inclusive {
             crate::lib::std::ops::Bound::Included(end_inclusive)

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -46,6 +46,7 @@ compile_error!("`debug` requires `std`");
 /// ```
 #[cfg_attr(not(feature = "debug"), allow(unused_variables))]
 #[cfg_attr(not(feature = "debug"), allow(unused_mut))]
+#[cfg_attr(not(feature = "debug"), inline(always))]
 pub fn trace<I: Stream, O, E>(
     name: impl crate::lib::std::fmt::Display,
     mut parser: impl Parser<I, O, E>,


### PR DESCRIPTION
#247 consolidated some of the parsers as suggested in #98 but there was a report of a slowdown from this change.

While this PR makes several changes, the core improvement is adding `#[inline(always)]` to the `Parser::parse_next` impls that we provide for users.  I assume that created a barrier in the compiler so it couldn't optimize out the overhead from `take_while`s dispatching.  Somehow this only made a big difference with the `ascii::` parsers and not from direct uses of `take_while`.

- winnow 0.4.4 for parse/hcl-edit/deeply_nested.tf: 15.235 µs
- winnow 0.4.6 for parse/hcl-edit/deeply_nested.tf: 18.273 µs
- winnow 0.4.4 for parse/hcl-edit/deeply_nested.tf: 14.513 µs