### PR TITLE
refactor(test): Rely on trait, rather than direct calls

### DIFF
--- a/benches/number.rs
+++ b/benches/number.rs
@@ -14,7 +14,7 @@ use winnow::stream::ParseSlice;
 type Stream<'i> = &'i [u8];
 
 fn parser(i: Stream<'_>) -> IResult<Stream<'_>, u64> {
-    be_u64(i)
+    be_u64.parse_peek(i)
 }
 
 fn number(c: &mut Criterion) {
@@ -29,20 +29,20 @@ fn number(c: &mut Criterion) {
 fn float_bytes(c: &mut Criterion) {
     println!(
         "float_bytes result: {:?}",
-        float::<_, f64, Error<_>>(&b"-1.234E-12"[..])
+        float::<_, f64, Error<_>>.parse_peek(&b"-1.234E-12"[..])
     );
     c.bench_function("float bytes", |b| {
-        b.iter(|| float::<_, f64, Error<_>>(&b"-1.234E-12"[..]));
+        b.iter(|| float::<_, f64, Error<_>>.parse_peek(&b"-1.234E-12"[..]));
     });
 }
 
 fn float_str(c: &mut Criterion) {
     println!(
         "float_str result: {:?}",
-        float::<_, f64, Error<_>>("-1.234E-12")
+        float::<_, f64, Error<_>>.parse_peek("-1.234E-12")
     );
     c.bench_function("float str", |b| {
-        b.iter(|| float::<_, f64, Error<_>>("-1.234E-12"));
+        b.iter(|| float::<_, f64, Error<_>>.parse_peek("-1.234E-12"));
     });
 }
 

--- a/examples/http/parser.rs
+++ b/examples/http/parser.rs
@@ -45,7 +45,7 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
 fn request(input: Stream<'_>) -> IResult<Stream<'_>, (Request<'_>, Vec<Header<'_>>)> {
     let (input, req) = request_line(input)?;
     let (input, h) = repeat(1.., message_header).parse_peek(input)?;
-    let (input, _) = line_ending(input)?;
+    let (input, _) = line_ending.parse_peek(input)?;
 
     Ok((input, (req, h)))
 }
@@ -56,7 +56,7 @@ fn request_line(input: Stream<'_>) -> IResult<Stream<'_>, Request<'_>> {
     let (input, uri) = take_while(1.., is_not_space).parse_peek(input)?;
     let (input, _) = take_while(1.., is_space).parse_peek(input)?;
     let (input, version) = http_version(input)?;
-    let (input, _) = line_ending(input)?;
+    let (input, _) = line_ending.parse_peek(input)?;
 
     Ok((
         input,
@@ -78,7 +78,7 @@ fn http_version(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
     let (input, _) = take_while(1.., is_horizontal_space).parse_peek(input)?;
     let (input, data) = take_while(1.., not_line_ending).parse_peek(input)?;
-    let (input, _) = line_ending(input)?;
+    let (input, _) = line_ending.parse_peek(input)?;
 
     Ok((input, data))
 }

--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -47,7 +47,7 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
 fn request(input: Stream<'_>) -> IResult<Stream<'_>, (Request<'_>, Vec<Header<'_>>)> {
     let (input, req) = request_line(input)?;
     let (input, h) = repeat(1.., message_header).parse_peek(input)?;
-    let (input, _) = line_ending(input)?;
+    let (input, _) = line_ending.parse_peek(input)?;
 
     Ok((input, (req, h)))
 }
@@ -58,7 +58,7 @@ fn request_line(input: Stream<'_>) -> IResult<Stream<'_>, Request<'_>> {
     let (input, uri) = take_while(1.., is_not_space).parse_peek(input)?;
     let (input, _) = take_while(1.., is_space).parse_peek(input)?;
     let (input, version) = http_version(input)?;
-    let (input, _) = line_ending(input)?;
+    let (input, _) = line_ending.parse_peek(input)?;
 
     Ok((
         input,
@@ -80,7 +80,7 @@ fn http_version(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
     let (input, _) = take_while(1.., is_horizontal_space).parse_peek(input)?;
     let (input, data) = take_while(1.., not_line_ending).parse_peek(input)?;
-    let (input, _) = line_ending(input)?;
+    let (input, _) = line_ending.parse_peek(input)?;
 
     Ok((input, data))
 }

--- a/examples/ini/parser_str.rs
+++ b/examples/ini/parser_str.rs
@@ -32,7 +32,7 @@ fn keys_and_values(input: Stream<'_>) -> IResult<Stream<'_>, HashMap<&str, &str>
 }
 
 fn key_value(i: Stream<'_>) -> IResult<Stream<'_>, (&str, &str)> {
-    let (i, key) = alphanumeric(i)?;
+    let (i, key) = alphanumeric.parse_peek(i)?;
     let (i, _) = (opt(space), "=", opt(space)).parse_peek(i)?;
     let (i, val) = take_till0(is_line_ending_or_comment).parse_peek(i)?;
     let (i, _) = opt(space).parse_peek(i)?;

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -62,7 +62,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
 
     pub fn number(&self) -> Option<f64> {
         println!("number()");
-        match float::<_, _, ()>(self.data()) {
+        match float::<_, _, ()>.parse_peek(self.data()) {
             Ok((i, o)) => {
                 self.offset(i);
                 println!("-> {}", o);

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -31,59 +31,68 @@ mod complete {
         let e: &[u8] = b" ";
         let f: &[u8] = b" ;";
         //assert_eq!(alpha1::<_, Error>(a), Err(ErrMode::Incomplete(Needed::Size(1))));
-        assert_parse!(alpha1(a), Ok((empty, a)));
+        assert_parse!(alpha1.parse_peek(a), Ok((empty, a)));
         assert_eq!(
-            alpha1(b),
+            alpha1.parse_peek(b),
             Err(ErrMode::Backtrack(Error::new(b, ErrorKind::Slice)))
         );
-        assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], &b"a"[..])));
-        assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12".as_bytes(), &b"az"[..])));
         assert_eq!(
-            digit1(a),
+            alpha1::<_, Error<_>>.parse_peek(c),
+            Ok((&c[1..], &b"a"[..]))
+        );
+        assert_eq!(
+            alpha1::<_, Error<_>>.parse_peek(d),
+            Ok(("é12".as_bytes(), &b"az"[..]))
+        );
+        assert_eq!(
+            digit1.parse_peek(a),
             Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Slice)))
         );
-        assert_eq!(digit1::<_, Error<_>>(b), Ok((empty, b)));
+        assert_eq!(digit1::<_, Error<_>>.parse_peek(b), Ok((empty, b)));
         assert_eq!(
-            digit1(c),
+            digit1.parse_peek(c),
             Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Slice)))
         );
         assert_eq!(
-            digit1(d),
+            digit1.parse_peek(d),
             Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Slice)))
         );
-        assert_eq!(hex_digit1::<_, Error<_>>(a), Ok((empty, a)));
-        assert_eq!(hex_digit1::<_, Error<_>>(b), Ok((empty, b)));
-        assert_eq!(hex_digit1::<_, Error<_>>(c), Ok((empty, c)));
+        assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(a), Ok((empty, a)));
+        assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(b), Ok((empty, b)));
+        assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(c), Ok((empty, c)));
         assert_eq!(
-            hex_digit1::<_, Error<_>>(d),
+            hex_digit1::<_, Error<_>>.parse_peek(d),
             Ok(("zé12".as_bytes(), &b"a"[..]))
         );
         assert_eq!(
-            hex_digit1(e),
+            hex_digit1.parse_peek(e),
             Err(ErrMode::Backtrack(Error::new(e, ErrorKind::Slice)))
         );
         assert_eq!(
-            oct_digit1(a),
+            oct_digit1.parse_peek(a),
             Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Slice)))
         );
-        assert_eq!(oct_digit1::<_, Error<_>>(b), Ok((empty, b)));
+        assert_eq!(oct_digit1::<_, Error<_>>.parse_peek(b), Ok((empty, b)));
         assert_eq!(
-            oct_digit1(c),
+            oct_digit1.parse_peek(c),
             Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Slice)))
         );
         assert_eq!(
-            oct_digit1(d),
+            oct_digit1.parse_peek(d),
             Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Slice)))
         );
-        assert_eq!(alphanumeric1::<_, Error<_>>(a), Ok((empty, a)));
+        assert_eq!(alphanumeric1::<_, Error<_>>.parse_peek(a), Ok((empty, a)));
         //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
-        assert_eq!(alphanumeric1::<_, Error<_>>(c), Ok((empty, c)));
+        assert_eq!(alphanumeric1::<_, Error<_>>.parse_peek(c), Ok((empty, c)));
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(d),
+            alphanumeric1::<_, Error<_>>.parse_peek(d),
             Ok(("é12".as_bytes(), &b"az"[..]))
         );
-        assert_eq!(space1::<_, Error<_>>(e), Ok((empty, e)));
-        assert_eq!(space1::<_, Error<_>>(f), Ok((&b";"[..], &b" "[..])));
+        assert_eq!(space1::<_, Error<_>>.parse_peek(e), Ok((empty, e)));
+        assert_eq!(
+            space1::<_, Error<_>>.parse_peek(f),
+            Ok((&b";"[..], &b" "[..]))
+        );
     }
 
     #[cfg(feature = "alloc")]
@@ -95,52 +104,55 @@ mod complete {
         let c = "a123";
         let d = "azé12";
         let e = " ";
-        assert_eq!(alpha1::<_, Error<_>>(a), Ok((empty, a)));
+        assert_eq!(alpha1::<_, Error<_>>.parse_peek(a), Ok((empty, a)));
         assert_eq!(
-            alpha1(b),
+            alpha1.parse_peek(b),
             Err(ErrMode::Backtrack(Error::new(b, ErrorKind::Slice)))
         );
-        assert_eq!(alpha1::<_, Error<_>>(c), Ok((&c[1..], "a")));
-        assert_eq!(alpha1::<_, Error<_>>(d), Ok(("é12", "az")));
+        assert_eq!(alpha1::<_, Error<_>>.parse_peek(c), Ok((&c[1..], "a")));
+        assert_eq!(alpha1::<_, Error<_>>.parse_peek(d), Ok(("é12", "az")));
         assert_eq!(
-            digit1(a),
+            digit1.parse_peek(a),
             Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Slice)))
         );
-        assert_eq!(digit1::<_, Error<_>>(b), Ok((empty, b)));
+        assert_eq!(digit1::<_, Error<_>>.parse_peek(b), Ok((empty, b)));
         assert_eq!(
-            digit1(c),
+            digit1.parse_peek(c),
             Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Slice)))
         );
         assert_eq!(
-            digit1(d),
+            digit1.parse_peek(d),
             Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Slice)))
         );
