### PR TITLE
fix(error)!: Clarify convert_error is meant to be used with streams

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,7 @@ use crate::lib::std::borrow::ToOwned;
 use crate::lib::std::fmt;
 use core::num::NonZeroUsize;
 
+use crate::stream::Stream;
 #[allow(unused_imports)] // Here for intra-doc links
 use crate::Parser;
 
@@ -497,7 +498,7 @@ impl<I: fmt::Debug + fmt::Display + Sync + Send + 'static> std::error::Error for
 
 /// Transforms a `VerboseError` into a trace with input position information
 #[cfg(feature = "alloc")]
-pub fn convert_error<I: core::ops::Deref<Target = str>>(
+pub fn convert_error<I: Stream + core::ops::Deref<Target = str>>(
     input: I,
     e: VerboseError<I>,
 ) -> crate::lib::std::string::String {


### PR DESCRIPTION
This is part of #261

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
