### PR TITLE
fix(error): Expose ErrMode::into_inner

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -147,13 +147,14 @@ impl<E> ErrMode<E> {
         self.map(ErrorConvert::convert)
     }
 
+    /// Unwrap the mode, returning the underlying error
+    ///
+    /// Returns `None` for [`ErrMode::Incomplete`]
     #[cfg_attr(debug_assertions, track_caller)]
-    pub(crate) fn into_inner(self) -> E {
+    pub fn into_inner(self) -> Option<E> {
         match self {
-            ErrMode::Backtrack(e) | ErrMode::Cut(e) => e,
-            ErrMode::Incomplete(_) => {
-                panic!("complete parsers should not report `ErrMode::Incomplete(_)`")
-            }
+            ErrMode::Backtrack(e) | ErrMode::Cut(e) => Some(e),
+            ErrMode::Incomplete(_) => None,
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -54,8 +54,14 @@ pub trait Parser<I, O, E> {
             "partial streams need to handle `ErrMode::Incomplete`"
         );
 
-        let (i, o) = self.parse_next(input).map_err(|e| e.into_inner())?;
-        let _ = crate::combinator::eof(i).map_err(|e| e.into_inner())?;
+        let (i, o) = self.parse_next(input).map_err(|e| {
+            e.into_inner()
+                .expect("complete parsers should not report `ErrMode::Incomplete(_)`")
+        })?;
+        let _ = crate::combinator::eof(i).map_err(|e| {
+            e.into_inner()
+                .expect("complete parsers should not report `ErrMode::Incomplete(_)`")
+        })?;
         Ok(o)
     }
 


### PR DESCRIPTION
Until we figure out `Parser::parse`, this is helpful.  It is likely helpful anyways.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