-        assert_eq!(hex_digit1::<_, Error<_>>(a), Ok((empty, a)));
-        assert_eq!(hex_digit1::<_, Error<_>>(b), Ok((empty, b)));
-        assert_eq!(hex_digit1::<_, Error<_>>(c), Ok((empty, c)));
-        assert_eq!(hex_digit1::<_, Error<_>>(d), Ok(("zé12", "a")));
+        assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(a), Ok((empty, a)));
+        assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(b), Ok((empty, b)));
+        assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(c), Ok((empty, c)));
+        assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(d), Ok(("zé12", "a")));
         assert_eq!(
-            hex_digit1(e),
+            hex_digit1.parse_peek(e),
             Err(ErrMode::Backtrack(Error::new(e, ErrorKind::Slice)))
         );
         assert_eq!(
-            oct_digit1(a),
+            oct_digit1.parse_peek(a),
             Err(ErrMode::Backtrack(Error::new(a, ErrorKind::Slice)))
         );
-        assert_eq!(oct_digit1::<_, Error<_>>(b), Ok((empty, b)));
+        assert_eq!(oct_digit1::<_, Error<_>>.parse_peek(b), Ok((empty, b)));
         assert_eq!(
-            oct_digit1(c),
+            oct_digit1.parse_peek(c),
             Err(ErrMode::Backtrack(Error::new(c, ErrorKind::Slice)))
         );
         assert_eq!(
-            oct_digit1(d),
+            oct_digit1.parse_peek(d),
             Err(ErrMode::Backtrack(Error::new(d, ErrorKind::Slice)))
         );
-        assert_eq!(alphanumeric1::<_, Error<_>>(a), Ok((empty, a)));
+        assert_eq!(alphanumeric1::<_, Error<_>>.parse_peek(a), Ok((empty, a)));
         //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
-        assert_eq!(alphanumeric1::<_, Error<_>>(c), Ok((empty, c)));
-        assert_eq!(alphanumeric1::<_, Error<_>>(d), Ok(("é12", "az")));
-        assert_eq!(space1::<_, Error<_>>(e), Ok((empty, e)));
+        assert_eq!(alphanumeric1::<_, Error<_>>.parse_peek(c), Ok((empty, c)));
+        assert_eq!(
+            alphanumeric1::<_, Error<_>>.parse_peek(d),
+            Ok(("é12", "az"))
+        );
+        assert_eq!(space1::<_, Error<_>>.parse_peek(e), Ok((empty, e)));
     }
 
     use crate::stream::Offset;
