### PR TITLE
fix(parser)!: Switch inherent method from parse_next to parse_peek

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -56,7 +56,7 @@ where
     I: Stream,
     I: Compare<&'static str>,
 {
-    trace("crlf", move |input: I| "\r\n".parse_peek(input)).parse_peek(input)
+    trace("crlf", "\r\n").parse_peek(input)
 }
 
 /// Recognizes a string of any char except '\r\n' or '\n'.
@@ -183,10 +183,7 @@ where
     I: Stream,
     I: Compare<&'static str>,
 {
-    trace("line_ending", move |input: I| {
-        alt(("\n", "\r\n")).parse_peek(input)
-    })
-    .parse_peek(input)
+    trace("line_ending", alt(("\n", "\r\n"))).parse_peek(input)
 }
 
 /// Matches a newline character '\n'.
@@ -224,11 +221,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
 {
-    trace("newline", move |input: I| {
-        '\n'.map(|c: <I as Stream>::Token| c.as_char())
-            .parse_peek(input)
-    })
-    .parse_peek(input)
+    trace("newline", '\n'.map(|c: <I as Stream>::Token| c.as_char())).parse_peek(input)
 }
 
 /// Matches a tab character '\t'.
@@ -266,11 +259,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
 {
-    trace("tab", move |input: I| {
-        '\t'.map(|c: <I as Stream>::Token| c.as_char())
-            .parse_peek(input)
-    })
-    .parse_peek(input)
+    trace("tab", '\t'.map(|c: <I as Stream>::Token| c.as_char())).parse_peek(input)
 }
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
@@ -310,9 +299,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("alpha0", move |input: I| {
-        take_while(0.., |c: <I as Stream>::Token| c.is_alpha()).parse_peek(input)
-    })
+    trace(
+        "alpha0",
+        take_while(0.., |c: <I as Stream>::Token| c.is_alpha()),
+    )
     .parse_peek(input)
 }
 
@@ -353,9 +343,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("alpha1", move |input: I| {
-        take_while(1.., |c: <I as Stream>::Token| c.is_alpha()).parse_peek(input)
-    })
+    trace(
+        "alpha1",
+        take_while(1.., |c: <I as Stream>::Token| c.is_alpha()),
+    )
     .parse_peek(input)
 }
 
@@ -397,9 +388,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("digit0", move |input: I| {
-        take_while(0.., |c: <I as Stream>::Token| c.is_dec_digit()).parse_peek(input)
-    })
+    trace(
+        "digit0",
+        take_while(0.., |c: <I as Stream>::Token| c.is_dec_digit()),
+    )
     .parse_peek(input)
 }
 
@@ -456,9 +448,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("digit1", move |input: I| {
-        take_while(1.., |c: <I as Stream>::Token| c.is_dec_digit()).parse_peek(input)
-    })
+    trace(
+        "digit1",
+        take_while(1.., |c: <I as Stream>::Token| c.is_dec_digit()),
+    )
     .parse_peek(input)
 }
 
@@ -498,9 +491,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("hex_digit0", move |input: I| {
-        take_while(0.., |c: <I as Stream>::Token| c.is_hex_digit()).parse_peek(input)
-    })
+    trace(
+        "hex_digit0",
+        take_while(0.., |c: <I as Stream>::Token| c.is_hex_digit()),
+    )
     .parse_peek(input)
 }
 
@@ -541,9 +535,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("hex_digit1", move |input: I| {
-        take_while(1.., |c: <I as Stream>::Token| c.is_hex_digit()).parse_peek(input)
-    })
+    trace(
+        "hex_digit1",
+        take_while(1.., |c: <I as Stream>::Token| c.is_hex_digit()),
+    )
     .parse_peek(input)
 }
 
@@ -584,9 +579,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("oct_digit0", move |input: I| {
-        take_while(0.., |c: <I as Stream>::Token| c.is_oct_digit()).parse_peek(input)
-    })
+    trace(
+        "oct_digit0",
+        take_while(0.., |c: <I as Stream>::Token| c.is_oct_digit()),
+    )
     .parse_peek(input)
 }
 
