### PR TITLE
perf!: Prevent use of slow `str.contains_token`

### DIFF
--- a/benches/contains_token.rs
+++ b/benches/contains_token.rs
@@ -17,9 +17,6 @@ fn contains_token(c: &mut criterion::Criterion) {
         let len = sample.len();
         group.throughput(criterion::Throughput::Bytes(len as u64));
 
-        group.bench_with_input(criterion::BenchmarkId::new("str", name), &len, |b, _| {
-            b.iter(|| black_box(parser_str.parse_next(black_box(sample)).unwrap()));
-        });
         group.bench_with_input(criterion::BenchmarkId::new("slice", name), &len, |b, _| {
             b.iter(|| black_box(parser_slice.parse_next(black_box(sample)).unwrap()));
         });
@@ -51,11 +48,6 @@ fn contains_token(c: &mut criterion::Criterion) {
         );
     }
     group.finish();
-}
-
-fn parser_str(input: &str) -> IResult<&str, usize> {
-    let contains = "0123456789";
-    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_next(input)
 }
 
 fn parser_slice(input: &str) -> IResult<&str, usize> {

--- a/examples/arithmetic/parser.rs
+++ b/examples/arithmetic/parser.rs
@@ -17,7 +17,7 @@ pub fn expr(i: &str) -> IResult<&str, i64> {
 
     fold_repeat(
         0..,
-        (one_of("+-"), term),
+        (one_of(['+', '-']), term),
         move || init,
         |acc, (op, val): (char, i64)| {
             if op == '+' {
@@ -38,7 +38,7 @@ fn term(i: &str) -> IResult<&str, i64> {
 
     fold_repeat(
         0..,
-        (one_of("*/"), factor),
+        (one_of(['*', '/']), factor),
         move || init,
         |acc, (op, val): (char, i64)| {
             if op == '*' {

--- a/examples/ini/parser_str.rs
+++ b/examples/ini/parser_str.rs
@@ -22,7 +22,7 @@ fn category_and_keys(i: Stream<'_>) -> IResult<Stream<'_>, (&str, HashMap<&str, 
 fn category(i: Stream<'_>) -> IResult<Stream<'_>, &str> {
     terminated(
         delimited('[', take_while(0.., |c| c != ']'), ']'),
-        opt(take_while(1.., " \r\n")),
+        opt(take_while(1.., [' ', '\r', '\n'])),
     )
     .parse_next(i)
 }
@@ -51,7 +51,7 @@ fn not_line_ending(i: Stream<'_>) -> IResult<Stream<'_>, &str> {
 }
 
 fn space_or_line_ending(i: Stream<'_>) -> IResult<Stream<'_>, &str> {
-    take_while(1.., " \r\n").parse_next(i)
+    take_while(1.., [' ', '\r', '\n']).parse_next(i)
 }
 
 #[test]

--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -103,7 +103,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
 fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of("\"").parse_next(input)?;
+    let (input, c) = none_of('\"').parse_next(input)?;
     if c == '\\' {
         alt((
             any.verify_map(|c| {
@@ -196,7 +196,7 @@ fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &
     take_while(0.., WS).parse_next(input)
 }
 
-const WS: &str = " \t\r\n";
+const WS: &[char] = &[' ', '\t', '\r', '\n'];
 
 #[cfg(test)]
 mod test {

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -112,7 +112,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
 fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of("\"").parse_next(input)?;
+    let (input, c) = none_of('\"').parse_next(input)?;
     if c == '\\' {
         dispatch!(any;
           '"' => success('"'),
@@ -203,7 +203,7 @@ fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &
     take_while(0.., WS).parse_next(input)
 }
 
-const WS: &str = " \t\r\n";
+const WS: &[char] = &[' ', '\t', '\r', '\n'];
 
 #[cfg(test)]
 mod test {

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -104,7 +104,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
 fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of("\"").parse_next(input)?;
+    let (input, c) = none_of('\"').parse_next(input)?;
     if c == '\\' {
         alt((
             any.verify_map(|c| {
@@ -198,11 +198,11 @@ fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &
 }
 
 fn ws_or_eof<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
-    rest.verify(|s: &str| s.chars().all(|c| WS.contains(c)))
+    rest.verify(|s: &str| s.chars().all(|c| WS.contains(&c)))
         .parse_next(input)
 }
 
-const WS: &str = " \t\r\n";
+const WS: &[char] = &[' ', '\t', '\r', '\n'];
 
 #[cfg(test)]
 mod test {

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -210,7 +210,7 @@ fn sp<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str, E> {
 }
 
 fn parse_str<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, &'a str, E> {
-    escaped(alphanumeric, '\\', one_of("\"n\\")).parse_next(i)
+    escaped(alphanumeric, '\\', one_of(['"', 'n', '\\'])).parse_next(i)
 }
 
 fn string(i: &str) -> IResult<&str, &str> {

--- a/examples/ndjson/parser.rs
+++ b/examples/ndjson/parser.rs
@@ -108,7 +108,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
 fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of("\"").parse_next(input)?;
+    let (input, c) = none_of('"').parse_next(input)?;
     if c == '\\' {
         alt((
             any.verify_map(|c| {
@@ -201,7 +201,7 @@ fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &
     take_while(0.., WS).parse_next(input)
 }
 
-const WS: &str = " \t";
+const WS: &[char] = &[' ', '\t'];
 
 #[cfg(test)]
 mod test {

--- a/examples/s_expression/parser.rs
+++ b/examples/s_expression/parser.rs
@@ -128,7 +128,7 @@ fn parse_builtin(i: &str) -> IResult<&str, BuiltIn, VerboseError<&str>> {
 /// we start by creating a parser for the built-in operator functions.
 fn parse_builtin_op(i: &str) -> IResult<&str, BuiltIn, VerboseError<&str>> {
     // one_of matches one of the characters we give it
-    let (i, t) = one_of("+-*/=").parse_next(i)?;
+    let (i, t) = one_of(['+', '-', '*', '/', '=']).parse_next(i)?;
 
     // because we are matching single character tokens, we can do the matching logic
     // on the returned value

--- a/examples/string/parser.rs
+++ b/examples/string/parser.rs
@@ -80,7 +80,7 @@ where
 fn parse_literal<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &'a str, E> {
     // `take_till1` parses a string of 0 or more characters that aren't one of the
     // given characters.
-    let not_quote_slash = take_till1("\"\\");
+    let not_quote_slash = take_till1(['"', '\\']);
 
     // `verify` runs a parser, then runs a verification function on the output of
     // the parser. The verification function accepts the output only if it

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -67,7 +67,7 @@
 //!
 //! pub fn peol_comment<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, (), E>
 //! {
-//!   ('%', take_till1("\n\r"))
+//!   ('%', take_till1(['\n', '\r']))
 //!     .void() // Output is thrown away.
 //!     .parse_next(i)
 //! }
@@ -164,7 +164,7 @@
 //!   preceded(
 //!     alt(("0x", "0X")),
 //!     repeat(1..,
-//!       terminated(one_of("0123456789abcdefABCDEF"), repeat(0.., '_').map(|()| ()))
+//!       terminated(one_of(('0'..='9', 'a'..='f', 'A'..='F')), repeat(0.., '_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
 //!   ).parse_next(input)
 //! }
@@ -186,7 +186,7 @@
 //!   preceded(
 //!     alt(("0x", "0X")),
 //!     repeat(1..,
-//!       terminated(one_of("0123456789abcdefABCDEF"), repeat(0.., '_').map(|()| ()))
+//!       terminated(one_of(('0'..='9', 'a'..='f', 'A'..='F')), repeat(0.., '_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
 //!   ).try_map(
 //!     |out: &str| i64::from_str_radix(&str::replace(&out, "_", ""), 16)
@@ -210,7 +210,7 @@
 //!   preceded(
 //!     alt(("0o", "0O")),
 //!     repeat(1..,
-//!       terminated(one_of("01234567"), repeat(0.., '_').map(|()| ()))
+//!       terminated(one_of('0'..='7'), repeat(0.., '_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
 //!   ).parse_next(input)
 //! }
@@ -232,7 +232,7 @@
 //!   preceded(
 //!     alt(("0b", "0B")),
 //!     repeat(1..,
-//!       terminated(one_of("01"), repeat(0.., '_').map(|()| ()))
+//!       terminated(one_of('0'..='1'), repeat(0.., '_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
 //!   ).parse_next(input)
 //! }
@@ -251,7 +251,7 @@
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
 //!   repeat(1..,
-//!     terminated(one_of("0123456789"), repeat(0.., '_').map(|()| ()))
+//!     terminated(one_of('0'..='9'), repeat(0.., '_').map(|()| ()))
 //!   ).map(|()| ())
 //!     .recognize()
 //!     .parse_next(input)
@@ -279,8 +279,8 @@
 //!       '.',
 //!       decimal,
 //!       opt((
-//!         one_of("eE"),
-//!         opt(one_of("+-")),
+//!         one_of(['e', 'E']),
+//!         opt(one_of(['+', '-'])),
 //!         decimal
 //!       ))
 //!     ).recognize()
@@ -291,8 +291,8 @@
 //!         '.',
 //!         decimal,
 //!       )),
-//!       one_of("eE"),
-//!       opt(one_of("+-")),
+//!       one_of(['e', 'E']),
+//!       opt(one_of(['+', '-'])),
 //!       decimal
 //!     ).recognize()
 //!     , // Case three: 42. and 42.42
@@ -306,7 +306,7 @@
 //!
 //! fn decimal(input: &str) -> IResult<&str, &str> {
 //!   repeat(1..,
-//!     terminated(one_of("0123456789"), repeat(0.., '_').map(|()| ()))
+//!     terminated(one_of('0'..='9'), repeat(0.., '_').map(|()| ()))
 //!   ).
 //!   map(|()| ())
 //!     .recognize()

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -64,7 +64,7 @@
 //! use winnow::token::one_of;
 //!
 //! fn parse_digits(input: &str) -> IResult<&str, char> {
-//!     one_of("0123456789abcdefgABCDEFG").parse_next(input)
+//!     one_of(('0'..='9', 'a'..='f', 'A'..='F')).parse_next(input)
 //! }
 //!
 //! fn main() {
@@ -84,7 +84,7 @@
 //! > # use winnow::prelude::*;
 //! > # use winnow::error::Error;
 //! > pub fn one_of<'i>(
-//! >     list: &'static str
+//! >     list: &'static [char]
 //! > ) -> impl Parser<&'i str, char, Error<&'i str>> {
 //! >     // ...
 //! > #    winnow::token::one_of(list)
@@ -108,7 +108,7 @@
 //! use winnow::token::take_while;
 //!
 //! fn parse_digits(input: &str) -> IResult<&str, &str> {
-//!     take_while(1.., "0123456789abcdefgABCDEFG").parse_next(input)
+//!     take_while(1.., ('0'..='9', 'a'..='f', 'A'..='F')).parse_next(input)
 //! }
 //!
 //! fn main() {

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -14,7 +14,6 @@ use crate::combinator::cut_err;
 use crate::combinator::opt;
 use crate::error::ParseError;
 use crate::error::{ErrMode, ErrorKind, Needed};
-use crate::stream::ContainsToken;
 use crate::stream::{AsBStr, AsChar, Offset, ParseSlice, Stream, StreamIsPartial};
 use crate::stream::{Compare, CompareResult};
 use crate::token::take_while;
@@ -1344,7 +1343,6 @@ where
     <I as Stream>::Token: AsChar + Copy,
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
-    &'static str: ContainsToken<<I as Stream>::Token>,
 {
     trace("float", move |input: I| {
         let (i, s) = recognize_float_or_exceptions(input)?;
@@ -1366,7 +1364,6 @@ where
     <I as Stream>::Token: AsChar + Copy,
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
-    &'static str: ContainsToken<<I as Stream>::Token>,
 {
     alt((
         recognize_float,
@@ -1385,15 +1382,14 @@ where
     <I as Stream>::Token: AsChar + Copy,
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
-    &'static str: ContainsToken<<I as Stream>::Token>,
 {
     (
-        opt(one_of("+-")),
+        opt(one_of(['+', '-'])),
         alt((
             (digit1, opt(('.', opt(digit1)))).map(|_| ()),
             ('.', digit1).map(|_| ()),
         )),
-        opt((one_of("eE"), opt(one_of("+-")), cut_err(digit1))),
+        opt((one_of(['e', 'E']), opt(one_of(['+', '-'])), cut_err(digit1))),
     )
         .recognize()
         .parse_next(input)
@@ -1415,7 +1411,7 @@ where
 /// use winnow::token::one_of;
 ///
 /// fn esc(s: &str) -> IResult<&str, &str> {
-///   escaped(digit1, '\\', one_of(r#""n\"#)).parse_next(s)
+///   escaped(digit1, '\\', one_of(['"', 'n', '\\'])).parse_next(s)
 /// }
 ///
 /// assert_eq!(esc("123;"), Ok((";", "123")));
@@ -1431,7 +1427,7 @@ where
 /// use winnow::token::one_of;
 ///
 /// fn esc(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   escaped(digit1, '\\', one_of("\"n\\")).parse_next(s)
+///   escaped(digit1, '\\', one_of(['"', 'n', '\\'])).parse_next(s)
 /// }
 ///
 /// assert_eq!(esc(Partial::new("123;")), Ok((Partial::new(";"), "123")));

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -571,7 +571,7 @@ mod complete {
         fn escaped_string(input: &str) -> IResult<&str, &str> {
             use crate::ascii::alpha0;
             use crate::token::one_of;
-            escaped(alpha0, '\\', one_of("n")).parse_next(input)
+            escaped(alpha0, '\\', one_of(['n'])).parse_next(input)
         }
 
         escaped_string("7").unwrap();
@@ -588,7 +588,11 @@ mod complete {
 
             delimited(
                 '"',
-                escaped(opt(none_of(r#"\""#)), '\\', one_of(r#"\"rnt"#)),
+                escaped(
+                    opt(none_of(['\\', '"'])),
+                    '\\',
+                    one_of(['\\', '"', 'r', 'n', 't']),
+                ),
                 '"',
             )
             .parse_next(input)
@@ -605,7 +609,7 @@ mod complete {
         use crate::token::one_of;
 
         fn esc(i: &[u8]) -> IResult<&[u8], &[u8]> {
-            escaped(alpha, '\\', one_of("\"n\\")).parse_next(i)
+            escaped(alpha, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
         assert_eq!(esc(&b"abcd;"[..]), Ok((&b";"[..], &b"abcd"[..])));
         assert_eq!(esc(&b"ab\\\"cd;"[..]), Ok((&b";"[..], &b"ab\\\"cd"[..])));
@@ -629,7 +633,7 @@ mod complete {
         );
 
         fn esc2(i: &[u8]) -> IResult<&[u8], &[u8]> {
-            escaped(digit, '\\', one_of("\"n\\")).parse_next(i)
+            escaped(digit, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
         assert_eq!(esc2(&b"12\\nnn34"[..]), Ok((&b"nn34"[..], &b"12\\n"[..])));
     }
@@ -641,7 +645,7 @@ mod complete {
         use crate::token::one_of;
 
         fn esc(i: &str) -> IResult<&str, &str> {
-            escaped(alpha, '\\', one_of("\"n\\")).parse_next(i)
+            escaped(alpha, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
         assert_eq!(esc("abcd;"), Ok((";", "abcd")));
         assert_eq!(esc("ab\\\"cd;"), Ok((";", "ab\\\"cd")));
@@ -662,12 +666,12 @@ mod complete {
         );
 
         fn esc2(i: &str) -> IResult<&str, &str> {
-            escaped(digit, '\\', one_of("\"n\\")).parse_next(i)
+            escaped(digit, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
         assert_eq!(esc2("12\\nnn34"), Ok(("nn34", "12\\n")));
 
         fn esc3(i: &str) -> IResult<&str, &str> {
-            escaped(alpha, '\u{241b}', one_of("\"n")).parse_next(i)
+            escaped(alpha, '\u{241b}', one_of(['\"', 'n'])).parse_next(i)
         }
         assert_eq!(esc3("ab␛ncd;"), Ok((";", "ab␛ncd")));
     }
@@ -676,7 +680,7 @@ mod complete {
     fn test_escaped_error() {
         fn esc(s: &str) -> IResult<&str, &str> {
             use crate::ascii::digit1;
-            escaped(digit1, '\\', one_of("\"n\\")).parse_next(s)
+            escaped(digit1, '\\', one_of(['\"', 'n', '\\'])).parse_next(s)
         }
 
         assert_eq!(esc("abcd"), Ok(("abcd", "")));
@@ -1377,7 +1381,7 @@ mod partial {
 
     fn digit_to_i16(input: Partial<&str>) -> IResult<Partial<&str>, i16> {
         let i = input;
-        let (i, opt_sign) = opt(one_of("+-")).parse_next(i)?;
+        let (i, opt_sign) = opt(one_of(['+', '-'])).parse_next(i)?;
         let sign = match opt_sign {
             Some('+') | None => true,
             Some('-') => false,

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -240,7 +240,7 @@ where
 ///
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///   alt((
-///     preceded(one_of("+-"), digit1),
+///     preceded(one_of(['+', '-']), digit1),
 ///     rest
 ///   )).parse_next(input)
 /// }
@@ -265,7 +265,7 @@ where
 ///
 /// fn parser(input: &str) -> IResult<&str, &str> {
 ///   alt((
-///     preceded(one_of("+-"), cut_err(digit1)),
+///     preceded(one_of(['+', '-']), cut_err(digit1)),
 ///     rest
 ///   )).parse_next(input)
 /// }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2415,14 +2415,6 @@ impl<const LEN: usize, C: AsChar> ContainsToken<C> for [char; LEN] {
     }
 }
 
-impl<C: AsChar> ContainsToken<C> for &'_ str {
-    #[inline(always)]
-    fn contains_token(&self, token: C) -> bool {
-        let token = token.as_char();
-        self.chars().any(|i| i == token)
-    }
-}
-
 impl<T> ContainsToken<T> for () {
     #[inline(always)]
     fn contains_token(&self, _token: T) -> bool {

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -260,9 +260,9 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::token::one_of;
-/// assert_eq!(one_of::<_, _, Error<_>>("abc").parse_next("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>>("a").parse_next("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::Verify))));
-/// assert_eq!(one_of::<_, _, Error<_>>("a").parse_next(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Token))));
+/// assert_eq!(one_of::<_, _, Error<_>>(['a', 'b', 'c']).parse_next("b"), Ok(("", 'b')));
+/// assert_eq!(one_of::<_, _, Error<_>>('a').parse_next("bc"), Err(ErrMode::Backtrack(Error::new("bc", ErrorKind::Verify))));
+/// assert_eq!(one_of::<_, _, Error<_>>('a').parse_next(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Token))));
 ///
 /// fn parser_fn(i: &str) -> IResult<&str, char> {
 ///     one_of(|c| c == 'a' || c == 'b').parse_next(i)
@@ -277,9 +277,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::token::one_of;
-/// assert_eq!(one_of::<_, _, Error<_>>("abc").parse_next(Partial::new("b")), Ok((Partial::new(""), 'b')));
-/// assert_eq!(one_of::<_, _, Error<_>>("a").parse_next(Partial::new("bc")), Err(ErrMode::Backtrack(Error::new(Partial::new("bc"), ErrorKind::Verify))));
-/// assert_eq!(one_of::<_, _, Error<_>>("a").parse_next(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(one_of::<_, _, Error<_>>(['a', 'b', 'c']).parse_next(Partial::new("b")), Ok((Partial::new(""), 'b')));
+/// assert_eq!(one_of::<_, _, Error<_>>('a').parse_next(Partial::new("bc")), Err(ErrMode::Backtrack(Error::new(Partial::new("bc"), ErrorKind::Verify))));
+/// assert_eq!(one_of::<_, _, Error<_>>('a').parse_next(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn parser_fn(i: Partial<&str>) -> IResult<Partial<&str>, char> {
 ///     one_of(|c| c == 'a' || c == 'b').parse_next(i)
@@ -317,9 +317,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::prelude::*;
 /// # use winnow::token::none_of;
-/// assert_eq!(none_of::<_, _, Error<_>>("abc").parse_next("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>>("ab").parse_next("a"), Err(ErrMode::Backtrack(Error::new("a", ErrorKind::Verify))));
-/// assert_eq!(none_of::<_, _, Error<_>>("a").parse_next(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Token))));
+/// assert_eq!(none_of::<_, _, Error<_>>(['a', 'b', 'c']).parse_next("z"), Ok(("", 'z')));
+/// assert_eq!(none_of::<_, _, Error<_>>(['a', 'b']).parse_next("a"), Err(ErrMode::Backtrack(Error::new("a", ErrorKind::Verify))));
+/// assert_eq!(none_of::<_, _, Error<_>>('a').parse_next(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Token))));
 /// ```
 ///
 /// ```
@@ -327,9 +327,9 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// # use winnow::token::none_of;
-/// assert_eq!(none_of::<_, _, Error<_>>("abc").parse_next(Partial::new("z")), Ok((Partial::new(""), 'z')));
-/// assert_eq!(none_of::<_, _, Error<_>>("ab").parse_next(Partial::new("a")), Err(ErrMode::Backtrack(Error::new(Partial::new("a"), ErrorKind::Verify))));
-/// assert_eq!(none_of::<_, _, Error<_>>("a").parse_next(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(none_of::<_, _, Error<_>>(['a', 'b', 'c']).parse_next(Partial::new("z")), Ok((Partial::new(""), 'z')));
+/// assert_eq!(none_of::<_, _, Error<_>>(['a', 'b']).parse_next(Partial::new("a")), Err(ErrMode::Backtrack(Error::new(Partial::new("a"), ErrorKind::Verify))));
+/// assert_eq!(none_of::<_, _, Error<_>>('a').parse_next(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Parser<I, <I as Stream>::Token, Error>
@@ -406,7 +406,7 @@ where
 /// assert_eq!(alpha(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::Slice))));
 ///
 /// fn hex(s: &str) -> IResult<&str, &str> {
-///   take_while(1.., "1234567890ABCDEF").parse_next(s)
+///   take_while(1.., ('0'..='9', 'A'..='F')).parse_next(s)
 /// }
 ///
 /// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
@@ -432,7 +432,7 @@ where
 /// assert_eq!(alpha(Partial::new(b"12345")), Err(ErrMode::Backtrack(Error::new(Partial::new(&b"12345"[..]), ErrorKind::Slice))));
 ///
 /// fn hex(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   take_while(1.., "1234567890ABCDEF").parse_next(s)
+///   take_while(1.., ('0'..='9', 'A'..='F')).parse_next(s)
 /// }
 ///
 /// assert_eq!(hex(Partial::new("123 and voila")), Ok((Partial::new(" and voila"), "123")));
@@ -713,7 +713,7 @@ where
 /// assert_eq!(till_colon(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
 ///
 /// fn not_space(s: &str) -> IResult<&str, &str> {
-///   take_till1(" \t\r\n").parse_next(s)
+///   take_till1([' ', '\t', '\r', '\n']).parse_next(s)
 /// }
 ///
 /// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
@@ -738,7 +738,7 @@ where
 /// assert_eq!(till_colon(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn not_space(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   take_till1(" \t\r\n").parse_next(s)
+///   take_till1([' ', '\t', '\r', '\n']).parse_next(s)
 /// }
 ///
 /// assert_eq!(not_space(Partial::new("Hello, World!")), Ok((Partial::new(" World!"), "Hello,")));

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -77,7 +77,7 @@ fn partial_any_str() {
 #[test]
 fn partial_one_of_test() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-        one_of("ab").parse_next(i)
+        one_of(['a', 'b']).parse_next(i)
     }
 
     let a = &b"abcd"[..];
@@ -93,7 +93,7 @@ fn partial_one_of_test() {
     );
 
     fn utf8(i: Partial<&str>) -> IResult<Partial<&str>, char> {
-        one_of("+\u{FF0B}").parse_next(i)
+        one_of(['+', '\u{FF0B}']).parse_next(i)
     }
 
     assert!(utf8(Partial::new("+")).is_ok());
@@ -141,7 +141,7 @@ fn char_str() {
 #[test]
 fn partial_none_of_test() {
     fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-        none_of("ab").parse_next(i)
+        none_of(['a', 'b']).parse_next(i)
     }
 
     let a = &b"abcd"[..];
@@ -160,7 +160,7 @@ fn partial_none_of_test() {
 #[test]
 fn partial_is_a() {
     fn a_or_b(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while(1.., "ab").parse_next(i)
+        take_while(1.., ['a', 'b']).parse_next(i)
     }
 
     let a = Partial::new(&b"abcd"[..]);
@@ -182,7 +182,7 @@ fn partial_is_a() {
 #[test]
 fn partial_is_not() {
     fn a_or_b(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_till1("ab").parse_next(i)
+        take_till1(['a', 'b']).parse_next(i)
     }
 
     let a = Partial::new(&b"cdab"[..]);

--- a/tests/testsuite/reborrow_fold.rs
+++ b/tests/testsuite/reborrow_fold.rs
@@ -11,7 +11,7 @@ use winnow::IResult;
 
 fn atom(_tomb: &mut ()) -> impl for<'a> FnMut(&'a [u8]) -> IResult<&'a [u8], String> {
     move |input| {
-        take_till1(" \t\r\n")
+        take_till1([' ', '\t', '\r', '\n'])
             .try_map(str::from_utf8)
             .map(ToString::to_string)
             .parse_next(input)

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -351,7 +351,7 @@ mod test {
     #[test]
     fn take_while1_set_succeed_str() {
         const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const MATCH: &str = "βèƒôřèÂßÇ";
+        const MATCH: &[char] = &['β', 'è', 'ƒ', 'ô', 'ř', 'è', 'Â', 'ß', 'Ç'];
         const CONSUMED: &str = "βèƒôřèÂßÇ";
         const LEFTOVER: &str = "áƒƭèř";
         fn test(input: &str) -> IResult<&str, &str> {
@@ -403,7 +403,7 @@ mod test {
     #[test]
     fn take_while1_set_fail_str() {
         const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const MATCH: &str = "Ûñℓúçƙ¥";
+        const MATCH: &[char] = &['Û', 'ñ', 'ℓ', 'ú', 'ç', 'ƙ', '¥'];
         fn test(input: &str) -> IResult<&str, &str> {
             take_while(1.., MATCH).parse_next(input)
         }
@@ -452,7 +452,7 @@ mod test {
     #[test]
     fn take_till1_succeed_str() {
         const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const AVOID: &str = "£úçƙ¥á";
+        const AVOID: &[char] = &['£', 'ú', 'ç', 'ƙ', '¥', 'á'];
         const CONSUMED: &str = "βèƒôřèÂßÇ";
         const LEFTOVER: &str = "áƒƭèř";
         fn test(input: &str) -> IResult<&str, &str> {
@@ -483,7 +483,7 @@ mod test {
     #[test]
     fn take_till1_failed_str() {
         const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const AVOID: &str = "βúçƙ¥";
+        const AVOID: &[char] = &['β', 'ú', 'ç', 'ƙ', '¥'];
         fn test(input: &str) -> IResult<&str, &str> {
             take_till1(AVOID).parse_next(input)
         }


### PR DESCRIPTION
`&str` is convenient but
- It reads oddly, lookling like they are sequenced
- No good way to warn people about the performance without just removing
  it

Re-measured to performance to be sure:
```
contains_token/str/canada
                        time:   [15.830 ms 15.851 ms 15.874 ms]
                        thrpt:  [135.24 MiB/s 135.44 MiB/s 135.61 MiB/s]
contains_token/slice/canada
                        time:   [2.1956 ms 2.2033 ms 2.2111 ms]
                        thrpt:  [970.92 MiB/s 974.35 MiB/s 977.76 MiB/s]
```
All other impls are in the ballpark of `slice`

Fixes #226