@@ -153,43 +165,43 @@ mod complete {
         let e = &b" \t\r\n;"[..];
         let f = &b"123abcDEF;"[..];
 
-        match alpha1::<_, Error<_>>(a) {
+        match alpha1::<_, Error<_>>.parse_peek(a) {
             Ok((i, _)) => {
                 assert_eq!(i.offset_from(&a) + i.len(), a.len());
             }
             _ => panic!("wrong return type in offset test for alpha"),
         }
-        match digit1::<_, Error<_>>(b) {
+        match digit1::<_, Error<_>>.parse_peek(b) {
             Ok((i, _)) => {
                 assert_eq!(i.offset_from(&b) + i.len(), b.len());
             }
             _ => panic!("wrong return type in offset test for digit"),
         }
-        match alphanumeric1::<_, Error<_>>(c) {
+        match alphanumeric1::<_, Error<_>>.parse_peek(c) {
             Ok((i, _)) => {
                 assert_eq!(i.offset_from(&c) + i.len(), c.len());
             }
             _ => panic!("wrong return type in offset test for alphanumeric"),
         }
-        match space1::<_, Error<_>>(d) {
+        match space1::<_, Error<_>>.parse_peek(d) {
             Ok((i, _)) => {
                 assert_eq!(i.offset_from(&d) + i.len(), d.len());
             }
             _ => panic!("wrong return type in offset test for space"),
         }
-        match multispace1::<_, Error<_>>(e) {
+        match multispace1::<_, Error<_>>.parse_peek(e) {
             Ok((i, _)) => {
                 assert_eq!(i.offset_from(&e) + i.len(), e.len());
             }
             _ => panic!("wrong return type in offset test for multispace"),
         }
-        match hex_digit1::<_, Error<_>>(f) {
+        match hex_digit1::<_, Error<_>>.parse_peek(f) {
             Ok((i, _)) => {
                 assert_eq!(i.offset_from(&f) + i.len(), f.len());
             }
             _ => panic!("wrong return type in offset test for hex_digit"),
         }
-        match oct_digit1::<_, Error<_>>(f) {
+        match oct_digit1::<_, Error<_>>.parse_peek(f) {
             Ok((i, _)) => {
                 assert_eq!(i.offset_from(&f) + i.len(), f.len());
             }
@@ -201,52 +213,55 @@ mod complete {
     fn is_not_line_ending_bytes() {
         let a: &[u8] = b"ab12cd\nefgh";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(a),
+            not_line_ending::<_, Error<_>>.parse_peek(a),
             Ok((&b"\nefgh"[..], &b"ab12cd"[..]))
         );
 
         let b: &[u8] = b"ab12cd\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(b),
+            not_line_ending::<_, Error<_>>.parse_peek(b),
             Ok((&b"\nefgh\nijkl"[..], &b"ab12cd"[..]))
         );
 
         let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(c),
+            not_line_ending::<_, Error<_>>.parse_peek(c),
             Ok((&b"\r\nefgh\nijkl"[..], &b"ab12cd"[..]))
         );
 
         let d: &[u8] = b"ab12cd";
-        assert_eq!(not_line_ending::<_, Error<_>>(d), Ok((&[][..], d)));
+        assert_eq!(
+            not_line_ending::<_, Error<_>>.parse_peek(d),
+            Ok((&[][..], d))
+        );
     }
 
     #[test]
     fn is_not_line_ending_str() {
         let f = "βèƒôřè\rÂßÇáƒƭèř";
         assert_eq!(
-            not_line_ending(f),
+            not_line_ending.parse_peek(f),
             Err(ErrMode::Backtrack(Error::new(f, ErrorKind::Tag)))
         );
 
         let g2: &str = "ab12cd";
-        assert_eq!(not_line_ending::<_, Error<_>>(g2), Ok(("", g2)));
+        assert_eq!(not_line_ending::<_, Error<_>>.parse_peek(g2), Ok(("", g2)));
     }
 
     #[test]
     fn hex_digit_test() {
         let i = &b"0123456789abcdefABCDEF;"[..];
-        assert_parse!(hex_digit1(i), Ok((&b";"[..], &i[..i.len() - 1])));
+        assert_parse!(hex_digit1.parse_peek(i), Ok((&b";"[..], &i[..i.len() - 1])));
 
         let i = &b"g"[..];
         assert_parse!(
-            hex_digit1(i),
+            hex_digit1.parse_peek(i),
             Err(ErrMode::Backtrack(error_position!(i, ErrorKind::Slice)))
         );
 
         let i = &b"G"[..];
         assert_parse!(
-            hex_digit1(i),
+            hex_digit1.parse_peek(i),
             Err(ErrMode::Backtrack(error_position!(i, ErrorKind::Slice)))
         );
 
@@ -267,11 +282,11 @@ mod complete {
     #[test]
     fn oct_digit_test() {
         let i = &b"01234567;"[..];
-        assert_parse!(oct_digit1(i), Ok((&b";"[..], &i[..i.len() - 1])));
+        assert_parse!(oct_digit1.parse_peek(i), Ok((&b";"[..], &i[..i.len() - 1])));
 
         let i = &b"8"[..];
         assert_parse!(
-            oct_digit1(i),
+            oct_digit1.parse_peek(i),
             Err(ErrMode::Backtrack(error_position!(i, ErrorKind::Slice)))
         );
 
@@ -310,73 +325,82 @@ mod complete {
     #[test]
     fn check_windows_lineending() {
         let input = b"\r\n";
-        let output = line_ending(&input[..]);
+        let output = line_ending.parse_peek(&input[..]);
         assert_parse!(output, Ok((&b""[..], &b"\r\n"[..])));
     }
 
     #[test]
     fn check_unix_lineending() {
         let input = b"\n";
-        let output = line_ending(&input[..]);
+        let output = line_ending.parse_peek(&input[..]);
         assert_parse!(output, Ok((&b""[..], &b"\n"[..])));
     }
 
     #[test]
     fn cr_lf() {
-        assert_parse!(crlf(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
         assert_parse!(
-            crlf(&b"\r"[..]),
+            crlf.parse_peek(&b"\r\na"[..]),
+            Ok((&b"a"[..], &b"\r\n"[..]))
+        );
+        assert_parse!(
+            crlf.parse_peek(&b"\r"[..]),
             Err(ErrMode::Backtrack(error_position!(
                 &b"\r"[..],
                 ErrorKind::Tag
             )))
         );
         assert_parse!(
-            crlf(&b"\ra"[..]),
+            crlf.parse_peek(&b"\ra"[..]),
             Err(ErrMode::Backtrack(error_position!(
                 &b"\ra"[..],
                 ErrorKind::Tag
             )))
         );
 
-        assert_parse!(crlf("\r\na"), Ok(("a", "\r\n")));
+        assert_parse!(crlf.parse_peek("\r\na"), Ok(("a", "\r\n")));
         assert_parse!(
-            crlf("\r"),
+            crlf.parse_peek("\r"),
             Err(ErrMode::Backtrack(error_position!("\r", ErrorKind::Tag)))
         );
         assert_parse!(
-            crlf("\ra"),
+            crlf.parse_peek("\ra"),
             Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::Tag)))
         );
     }
 
     #[test]
     fn end_of_line() {
-        assert_parse!(line_ending(&b"\na"[..]), Ok((&b"a"[..], &b"\n"[..])));
-        assert_parse!(line_ending(&b"\r\na"[..]), Ok((&b"a"[..], &b"\r\n"[..])));
         assert_parse!(
-            line_ending(&b"\r"[..]),
+            line_ending.parse_peek(&b"\na"[..]),
+            Ok((&b"a"[..], &b"\n"[..]))
+        );
+        assert_parse!(
+            line_ending.parse_peek(&b"\r\na"[..]),
+            Ok((&b"a"[..], &b"\r\n"[..]))
+        );
+        assert_parse!(
+            line_ending.parse_peek(&b"\r"[..]),
             Err(ErrMode::Backtrack(error_position!(
                 &b"\r"[..],
                 ErrorKind::Tag
             )))
         );
         assert_parse!(
-            line_ending(&b"\ra"[..]),
+            line_ending.parse_peek(&b"\ra"[..]),
             Err(ErrMode::Backtrack(error_position!(
                 &b"\ra"[..],
                 ErrorKind::Tag
             )))
         );
 
-        assert_parse!(line_ending("\na"), Ok(("a", "\n")));
-        assert_parse!(line_ending("\r\na"), Ok(("a", "\r\n")));
+        assert_parse!(line_ending.parse_peek("\na"), Ok(("a", "\n")));
+        assert_parse!(line_ending.parse_peek("\r\na"), Ok(("a", "\r\n")));
         assert_parse!(
-            line_ending("\r"),
+            line_ending.parse_peek("\r"),
             Err(ErrMode::Backtrack(error_position!("\r", ErrorKind::Tag)))
         );
         assert_parse!(
-            line_ending("\ra"),
+            line_ending.parse_peek("\ra"),
             Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::Tag)))
         );
     }
@@ -390,7 +414,7 @@ mod complete {
             _ => unreachable!(),
         };
 
-        let (i, s) = digit1::<_, crate::error::Error<_>>(i)?;
+        let (i, s) = digit1::<_, crate::error::Error<_>>.parse_peek(i)?;
         match s.parse_slice() {
             Some(n) => {
                 if sign {
@@ -404,7 +428,7 @@ mod complete {
     }
 
     fn digit_to_u32(i: &str) -> IResult<&str, u32> {
-        let (i, s) = digit1(i)?;
+        let (i, s) = digit1.parse_peek(i)?;
         match s.parse_slice() {
             Some(n) => Ok((i, n)),
             None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
@@ -416,7 +440,7 @@ mod complete {
       #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
       fn ints(s in "\\PC*") {
           let res1 = digit_to_i16(&s);
-          let res2 = dec_int(s.as_str());
+          let res2 = dec_int.parse_peek(s.as_str());
           assert_eq!(res1, res2);
       }
 
@@ -424,7 +448,7 @@ mod complete {
       #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
       fn uints(s in "\\PC*") {
           let res1 = digit_to_u32(&s);
-          let res2 = dec_uint(s.as_str());
+          let res2 = dec_uint.parse_peek(s.as_str());
           assert_eq!(res1, res2);
       }
     }
@@ -432,7 +456,7 @@ mod complete {
     #[test]
     fn hex_uint_tests() {
         fn hex_u32(input: &[u8]) -> IResult<&[u8], u32> {
-            hex_uint(input)
+            hex_uint.parse_peek(input)
         }
 
         assert_parse!(
@@ -510,30 +534,36 @@ mod complete {
 
             let larger = test.to_string();
 
-            assert_parse!(float(larger.as_bytes()), Ok((&b""[..], expected32)));
-            assert_parse!(float(&larger[..]), Ok(("", expected32)));
+            assert_parse!(
+                float.parse_peek(larger.as_bytes()),
+                Ok((&b""[..], expected32))
+            );
+            assert_parse!(float.parse_peek(&larger[..]), Ok(("", expected32)));
 
-            assert_parse!(float(larger.as_bytes()), Ok((&b""[..], expected64)));
-            assert_parse!(float(&larger[..]), Ok(("", expected64)));
+            assert_parse!(
+                float.parse_peek(larger.as_bytes()),
+                Ok((&b""[..], expected64))
+            );
+            assert_parse!(float.parse_peek(&larger[..]), Ok(("", expected64)));
         }
 
         let remaining_exponent = "-1.234E-";
         assert_parse!(
-            float::<_, f64, _>(remaining_exponent),
+            float::<_, f64, _>.parse_peek(remaining_exponent),
             Err(ErrMode::Cut(Error {
                 input: "",
                 kind: ErrorKind::Slice
             }))
         );
 
-        let (i, nan) = float::<_, f32, ()>("NaN").unwrap();
+        let (i, nan) = float::<_, f32, ()>.parse_peek("NaN").unwrap();
         assert!(nan.is_nan());
         assert_eq!(i, "");
 
-        let (i, inf) = float::<_, f32, ()>("inf").unwrap();
+        let (i, inf) = float::<_, f32, ()>.parse_peek("inf").unwrap();
         assert!(inf.is_infinite());
         assert_eq!(i, "");
-        let (i, inf) = float::<_, f32, ()>("infinity").unwrap();
+        let (i, inf) = float::<_, f32, ()>.parse_peek("infinity").unwrap();
         assert!(inf.is_infinite());
         assert_eq!(i, "");
     }
@@ -561,7 +591,7 @@ mod complete {
       fn floats(s in "\\PC*") {
           println!("testing {}", s);
           let res1 = parse_f64(&s);
-          let res2 = float::<_, f64, ()>(s.as_str());
+          let res2 = float::<_, f64, ()>.parse_peek(s.as_str());
           assert_eq!(res1, res2);
       }
     }
@@ -856,116 +886,116 @@ mod partial {
         let f: &[u8] = b" ;";
         //assert_eq!(alpha1::<_, Error<_>>(a), Err(ErrMode::Incomplete(Needed::new(1))));
         assert_parse!(
-            alpha1(Partial::new(a)),
+            alpha1.parse_peek(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            alpha1(Partial::new(b)),
+            alpha1.parse_peek(Partial::new(b)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(b),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            alpha1::<_, Error<_>>(Partial::new(c)),
+            alpha1::<_, Error<_>>.parse_peek(Partial::new(c)),
             Ok((Partial::new(&c[1..]), &b"a"[..]))
         );
         assert_eq!(
-            alpha1::<_, Error<_>>(Partial::new(d)),
+            alpha1::<_, Error<_>>.parse_peek(Partial::new(d)),
             Ok((Partial::new("é12".as_bytes()), &b"az"[..]))
         );
         assert_eq!(
-            digit1(Partial::new(a)),
+            digit1.parse_peek(Partial::new(a)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(a),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            digit1::<_, Error<_>>(Partial::new(b)),
+            digit1::<_, Error<_>>.parse_peek(Partial::new(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            digit1(Partial::new(c)),
+            digit1.parse_peek(Partial::new(c)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(c),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            digit1(Partial::new(d)),
+            digit1.parse_peek(Partial::new(d)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(d),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial::new(a)),
+            hex_digit1::<_, Error<_>>.parse_peek(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial::new(b)),
+            hex_digit1::<_, Error<_>>.parse_peek(Partial::new(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial::new(c)),
+            hex_digit1::<_, Error<_>>.parse_peek(Partial::new(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial::new(d)),
+            hex_digit1::<_, Error<_>>.parse_peek(Partial::new(d)),
             Ok((Partial::new("zé12".as_bytes()), &b"a"[..]))
         );
         assert_eq!(
-            hex_digit1(Partial::new(e)),
+            hex_digit1.parse_peek(Partial::new(e)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(e),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            oct_digit1(Partial::new(a)),
+            oct_digit1.parse_peek(Partial::new(a)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(a),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            oct_digit1::<_, Error<_>>(Partial::new(b)),
+            oct_digit1::<_, Error<_>>.parse_peek(Partial::new(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            oct_digit1(Partial::new(c)),
+            oct_digit1.parse_peek(Partial::new(c)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(c),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            oct_digit1(Partial::new(d)),
+            oct_digit1.parse_peek(Partial::new(d)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(d),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial::new(a)),
+            alphanumeric1::<_, Error<_>>.parse_peek(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial::new(c)),
+            alphanumeric1::<_, Error<_>>.parse_peek(Partial::new(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial::new(d)),
+            alphanumeric1::<_, Error<_>>.parse_peek(Partial::new(d)),
             Ok((Partial::new("é12".as_bytes()), &b"az"[..]))
         );
         assert_eq!(
-            space1::<_, Error<_>>(Partial::new(e)),
+            space1::<_, Error<_>>.parse_peek(Partial::new(e)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            space1::<_, Error<_>>(Partial::new(f)),
+            space1::<_, Error<_>>.parse_peek(Partial::new(f)),
             Ok((Partial::new(&b";"[..]), &b" "[..]))
         );
     }
@@ -979,112 +1009,112 @@ mod partial {
         let d = "azé12";
         let e = " ";
         assert_eq!(
-            alpha1::<_, Error<_>>(Partial::new(a)),
+            alpha1::<_, Error<_>>.parse_peek(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            alpha1(Partial::new(b)),
+            alpha1.parse_peek(Partial::new(b)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(b),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            alpha1::<_, Error<_>>(Partial::new(c)),
+            alpha1::<_, Error<_>>.parse_peek(Partial::new(c)),
             Ok((Partial::new(&c[1..]), "a"))
         );
         assert_eq!(
-            alpha1::<_, Error<_>>(Partial::new(d)),
+            alpha1::<_, Error<_>>.parse_peek(Partial::new(d)),
             Ok((Partial::new("é12"), "az"))
         );
         assert_eq!(
-            digit1(Partial::new(a)),
+            digit1.parse_peek(Partial::new(a)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(a),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            digit1::<_, Error<_>>(Partial::new(b)),
+            digit1::<_, Error<_>>.parse_peek(Partial::new(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            digit1(Partial::new(c)),
+            digit1.parse_peek(Partial::new(c)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(c),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            digit1(Partial::new(d)),
+            digit1.parse_peek(Partial::new(d)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(d),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial::new(a)),
+            hex_digit1::<_, Error<_>>.parse_peek(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial::new(b)),
+            hex_digit1::<_, Error<_>>.parse_peek(Partial::new(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial::new(c)),
+            hex_digit1::<_, Error<_>>.parse_peek(Partial::new(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            hex_digit1::<_, Error<_>>(Partial::new(d)),
+            hex_digit1::<_, Error<_>>.parse_peek(Partial::new(d)),
             Ok((Partial::new("zé12"), "a"))
         );
         assert_eq!(
-            hex_digit1(Partial::new(e)),
+            hex_digit1.parse_peek(Partial::new(e)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(e),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            oct_digit1(Partial::new(a)),
+            oct_digit1.parse_peek(Partial::new(a)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(a),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            oct_digit1::<_, Error<_>>(Partial::new(b)),
+            oct_digit1::<_, Error<_>>.parse_peek(Partial::new(b)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            oct_digit1(Partial::new(c)),
+            oct_digit1.parse_peek(Partial::new(c)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(c),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            oct_digit1(Partial::new(d)),
+            oct_digit1.parse_peek(Partial::new(d)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(d),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial::new(a)),
+            alphanumeric1::<_, Error<_>>.parse_peek(Partial::new(a)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial::new(c)),
+            alphanumeric1::<_, Error<_>>.parse_peek(Partial::new(c)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            alphanumeric1::<_, Error<_>>(Partial::new(d)),
+            alphanumeric1::<_, Error<_>>.parse_peek(Partial::new(d)),
             Ok((Partial::new("é12"), "az"))
         );
         assert_eq!(
-            space1::<_, Error<_>>(Partial::new(e)),
+            space1::<_, Error<_>>.parse_peek(Partial::new(e)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -1099,49 +1129,49 @@ mod partial {
         let e = &b" \t\r\n;"[..];
         let f = &b"123abcDEF;"[..];
 
-        match alpha1::<_, Error<_>>(Partial::new(a)) {
+        match alpha1::<_, Error<_>>.parse_peek(Partial::new(a)) {
             Ok((i, _)) => {
                 let i = i.into_inner();
                 assert_eq!(i.offset_from(&a) + i.len(), a.len());
             }
             _ => panic!("wrong return type in offset test for alpha"),
         }
-        match digit1::<_, Error<_>>(Partial::new(b)) {
+        match digit1::<_, Error<_>>.parse_peek(Partial::new(b)) {
             Ok((i, _)) => {
                 let i = i.into_inner();
                 assert_eq!(i.offset_from(&b) + i.len(), b.len());
             }
             _ => panic!("wrong return type in offset test for digit"),
         }
-        match alphanumeric1::<_, Error<_>>(Partial::new(c)) {
+        match alphanumeric1::<_, Error<_>>.parse_peek(Partial::new(c)) {
             Ok((i, _)) => {
                 let i = i.into_inner();
                 assert_eq!(i.offset_from(&c) + i.len(), c.len());
             }
             _ => panic!("wrong return type in offset test for alphanumeric"),
         }
-        match space1::<_, Error<_>>(Partial::new(d)) {
+        match space1::<_, Error<_>>.parse_peek(Partial::new(d)) {
             Ok((i, _)) => {
                 let i = i.into_inner();
                 assert_eq!(i.offset_from(&d) + i.len(), d.len());
             }
             _ => panic!("wrong return type in offset test for space"),
         }
-        match multispace1::<_, Error<_>>(Partial::new(e)) {
+        match multispace1::<_, Error<_>>.parse_peek(Partial::new(e)) {
             Ok((i, _)) => {
                 let i = i.into_inner();
                 assert_eq!(i.offset_from(&e) + i.len(), e.len());
             }
             _ => panic!("wrong return type in offset test for multispace"),
         }
-        match hex_digit1::<_, Error<_>>(Partial::new(f)) {
+        match hex_digit1::<_, Error<_>>.parse_peek(Partial::new(f)) {
             Ok((i, _)) => {
                 let i = i.into_inner();
                 assert_eq!(i.offset_from(&f) + i.len(), f.len());
             }
             _ => panic!("wrong return type in offset test for hex_digit"),
         }
-        match oct_digit1::<_, Error<_>>(Partial::new(f)) {
+        match oct_digit1::<_, Error<_>>.parse_peek(Partial::new(f)) {
             Ok((i, _)) => {
                 let i = i.into_inner();
                 assert_eq!(i.offset_from(&f) + i.len(), f.len());
@@ -1154,25 +1184,25 @@ mod partial {
     fn is_not_line_ending_bytes() {
         let a: &[u8] = b"ab12cd\nefgh";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial::new(a)),
+            not_line_ending::<_, Error<_>>.parse_peek(Partial::new(a)),
             Ok((Partial::new(&b"\nefgh"[..]), &b"ab12cd"[..]))
         );
 
         let b: &[u8] = b"ab12cd\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial::new(b)),
+            not_line_ending::<_, Error<_>>.parse_peek(Partial::new(b)),
             Ok((Partial::new(&b"\nefgh\nijkl"[..]), &b"ab12cd"[..]))
         );
 
         let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial::new(c)),
+            not_line_ending::<_, Error<_>>.parse_peek(Partial::new(c)),
             Ok((Partial::new(&b"\r\nefgh\nijkl"[..]), &b"ab12cd"[..]))
         );
 
         let d: &[u8] = b"ab12cd";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial::new(d)),
+            not_line_ending::<_, Error<_>>.parse_peek(Partial::new(d)),
             Err(ErrMode::Incomplete(Needed::Unknown))
         );
     }
@@ -1181,7 +1211,7 @@ mod partial {
     fn is_not_line_ending_str() {
         let f = "βèƒôřè\rÂßÇáƒƭèř";
         assert_eq!(
-            not_line_ending(Partial::new(f)),
+            not_line_ending.parse_peek(Partial::new(f)),
             Err(ErrMode::Backtrack(Error::new(
                 Partial::new(f),
                 ErrorKind::Tag
@@ -1190,7 +1220,7 @@ mod partial {
 
         let g2: &str = "ab12cd";
         assert_eq!(
-            not_line_ending::<_, Error<_>>(Partial::new(g2)),
+            not_line_ending::<_, Error<_>>.parse_peek(Partial::new(g2)),
             Err(ErrMode::Incomplete(Needed::Unknown))
         );
     }
@@ -1199,13 +1229,13 @@ mod partial {
     fn hex_digit_test() {
         let i = &b"0123456789abcdefABCDEF;"[..];
         assert_parse!(
-            hex_digit1(Partial::new(i)),
+            hex_digit1.parse_peek(Partial::new(i)),
             Ok((Partial::new(&b";"[..]), &i[..i.len() - 1]))
         );
 
         let i = &b"g"[..];
         assert_parse!(
-            hex_digit1(Partial::new(i)),
+            hex_digit1.parse_peek(Partial::new(i)),
             Err(ErrMode::Backtrack(error_position!(
                 Partial::new(i),
                 ErrorKind::Slice
@@ -1214,7 +1244,7 @@ mod partial {
 
         let i = &b"G"[..];
         assert_parse!(
-            hex_digit1(Partial::new(i)),
+            hex_digit1.parse_peek(Partial::new(i)),
             Err(ErrMode::Backtrack(error_position!(
                 Partial::new(i),
                 ErrorKind::Slice
@@ -1239,13 +1269,13 @@ mod partial {
     fn oct_digit_test() {
         let i = &b"01234567;"[..];
         assert_parse!(
-            oct_digit1(Partial::new(i)),
+            oct_digit1.parse_peek(Partial::new(i)),
             Ok((Partial::new(&b";"[..]), &i[..i.len() - 1]))
         );
 
         let i = &b"8"[..];
         assert_parse!(
-            oct_digit1(Partial::new(i)),
+            oct_digit1.parse_peek(Partial::new(i)),
             Err(ErrMode::Backtrack(error_position!(
                 Partial::new(i),
                 ErrorKind::Slice
@@ -1295,42 +1325,45 @@ mod partial {
     #[test]
     fn check_windows_lineending() {
         let input = b"\r\n";
-        let output = line_ending(Partial::new(&input[..]));
+        let output = line_ending.parse_peek(Partial::new(&input[..]));
         assert_parse!(output, Ok((Partial::new(&b""[..]), &b"\r\n"[..])));
     }
 
     #[test]
     fn check_unix_lineending() {
         let input = b"\n";
-        let output = line_ending(Partial::new(&input[..]));
+        let output = line_ending.parse_peek(Partial::new(&input[..]));
         assert_parse!(output, Ok((Partial::new(&b""[..]), &b"\n"[..])));
     }
 
     #[test]
     fn cr_lf() {
         assert_parse!(
-            crlf(Partial::new(&b"\r\na"[..])),
+            crlf.parse_peek(Partial::new(&b"\r\na"[..])),
             Ok((Partial::new(&b"a"[..]), &b"\r\n"[..]))
         );
         assert_parse!(
-            crlf(Partial::new(&b"\r"[..])),
+            crlf.parse_peek(Partial::new(&b"\r"[..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_parse!(
-            crlf(Partial::new(&b"\ra"[..])),
+            crlf.parse_peek(Partial::new(&b"\ra"[..])),
             Err(ErrMode::Backtrack(error_position!(
                 Partial::new(&b"\ra"[..]),
                 ErrorKind::Tag
             )))
         );
 
-        assert_parse!(crlf(Partial::new("\r\na")), Ok((Partial::new("a"), "\r\n")));
         assert_parse!(
-            crlf(Partial::new("\r")),
+            crlf.parse_peek(Partial::new("\r\na")),
+            Ok((Partial::new("a"), "\r\n"))
+        );
+        assert_parse!(
+            crlf.parse_peek(Partial::new("\r")),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_parse!(
-            crlf(Partial::new("\ra")),
+            crlf.parse_peek(Partial::new("\ra")),
             Err(ErrMode::Backtrack(error_position!(
                 Partial::new("\ra"),
                 ErrorKind::Tag
@@ -1341,19 +1374,19 @@ mod partial {
     #[test]
     fn end_of_line() {
         assert_parse!(
-            line_ending(Partial::new(&b"\na"[..])),
+            line_ending.parse_peek(Partial::new(&b"\na"[..])),
             Ok((Partial::new(&b"a"[..]), &b"\n"[..]))
         );
         assert_parse!(
-            line_ending(Partial::new(&b"\r\na"[..])),
+            line_ending.parse_peek(Partial::new(&b"\r\na"[..])),
             Ok((Partial::new(&b"a"[..]), &b"\r\n"[..]))
         );
         assert_parse!(
-            line_ending(Partial::new(&b"\r"[..])),
+            line_ending.parse_peek(Partial::new(&b"\r"[..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_parse!(
-            line_ending(Partial::new(&b"\ra"[..])),
+            line_ending.parse_peek(Partial::new(&b"\ra"[..])),
             Err(ErrMode::Backtrack(error_position!(
                 Partial::new(&b"\ra"[..]),
                 ErrorKind::Tag
@@ -1361,19 +1394,19 @@ mod partial {
         );
 
         assert_parse!(
-            line_ending(Partial::new("\na")),
+            line_ending.parse_peek(Partial::new("\na")),
             Ok((Partial::new("a"), "\n"))
         );
         assert_parse!(
-            line_ending(Partial::new("\r\na")),
+            line_ending.parse_peek(Partial::new("\r\na")),
             Ok((Partial::new("a"), "\r\n"))
         );
         assert_parse!(
-            line_ending(Partial::new("\r")),
+            line_ending.parse_peek(Partial::new("\r")),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_parse!(
-            line_ending(Partial::new("\ra")),
+            line_ending.parse_peek(Partial::new("\ra")),
             Err(ErrMode::Backtrack(error_position!(
                 Partial::new("\ra"),
                 ErrorKind::Tag
@@ -1390,7 +1423,7 @@ mod partial {
             _ => unreachable!(),
         };
 
-        let (i, s) = digit1::<_, crate::error::Error<_>>(i)?;
+        let (i, s) = digit1::<_, crate::error::Error<_>>.parse_peek(i)?;
         match s.parse_slice() {
             Some(n) => {
                 if sign {
@@ -1404,7 +1437,7 @@ mod partial {
     }
 
     fn digit_to_u32(i: Partial<&str>) -> IResult<Partial<&str>, u32> {
-        let (i, s) = digit1(i)?;
+        let (i, s) = digit1.parse_peek(i)?;
         match s.parse_slice() {
             Some(n) => Ok((i, n)),
             None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
@@ -1416,7 +1449,7 @@ mod partial {
       #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
       fn ints(s in "\\PC*") {
           let res1 = digit_to_i16(Partial::new(&s));
-          let res2 = dec_int(Partial::new(s.as_str()));
+          let res2 = dec_int.parse_peek(Partial::new(s.as_str()));
           assert_eq!(res1, res2);
       }
 
@@ -1424,7 +1457,7 @@ mod partial {
       #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
       fn uints(s in "\\PC*") {
           let res1 = digit_to_u32(Partial::new(&s));
-          let res2 = dec_uint(Partial::new(s.as_str()));
+          let res2 = dec_uint.parse_peek(Partial::new(s.as_str()));
           assert_eq!(res1, res2);
       }
     }
@@ -1432,7 +1465,7 @@ mod partial {
     #[test]
     fn hex_uint_tests() {
         fn hex_u32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-            hex_uint(input)
+            hex_uint.parse_peek(input)
         }
 
         assert_parse!(

--- a/src/binary/bits/tests.rs
+++ b/src/binary/bits/tests.rs
@@ -148,7 +148,7 @@ fn test_tag_partial_err() {
 fn test_bool_0_complete() {
     let input = [0b10000000].as_ref();
 
-    let result: crate::IResult<(&[u8], usize), bool> = bool((input, 0));
+    let result: crate::IResult<(&[u8], usize), bool> = bool.parse_peek((input, 0));
 
     assert_eq!(result, Ok(((input, 1), true)));
 }
@@ -157,7 +157,7 @@ fn test_bool_0_complete() {
 fn test_bool_eof_complete() {
     let input = [0b10000000].as_ref();
 
-    let result: crate::IResult<(&[u8], usize), bool> = bool((input, 8));
+    let result: crate::IResult<(&[u8], usize), bool> = bool.parse_peek((input, 8));
 
     assert_eq!(
         result,
@@ -172,7 +172,7 @@ fn test_bool_eof_complete() {
 fn test_bool_0_partial() {
     let input = Partial::new([0b10000000].as_ref());
 
-    let result: crate::IResult<(Partial<&[u8]>, usize), bool> = bool((input, 0));
+    let result: crate::IResult<(Partial<&[u8]>, usize), bool> = bool.parse_peek((input, 0));
 
     assert_eq!(result, Ok(((input, 1), true)));
 }

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -13,58 +13,82 @@ mod complete {
 
     #[test]
     fn i8_tests() {
-        assert_parse!(i8(&[0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(i8(&[0x7f][..]), Ok((&b""[..], 127)));
-        assert_parse!(i8(&[0xff][..]), Ok((&b""[..], -1)));
-        assert_parse!(i8(&[0x80][..]), Ok((&b""[..], -128)));
+        assert_parse!(i8.parse_peek(&[0x00][..]), Ok((&b""[..], 0)));
+        assert_parse!(i8.parse_peek(&[0x7f][..]), Ok((&b""[..], 127)));
+        assert_parse!(i8.parse_peek(&[0xff][..]), Ok((&b""[..], -1)));
+        assert_parse!(i8.parse_peek(&[0x80][..]), Ok((&b""[..], -128)));
     }
 
     #[test]
     fn be_i8_tests() {
-        assert_parse!(be_i8(&[0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(be_i8(&[0x7f][..]), Ok((&b""[..], 127)));
-        assert_parse!(be_i8(&[0xff][..]), Ok((&b""[..], -1)));
-        assert_parse!(be_i8(&[0x80][..]), Ok((&b""[..], -128)));
+        assert_parse!(be_i8.parse_peek(&[0x00][..]), Ok((&b""[..], 0)));
+        assert_parse!(be_i8.parse_peek(&[0x7f][..]), Ok((&b""[..], 127)));
+        assert_parse!(be_i8.parse_peek(&[0xff][..]), Ok((&b""[..], -1)));
+        assert_parse!(be_i8.parse_peek(&[0x80][..]), Ok((&b""[..], -128)));
     }
 
     #[test]
     fn be_i16_tests() {
-        assert_parse!(be_i16(&[0x00, 0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(be_i16(&[0x7f, 0xff][..]), Ok((&b""[..], 32_767_i16)));
-        assert_parse!(be_i16(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
-        assert_parse!(be_i16(&[0x80, 0x00][..]), Ok((&b""[..], -32_768_i16)));
+        assert_parse!(be_i16.parse_peek(&[0x00, 0x00][..]), Ok((&b""[..], 0)));
+        assert_parse!(
+            be_i16.parse_peek(&[0x7f, 0xff][..]),
+            Ok((&b""[..], 32_767_i16))
+        );
+        assert_parse!(be_i16.parse_peek(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
+        assert_parse!(
+            be_i16.parse_peek(&[0x80, 0x00][..]),
+            Ok((&b""[..], -32_768_i16))
+        );
     }
 
     #[test]
     fn be_u24_tests() {
-        assert_parse!(be_u24(&[0x00, 0x00, 0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(be_u24(&[0x00, 0xFF, 0xFF][..]), Ok((&b""[..], 65_535_u32)));
         assert_parse!(
-            be_u24(&[0x12, 0x34, 0x56][..]),
+            be_u24.parse_peek(&[0x00, 0x00, 0x00][..]),
+            Ok((&b""[..], 0))
+        );
+        assert_parse!(
+            be_u24.parse_peek(&[0x00, 0xFF, 0xFF][..]),
+            Ok((&b""[..], 65_535_u32))
+        );
+        assert_parse!(
+            be_u24.parse_peek(&[0x12, 0x34, 0x56][..]),
             Ok((&b""[..], 1_193_046_u32))
         );
     }
 
     #[test]
     fn be_i24_tests() {
-        assert_parse!(be_i24(&[0xFF, 0xFF, 0xFF][..]), Ok((&b""[..], -1_i32)));
-        assert_parse!(be_i24(&[0xFF, 0x00, 0x00][..]), Ok((&b""[..], -65_536_i32)));
         assert_parse!(
-            be_i24(&[0xED, 0xCB, 0xAA][..]),
+            be_i24.parse_peek(&[0xFF, 0xFF, 0xFF][..]),
+            Ok((&b""[..], -1_i32))
+        );
+        assert_parse!(
+            be_i24.parse_peek(&[0xFF, 0x00, 0x00][..]),
+            Ok((&b""[..], -65_536_i32))
+        );
+        assert_parse!(
+            be_i24.parse_peek(&[0xED, 0xCB, 0xAA][..]),
             Ok((&b""[..], -1_193_046_i32))
         );
     }
 
     #[test]
     fn be_i32_tests() {
-        assert_parse!(be_i32(&[0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 0)));
         assert_parse!(
-            be_i32(&[0x7f, 0xff, 0xff, 0xff][..]),
+            be_i32.parse_peek(&[0x00, 0x00, 0x00, 0x00][..]),
+            Ok((&b""[..], 0))
+        );
+        assert_parse!(
+            be_i32.parse_peek(&[0x7f, 0xff, 0xff, 0xff][..]),
             Ok((&b""[..], 2_147_483_647_i32))
         );
-        assert_parse!(be_i32(&[0xff, 0xff, 0xff, 0xff][..]), Ok((&b""[..], -1)));
         assert_parse!(
-            be_i32(&[0x80, 0x00, 0x00, 0x00][..]),
+            be_i32.parse_peek(&[0xff, 0xff, 0xff, 0xff][..]),
+            Ok((&b""[..], -1))
+        );
+        assert_parse!(
+            be_i32.parse_peek(&[0x80, 0x00, 0x00, 0x00][..]),
             Ok((&b""[..], -2_147_483_648_i32))
         );
     }
@@ -72,19 +96,19 @@ mod complete {
     #[test]
     fn be_i64_tests() {
         assert_parse!(
-            be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+            be_i64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
             Ok((&b""[..], 0))
         );
         assert_parse!(
-            be_i64(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
+            be_i64.parse_peek(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
             Ok((&b""[..], 9_223_372_036_854_775_807_i64))
         );
         assert_parse!(
-            be_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
+            be_i64.parse_peek(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
             Ok((&b""[..], -1))
         );
         assert_parse!(
-            be_i64(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+            be_i64.parse_peek(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
             Ok((&b""[..], -9_223_372_036_854_775_808_i64))
         );
     }
@@ -92,7 +116,7 @@ mod complete {
     #[test]
     fn be_i128_tests() {
         assert_parse!(
-            be_i128(
+            be_i128.parse_peek(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
@@ -101,7 +125,7 @@ mod complete {
             Ok((&b""[..], 0))
         );
         assert_parse!(
-            be_i128(
+            be_i128.parse_peek(
                 &[
                     0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff
@@ -113,7 +137,7 @@ mod complete {
             ))
         );
         assert_parse!(
-            be_i128(
+            be_i128.parse_peek(
                 &[
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff
@@ -122,7 +146,7 @@ mod complete {
             Ok((&b""[..], -1))
         );
         assert_parse!(
-            be_i128(
+            be_i128.parse_peek(
                 &[
                     0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
@@ -137,50 +161,74 @@ mod complete {
 
     #[test]
     fn le_i8_tests() {
-        assert_parse!(le_i8(&[0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(le_i8(&[0x7f][..]), Ok((&b""[..], 127)));
-        assert_parse!(le_i8(&[0xff][..]), Ok((&b""[..], -1)));
-        assert_parse!(le_i8(&[0x80][..]), Ok((&b""[..], -128)));
+        assert_parse!(le_i8.parse_peek(&[0x00][..]), Ok((&b""[..], 0)));
+        assert_parse!(le_i8.parse_peek(&[0x7f][..]), Ok((&b""[..], 127)));
+        assert_parse!(le_i8.parse_peek(&[0xff][..]), Ok((&b""[..], -1)));
+        assert_parse!(le_i8.parse_peek(&[0x80][..]), Ok((&b""[..], -128)));
     }
 
     #[test]
     fn le_i16_tests() {
-        assert_parse!(le_i16(&[0x00, 0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(le_i16(&[0xff, 0x7f][..]), Ok((&b""[..], 32_767_i16)));
-        assert_parse!(le_i16(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
-        assert_parse!(le_i16(&[0x00, 0x80][..]), Ok((&b""[..], -32_768_i16)));
+        assert_parse!(le_i16.parse_peek(&[0x00, 0x00][..]), Ok((&b""[..], 0)));
+        assert_parse!(
+            le_i16.parse_peek(&[0xff, 0x7f][..]),
+            Ok((&b""[..], 32_767_i16))
+        );
+        assert_parse!(le_i16.parse_peek(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
+        assert_parse!(
+            le_i16.parse_peek(&[0x00, 0x80][..]),
+            Ok((&b""[..], -32_768_i16))
+        );
     }
 
     #[test]
     fn le_u24_tests() {
-        assert_parse!(le_u24(&[0x00, 0x00, 0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(le_u24(&[0xFF, 0xFF, 0x00][..]), Ok((&b""[..], 65_535_u32)));
         assert_parse!(
-            le_u24(&[0x56, 0x34, 0x12][..]),
+            le_u24.parse_peek(&[0x00, 0x00, 0x00][..]),
+            Ok((&b""[..], 0))
+        );
+        assert_parse!(
+            le_u24.parse_peek(&[0xFF, 0xFF, 0x00][..]),
+            Ok((&b""[..], 65_535_u32))
+        );
+        assert_parse!(
+            le_u24.parse_peek(&[0x56, 0x34, 0x12][..]),
             Ok((&b""[..], 1_193_046_u32))
         );
     }
 
     #[test]
     fn le_i24_tests() {
-        assert_parse!(le_i24(&[0xFF, 0xFF, 0xFF][..]), Ok((&b""[..], -1_i32)));
-        assert_parse!(le_i24(&[0x00, 0x00, 0xFF][..]), Ok((&b""[..], -65_536_i32)));
         assert_parse!(
-            le_i24(&[0xAA, 0xCB, 0xED][..]),
+            le_i24.parse_peek(&[0xFF, 0xFF, 0xFF][..]),
+            Ok((&b""[..], -1_i32))
+        );
+        assert_parse!(
+            le_i24.parse_peek(&[0x00, 0x00, 0xFF][..]),
+            Ok((&b""[..], -65_536_i32))
+        );
+        assert_parse!(
+            le_i24.parse_peek(&[0xAA, 0xCB, 0xED][..]),
             Ok((&b""[..], -1_193_046_i32))
         );
     }
 
     #[test]
     fn le_i32_tests() {
-        assert_parse!(le_i32(&[0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 0)));
         assert_parse!(
-            le_i32(&[0xff, 0xff, 0xff, 0x7f][..]),
+            le_i32.parse_peek(&[0x00, 0x00, 0x00, 0x00][..]),
+            Ok((&b""[..], 0))
+        );
+        assert_parse!(
+            le_i32.parse_peek(&[0xff, 0xff, 0xff, 0x7f][..]),
             Ok((&b""[..], 2_147_483_647_i32))
         );
-        assert_parse!(le_i32(&[0xff, 0xff, 0xff, 0xff][..]), Ok((&b""[..], -1)));
         assert_parse!(
-            le_i32(&[0x00, 0x00, 0x00, 0x80][..]),
+            le_i32.parse_peek(&[0xff, 0xff, 0xff, 0xff][..]),
+            Ok((&b""[..], -1))
+        );
+        assert_parse!(
+            le_i32.parse_peek(&[0x00, 0x00, 0x00, 0x80][..]),
             Ok((&b""[..], -2_147_483_648_i32))
         );
     }
@@ -188,19 +236,19 @@ mod complete {
     #[test]
     fn le_i64_tests() {
         assert_parse!(
-            le_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+            le_i64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
             Ok((&b""[..], 0))
         );
         assert_parse!(
-            le_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f][..]),
+            le_i64.parse_peek(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f][..]),
             Ok((&b""[..], 9_223_372_036_854_775_807_i64))
         );
         assert_parse!(
-            le_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
+            le_i64.parse_peek(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
             Ok((&b""[..], -1))
         );
         assert_parse!(
-            le_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80][..]),
+            le_i64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80][..]),
             Ok((&b""[..], -9_223_372_036_854_775_808_i64))
         );
     }
@@ -208,7 +256,7 @@ mod complete {
     #[test]
     fn le_i128_tests() {
         assert_parse!(
-            le_i128(
+            le_i128.parse_peek(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
@@ -217,7 +265,7 @@ mod complete {
             Ok((&b""[..], 0))
         );
         assert_parse!(
-            le_i128(
+            le_i128.parse_peek(
                 &[
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0x7f
@@ -229,7 +277,7 @@ mod complete {
             ))
         );
         assert_parse!(
-            le_i128(
+            le_i128.parse_peek(
                 &[
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff
@@ -238,7 +286,7 @@ mod complete {
             Ok((&b""[..], -1))
         );
         assert_parse!(
-            le_i128(
+            le_i128.parse_peek(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x80
@@ -253,9 +301,12 @@ mod complete {
 
     #[test]
     fn be_f32_tests() {
-        assert_parse!(be_f32(&[0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 0_f32)));
         assert_parse!(
-            be_f32(&[0x4d, 0x31, 0x1f, 0xd8][..]),
+            be_f32.parse_peek(&[0x00, 0x00, 0x00, 0x00][..]),
+            Ok((&b""[..], 0_f32))
+        );
+        assert_parse!(
+            be_f32.parse_peek(&[0x4d, 0x31, 0x1f, 0xd8][..]),
             Ok((&b""[..], 185_728_380_f32))
         );
     }
@@ -263,20 +314,23 @@ mod complete {
     #[test]
     fn be_f64_tests() {
         assert_parse!(
-            be_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+            be_f64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
             Ok((&b""[..], 0_f64))
         );
         assert_parse!(
-            be_f64(&[0x41, 0xa6, 0x23, 0xfb, 0x10, 0x00, 0x00, 0x00][..]),
+            be_f64.parse_peek(&[0x41, 0xa6, 0x23, 0xfb, 0x10, 0x00, 0x00, 0x00][..]),
             Ok((&b""[..], 185_728_392_f64))
         );
     }
 
     #[test]
     fn le_f32_tests() {
-        assert_parse!(le_f32(&[0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 0_f32)));
         assert_parse!(
-            le_f32(&[0xd8, 0x1f, 0x31, 0x4d][..]),
+            le_f32.parse_peek(&[0x00, 0x00, 0x00, 0x00][..]),
+            Ok((&b""[..], 0_f32))
+        );
+        assert_parse!(
+            le_f32.parse_peek(&[0xd8, 0x1f, 0x31, 0x4d][..]),
             Ok((&b""[..], 185_728_380_f32))
         );
     }
@@ -284,11 +338,11 @@ mod complete {
     #[test]
     fn le_f64_tests() {
         assert_parse!(
-            le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+            le_f64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
             Ok((&b""[..], 0_f64))
         );
         assert_parse!(
-            le_f64(&[0x00, 0x00, 0x00, 0x10, 0xfb, 0x23, 0xa6, 0x41][..]),
+            le_f64.parse_peek(&[0x00, 0x00, 0x00, 0x10, 0xfb, 0x23, 0xa6, 0x41][..]),
             Ok((&b""[..], 185_728_392_f64))
         );
     }
@@ -403,23 +457,23 @@ mod partial {
     #[test]
     fn i8_tests() {
         assert_parse!(
-            be_i8(Partial::new(&[0x00][..])),
+            be_i8.parse_peek(Partial::new(&[0x00][..])),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_i8(Partial::new(&[0x7f][..])),
+            be_i8.parse_peek(Partial::new(&[0x7f][..])),
             Ok((Partial::new(&b""[..]), 127))
         );
         assert_parse!(
-            be_i8(Partial::new(&[0xff][..])),
+            be_i8.parse_peek(Partial::new(&[0xff][..])),
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            be_i8(Partial::new(&[0x80][..])),
+            be_i8.parse_peek(Partial::new(&[0x80][..])),
             Ok((Partial::new(&b""[..]), -128))
         );
         assert_parse!(
-            be_i8(Partial::new(&[][..])),
+            be_i8.parse_peek(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -427,27 +481,27 @@ mod partial {
     #[test]
     fn i16_tests() {
         assert_parse!(
-            be_i16(Partial::new(&[0x00, 0x00][..])),
+            be_i16.parse_peek(Partial::new(&[0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_i16(Partial::new(&[0x7f, 0xff][..])),
+            be_i16.parse_peek(Partial::new(&[0x7f, 0xff][..])),
             Ok((Partial::new(&b""[..]), 32_767_i16))
         );
         assert_parse!(
-            be_i16(Partial::new(&[0xff, 0xff][..])),
+            be_i16.parse_peek(Partial::new(&[0xff, 0xff][..])),
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            be_i16(Partial::new(&[0x80, 0x00][..])),
+            be_i16.parse_peek(Partial::new(&[0x80, 0x00][..])),
             Ok((Partial::new(&b""[..]), -32_768_i16))
         );
         assert_parse!(
-            be_i16(Partial::new(&[][..])),
+            be_i16.parse_peek(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i16(Partial::new(&[0x00][..])),
+            be_i16.parse_peek(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -455,27 +509,27 @@ mod partial {
     #[test]
     fn u24_tests() {
         assert_parse!(
-            be_u24(Partial::new(&[0x00, 0x00, 0x00][..])),
+            be_u24.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_u24(Partial::new(&[0x00, 0xFF, 0xFF][..])),
+            be_u24.parse_peek(Partial::new(&[0x00, 0xFF, 0xFF][..])),
             Ok((Partial::new(&b""[..]), 65_535_u32))
         );
         assert_parse!(
-            be_u24(Partial::new(&[0x12, 0x34, 0x56][..])),
+            be_u24.parse_peek(Partial::new(&[0x12, 0x34, 0x56][..])),
             Ok((Partial::new(&b""[..]), 1_193_046_u32))
         );
         assert_parse!(
-            be_u24(Partial::new(&[][..])),
+            be_u24.parse_peek(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_u24(Partial::new(&[0x00][..])),
+            be_u24.parse_peek(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_u24(Partial::new(&[0x00, 0x00][..])),
+            be_u24.parse_peek(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -483,27 +537,27 @@ mod partial {
     #[test]
     fn i24_tests() {
         assert_parse!(
-            be_i24(Partial::new(&[0xFF, 0xFF, 0xFF][..])),
+            be_i24.parse_peek(Partial::new(&[0xFF, 0xFF, 0xFF][..])),
             Ok((Partial::new(&b""[..]), -1_i32))
         );
         assert_parse!(
-            be_i24(Partial::new(&[0xFF, 0x00, 0x00][..])),
+            be_i24.parse_peek(Partial::new(&[0xFF, 0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), -65_536_i32))
         );
         assert_parse!(
-            be_i24(Partial::new(&[0xED, 0xCB, 0xAA][..])),
+            be_i24.parse_peek(Partial::new(&[0xED, 0xCB, 0xAA][..])),
             Ok((Partial::new(&b""[..]), -1_193_046_i32))
         );
         assert_parse!(
-            be_i24(Partial::new(&[][..])),
+            be_i24.parse_peek(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_i24(Partial::new(&[0x00][..])),
+            be_i24.parse_peek(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i24(Partial::new(&[0x00, 0x00][..])),
+            be_i24.parse_peek(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -511,35 +565,35 @@ mod partial {
     #[test]
     fn i32_tests() {
         assert_parse!(
-            be_i32(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            be_i32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_i32(Partial::new(&[0x7f, 0xff, 0xff, 0xff][..])),
+            be_i32.parse_peek(Partial::new(&[0x7f, 0xff, 0xff, 0xff][..])),
             Ok((Partial::new(&b""[..]), 2_147_483_647_i32))
         );
         assert_parse!(
-            be_i32(Partial::new(&[0xff, 0xff, 0xff, 0xff][..])),
+            be_i32.parse_peek(Partial::new(&[0xff, 0xff, 0xff, 0xff][..])),
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            be_i32(Partial::new(&[0x80, 0x00, 0x00, 0x00][..])),
+            be_i32.parse_peek(Partial::new(&[0x80, 0x00, 0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), -2_147_483_648_i32))
         );
         assert_parse!(
-            be_i32(Partial::new(&[][..])),
+            be_i32.parse_peek(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(4)))
         );
         assert_parse!(
-            be_i32(Partial::new(&[0x00][..])),
+            be_i32.parse_peek(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_i32(Partial::new(&[0x00, 0x00][..])),
+            be_i32.parse_peek(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i32(Partial::new(&[0x00, 0x00, 0x00][..])),
+            be_i32.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -547,59 +601,59 @@ mod partial {
     #[test]
     fn i64_tests() {
         assert_parse!(
-            be_i64(Partial::new(
+            be_i64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_i64(Partial::new(
+            be_i64.parse_peek(Partial::new(
                 &[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
             )),
             Ok((Partial::new(&b""[..]), 9_223_372_036_854_775_807_i64))
         );
         assert_parse!(
-            be_i64(Partial::new(
+            be_i64.parse_peek(Partial::new(
                 &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
             )),
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            be_i64(Partial::new(
+            be_i64.parse_peek(Partial::new(
                 &[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Ok((Partial::new(&b""[..]), -9_223_372_036_854_775_808_i64))
         );
         assert_parse!(
-            be_i64(Partial::new(&[][..])),
+            be_i64.parse_peek(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(8)))
         );
         assert_parse!(
-            be_i64(Partial::new(&[0x00][..])),
+            be_i64.parse_peek(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(7)))
         );
         assert_parse!(
-            be_i64(Partial::new(&[0x00, 0x00][..])),
+            be_i64.parse_peek(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(6)))
         );
         assert_parse!(
-            be_i64(Partial::new(&[0x00, 0x00, 0x00][..])),
+            be_i64.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(5)))
         );
         assert_parse!(
-            be_i64(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            be_i64.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(4)))
         );
         assert_parse!(
-            be_i64(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i64.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_i64(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i64.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i64(Partial::new(
+            be_i64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(1)))
@@ -609,7 +663,7 @@ mod partial {
     #[test]
     fn i128_tests() {
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
@@ -618,7 +672,7 @@ mod partial {
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[
                     0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff
@@ -630,7 +684,7 @@ mod partial {
             ))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff
@@ -639,7 +693,7 @@ mod partial {
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[
                     0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
@@ -651,77 +705,77 @@ mod partial {
             ))
         );
         assert_parse!(
-            be_i128(Partial::new(&[][..])),
+            be_i128.parse_peek(Partial::new(&[][..])),
             Err(ErrMode::Incomplete(Needed::new(16)))
         );
         assert_parse!(
-            be_i128(Partial::new(&[0x00][..])),
+            be_i128.parse_peek(Partial::new(&[0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(15)))
         );
         assert_parse!(
-            be_i128(Partial::new(&[0x00, 0x00][..])),
+            be_i128.parse_peek(Partial::new(&[0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(14)))
         );
         assert_parse!(
-            be_i128(Partial::new(&[0x00, 0x00, 0x00][..])),
+            be_i128.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(13)))
         );
         assert_parse!(
-            be_i128(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            be_i128.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(12)))
         );
         assert_parse!(
-            be_i128(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i128.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(11)))
         );
         assert_parse!(
-            be_i128(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
+            be_i128.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
             Err(ErrMode::Incomplete(Needed::new(10)))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(9)))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(8)))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(7)))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(6)))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(5)))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(4)))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Err(ErrMode::Incomplete(Needed::new(3)))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00
@@ -730,7 +784,7 @@ mod partial {
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
         assert_parse!(
-            be_i128(Partial::new(
+            be_i128.parse_peek(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00
@@ -743,19 +797,19 @@ mod partial {
     #[test]
     fn le_i8_tests() {
         assert_parse!(
-            le_i8(Partial::new(&[0x00][..])),
+            le_i8.parse_peek(Partial::new(&[0x00][..])),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_i8(Partial::new(&[0x7f][..])),
+            le_i8.parse_peek(Partial::new(&[0x7f][..])),
             Ok((Partial::new(&b""[..]), 127))
         );
         assert_parse!(
-            le_i8(Partial::new(&[0xff][..])),
+            le_i8.parse_peek(Partial::new(&[0xff][..])),
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            le_i8(Partial::new(&[0x80][..])),
+            le_i8.parse_peek(Partial::new(&[0x80][..])),
             Ok((Partial::new(&b""[..]), -128))
         );
     }
@@ -763,19 +817,19 @@ mod partial {
     #[test]
     fn le_i16_tests() {
         assert_parse!(
-            le_i16(Partial::new(&[0x00, 0x00][..])),
+            le_i16.parse_peek(Partial::new(&[0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_i16(Partial::new(&[0xff, 0x7f][..])),
+            le_i16.parse_peek(Partial::new(&[0xff, 0x7f][..])),
             Ok((Partial::new(&b""[..]), 32_767_i16))
         );
         assert_parse!(
-            le_i16(Partial::new(&[0xff, 0xff][..])),
+            le_i16.parse_peek(Partial::new(&[0xff, 0xff][..])),
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            le_i16(Partial::new(&[0x00, 0x80][..])),
+            le_i16.parse_peek(Partial::new(&[0x00, 0x80][..])),
             Ok((Partial::new(&b""[..]), -32_768_i16))
         );
     }
@@ -783,15 +837,15 @@ mod partial {
     #[test]
     fn le_u24_tests() {
         assert_parse!(
-            le_u24(Partial::new(&[0x00, 0x00, 0x00][..])),
+            le_u24.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_u24(Partial::new(&[0xFF, 0xFF, 0x00][..])),
+            le_u24.parse_peek(Partial::new(&[0xFF, 0xFF, 0x00][..])),
             Ok((Partial::new(&b""[..]), 65_535_u32))
         );
         assert_parse!(
-            le_u24(Partial::new(&[0x56, 0x34, 0x12][..])),
+            le_u24.parse_peek(Partial::new(&[0x56, 0x34, 0x12][..])),
             Ok((Partial::new(&b""[..]), 1_193_046_u32))
         );
     }
@@ -799,15 +853,15 @@ mod partial {
     #[test]
     fn le_i24_tests() {
         assert_parse!(
-            le_i24(Partial::new(&[0xFF, 0xFF, 0xFF][..])),
+            le_i24.parse_peek(Partial::new(&[0xFF, 0xFF, 0xFF][..])),
             Ok((Partial::new(&b""[..]), -1_i32))
         );
         assert_parse!(
-            le_i24(Partial::new(&[0x00, 0x00, 0xFF][..])),
+            le_i24.parse_peek(Partial::new(&[0x00, 0x00, 0xFF][..])),
             Ok((Partial::new(&b""[..]), -65_536_i32))
         );
         assert_parse!(
-            le_i24(Partial::new(&[0xAA, 0xCB, 0xED][..])),
+            le_i24.parse_peek(Partial::new(&[0xAA, 0xCB, 0xED][..])),
             Ok((Partial::new(&b""[..]), -1_193_046_i32))
         );
     }
@@ -815,19 +869,19 @@ mod partial {
     #[test]
     fn le_i32_tests() {
         assert_parse!(
-            le_i32(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            le_i32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_i32(Partial::new(&[0xff, 0xff, 0xff, 0x7f][..])),
+            le_i32.parse_peek(Partial::new(&[0xff, 0xff, 0xff, 0x7f][..])),
             Ok((Partial::new(&b""[..]), 2_147_483_647_i32))
         );
         assert_parse!(
-            le_i32(Partial::new(&[0xff, 0xff, 0xff, 0xff][..])),
+            le_i32.parse_peek(Partial::new(&[0xff, 0xff, 0xff, 0xff][..])),
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            le_i32(Partial::new(&[0x00, 0x00, 0x00, 0x80][..])),
+            le_i32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x80][..])),
             Ok((Partial::new(&b""[..]), -2_147_483_648_i32))
         );
     }
@@ -835,25 +889,25 @@ mod partial {
     #[test]
     fn le_i64_tests() {
         assert_parse!(
-            le_i64(Partial::new(
+            le_i64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_i64(Partial::new(
+            le_i64.parse_peek(Partial::new(
                 &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f][..]
             )),
             Ok((Partial::new(&b""[..]), 9_223_372_036_854_775_807_i64))
         );
         assert_parse!(
-            le_i64(Partial::new(
+            le_i64.parse_peek(Partial::new(
                 &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
             )),
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            le_i64(Partial::new(
+            le_i64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80][..]
             )),
             Ok((Partial::new(&b""[..]), -9_223_372_036_854_775_808_i64))
@@ -863,7 +917,7 @@ mod partial {
     #[test]
     fn le_i128_tests() {
         assert_parse!(
-            le_i128(Partial::new(
+            le_i128.parse_peek(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
@@ -872,7 +926,7 @@ mod partial {
             Ok((Partial::new(&b""[..]), 0))
         );
         assert_parse!(
-            le_i128(Partial::new(
+            le_i128.parse_peek(Partial::new(
                 &[
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0x7f
@@ -884,7 +938,7 @@ mod partial {
             ))
         );
         assert_parse!(
-            le_i128(Partial::new(
+            le_i128.parse_peek(Partial::new(
                 &[
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff
@@ -893,7 +947,7 @@ mod partial {
             Ok((Partial::new(&b""[..]), -1))
         );
         assert_parse!(
-            le_i128(Partial::new(
+            le_i128.parse_peek(Partial::new(
                 &[
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x80
@@ -909,11 +963,11 @@ mod partial {
     #[test]
     fn be_f32_tests() {
         assert_parse!(
-            be_f32(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            be_f32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), 0_f32))
         );
         assert_parse!(
-            be_f32(Partial::new(&[0x4d, 0x31, 0x1f, 0xd8][..])),
+            be_f32.parse_peek(Partial::new(&[0x4d, 0x31, 0x1f, 0xd8][..])),
             Ok((Partial::new(&b""[..]), 185_728_380_f32))
         );
     }
@@ -921,13 +975,13 @@ mod partial {
     #[test]
     fn be_f64_tests() {
         assert_parse!(
-            be_f64(Partial::new(
+            be_f64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Ok((Partial::new(&b""[..]), 0_f64))
         );
         assert_parse!(
-            be_f64(Partial::new(
+            be_f64.parse_peek(Partial::new(
                 &[0x41, 0xa6, 0x23, 0xfb, 0x10, 0x00, 0x00, 0x00][..]
             )),
             Ok((Partial::new(&b""[..]), 185_728_392_f64))
@@ -937,11 +991,11 @@ mod partial {
     #[test]
     fn le_f32_tests() {
         assert_parse!(
-            le_f32(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
+            le_f32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
             Ok((Partial::new(&b""[..]), 0_f32))
         );
         assert_parse!(
-            le_f32(Partial::new(&[0xd8, 0x1f, 0x31, 0x4d][..])),
+            le_f32.parse_peek(Partial::new(&[0xd8, 0x1f, 0x31, 0x4d][..])),
             Ok((Partial::new(&b""[..]), 185_728_380_f32))
         );
     }
@@ -949,13 +1003,13 @@ mod partial {
     #[test]
     fn le_f64_tests() {
         assert_parse!(
-            le_f64(Partial::new(
+            le_f64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
             Ok((Partial::new(&b""[..]), 0_f64))
         );
         assert_parse!(
-            le_f64(Partial::new(
+            le_f64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x10, 0xfb, 0x23, 0xa6, 0x41][..]
             )),
             Ok((Partial::new(&b""[..]), 185_728_392_f64))

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -8,11 +8,12 @@ use crate::*;
 /// # Example
 ///
 /// ```rust
+/// # use winnow::prelude::*;
 /// # use winnow::error::ErrorKind;
 /// # use winnow::error::Error;
 /// use winnow::combinator::rest;
-/// assert_eq!(rest::<_,Error<_>>("abc"), Ok(("", "abc")));
-/// assert_eq!(rest::<_,Error<_>>(""), Ok(("", "")));
+/// assert_eq!(rest::<_,Error<_>>.parse_peek("abc"), Ok(("", "abc")));
+/// assert_eq!(rest::<_,Error<_>>.parse_peek(""), Ok(("", "")));
 /// ```
 #[inline]
 pub fn rest<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
@@ -29,11 +30,12 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::prelude::*;
 /// # use winnow::error::ErrorKind;
 /// # use winnow::error::Error;
 /// use winnow::combinator::rest_len;
-/// assert_eq!(rest_len::<_,Error<_>>("abc"), Ok(("abc", 3)));
-/// assert_eq!(rest_len::<_,Error<_>>(""), Ok(("", 0)));
+/// assert_eq!(rest_len::<_,Error<_>>.parse_peek("abc"), Ok(("abc", 3)));
+/// assert_eq!(rest_len::<_,Error<_>>.parse_peek(""), Ok(("", 0)));
 /// ```
 #[inline]
 pub fn rest_len<I, E: ParseError<I>>(input: I) -> IResult<I, usize, E>
@@ -473,10 +475,11 @@ pub fn success<I: Stream, O: Clone, E: ParseError<I>>(val: O) -> impl Parser<I, 
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult};
+/// # use winnow::prelude::*;
 /// use winnow::combinator::fail;
 ///
 /// let s = "string";
-/// assert_eq!(fail::<_, &str, _>(s), Err(ErrMode::Backtrack(Error::new(s, ErrorKind::Fail))));
+/// assert_eq!(fail::<_, &str, _>.parse_peek(s), Err(ErrMode::Backtrack(Error::new(s, ErrorKind::Fail))));
 /// ```
 #[doc(alias = "unexpected")]
 pub fn fail<I: Stream, O, E: ParseError<I>>(i: I) -> IResult<I, O, E> {

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -30,7 +30,7 @@ fn eof_on_slices() {
     let not_over: &[u8] = &b"Hello, world!"[..];
     let is_over: &[u8] = &b""[..];
 
-    let res_not_over = eof(not_over);
+    let res_not_over = eof.parse_peek(not_over);
     assert_parse!(
         res_not_over,
         Err(ErrMode::Backtrack(error_position!(
@@ -39,7 +39,7 @@ fn eof_on_slices() {
         )))
     );
 
-    let res_over = eof(is_over);
+    let res_over = eof.parse_peek(is_over);
     assert_parse!(res_over, Ok((is_over, is_over)));
 }
 
@@ -48,7 +48,7 @@ fn eof_on_strs() {
     let not_over: &str = "Hello, world!";
     let is_over: &str = "";
 
-    let res_not_over = eof(not_over);
+    let res_not_over = eof.parse_peek(not_over);
     assert_parse!(
         res_not_over,
         Err(ErrMode::Backtrack(error_position!(
@@ -57,7 +57,7 @@ fn eof_on_strs() {
         )))
     );
 
-    let res_over = eof(is_over);
+    let res_over = eof.parse_peek(is_over);
     assert_parse!(res_over, Ok((is_over, is_over)));
 }
 
@@ -65,20 +65,20 @@ fn eof_on_strs() {
 fn rest_on_slices() {
     let input: &[u8] = &b"Hello, world!"[..];
     let empty: &[u8] = &b""[..];
-    assert_parse!(rest(input), Ok((empty, input)));
+    assert_parse!(rest.parse_peek(input), Ok((empty, input)));
 }
 
 #[test]
 fn rest_on_strs() {
     let input: &str = "Hello, world!";
     let empty: &str = "";
-    assert_parse!(rest(input), Ok((empty, input)));
+    assert_parse!(rest.parse_peek(input), Ok((empty, input)));
 }
 
 #[test]
 fn rest_len_on_slices() {
     let input: &[u8] = &b"Hello, world!"[..];
-    assert_parse!(rest_len(input), Ok((input, input.len())));
+    assert_parse!(rest_len.parse_peek(input), Ok((input, input.len())));
 }
 
 use crate::lib::std::convert::From;
@@ -102,7 +102,7 @@ struct CustomError;
 #[allow(dead_code)]
 fn custom_error(input: &[u8]) -> IResult<&[u8], &[u8], CustomError> {
     //fix_error!(input, CustomError<_>, alphanumeric)
-    crate::ascii::alphanumeric1(input)
+    crate::ascii::alphanumeric1.parse_peek(input)
 }
 
 #[test]
@@ -307,14 +307,14 @@ fn fail_test() {
     let b = "another string";
 
     assert_eq!(
-        fail::<_, &str, _>(a),
+        fail::<_, &str, _>.parse_peek(a),
         Err(ErrMode::Backtrack(Error {
             input: a,
             kind: ErrorKind::Fail
         }))
     );
     assert_eq!(
-        fail::<_, &str, _>(b),
+        fail::<_, &str, _>.parse_peek(b),
         Err(ErrMode::Backtrack(Error {
             input: b,
             kind: ErrorKind::Fail

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -69,7 +69,7 @@ proptest! {
 fn partial_any_str() {
     use super::any;
     assert_eq!(
-        any::<_, Error<Partial<&str>>>(Partial::new("Ә")),
+        any::<_, Error<Partial<&str>>>.parse_peek(Partial::new("Ә")),
         Ok((Partial::new(""), 'Ә'))
     );
 }

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -97,10 +97,10 @@ fn take_till0_issue() {
 fn issue_655() {
     use winnow::ascii::{line_ending, not_line_ending};
     fn twolines(i: Partial<&str>) -> IResult<Partial<&str>, (&str, &str)> {
-        let (i, l1) = not_line_ending(i)?;
-        let (i, _) = line_ending(i)?;
-        let (i, l2) = not_line_ending(i)?;
-        let (i, _) = line_ending(i)?;
+        let (i, l1) = not_line_ending.parse_peek(i)?;
+        let (i, _) = line_ending.parse_peek(i)?;
+        let (i, l2) = not_line_ending.parse_peek(i)?;
+        let (i, _) = line_ending.parse_peek(i)?;
 
         Ok((i, (l1, l2)))
     }
@@ -153,7 +153,7 @@ mod issue_647 {
     }
 
     fn data(input: Stream<'_>) -> IResult<Stream<'_>, Data> {
-        let (i, c) = be_f64(input)?;
+        let (i, c) = be_f64.parse_peek(input)?;
         let (i, _) = "\n".parse_peek(i)?;
         let (i, v) = list(i, &c)?;
         Ok((i, Data { c, v }))

--- a/tests/testsuite/multiline.rs
+++ b/tests/testsuite/multiline.rs
@@ -11,7 +11,7 @@ pub fn end_of_line(input: &str) -> IResult<&str, &str> {
     if input.is_empty() {
         Ok((input, input))
     } else {
-        eol(input)
+        eol.parse_peek(input)
     }
 }
 

--- a/tests/testsuite/reborrow_fold.rs
+++ b/tests/testsuite/reborrow_fold.rs
@@ -5,17 +5,15 @@ use std::str;
 
 use winnow::combinator::delimited;
 use winnow::combinator::fold_repeat;
+use winnow::error::Error;
 use winnow::prelude::*;
 use winnow::token::take_till1;
 use winnow::IResult;
 
-fn atom(_tomb: &mut ()) -> impl for<'a> FnMut(&'a [u8]) -> IResult<&'a [u8], String> {
-    move |input| {
-        take_till1([' ', '\t', '\r', '\n'])
-            .try_map(str::from_utf8)
-            .map(ToString::to_string)
-            .parse_peek(input)
-    }
+fn atom<'a>(_tomb: &mut ()) -> impl Parser<&'a [u8], String, Error<&'a [u8]>> {
+    take_till1([' ', '\t', '\r', '\n'])
+        .try_map(str::from_utf8)
+        .map(ToString::to_string)
 }
 
 // FIXME: should we support the use case of borrowing data mutably in a parser?


### PR DESCRIPTION
This is a step towards #72

v0.4.7
```
json/basic/canada       time:   [10.272 ms 10.308 ms 10.347 ms]
json/verbose/canada     time:   [32.539 ms 32.714 ms 32.893 ms]
json/dispatch/canada    time:   [8.9747 ms 8.9926 ms 9.0118 ms]
json/streaming/canada   time:   [10.612 ms 10.667 ms 10.726 ms]
```

#276
```
json/basic/canada       time:   [10.226 ms 10.241 ms 10.256 ms]
json/unit/canada        time:   [8.6800 ms 8.7021 ms 8.7269 ms]
json/verbose/canada     time:   [30.948 ms 30.991 ms 31.037 ms]
json/dispatch/canada    time:   [8.5036 ms 8.5273 ms 8.5542 ms]
json/streaming/canada   time:   [10.727 ms 10.753 ms 10.781 ms]
```

#277
```
json/basic/canada       time:   [9.6649 ms 9.6840 ms 9.7037 ms]
json/unit/canada        time:   [9.0364 ms 9.0944 ms 9.1513 ms]
json/verbose/canada     time:   [31.032 ms 31.072 ms 31.114 ms]
json/dispatch/canada    time:   [8.5341 ms 8.5538 ms 8.5749 ms]
json/streaming/canada   time:   [10.679 ms 10.707 ms 10.739 ms]
```