@@ -627,9 +623,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("oct_digit0", move |input: I| {
-        take_while(1.., |c: <I as Stream>::Token| c.is_oct_digit()).parse_peek(input)
-    })
+    trace(
+        "oct_digit0",
+        take_while(1.., |c: <I as Stream>::Token| c.is_oct_digit()),
+    )
     .parse_peek(input)
 }
 
@@ -670,9 +667,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("alphanumeric0", move |input: I| {
-        take_while(0.., |c: <I as Stream>::Token| c.is_alphanum()).parse_peek(input)
-    })
+    trace(
+        "alphanumeric0",
+        take_while(0.., |c: <I as Stream>::Token| c.is_alphanum()),
+    )
     .parse_peek(input)
 }
 
@@ -713,9 +711,10 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace("alphanumeric1", move |input: I| {
-        take_while(1.., |c: <I as Stream>::Token| c.is_alphanum()).parse_peek(input)
-    })
+    trace(
+        "alphanumeric1",
+        take_while(1.., |c: <I as Stream>::Token| c.is_alphanum()),
+    )
     .parse_peek(input)
 }
 
@@ -744,13 +743,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
 {
-    trace("space0", move |input: I| {
+    trace(
+        "space0",
         take_while(0.., |c: <I as Stream>::Token| {
             let ch = c.as_char();
             matches!(ch, ' ' | '\t')
-        })
-        .parse_peek(input)
-    })
+        }),
+    )
     .parse_peek(input)
 }
 
@@ -791,13 +790,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
 {
-    trace("space1", move |input: I| {
+    trace(
+        "space1",
         take_while(1.., |c: <I as Stream>::Token| {
             let ch = c.as_char();
             matches!(ch, ' ' | '\t')
-        })
-        .parse_peek(input)
-    })
+        }),
+    )
     .parse_peek(input)
 }
 
@@ -838,13 +837,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
 {
-    trace("multispace0", move |input: I| {
+    trace(
+        "multispace0",
         take_while(0.., |c: <I as Stream>::Token| {
             let ch = c.as_char();
             matches!(ch, ' ' | '\t' | '\r' | '\n')
-        })
-        .parse_peek(input)
-    })
+        }),
+    )
     .parse_peek(input)
 }
 
@@ -885,13 +884,13 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
 {
-    trace("multispace1", move |input: I| {
+    trace(
+        "multispace1",
         take_while(1.., |c: <I as Stream>::Token| {
             let ch = c.as_char();
             matches!(ch, ' ' | '\t' | '\r' | '\n')
-        })
-        .parse_peek(input)
-    })
+        }),
+    )
     .parse_peek(input)
 }
 

--- a/src/combinator/parser.rs
+++ b/src/combinator/parser.rs
@@ -1,7 +1,7 @@
 use crate::error::{ContextError, ErrMode, ErrorKind, FromExternalError, ParseError};
 use crate::lib::std::borrow::Borrow;
 use crate::lib::std::ops::Range;
-use crate::parser::unpeek;
+use crate::parser::parser;
 use crate::stream::StreamIsPartial;
 use crate::stream::{Location, Stream};
 use crate::trace::trace;
@@ -20,10 +20,7 @@ impl<'p, P> ByRef<'p, P> {
     }
 }
 
-impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P>
-where
-    I: Clone,
-{
+impl<'p, I, O, E, P: Parser<I, O, E>> Parser<I, O, E> for ByRef<'p, P> {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
         self.p.parse_next(i)
@@ -66,17 +63,12 @@ impl<F, G, I, O, O2, E> Parser<I, O2, E> for Map<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
     G: Fn(O) -> O2,
-    I: Clone,
 {
-    #[inline(always)]
+    #[inline]
     fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, i: I) -> IResult<I, O2, E> {
-        match self.parser.parse_peek(i) {
+        match self.parser.parse_next(i) {
             Err(e) => Err(e),
-            Ok((i, o)) => Ok((i, (self.map)(o))),
+            Ok(o) => Ok((self.map)(o)),
         }
     }
 }
@@ -87,7 +79,7 @@ pub struct TryMap<F, G, I, O, O2, E, E2>
 where
     F: Parser<I, O, E>,
     G: FnMut(O) -> Result<O2, E2>,
-    I: Clone,
+    I: Stream,
     E: FromExternalError<I, E2>,
 {
     parser: F,
@@ -103,7 +95,7 @@ impl<F, G, I, O, O2, E, E2> TryMap<F, G, I, O, O2, E, E2>
 where
     F: Parser<I, O, E>,
     G: FnMut(O) -> Result<O2, E2>,
-    I: Clone,
+    I: Stream,
     E: FromExternalError<I, E2>,
 {
     pub(crate) fn new(parser: F, map: G) -> Self {
@@ -123,21 +115,17 @@ impl<F, G, I, O, O2, E, E2> Parser<I, O2, E> for TryMap<F, G, I, O, O2, E, E2>
 where
     F: Parser<I, O, E>,
     G: FnMut(O) -> Result<O2, E2>,
-    I: Clone,
+    I: Stream,
     E: FromExternalError<I, E2>,
 {
-    #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, O2, E> {
-        let i = input.clone();
-        let (input, o) = self.parser.parse_peek(input)?;
-        let res = match (self.map)(o) {
-            Ok(o2) => Ok((input, o2)),
-            Err(e) => Err(ErrMode::from_external_error(i, ErrorKind::Verify, e)),
-        };
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<O2, E> {
+        let start = input.checkpoint();
+        let o = self.parser.parse_next(input)?;
+        let res = (self.map)(o).map_err(|err| {
+            input.reset(start);
+            ErrMode::from_external_error(input.clone(), ErrorKind::Verify, err)
+        });
         trace_result("verify", &res);
         res
     }
@@ -149,7 +137,7 @@ pub struct VerifyMap<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
     G: FnMut(O) -> Option<O2>,
-    I: Clone,
+    I: Stream,
     E: ParseError<I>,
 {
     parser: F,
@@ -164,7 +152,7 @@ impl<F, G, I, O, O2, E> VerifyMap<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
     G: FnMut(O) -> Option<O2>,
-    I: Clone,
+    I: Stream,
     E: ParseError<I>,
 {
     pub(crate) fn new(parser: F, map: G) -> Self {
@@ -183,21 +171,17 @@ impl<F, G, I, O, O2, E> Parser<I, O2, E> for VerifyMap<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
     G: FnMut(O) -> Option<O2>,
-    I: Clone,
+    I: Stream,
     E: ParseError<I>,
 {
-    #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, O2, E> {
-        let i = input.clone();
-        let (input, o) = self.parser.parse_peek(input)?;
-        let res = match (self.map)(o) {
-            Some(o2) => Ok((input, o2)),
-            None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
-        };
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<O2, E> {
+        let start = input.checkpoint();
+        let o = self.parser.parse_next(input)?;
+        let res = (self.map)(o).ok_or_else(|| {
+            input.reset(start);
+            ErrMode::from_error_kind(input.clone(), ErrorKind::Verify)
+        });
         trace_result("verify", &res);
         res
     }
@@ -210,6 +194,7 @@ where
     F: Parser<I, O, E>,
     G: Parser<O, O2, E>,
     O: StreamIsPartial,
+    I: Stream,
 {
     outer: F,
     inner: G,
@@ -224,6 +209,7 @@ where
     F: Parser<I, O, E>,
     G: Parser<O, O2, E>,
     O: StreamIsPartial,
+    I: Stream,
 {
     pub(crate) fn new(outer: F, inner: G) -> Self {
         Self {
@@ -242,18 +228,18 @@ where
     F: Parser<I, O, E>,
     G: Parser<O, O2, E>,
     O: StreamIsPartial,
-    I: Clone,
+    I: Stream,
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, i: I) -> IResult<I, O2, E> {
-        let (i, mut o) = self.outer.parse_peek(i)?;
+        let start = i.checkpoint();
+        let mut o = self.outer.parse_next(i)?;
         let _ = o.complete();
-        let (_, o2) = self.inner.parse_peek(o)?;
-        Ok((i, o2))
+        let o2 = self.inner.parse_next(&mut o).map_err(|err| {
+            i.reset(start);
+            err
+        })?;
+        Ok(o2)
     }
 }
 
@@ -298,20 +284,16 @@ where
     O: crate::stream::ParseSlice<O2>,
     E: ParseError<I>,
 {
-    #[inline(always)]
+    #[inline]
     fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, i: I) -> IResult<I, O2, E> {
-        let input = i.clone();
-        let (i, o) = self.p.parse_peek(i)?;
-
-        let res = o
-            .parse_slice()
-            .ok_or_else(|| ErrMode::from_error_kind(input, ErrorKind::Verify));
+        let start = i.checkpoint();
+        let o = self.p.parse_next(i)?;
+        let res = o.parse_slice().ok_or_else(|| {
+            i.reset(start);
+            ErrMode::from_error_kind(i.clone(), ErrorKind::Verify)
+        });
         trace_result("verify", &res);
-        Ok((i, res?))
+        res
     }
 }
 
@@ -356,16 +338,11 @@ where
     F: Parser<I, O, E>,
     G: FnMut(O) -> H,
     H: Parser<I, O2, E>,
-    I: Clone,
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, i: I) -> IResult<I, O2, E> {
-        let (i, o) = self.f.parse_peek(i)?;
-        (self.g)(o).parse_peek(i)
+        let o = self.f.parse_next(i)?;
+        (self.g)(o).parse_next(i)
     }
 }
 
@@ -387,22 +364,18 @@ where
     F: Parser<I, O, E>,
     E: ParseError<I>,
 {
-    #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, O, E> {
-        trace("complete_err", |input: I| {
-            let i = input.clone();
-            match (self.f).parse_peek(input) {
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<O, E> {
+        trace(
+            "complete_err",
+            parser(|input: &mut I| match (self.f).parse_next(input) {
                 Err(ErrMode::Incomplete(_)) => {
-                    Err(ErrMode::from_error_kind(i, ErrorKind::Complete))
+                    Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Complete))
                 }
                 rest => rest,
-            }
-        })
-        .parse_peek(input)
+            }),
+        )
+        .parse_next(input)
     }
 }
 
@@ -412,7 +385,7 @@ pub struct Verify<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
     G: Fn(&O2) -> bool,
-    I: Clone,
+    I: Stream,
     O: Borrow<O2>,
     O2: ?Sized,
     E: ParseError<I>,
@@ -429,7 +402,7 @@ impl<F, G, I, O, O2, E> Verify<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
     G: Fn(&O2) -> bool,
-    I: Clone,
+    I: Stream,
     O: Borrow<O2>,
     O2: ?Sized,
     E: ParseError<I>,
@@ -450,25 +423,19 @@ impl<F, G, I, O, O2, E> Parser<I, O, E> for Verify<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
     G: Fn(&O2) -> bool,
-    I: Clone,
+    I: Stream,
     O: Borrow<O2>,
     O2: ?Sized,
     E: ParseError<I>,
 {
-    #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, O, E> {
-        let i = input.clone();
-        let (input, o) = self.parser.parse_peek(input)?;
-
-        let res = if (self.filter)(o.borrow()) {
-            Ok((input, o))
-        } else {
-            Err(ErrMode::from_error_kind(i, ErrorKind::Verify))
-        };
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<O, E> {
+        let start = input.checkpoint();
+        let o = self.parser.parse_next(input)?;
+        let res = (self.filter)(o.borrow()).then_some(o).ok_or_else(|| {
+            input.reset(start);
+            ErrMode::from_error_kind(input.clone(), ErrorKind::Verify)
+        });
         trace_result("verify", &res);
         res
     }
@@ -508,17 +475,10 @@ impl<F, I, O, O2, E> Parser<I, O2, E> for Value<F, I, O, O2, E>
 where
     F: Parser<I, O, E>,
     O2: Clone,
-    I: Clone,
 {
-    #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, O2, E> {
-        (self.parser)
-            .parse_peek(input)
-            .map(|(i, _)| (i, self.val.clone()))
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<O2, E> {
+        (self.parser).parse_next(input).map(|_| self.val.clone())
     }
 }
 
@@ -551,15 +511,10 @@ where
 impl<F, I, O, E> Parser<I, (), E> for Void<F, I, O, E>
 where
     F: Parser<I, O, E>,
-    I: Clone,
 {
     #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<(), E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, (), E> {
-        (self.parser).parse_peek(input).map(|(i, _)| (i, ()))
+    fn parse_next(&mut self, input: &mut I) -> PResult<(), E> {
+        (self.parser).parse_next(input).map(|_| ())
     }
 }
 
@@ -596,19 +551,15 @@ where
     F: Parser<I, O, E>,
     I: Stream,
 {
-    #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, <I as Stream>::Slice, E> {
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<<I as Stream>::Slice, E> {
         let checkpoint = input.checkpoint();
-        match (self.parser).parse_peek(input) {
-            Ok((mut input, _)) => {
+        match (self.parser).parse_next(input) {
+            Ok(_) => {
                 let offset = input.offset_from(&checkpoint);
                 input.reset(checkpoint);
-                let (input, recognized) = input.peek_slice(offset);
-                Ok((input, recognized))
+                let recognized = input.next_slice(offset);
+                Ok(recognized)
             }
             Err(e) => Err(e),
         }
@@ -648,19 +599,15 @@ where
     F: Parser<I, O, E>,
     I: Stream,
 {
-    #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<(O, <I as Stream>::Slice), E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, (O, <I as Stream>::Slice), E> {
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<(O, <I as Stream>::Slice), E> {
         let checkpoint = input.checkpoint();
-        match (self.parser).parse_peek(input) {
-            Ok((mut input, result)) => {
+        match (self.parser).parse_next(input) {
+            Ok(result) => {
                 let offset = input.offset_from(&checkpoint);
                 input.reset(checkpoint);
-                let (input, recognized) = input.peek_slice(offset);
-                Ok((input, (result, recognized)))
+                let recognized = input.next_slice(offset);
+                Ok((result, recognized))
             }
             Err(e) => Err(e),
         }
@@ -700,16 +647,12 @@ where
     F: Parser<I, O, E>,
     I: Clone + Location,
 {
-    #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<Range<usize>, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, Range<usize>, E> {
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<Range<usize>, E> {
         let start = input.location();
-        self.parser.parse_peek(input).map(move |(remaining, _)| {
-            let end = remaining.location();
-            (remaining, (start..end))
+        self.parser.parse_next(input).map(move |_| {
+            let end = input.location();
+            start..end
         })
     }
 }
@@ -747,19 +690,13 @@ where
     F: Parser<I, O, E>,
     I: Clone + Location,
 {
-    #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<(O, Range<usize>), E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, input: I) -> IResult<I, (O, Range<usize>), E> {
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<(O, Range<usize>), E> {
         let start = input.location();
-        self.parser
-            .parse_peek(input)
-            .map(move |(remaining, output)| {
-                let end = remaining.location();
-                (remaining, (output, (start..end)))
-            })
+        self.parser.parse_next(input).map(move |output| {
+            let end = input.location();
+            (output, (start..end))
+        })
     }
 }
 
@@ -797,18 +734,10 @@ impl<F, I, O, O2, E> Parser<I, O2, E> for OutputInto<F, I, O, O2, E>
 where
     F: Parser<I, O, E>,
     O: Into<O2>,
-    I: Clone,
 {
-    #[inline(always)]
+    #[inline]
     fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, i: I) -> IResult<I, O2, E> {
-        match self.parser.parse_peek(i) {
-            Ok((i, o)) => Ok((i, o.into())),
-            Err(err) => Err(err),
-        }
+        self.parser.parse_next(i).map(|o| o.into())
     }
 }
 
@@ -846,15 +775,10 @@ impl<F, I, O, E, E2> Parser<I, O, E2> for ErrInto<F, I, O, E, E2>
 where
     F: Parser<I, O, E>,
     E: Into<E2>,
-    I: Clone,
 {
-    #[inline(always)]
+    #[inline]
     fn parse_next(&mut self, i: &mut I) -> PResult<O, E2> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, i: I) -> IResult<I, O, E2> {
-        match self.parser.parse_peek(i) {
+        match self.parser.parse_next(i) {
             Ok(ok) => Ok(ok),
             Err(ErrMode::Backtrack(e)) => Err(ErrMode::Backtrack(e.into())),
             Err(ErrMode::Cut(e)) => Err(ErrMode::Cut(e.into())),
@@ -904,21 +828,21 @@ where
     E: ContextError<I, C>,
     C: Clone + crate::lib::std::fmt::Debug,
 {
-    #[inline(always)]
+    #[inline]
     fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, i: I) -> IResult<I, O, E> {
         #[cfg(feature = "debug")]
         let name = format!("context={:?}", self.context);
         #[cfg(not(feature = "debug"))]
         let name = "context";
-        trace(name, move |i: I| {
-            (self.parser)
-                .parse_peek(i.clone())
-                .map_err(|err| err.map(|err| err.add_context(i, self.context.clone())))
-        })
-        .parse_peek(i)
+        trace(
+            name,
+            parser(move |i: &mut I| {
+                let start = i.clone();
+                (self.parser)
+                    .parse_next(i)
+                    .map_err(|err| err.map(|err| err.add_context(start, self.context.clone())))
+            }),
+        )
+        .parse_next(i)
     }
 }

--- a/src/combinator/parser.rs
+++ b/src/combinator/parser.rs
@@ -26,11 +26,7 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    fn parse_peek(&mut self, i: I) -> IResult<I, O, E> {
-        self.p.parse_peek(i)
+        self.p.parse_next(i)
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,7 +41,7 @@ use crate::stream::{AsChar, Compare, Location, ParseSlice, Stream, StreamIsParti
 pub trait Parser<I, O, E> {
     /// Parse all of `input`, generating `O` from it
     #[inline]
-    fn parse(&mut self, input: I) -> Result<O, E>
+    fn parse(&mut self, mut input: I) -> Result<O, E>
     where
         I: Stream,
         // Force users to deal with `Incomplete` when `StreamIsPartial<true>`
@@ -54,11 +54,11 @@ pub trait Parser<I, O, E> {
             "partial streams need to handle `ErrMode::Incomplete`"
         );
 
-        let (i, o) = self.parse_peek(input).map_err(|e| {
+        let o = self.parse_next(&mut input).map_err(|e| {
             e.into_inner()
                 .expect("complete parsers should not report `ErrMode::Incomplete(_)`")
         })?;
-        let _ = crate::combinator::eof(i).map_err(|e| {
+        let _ = crate::combinator::eof.parse_next(&mut input).map_err(|e| {
             e.into_inner()
                 .expect("complete parsers should not report `ErrMode::Incomplete(_)`")
         })?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -662,12 +662,7 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<u8, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    #[inline(always)]
-    fn parse_peek(&mut self, i: I) -> IResult<I, u8, E> {
-        crate::token::one_of(*self).parse_peek(i)
+        crate::token::one_of(*self).parse_next(i)
     }
 }
 
@@ -695,12 +690,7 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Token, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    #[inline(always)]
-    fn parse_peek(&mut self, i: I) -> IResult<I, <I as Stream>::Token, E> {
-        crate::token::one_of(*self).parse_peek(i)
+        crate::token::one_of(*self).parse_next(i)
     }
 }
 
@@ -729,12 +719,7 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    #[inline(always)]
-    fn parse_peek(&mut self, i: I) -> IResult<I, <I as Stream>::Slice, E> {
-        crate::token::tag(*self).parse_peek(i)
+        crate::token::tag(*self).parse_next(i)
     }
 }
 
@@ -763,12 +748,7 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    #[inline(always)]
-    fn parse_peek(&mut self, i: I) -> IResult<I, <I as Stream>::Slice, E> {
-        crate::token::tag(*self).parse_peek(i)
+        crate::token::tag(*self).parse_next(i)
     }
 }
 
@@ -797,27 +777,14 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    #[inline(always)]
-    fn parse_peek(&mut self, i: I) -> IResult<I, <I as Stream>::Slice, E> {
-        crate::token::tag(*self).parse_peek(i)
+        crate::token::tag(*self).parse_next(i)
     }
 }
 
-impl<I, E: ParseError<I>> Parser<I, (), E> for ()
-where
-    I: Clone,
-{
+impl<I, E: ParseError<I>> Parser<I, (), E> for () {
     #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<(), E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    #[inline(always)]
-    fn parse_peek(&mut self, i: I) -> IResult<I, (), E> {
-        Ok((i, ()))
+    fn parse_next(&mut self, _i: &mut I) -> PResult<(), E> {
+        Ok(())
     }
 }
 
@@ -826,21 +793,15 @@ macro_rules! impl_parser_for_tuple {
     #[allow(non_snake_case)]
     impl<I, $($output),+, E: ParseError<I>, $($parser),+> Parser<I, ($($output),+,), E> for ($($parser),+,)
     where
-      I: Clone,
       $($parser: Parser<I, $output, E>),+
     {
       #[inline(always)]
       fn parse_next(&mut self, i: &mut I) -> PResult<($($output),+,), E> {
-          unpeek(|i| self.parse_peek(i))(i)
-      }
-
-      #[inline(always)]
-      fn parse_peek(&mut self, i: I) -> IResult<I, ($($output),+,), E> {
         let ($(ref mut $parser),+,) = *self;
 
-        $(let(i, $output) = $parser.parse_peek(i)?;)+
+        $(let $output = $parser.parse_next(i)?;)+
 
-        Ok((i, ($($output),+,)))
+        Ok(($($output),+,))
       }
     }
   )
@@ -887,18 +848,10 @@ impl_parser_for_tuples!(
 use alloc::boxed::Box;
 
 #[cfg(feature = "alloc")]
-impl<'a, I, O, E> Parser<I, O, E> for Box<dyn Parser<I, O, E> + 'a>
-where
-    I: Clone,
-{
+impl<'a, I, O, E> Parser<I, O, E> for Box<dyn Parser<I, O, E> + 'a> {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
-        unpeek(|i| self.parse_peek(i))(i)
-    }
-
-    #[inline(always)]
-    fn parse_peek(&mut self, input: I) -> IResult<I, O, E> {
-        (**self).parse_peek(input)
+        (**self).parse_next(i)
     }
 }
 


### PR DESCRIPTION
The `FnMut` impl is still focused on `parse_peek`

This is a step towards #72

v0.4.7
```
json/basic/canada       time:   [10.272 ms 10.308 ms 10.347 ms]
json/verbose/canada     time:   [32.539 ms 32.714 ms 32.893 ms]
json/dispatch/canada    time:   [8.9747 ms 8.9926 ms 9.0118 ms]
json/streaming/canada   time:   [10.612 ms 10.667 ms 10.726 ms]
```

#274
```
json/basic/canada       time:   [10.231 ms 10.253 ms 10.279 ms]
json/unit/canada        time:   [9.3250 ms 9.3526 ms 9.3808 ms]
json/verbose/canada     time:   [29.832 ms 29.891 ms 29.957 ms]
json/dispatch/canada    time:   [8.4980 ms 8.5093 ms 8.5211 ms]
json/streaming/canada   time:   [10.007 ms 10.044 ms 10.081 ms]
```

#277