### PR TITLE
fix(ascii): Correctly parse 'infinity' 

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1368,8 +1368,8 @@ where
     alt((
         recognize_float,
         crate::token::tag_no_case("nan"),
-        crate::token::tag_no_case("inf"),
         crate::token::tag_no_case("infinity"),
+        crate::token::tag_no_case("inf"),
     ))
     .parse_next(input)
 }

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -535,7 +535,7 @@ mod complete {
         assert_eq!(i, "");
         let (i, inf) = float::<_, f32, ()>("infinity").unwrap();
         assert!(inf.is_infinite());
-        assert_eq!(i, "inity");
+        assert_eq!(i, "");
     }
 
     #[cfg(feature = "std")]

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -526,13 +526,16 @@ mod complete {
             }))
         );
 
-        let (_i, nan) = float::<_, f32, ()>("NaN").unwrap();
+        let (i, nan) = float::<_, f32, ()>("NaN").unwrap();
         assert!(nan.is_nan());
+        assert_eq!(i, "");
 
-        let (_i, inf) = float::<_, f32, ()>("inf").unwrap();
+        let (i, inf) = float::<_, f32, ()>("inf").unwrap();
         assert!(inf.is_infinite());
-        let (_i, inf) = float::<_, f32, ()>("infinite").unwrap();
+        assert_eq!(i, "");
+        let (i, inf) = float::<_, f32, ()>("infinity").unwrap();
         assert!(inf.is_infinite());
+        assert_eq!(i, "inity");
     }
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
This was identified in nom in rust-bakery/nom#1673