### PR TITLE
fix(ascii): Allow escaped_transform on core

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1623,7 +1623,6 @@ where
 ///
 /// assert_eq!(parser(Partial::new("ab\\\"cd\"")), Ok((Partial::new("\""), String::from("ab\"cd"))));
 /// ```
-#[cfg(feature = "alloc")]
 #[inline(always)]
 pub fn escaped_transform<I, Error, F, G, Output>(
     mut normal: F,
@@ -1648,7 +1647,6 @@ where
     })
 }
 
-#[cfg(feature = "alloc")]
 fn streaming_escaped_transform_internal<I, Error, F, G, Output>(
     input: I,
     normal: &mut F,
@@ -1703,7 +1701,6 @@ where
     Err(ErrMode::Incomplete(Needed::Unknown))
 }
 
-#[cfg(feature = "alloc")]
 fn complete_escaped_transform_internal<I, Error, F, G, Output>(
     input: I,
     normal: &mut F,


### PR DESCRIPTION
This is mostly cleanup found when working on checkpointing in prep for mutable input