### PR TITLE
fix(parser)!: Make `FnMut`s take `&mut I`

### DIFF
--- a/benches/contains_token.rs
+++ b/benches/contains_token.rs
@@ -18,32 +18,26 @@ fn contains_token(c: &mut criterion::Criterion) {
         group.throughput(criterion::Throughput::Bytes(len as u64));
 
         group.bench_with_input(criterion::BenchmarkId::new("slice", name), &len, |b, _| {
-            b.iter(|| black_box(parser_slice.parse_peek(black_box(sample)).unwrap()));
+            b.iter(|| black_box(parser_slice(black_box(sample)).unwrap()));
         });
         group.bench_with_input(criterion::BenchmarkId::new("array", name), &len, |b, _| {
-            b.iter(|| black_box(parser_array.parse_peek(black_box(sample)).unwrap()));
+            b.iter(|| black_box(parser_array(black_box(sample)).unwrap()));
         });
         group.bench_with_input(criterion::BenchmarkId::new("tuple", name), &len, |b, _| {
-            b.iter(|| black_box(parser_tuple.parse_peek(black_box(sample)).unwrap()));
+            b.iter(|| black_box(parser_tuple(black_box(sample)).unwrap()));
         });
         group.bench_with_input(
             criterion::BenchmarkId::new("closure-or", name),
             &len,
             |b, _| {
-                b.iter(|| black_box(parser_closure_or.parse_peek(black_box(sample)).unwrap()));
+                b.iter(|| black_box(parser_closure_or(black_box(sample)).unwrap()));
             },
         );
         group.bench_with_input(
             criterion::BenchmarkId::new("closure-matches", name),
             &len,
             |b, _| {
-                b.iter(|| {
-                    black_box(
-                        parser_closure_matches
-                            .parse_peek(black_box(sample))
-                            .unwrap(),
-                    )
-                });
+                b.iter(|| black_box(parser_closure_matches(black_box(sample)).unwrap()));
             },
         );
     }

--- a/examples/arithmetic/main.rs
+++ b/examples/arithmetic/main.rs
@@ -1,4 +1,5 @@
 use winnow::prelude::*;
+use winnow::unpeek;
 
 mod parser;
 mod parser_ast;
@@ -10,7 +11,7 @@ fn main() -> Result<(), lexopt::Error> {
 
     println!("{} =", input);
     match args.implementation {
-        Impl::Eval => match parser::expr.parse(input) {
+        Impl::Eval => match unpeek(parser::expr).parse(input) {
             Ok(result) => {
                 println!("  {}", result);
             }
@@ -18,7 +19,7 @@ fn main() -> Result<(), lexopt::Error> {
                 println!("  {}", err);
             }
         },
-        Impl::Ast => match parser_ast::expr.parse(input) {
+        Impl::Ast => match unpeek(parser_ast::expr).parse(input) {
             Ok(result) => {
                 println!("  {:#?}", result);
             }

--- a/examples/arithmetic/parser.rs
+++ b/examples/arithmetic/parser.rs
@@ -7,7 +7,7 @@ use winnow::{
     combinator::delimited,
     combinator::fold_repeat,
     token::one_of,
-    IResult,
+    unpeek, IResult,
 };
 
 // Parser definition
@@ -17,7 +17,7 @@ pub fn expr(i: &str) -> IResult<&str, i64> {
 
     fold_repeat(
         0..,
-        (one_of(['+', '-']), term),
+        (one_of(['+', '-']), unpeek(term)),
         move || init,
         |acc, (op, val): (char, i64)| {
             if op == '+' {
@@ -38,7 +38,7 @@ fn term(i: &str) -> IResult<&str, i64> {
 
     fold_repeat(
         0..,
-        (one_of(['*', '/']), factor),
+        (one_of(['*', '/']), unpeek(factor)),
         move || init,
         |acc, (op, val): (char, i64)| {
             if op == '*' {
@@ -60,8 +60,8 @@ fn factor(i: &str) -> IResult<&str, i64> {
         spaces,
         alt((
             digits.try_map(FromStr::from_str),
-            delimited('(', expr, ')'),
-            parens,
+            delimited('(', unpeek(expr), ')'),
+            unpeek(parens),
         )),
         spaces,
     )
@@ -70,7 +70,7 @@ fn factor(i: &str) -> IResult<&str, i64> {
 
 // We parse any expr surrounded by parens, ignoring all whitespaces around those
 fn parens(i: &str) -> IResult<&str, i64> {
-    delimited('(', expr, ')').parse_peek(i)
+    delimited('(', unpeek(expr), ')').parse_peek(i)
 }
 
 #[test]

--- a/examples/css/main.rs
+++ b/examples/css/main.rs
@@ -1,4 +1,5 @@
 use winnow::prelude::*;
+use winnow::unpeek;
 
 mod parser;
 
@@ -10,7 +11,7 @@ fn main() -> Result<(), lexopt::Error> {
     let input = args.input.as_deref().unwrap_or("#AAAAAA");
 
     println!("{} =", input);
-    match hex_color.parse(input) {
+    match unpeek(hex_color).parse(input) {
         Ok(result) => {
             println!("  {:?}", result);
         }

--- a/examples/css/parser.rs
+++ b/examples/css/parser.rs
@@ -1,5 +1,6 @@
 use winnow::prelude::*;
 use winnow::token::take_while;
+use winnow::unpeek;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Color {
@@ -13,13 +14,20 @@ impl std::str::FromStr for Color {
     type Err = winnow::error::Error<String>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        hex_color.parse(s).map_err(winnow::error::Error::into_owned)
+        unpeek(hex_color)
+            .parse(s)
+            .map_err(winnow::error::Error::into_owned)
     }
 }
 
 pub fn hex_color(input: &str) -> IResult<&str, Color> {
     let (input, _) = "#".parse_peek(input)?;
-    let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse_peek(input)?;
+    let (input, (red, green, blue)) = (
+        unpeek(hex_primary),
+        unpeek(hex_primary),
+        unpeek(hex_primary),
+    )
+        .parse_peek(input)?;
 
     Ok((input, Color { red, green, blue }))
 }

--- a/examples/http/parser.rs
+++ b/examples/http/parser.rs
@@ -1,3 +1,4 @@
+use winnow::unpeek;
 use winnow::{ascii::line_ending, combinator::repeat, token::take_while, IResult, Parser};
 
 pub type Stream<'i> = &'i [u8];
@@ -44,7 +45,7 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
 
 fn request(input: Stream<'_>) -> IResult<Stream<'_>, (Request<'_>, Vec<Header<'_>>)> {
     let (input, req) = request_line(input)?;
-    let (input, h) = repeat(1.., message_header).parse_peek(input)?;
+    let (input, h) = repeat(1.., unpeek(message_header)).parse_peek(input)?;
     let (input, _) = line_ending.parse_peek(input)?;
 
     Ok((input, (req, h)))
@@ -86,7 +87,7 @@ fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 fn message_header(input: Stream<'_>) -> IResult<Stream<'_>, Header<'_>> {
     let (input, name) = take_while(1.., is_token).parse_peek(input)?;
     let (input, _) = ':'.parse_peek(input)?;
-    let (input, value) = repeat(1.., message_header_value).parse_peek(input)?;
+    let (input, value) = repeat(1.., unpeek(message_header_value)).parse_peek(input)?;
 
     Ok((input, Header { name, value }))
 }

--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -1,5 +1,6 @@
 use winnow::{
-    ascii::line_ending, combinator::repeat, stream::Partial, token::take_while, IResult, Parser,
+    ascii::line_ending, combinator::repeat, stream::Partial, token::take_while, unpeek, IResult,
+    Parser,
 };
 
 pub type Stream<'i> = Partial<&'i [u8]>;
@@ -46,7 +47,7 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
 
 fn request(input: Stream<'_>) -> IResult<Stream<'_>, (Request<'_>, Vec<Header<'_>>)> {
     let (input, req) = request_line(input)?;
-    let (input, h) = repeat(1.., message_header).parse_peek(input)?;
+    let (input, h) = repeat(1.., unpeek(message_header)).parse_peek(input)?;
     let (input, _) = line_ending.parse_peek(input)?;
 
     Ok((input, (req, h)))
@@ -88,7 +89,7 @@ fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
 fn message_header(input: Stream<'_>) -> IResult<Stream<'_>, Header<'_>> {
     let (input, name) = take_while(1.., is_token).parse_peek(input)?;
     let (input, _) = ':'.parse_peek(input)?;
-    let (input, value) = repeat(1.., message_header_value).parse_peek(input)?;
+    let (input, value) = repeat(1.., unpeek(message_header_value)).parse_peek(input)?;
 
     Ok((input, Header { name, value }))
 }

--- a/examples/ini/bench.rs
+++ b/examples/ini/bench.rs
@@ -1,5 +1,6 @@
 use winnow::combinator::repeat;
 use winnow::prelude::*;
+use winnow::unpeek;
 
 mod parser;
 mod parser_str;
@@ -32,7 +33,7 @@ file=payroll.dat
 \0";
 
     fn acc(i: parser::Stream<'_>) -> IResult<parser::Stream<'_>, Vec<(&str, &str)>> {
-        repeat(0.., parser::key_value).parse_peek(i)
+        repeat(0.., unpeek(parser::key_value)).parse_peek(i)
     }
 
     let mut group = c.benchmark_group("ini keys and values");

--- a/examples/ini/main.rs
+++ b/examples/ini/main.rs
@@ -1,4 +1,5 @@
 use winnow::prelude::*;
+use winnow::unpeek;
 
 mod parser;
 mod parser_str;
@@ -9,7 +10,7 @@ fn main() -> Result<(), lexopt::Error> {
     let input = args.input.as_deref().unwrap_or("1 + 1");
 
     if args.binary {
-        match parser::categories.parse(input.as_bytes()) {
+        match unpeek(parser::categories).parse(input.as_bytes()) {
             Ok(result) => {
                 println!("  {:?}", result);
             }
@@ -18,7 +19,7 @@ fn main() -> Result<(), lexopt::Error> {
             }
         }
     } else {
-        match parser_str::categories.parse(input) {
+        match unpeek(parser_str::categories).parse(input) {
             Ok(result) => {
                 println!("  {:?}", result);
             }

--- a/examples/ini/parser.rs
+++ b/examples/ini/parser.rs
@@ -8,6 +8,7 @@ use winnow::{
     combinator::repeat,
     combinator::{delimited, separated_pair, terminated},
     token::take_while,
+    unpeek,
 };
 
 pub type Stream<'i> = &'i [u8];
@@ -16,9 +17,9 @@ pub fn categories(i: Stream<'_>) -> IResult<Stream<'_>, HashMap<&str, HashMap<&s
     repeat(
         0..,
         separated_pair(
-            category,
+            unpeek(category),
             opt(multispace),
-            repeat(0.., terminated(key_value, opt(multispace))),
+            repeat(0.., terminated(unpeek(key_value), opt(multispace))),
         ),
     )
     .parse_peek(i)

--- a/examples/ini/parser_str.rs
+++ b/examples/ini/parser_str.rs
@@ -7,16 +7,17 @@ use winnow::{
     combinator::repeat,
     combinator::{delimited, terminated},
     token::{take_till0, take_while},
+    unpeek,
 };
 
 pub type Stream<'i> = &'i str;
 
 pub fn categories(input: Stream<'_>) -> IResult<Stream<'_>, HashMap<&str, HashMap<&str, &str>>> {
-    repeat(0.., category_and_keys).parse_peek(input)
+    repeat(0.., unpeek(category_and_keys)).parse_peek(input)
 }
 
 fn category_and_keys(i: Stream<'_>) -> IResult<Stream<'_>, (&str, HashMap<&str, &str>)> {
-    (category, keys_and_values).parse_peek(i)
+    (unpeek(category), unpeek(keys_and_values)).parse_peek(i)
 }
 
 fn category(i: Stream<'_>) -> IResult<Stream<'_>, &str> {
@@ -28,7 +29,7 @@ fn category(i: Stream<'_>) -> IResult<Stream<'_>, &str> {
 }
 
 fn keys_and_values(input: Stream<'_>) -> IResult<Stream<'_>, HashMap<&str, &str>> {
-    repeat(0.., key_value).parse_peek(input)
+    repeat(0.., unpeek(key_value)).parse_peek(input)
 }
 
 fn key_value(i: Stream<'_>) -> IResult<Stream<'_>, (&str, &str)> {
@@ -36,8 +37,8 @@ fn key_value(i: Stream<'_>) -> IResult<Stream<'_>, (&str, &str)> {
     let (i, _) = (opt(space), "=", opt(space)).parse_peek(i)?;
     let (i, val) = take_till0(is_line_ending_or_comment).parse_peek(i)?;
     let (i, _) = opt(space).parse_peek(i)?;
-    let (i, _) = opt((";", not_line_ending)).parse_peek(i)?;
-    let (i, _) = opt(space_or_line_ending).parse_peek(i)?;
+    let (i, _) = opt((";", unpeek(not_line_ending))).parse_peek(i)?;
+    let (i, _) = opt(unpeek(space_or_line_ending)).parse_peek(i)?;
 
     Ok((i, (key, val)))
 }

--- a/examples/json/main.rs
+++ b/examples/json/main.rs
@@ -8,6 +8,7 @@ use winnow::error::convert_error;
 use winnow::error::Error;
 use winnow::error::VerboseError;
 use winnow::prelude::*;
+use winnow::unpeek;
 
 fn main() -> Result<(), lexopt::Error> {
     let args = Args::parse()?;
@@ -27,7 +28,7 @@ fn main() -> Result<(), lexopt::Error> {
     });
 
     if args.verbose {
-        match parser::json::<VerboseError<&str>>.parse(data) {
+        match unpeek(parser::json::<VerboseError<&str>>).parse(data) {
             Ok(json) => {
                 println!("{:#?}", json);
             }
@@ -41,8 +42,8 @@ fn main() -> Result<(), lexopt::Error> {
         }
     } else {
         let result = match args.implementation {
-            Impl::Naive => parser::json::<Error<&str>>.parse(data),
-            Impl::Dispatch => parser_dispatch::json::<Error<&str>>.parse(data),
+            Impl::Naive => unpeek(parser::json::<Error<&str>>).parse(data),
+            Impl::Dispatch => unpeek(parser_dispatch::json::<Error<&str>>).parse(data),
         };
         match result {
             Ok(json) => {

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -13,6 +13,7 @@ use winnow::{
     combinator::{fold_repeat, separated0},
     error::{ContextError, ParseError},
     token::{any, none_of, take, take_while},
+    unpeek,
 };
 
 use crate::json::JsonValue;
@@ -34,7 +35,7 @@ pub type Stream<'i> = &'i str;
 pub fn json<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, JsonValue, E> {
-    delimited(ws, json_value, ws).parse_peek(input)
+    delimited(unpeek(ws), unpeek(json_value), unpeek(ws)).parse_peek(input)
 }
 
 /// `alt` is a combinator that tries multiple parsers one by one, until
@@ -45,15 +46,15 @@ fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static 
     // `dispatch` gives you `match`-like behavior compared to `alt` successively trying different
     // implementations.
     dispatch!(peek(any);
-        'n' => null.value(JsonValue::Null),
-        't' => true_.map(JsonValue::Boolean),
-        'f' => false_.map(JsonValue::Boolean),
-        '"' => string.map(JsonValue::Str),
+        'n' => unpeek(null).value(JsonValue::Null),
+        't' => unpeek(true_).map(JsonValue::Boolean),
+        'f' => unpeek(false_).map(JsonValue::Boolean),
+        '"' => unpeek(string).map(JsonValue::Str),
         '+' => float.map(JsonValue::Num),
         '-' => float.map(JsonValue::Num),
         '0'..='9' => float.map(JsonValue::Num),
-        '[' => array.map(JsonValue::Array),
-        '{' => object.map(JsonValue::Object),
+        '[' => unpeek(array).map(JsonValue::Array),
+        '{' => unpeek(object).map(JsonValue::Object),
         _ => fail,
     )
     .parse_peek(input)
@@ -96,7 +97,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_repeat(0.., character, String::new, |mut string, c| {
+            fold_repeat(0.., unpeek(character), String::new, |mut string, c| {
                 string.push(c);
                 string
             }),
@@ -123,7 +124,7 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
           'n' => success('\n'),
           'r' => success('\r'),
           't' => success('\t'),
-          'u' => unicode_escape,
+          'u' => unpeek(unicode_escape),
           _ => fail,
         )
         .parse_peek(input)
@@ -137,11 +138,11 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
 ) -> IResult<Stream<'i>, char, E> {
     alt((
         // Not a surrogate
-        u16_hex
+        unpeek(u16_hex)
             .verify(|cp| !(0xD800..0xE000).contains(cp))
             .map(|cp| cp as u32),
         // See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF for details
-        separated_pair(u16_hex, "\\u", u16_hex)
+        separated_pair(unpeek(u16_hex), "\\u", unpeek(u16_hex))
             .verify(|(high, low)| (0xD800..0xDC00).contains(high) && (0xDC00..0xE000).contains(low))
             .map(|(high, low)| {
                 let high_ten = (high as u32) - 0xD800;
@@ -170,8 +171,11 @@ fn array<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, Vec<JsonValue>, E> {
     preceded(
-        ('[', ws),
-        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
+        ('[', unpeek(ws)),
+        cut_err(terminated(
+            separated0(unpeek(json_value), (unpeek(ws), ',', unpeek(ws))),
+            (unpeek(ws), ']'),
+        )),
     )
     .context("array")
     .parse_peek(input)
@@ -181,8 +185,11 @@ fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, HashMap<String, JsonValue>, E> {
     preceded(
-        ('{', ws),
-        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
+        ('{', unpeek(ws)),
+        cut_err(terminated(
+            separated0(unpeek(key_value), (unpeek(ws), ',', unpeek(ws))),
+            (unpeek(ws), '}'),
+        )),
     )
     .context("object")
     .parse_peek(input)
@@ -191,7 +198,12 @@ fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, (String, JsonValue), E> {
-    separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_peek(input)
+    separated_pair(
+        unpeek(string),
+        cut_err((unpeek(ws), ':', unpeek(ws))),
+        unpeek(json_value),
+    )
+    .parse_peek(input)
 }
 
 /// Parser combinators are constructed from the bottom up:

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -11,6 +11,7 @@ use winnow::{
     error::{ContextError, ParseError},
     stream::Partial,
     token::{any, none_of, take, take_while},
+    unpeek,
 };
 
 use crate::json::JsonValue;
@@ -32,7 +33,7 @@ pub type Stream<'i> = Partial<&'i str>;
 pub fn json<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, JsonValue, E> {
-    delimited(ws, json_value, ws_or_eof).parse_peek(input)
+    delimited(unpeek(ws), unpeek(json_value), unpeek(ws_or_eof)).parse_peek(input)
 }
 
 /// `alt` is a combinator that tries multiple parsers one by one, until
@@ -43,12 +44,12 @@ fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static 
     // `alt` combines the each value parser. It returns the result of the first
     // successful parser, or an error
     alt((
-        null.value(JsonValue::Null),
-        boolean.map(JsonValue::Boolean),
-        string.map(JsonValue::Str),
+        unpeek(null).value(JsonValue::Null),
+        unpeek(boolean).map(JsonValue::Boolean),
+        unpeek(string).map(JsonValue::Str),
         float.map(JsonValue::Num),
-        array.map(JsonValue::Array),
-        object.map(JsonValue::Object),
+        unpeek(array).map(JsonValue::Array),
+        unpeek(object).map(JsonValue::Object),
     ))
     .parse_peek(input)
 }
@@ -88,7 +89,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_repeat(0.., character, String::new, |mut string, c| {
+            fold_repeat(0.., unpeek(character), String::new, |mut string, c| {
                 string.push(c);
                 string
             }),
@@ -118,7 +119,7 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
                     _ => return None,
                 })
             }),
-            preceded('u', unicode_escape),
+            preceded('u', unpeek(unicode_escape)),
         ))
         .parse_peek(input)
     } else {
@@ -131,11 +132,11 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
 ) -> IResult<Stream<'i>, char, E> {
     alt((
         // Not a surrogate
-        u16_hex
+        unpeek(u16_hex)
             .verify(|cp| !(0xD800..0xE000).contains(cp))
             .map(|cp| cp as u32),
         // See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF for details
-        separated_pair(u16_hex, "\\u", u16_hex)
+        separated_pair(unpeek(u16_hex), "\\u", unpeek(u16_hex))
             .verify(|(high, low)| (0xD800..0xDC00).contains(high) && (0xDC00..0xE000).contains(low))
             .map(|(high, low)| {
                 let high_ten = (high as u32) - 0xD800;
@@ -164,8 +165,11 @@ fn array<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, Vec<JsonValue>, E> {
     preceded(
-        ('[', ws),
-        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
+        ('[', unpeek(ws)),
+        cut_err(terminated(
+            separated0(unpeek(json_value), (unpeek(ws), ',', unpeek(ws))),
+            (unpeek(ws), ']'),
+        )),
     )
     .context("array")
     .parse_peek(input)
@@ -175,8 +179,11 @@ fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, HashMap<String, JsonValue>, E> {
     preceded(
-        ('{', ws),
-        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
+        ('{', unpeek(ws)),
+        cut_err(terminated(
+            separated0(unpeek(key_value), (unpeek(ws), ',', unpeek(ws))),
+            (unpeek(ws), '}'),
+        )),
     )
     .context("object")
     .parse_peek(input)
@@ -185,7 +192,12 @@ fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
 fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
     input: Stream<'i>,
 ) -> IResult<Stream<'i>, (String, JsonValue), E> {
-    separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_peek(input)
+    separated_pair(
+        unpeek(string),
+        cut_err((unpeek(ws), ':', unpeek(ws))),
+        unpeek(json_value),
+    )
+    .parse_peek(input)
 }
 
 /// Parser combinators are constructed from the bottom up:

--- a/examples/string/main.rs
+++ b/examples/string/main.rs
@@ -14,12 +14,13 @@
 mod parser;
 
 use winnow::prelude::*;
+use winnow::unpeek;
 
 fn main() -> Result<(), lexopt::Error> {
     let args = Args::parse()?;
 
     let data = args.input.as_deref().unwrap_or("\"abc\"");
-    let result = parser::parse_string::<()>.parse(data);
+    let result = unpeek(parser::parse_string::<()>).parse(data);
     match result {
         Ok(data) => println!("{}", data),
         Err(err) => println!("{:?}", err),

--- a/examples/string/parser.rs
+++ b/examples/string/parser.rs
@@ -16,6 +16,7 @@ use winnow::combinator::{delimited, preceded};
 use winnow::error::{FromExternalError, ParseError};
 use winnow::prelude::*;
 use winnow::token::{take_till1, take_while};
+use winnow::unpeek;
 
 /// Parse a string. Use a loop of `parse_fragment` and push all of the fragments
 /// into an output string.
@@ -28,7 +29,7 @@ where
     let build_string = fold_repeat(
         0..,
         // Our parser function – parses a single string fragment
-        parse_fragment,
+        unpeek(parse_fragment),
         // Our init value, an empty string
         String::new,
         // Our folding function. For each fragment, append the fragment to the
@@ -69,9 +70,9 @@ where
     alt((
         // The `map` combinator runs a parser, then applies a function to the output
         // of that parser.
-        parse_literal.map(StringFragment::Literal),
-        parse_escaped_char.map(StringFragment::EscapedChar),
-        parse_escaped_whitespace.value(StringFragment::EscapedWS),
+        unpeek(parse_literal).map(StringFragment::Literal),
+        unpeek(parse_escaped_char).map(StringFragment::EscapedChar),
+        unpeek(parse_escaped_whitespace).value(StringFragment::EscapedWS),
     ))
     .parse_peek(input)
 }
@@ -105,7 +106,7 @@ where
         // `alt` tries each parser in sequence, returning the result of
         // the first successful match
         alt((
-            parse_unicode,
+            unpeek(parse_unicode),
             // The `value` parser returns a fixed value (the first argument) if its
             // parser (the second argument) succeeds. In these cases, it looks for
             // the marker characters (n, r, t, etc) and returns the matching

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -278,7 +278,7 @@
 //!   token::one_of,
 //! };
 //!
-//! fn float(input: &str) -> IResult<&str, &str> {
+//! fn float<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //!   alt((
 //!     // Case one: .42
 //!     (
@@ -307,16 +307,16 @@
 //!       '.',
 //!       opt(decimal)
 //!     ).recognize()
-//!   )).parse_peek(input)
+//!   )).parse_next(input)
 //! }
 //!
-//! fn decimal(input: &str) -> IResult<&str, &str> {
+//! fn decimal<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //!   repeat(1..,
 //!     terminated(one_of('0'..='9'), repeat(0.., '_').map(|()| ()))
 //!   ).
 //!   map(|()| ())
 //!     .recognize()
-//!     .parse_peek(input)
+//!     .parse_next(input)
 //! }
 //! ```
 //!

--- a/src/_topic/performance.rs
+++ b/src/_topic/performance.rs
@@ -40,10 +40,10 @@
 //! #    I: winnow::stream::StreamIsPartial,
 //! #    E: winnow::error::ParseError<I>,
 //! {
-//!     move |input: I| {
+//!     move |input: &mut I| {
 //!         // ...some chained combinators...
 //! # winnow::token::any
-//!             .parse_peek(input)
+//!             .parse_next(input)
 //!     }
 //! }
 //! ```

--- a/src/_tutorial/chapter_1.rs
+++ b/src/_tutorial/chapter_1.rs
@@ -9,51 +9,47 @@
 //!  - `Ok` indicates the parser successfully found what it was looking for; or
 //!  - `Err` indicates the parser could not find what it was looking for.
 //!
-//! Parsers do more than just return a binary "success"/"failure" code. If
-//! the parser was successful, then it will return a tuple where the first field
-//! will contain everything the parser did not process. The second will contain
-//! everything the parser processed. The idea is that a parser can happily parse the first
-//! *part* of an input, without being able to parse the whole thing.
+//! Parsers do more than just return a binary "success"/"failure" code.
+//! On success, the parser will return the processed data.  The input will be left pointing to
+//! data that still needs processing
 //!
 //! If the parser failed, then there are multiple errors that could be returned.
 //! For simplicity, however, in the next chapters we will leave these unexplored.
 //!
 //! ```text
-//!                                    ┌─► Ok(
-//!                                    │      what the parser didn't touch,
-//!                                    │      what matched the parser
-//!                                    │   )
+//!                                    ┌─► Ok(what matched the parser)
 //!              ┌─────────┐           │
 //!  my input───►│my parser├──►either──┤
 //!              └─────────┘           └─► Err(...)
 //! ```
 //!
 //!
-//! To represent this model of the world, winnow uses the [`IResult<I, O>`] type.
-//! The `Ok` variant has a tuple of `(remainder: I, output: O)`;
+//! To represent this model of the world, winnow uses the [`PResult<O>`] type.
+//! The `Ok` variant has `output: O`;
 //! whereas the `Err` variant stores an error.
 //!
 //! You can import that from:
 //!
 //! ```rust
-//! use winnow::IResult;
+//! use winnow::PResult;
 //! ```
+//!
+//! To combine parsers, we need a common way to refer to them which is where the [`Parser<I, O, E>`]
+//! trait comes in with [`Parser::parse_next`] being the primary way to drive
+//! parsing forward.
 //!
 //! You'll note that `I` and `O` are parameterized -- while most of the examples in this book
 //! will be with `&str` (i.e. parsing a string); they do not have to be strings; nor do they
 //! have to be the same type (consider the simple example where `I = &str`, and `O = u64` -- this
 //! parses a string into an unsigned integer.)
 //!
-//! To combine parsers, we need a common way to refer to them which is where the [`Parser`]
-//! trait comes in with [`Parser::parse_peek`] being the primary way to drive
-//! parsing forward.
 //!
 //! # Let's write our first parser!
 //!
 //! The simplest parser we can write is one which successfully does nothing.
 //!
 //! To make it easier to implement a [`Parser`], the trait is implemented for
-//! functions of the form `Fn(I) -> IResult<I, O>`.
+//! functions of the form `Fn(&mut I) -> PResult<O>`.
 //!
 //! This parser function should take in a `&str`:
 //!
@@ -62,27 +58,27 @@
 //!  - Since it doesn't parse anything, it also should just return an empty string.
 //!
 //! ```rust
-//! use winnow::IResult;
+//! use winnow::PResult;
 //! use winnow::Parser;
 //!
-//! pub fn do_nothing_parser(input: &str) -> IResult<&str, &str> {
-//!     Ok((input, ""))
+//! pub fn do_nothing_parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//!     Ok("")
 //! }
 //!
 //! fn main() {
-//!     let input = "0x1a2b Hello";
+//!     let mut input = "0x1a2b Hello";
 //!
-//!     let (remainder, output) = do_nothing_parser.parse_peek(input).unwrap();
+//!     let output = do_nothing_parser.parse_next(&mut input).unwrap();
 //!     // Same as:
-//!     // let (remainder, output) = do_nothing_parser(input).unwrap();
+//!     // let output = do_nothing_parser(&mut input).unwrap();
 //!
-//!     assert_eq!(remainder, "0x1a2b Hello");
+//!     assert_eq!(input, "0x1a2b Hello");
 //!     assert_eq!(output, "");
 //! }
 //! ```
 
 #![allow(unused_imports)]
-use crate::IResult;
+use crate::PResult;
 use crate::Parser;
 
 pub use super::chapter_0 as previous;

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -9,21 +9,21 @@
 //!
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::IResult;
+//! # use winnow::PResult;
 //! #
-//! fn parse_prefix(input: &str) -> IResult<&str, char> {
-//!     '0'.parse_peek(input)
+//! fn parse_prefix(input: &mut &str) -> PResult<char> {
+//!     '0'.parse_next(input)
 //! }
 //!
 //! fn main()  {
-//!     let input = "0x1a2b Hello";
+//!     let mut input = "0x1a2b Hello";
 //!
-//!     let (remainder, output) = parse_prefix.parse_peek(input).unwrap();
+//!     let output = parse_prefix.parse_next(&mut input).unwrap();
 //!
-//!     assert_eq!(remainder, "x1a2b Hello");
+//!     assert_eq!(input, "x1a2b Hello");
 //!     assert_eq!(output, '0');
 //!
-//!     assert!(parse_prefix("d").is_err());
+//!     assert!(parse_prefix.parse_next(&mut "d").is_err());
 //! }
 //! ```
 //!
@@ -34,20 +34,20 @@
 //!
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::IResult;
+//! # use winnow::PResult;
 //! #
-//! fn parse_prefix(input: &str) -> IResult<&str, &str> {
-//!     "0x".parse_peek(input)
+//! fn parse_prefix<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//!     "0x".parse_next(input)
 //! }
 //!
 //! fn main()  {
-//!     let input = "0x1a2b Hello";
+//!     let mut input = "0x1a2b Hello";
 //!
-//!     let (remainder, output) = parse_prefix.parse_peek(input).unwrap();
-//!     assert_eq!(remainder, "1a2b Hello");
+//!     let output = parse_prefix.parse_next(&mut input).unwrap();
+//!     assert_eq!(input, "1a2b Hello");
 //!     assert_eq!(output, "0x");
 //!
-//!     assert!(parse_prefix("0o123").is_err());
+//!     assert!(parse_prefix.parse_next(&mut "0o123").is_err());
 //! }
 //! ```
 //!
@@ -60,21 +60,21 @@
 //!
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::IResult;
+//! # use winnow::PResult;
 //! use winnow::token::one_of;
 //!
-//! fn parse_digits(input: &str) -> IResult<&str, char> {
-//!     one_of(('0'..='9', 'a'..='f', 'A'..='F')).parse_peek(input)
+//! fn parse_digits(input: &mut &str) -> PResult<char> {
+//!     one_of(('0'..='9', 'a'..='f', 'A'..='F')).parse_next(input)
 //! }
 //!
 //! fn main() {
-//!     let input = "1a2b Hello";
+//!     let mut input = "1a2b Hello";
 //!
-//!     let (remainder, output) = parse_digits.parse_peek(input).unwrap();
-//!     assert_eq!(remainder, "a2b Hello");
+//!     let output = parse_digits.parse_next(&mut input).unwrap();
+//!     assert_eq!(input, "a2b Hello");
 //!     assert_eq!(output, '1');
 //!
-//!     assert!(parse_digits("Z").is_err());
+//!     assert!(parse_digits.parse_next(&mut "Z").is_err());
 //! }
 //! ```
 //!
@@ -104,42 +104,42 @@
 //! You can then capture sequences of these characters with parsers like [`take_while`].
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::IResult;
+//! # use winnow::PResult;
 //! use winnow::token::take_while;
 //!
-//! fn parse_digits(input: &str) -> IResult<&str, &str> {
-//!     take_while(1.., ('0'..='9', 'a'..='f', 'A'..='F')).parse_peek(input)
+//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//!     take_while(1.., ('0'..='9', 'a'..='f', 'A'..='F')).parse_next(input)
 //! }
 //!
 //! fn main() {
-//!     let input = "1a2b Hello";
+//!     let mut input = "1a2b Hello";
 //!
-//!     let (remainder, output) = parse_digits.parse_peek(input).unwrap();
-//!     assert_eq!(remainder, " Hello");
+//!     let output = parse_digits.parse_next(&mut input).unwrap();
+//!     assert_eq!(input, " Hello");
 //!     assert_eq!(output, "1a2b");
 //!
-//!     assert!(parse_digits("Z").is_err());
+//!     assert!(parse_digits.parse_next(&mut "Z").is_err());
 //! }
 //! ```
 //!
 //! We could simplify this further with by using one of the built-in character classes, [`hex_digit1`]:
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::IResult;
+//! # use winnow::PResult;
 //! use winnow::ascii::hex_digit1;
 //!
-//! fn parse_digits(input: &str) -> IResult<&str, &str> {
-//!     hex_digit1.parse_peek(input)
+//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//!     hex_digit1.parse_next(input)
 //! }
 //!
 //! fn main() {
-//!     let input = "1a2b Hello";
+//!     let mut input = "1a2b Hello";
 //!
-//!     let (remainder, output) = parse_digits.parse_peek(input).unwrap();
-//!     assert_eq!(remainder, " Hello");
+//!     let output = parse_digits.parse_next(&mut input).unwrap();
+//!     assert_eq!(input, " Hello");
 //!     assert_eq!(output, "1a2b");
 //!
-//!     assert!(parse_digits("Z").is_err());
+//!     assert!(parse_digits.parse_next(&mut "Z").is_err());
 //! }
 //! ```
 

--- a/src/_tutorial/chapter_5.rs
+++ b/src/_tutorial/chapter_5.rs
@@ -1,12 +1,11 @@
 //! # Chapter 5: Repetition
 //!
 //! In [`chapter_3`], we covered how to sequence different parsers into a tuple but sometimes you need to run a
-//! single parser multiple times, collecting the result into a [`Vec`].
+//! single parser multiple times, collecting the result into a container, like [`Vec`].
 //!
 //! Let's take our `parse_digits` and collect a list of them with [`repeat`]:
 //! ```rust
-//! # use winnow::IResult;
-//! # use winnow::Parser;
+//! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
@@ -15,120 +14,119 @@
 //! use winnow::combinator::repeat;
 //! use winnow::combinator::terminated;
 //!
-//! fn parse_list(input: &str) -> IResult<&str, Vec<usize>> {
-//!     repeat(0.., terminated(parse_digits, opt(','))).parse_peek(input)
+//! fn parse_list(input: &mut &str) -> PResult<Vec<usize>> {
+//!     repeat(0.., terminated(parse_digits, opt(','))).parse_next(input)
 //! }
 //!
 //! // ...
-//! # fn parse_digits(input: &str) -> IResult<&str, usize> {
+//! # fn parse_digits(input: &mut &str) -> PResult<usize> {
 //! #     dispatch!(take(2usize);
-//! #          "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
-//! #          "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
-//! #          "0d" => parse_dec_digits.try_map(|s| usize::from_str_radix(s, 10)),
-//! #          "0x" => parse_hex_digits.try_map(|s| usize::from_str_radix(s, 16)),
-//! #          _ => fail,
-//! #      ).parse_peek(input)
+//! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
+//! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
+//! #         "0d" => parse_dec_digits.try_map(|s| usize::from_str_radix(s, 10)),
+//! #         "0x" => parse_hex_digits.try_map(|s| usize::from_str_radix(s, 16)),
+//! #         _ => fail,
+//! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
 //! #         ('a'..='f'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //!
 //! fn main() {
-//!     let input = "0x1a2b,0x3c4d,0x5e6f Hello";
+//!     let mut input = "0x1a2b,0x3c4d,0x5e6f Hello";
 //!
-//!     let (remainder, digits) = parse_list.parse_peek(input).unwrap();
+//!     let digits = parse_list.parse_next(&mut input).unwrap();
 //!
-//!     assert_eq!(remainder, " Hello");
+//!     assert_eq!(input, " Hello");
 //!     assert_eq!(digits, vec![0x1a2b, 0x3c4d, 0x5e6f]);
 //!
-//!     assert!(parse_digits("ghiWorld").is_err());
+//!     assert!(parse_digits(&mut "ghiWorld").is_err());
 //! }
 //! ```
 //!
 //! You'll notice that the above allows trailing `,` when we intended to not support that.  We can
 //! easily fix this by using [`separated0`]:
 //! ```rust
-//! # use winnow::IResult;
-//! # use winnow::Parser;
+//! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
 //! # use winnow::combinator::fail;
 //! use winnow::combinator::separated0;
 //!
-//! fn parse_list(input: &str) -> IResult<&str, Vec<usize>> {
-//!     separated0(parse_digits, ",").parse_peek(input)
+//! fn parse_list(input: &mut &str) -> PResult<Vec<usize>> {
+//!     separated0(parse_digits, ",").parse_next(input)
 //! }
 //!
 //! // ...
-//! # fn parse_digits(input: &str) -> IResult<&str, usize> {
+//! # fn parse_digits(input: &mut &str) -> PResult<usize> {
 //! #     dispatch!(take(2usize);
-//! #          "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
-//! #          "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
-//! #          "0d" => parse_dec_digits.try_map(|s| usize::from_str_radix(s, 10)),
-//! #          "0x" => parse_hex_digits.try_map(|s| usize::from_str_radix(s, 16)),
-//! #          _ => fail,
-//! #      ).parse_peek(input)
+//! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
+//! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
+//! #         "0d" => parse_dec_digits.try_map(|s| usize::from_str_radix(s, 10)),
+//! #         "0x" => parse_hex_digits.try_map(|s| usize::from_str_radix(s, 16)),
+//! #         _ => fail,
+//! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
 //! #         ('a'..='f'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //!
 //! fn main() {
-//!     let input = "0x1a2b,0x3c4d,0x5e6f Hello";
+//!     let mut input = "0x1a2b,0x3c4d,0x5e6f Hello";
 //!
-//!     let (remainder, digits) = parse_list.parse_peek(input).unwrap();
+//!     let digits = parse_list.parse_next(&mut input).unwrap();
 //!
-//!     assert_eq!(remainder, " Hello");
+//!     assert_eq!(input, " Hello");
 //!     assert_eq!(digits, vec![0x1a2b, 0x3c4d, 0x5e6f]);
 //!
-//!     assert!(parse_digits("ghiWorld").is_err());
+//!     assert!(parse_digits(&mut "ghiWorld").is_err());
 //! }
 //! ```
 //!
@@ -136,68 +134,66 @@
 //! [`Accumulate`] to gather the results.  This let's us make more complex parsers than we did in
 //! [`chapter_2`] by accumulating the results into a `()` and [`recognize`][Parser::recognize]-ing the captured input:
 //! ```rust
-//! # use winnow::IResult;
-//! # use winnow::Parser;
+//! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
 //! # use winnow::combinator::fail;
 //! # use winnow::combinator::separated0;
 //! #
-//! fn recognize_list(input: &str) -> IResult<&str, &str> {
-//!     parse_list.recognize().parse_peek(input)
+//! fn recognize_list<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//!     parse_list.recognize().parse_next(input)
 //! }
 //!
-//! fn parse_list(input: &str) -> IResult<&str, ()> {
-//!     separated0(parse_digits, ",").parse_peek(input)
+//! fn parse_list(input: &mut &str) -> PResult<()> {
+//!     separated0(parse_digits, ",").parse_next(input)
 //! }
 //!
-//! // ...
-//! # fn parse_digits(input: &str) -> IResult<&str, usize> {
+//! # fn parse_digits(input: &mut &str) -> PResult<usize> {
 //! #     dispatch!(take(2usize);
-//! #          "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
-//! #          "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
-//! #          "0d" => parse_dec_digits.try_map(|s| usize::from_str_radix(s, 10)),
-//! #          "0x" => parse_hex_digits.try_map(|s| usize::from_str_radix(s, 16)),
-//! #          _ => fail,
-//! #      ).parse_peek(input)
+//! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
+//! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
+//! #         "0d" => parse_dec_digits.try_map(|s| usize::from_str_radix(s, 10)),
+//! #         "0x" => parse_hex_digits.try_map(|s| usize::from_str_radix(s, 16)),
+//! #         _ => fail,
+//! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
 //! #         ('a'..='f'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //!
 //! fn main() {
-//!     let input = "0x1a2b,0x3c4d,0x5e6f Hello";
+//!     let mut input = "0x1a2b,0x3c4d,0x5e6f Hello";
 //!
-//!     let (remainder, digits) = recognize_list.parse_peek(input).unwrap();
+//!     let digits = recognize_list.parse_next(&mut input).unwrap();
 //!
-//!     assert_eq!(remainder, " Hello");
+//!     assert_eq!(input, " Hello");
 //!     assert_eq!(digits, "0x1a2b,0x3c4d,0x5e6f");
 //!
-//!     assert!(parse_digits("ghiWorld").is_err());
+//!     assert!(parse_digits(&mut "ghiWorld").is_err());
 //! }
 //! ```
 

--- a/src/_tutorial/chapter_7.rs
+++ b/src/_tutorial/chapter_7.rs
@@ -7,14 +7,14 @@
 //! ```rust
 //! # use winnow::error::VerboseError;
 //! # use winnow::error::ErrMode;
-//! type IResult<'i, O> = Result<
+//! type PResult<'i, O> = Result<
 //!     (&'i str, O),
 //!     ErrMode<
 //!         VerboseError<&'i str>
 //!     >
 //! >;
 //! ```
-//! 1. We have to decide what to do about the `remainder` of the input.  
+//! 1. We have to decide what to do about the "remainder" of the input.
 //! 2. The error type is not compatible with the rest of the Rust ecosystem
 //!
 //! Normally, Rust applications want errors that are `std::error::Error + Send + Sync + 'static`
@@ -26,7 +26,7 @@
 //!
 //! winnow provides some helpers for this:
 //! ```rust
-//! # use winnow::IResult;
+//! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
@@ -49,40 +49,40 @@
 //! }
 //!
 //! // ...
-//! # fn parse_digits(input: &str) -> IResult<&str, usize> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> PResult<usize, Error<&'s str>> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
 //! #         "0d" => parse_dec_digits.try_map(|s| usize::from_str_radix(s, 10)),
 //! #         "0x" => parse_hex_digits.try_map(|s| usize::from_str_radix(s, 16)),
 //! #         _ => fail,
-//! #     ).parse_peek(input)
+//! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits(input: &str) -> IResult<&str, &str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
 //! #         ('a'..='f'),
-//! #     )).parse_peek(input)
+//! #     )).parse_next(input)
 //! # }
 //!
 //! fn main() {
@@ -106,6 +106,6 @@ use super::chapter_1;
 use crate::combinator::eof;
 use crate::error::ErrMode;
 use crate::error::Error;
-use crate::IResult;
+use crate::PResult;
 
 pub use super::chapter_6 as previous;

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -18,7 +18,9 @@ use crate::stream::{AsBStr, AsChar, ParseSlice, Stream, StreamIsPartial};
 use crate::stream::{Compare, CompareResult};
 use crate::token::take_while;
 use crate::trace::trace;
+use crate::unpeek;
 use crate::IResult;
+use crate::PResult;
 use crate::Parser;
 
 /// Recognizes the string "\r\n".
@@ -30,33 +32,35 @@ use crate::Parser;
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}};
 /// # use winnow::ascii::crlf;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     crlf(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     crlf.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek("\r\nc"), Ok(("c", "\r\n")));
+/// assert_eq!(parser.parse_peek("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::crlf;
-/// assert_eq!(crlf::<_, Error<_>>(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
-/// assert_eq!(crlf::<_, Error<_>>(Partial::new("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("ab\r\nc"), ErrorKind::Tag))));
-/// assert_eq!(crlf::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(crlf::<_, Error<_>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
+/// assert_eq!(crlf::<_, Error<_>>.parse_peek(Partial::new("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("ab\r\nc"), ErrorKind::Tag))));
+/// assert_eq!(crlf::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn crlf<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn crlf<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
     I: Compare<&'static str>,
 {
-    trace("crlf", "\r\n").parse_peek(input)
+    trace("crlf", "\r\n").parse_next(input)
 }
 
 /// Recognizes a string of any char except '\r\n' or '\n'.
@@ -68,46 +72,51 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::not_line_ending;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     not_line_ending(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     not_line_ending.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("ab\r\nc"), Ok(("\r\nc", "ab")));
-/// assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
-/// assert_eq!(parser("abc"), Ok(("", "abc")));
-/// assert_eq!(parser(""), Ok(("", "")));
-/// assert_eq!(parser("a\rb\nc"), Err(ErrMode::Backtrack(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
-/// assert_eq!(parser("a\rbc"), Err(ErrMode::Backtrack(Error { input: "a\rbc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser.parse_peek("ab\r\nc"), Ok(("\r\nc", "ab")));
+/// assert_eq!(parser.parse_peek("ab\nc"), Ok(("\nc", "ab")));
+/// assert_eq!(parser.parse_peek("abc"), Ok(("", "abc")));
+/// assert_eq!(parser.parse_peek(""), Ok(("", "")));
+/// assert_eq!(parser.parse_peek("a\rb\nc"), Err(ErrMode::Backtrack(Error { input: "a\rb\nc", kind: ErrorKind::Tag })));
+/// assert_eq!(parser.parse_peek("a\rbc"), Err(ErrMode::Backtrack(Error { input: "a\rbc", kind: ErrorKind::Tag })));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::not_line_ending;
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("ab\r\nc")), Ok((Partial::new("\r\nc"), "ab")));
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("a\rb\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("a\rb\nc"), ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, Error<_>>(Partial::new("a\rbc")), Err(ErrMode::Backtrack(Error::new(Partial::new("a\rbc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>.parse_peek(Partial::new("ab\r\nc")), Ok((Partial::new("\r\nc"), "ab")));
+/// assert_eq!(not_line_ending::<_, Error<_>>.parse_peek(Partial::new("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(not_line_ending::<_, Error<_>>.parse_peek(Partial::new("a\rb\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("a\rb\nc"), ErrorKind::Tag ))));
+/// assert_eq!(not_line_ending::<_, Error<_>>.parse_peek(Partial::new("a\rbc")), Err(ErrMode::Backtrack(Error::new(Partial::new("a\rbc"), ErrorKind::Tag ))));
 /// ```
 #[inline(always)]
-pub fn not_line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn not_line_ending<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream + AsBStr,
     I: Compare<&'static str>,
     <I as Stream>::Token: AsChar,
 {
-    trace("not_line_ending", move |input: I| {
-        if <I as StreamIsPartial>::is_partial_supported() {
-            not_line_ending_::<_, _, true>(input)
-        } else {
-            not_line_ending_::<_, _, false>(input)
-        }
-    })
-    .parse_peek(input)
+    trace(
+        "not_line_ending",
+        unpeek(move |input: I| {
+            if <I as StreamIsPartial>::is_partial_supported() {
+                not_line_ending_::<_, _, true>(input)
+            } else {
+                not_line_ending_::<_, _, false>(input)
+            }
+        }),
+    )
+    .parse_next(input)
 }
 
 fn not_line_ending_<I, E: ParseError<I>, const PARTIAL: bool>(
@@ -157,33 +166,35 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::line_ending;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     line_ending(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     line_ending.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek("\r\nc"), Ok(("c", "\r\n")));
+/// assert_eq!(parser.parse_peek("ab\r\nc"), Err(ErrMode::Backtrack(Error::new("ab\r\nc", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::line_ending;
-/// assert_eq!(line_ending::<_, Error<_>>(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
-/// assert_eq!(line_ending::<_, Error<_>>(Partial::new("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("ab\r\nc"), ErrorKind::Tag))));
-/// assert_eq!(line_ending::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(line_ending::<_, Error<_>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
+/// assert_eq!(line_ending::<_, Error<_>>.parse_peek(Partial::new("ab\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("ab\r\nc"), ErrorKind::Tag))));
+/// assert_eq!(line_ending::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn line_ending<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn line_ending<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
     I: Compare<&'static str>,
 {
-    trace("line_ending", alt(("\n", "\r\n"))).parse_peek(input)
+    trace("line_ending", alt(("\n", "\r\n"))).parse_next(input)
 }
 
 /// Matches a newline character '\n'.
@@ -195,33 +206,35 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::newline;
-/// fn parser(input: &str) -> IResult<&str, char> {
-///     newline(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<char, Error<&'s str>> {
+///     newline.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("\nc"), Ok(("c", '\n')));
-/// assert_eq!(parser("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Verify))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Token))));
+/// assert_eq!(parser.parse_peek("\nc"), Ok(("c", '\n')));
+/// assert_eq!(parser.parse_peek("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Verify))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Token))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::newline;
-/// assert_eq!(newline::<_, Error<_>>(Partial::new("\nc")), Ok((Partial::new("c"), '\n')));
-/// assert_eq!(newline::<_, Error<_>>(Partial::new("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("\r\nc"), ErrorKind::Verify))));
-/// assert_eq!(newline::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(newline::<_, Error<_>>.parse_peek(Partial::new("\nc")), Ok((Partial::new("c"), '\n')));
+/// assert_eq!(newline::<_, Error<_>>.parse_peek(Partial::new("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("\r\nc"), ErrorKind::Verify))));
+/// assert_eq!(newline::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn newline<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
+pub fn newline<I, Error: ParseError<I>>(input: &mut I) -> PResult<char, Error>
 where
     I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
 {
-    trace("newline", '\n'.map(|c: <I as Stream>::Token| c.as_char())).parse_peek(input)
+    trace("newline", '\n'.map(|c: <I as Stream>::Token| c.as_char())).parse_next(input)
 }
 
 /// Matches a tab character '\t'.
@@ -233,33 +246,35 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::tab;
-/// fn parser(input: &str) -> IResult<&str, char> {
-///     tab(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<char, Error<&'s str>> {
+///     tab.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("\tc"), Ok(("c", '\t')));
-/// assert_eq!(parser("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Verify))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Token))));
+/// assert_eq!(parser.parse_peek("\tc"), Ok(("c", '\t')));
+/// assert_eq!(parser.parse_peek("\r\nc"), Err(ErrMode::Backtrack(Error::new("\r\nc", ErrorKind::Verify))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Token))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::tab;
-/// assert_eq!(tab::<_, Error<_>>(Partial::new("\tc")), Ok((Partial::new("c"), '\t')));
-/// assert_eq!(tab::<_, Error<_>>(Partial::new("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("\r\nc"), ErrorKind::Verify))));
-/// assert_eq!(tab::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(tab::<_, Error<_>>.parse_peek(Partial::new("\tc")), Ok((Partial::new("c"), '\t')));
+/// assert_eq!(tab::<_, Error<_>>.parse_peek(Partial::new("\r\nc")), Err(ErrMode::Backtrack(Error::new(Partial::new("\r\nc"), ErrorKind::Verify))));
+/// assert_eq!(tab::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn tab<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
+pub fn tab<I, Error: ParseError<I>>(input: &mut I) -> PResult<char, Error>
 where
     I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
 {
-    trace("tab", '\t'.map(|c: <I as Stream>::Token| c.as_char())).parse_peek(input)
+    trace("tab", '\t'.map(|c: <I as Stream>::Token| c.as_char())).parse_next(input)
 }
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
@@ -273,27 +288,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::ascii::alpha0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     alpha0(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     alpha0.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("ab1c"), Ok(("1c", "ab")));
-/// assert_eq!(parser("1c"), Ok(("1c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// assert_eq!(parser.parse_peek("ab1c"), Ok(("1c", "ab")));
+/// assert_eq!(parser.parse_peek("1c"), Ok(("1c", "")));
+/// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alpha0;
-/// assert_eq!(alpha0::<_, Error<_>>(Partial::new("ab1c")), Ok((Partial::new("1c"), "ab")));
-/// assert_eq!(alpha0::<_, Error<_>>(Partial::new("1c")), Ok((Partial::new("1c"), "")));
-/// assert_eq!(alpha0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha0::<_, Error<_>>.parse_peek(Partial::new("ab1c")), Ok((Partial::new("1c"), "ab")));
+/// assert_eq!(alpha0::<_, Error<_>>.parse_peek(Partial::new("1c")), Ok((Partial::new("1c"), "")));
+/// assert_eq!(alpha0::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn alpha0<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -303,7 +320,7 @@ where
         "alpha0",
         take_while(0.., |c: <I as Stream>::Token| c.is_alpha()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes one or more lowercase and uppercase ASCII alphabetic characters: a-z, A-Z
@@ -317,27 +334,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::alpha1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     alpha1(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     alpha1.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(parser("1c"), Err(ErrMode::Backtrack(Error::new("1c", ErrorKind::Slice))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek("aB1c"), Ok(("1c", "aB")));
+/// assert_eq!(parser.parse_peek("1c"), Err(ErrMode::Backtrack(Error::new("1c", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alpha1;
-/// assert_eq!(alpha1::<_, Error<_>>(Partial::new("aB1c")), Ok((Partial::new("1c"), "aB")));
-/// assert_eq!(alpha1::<_, Error<_>>(Partial::new("1c")), Err(ErrMode::Backtrack(Error::new(Partial::new("1c"), ErrorKind::Slice))));
-/// assert_eq!(alpha1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha1::<_, Error<_>>.parse_peek(Partial::new("aB1c")), Ok((Partial::new("1c"), "aB")));
+/// assert_eq!(alpha1::<_, Error<_>>.parse_peek(Partial::new("1c")), Err(ErrMode::Backtrack(Error::new(Partial::new("1c"), ErrorKind::Slice))));
+/// assert_eq!(alpha1::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn alpha1<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -347,7 +366,7 @@ where
         "alpha1",
         take_while(1.., |c: <I as Stream>::Token| c.is_alpha()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes zero or more ASCII numerical characters: 0-9
@@ -361,28 +380,30 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::ascii::digit0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     digit0(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     digit0.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("21c"), Ok(("c", "21")));
-/// assert_eq!(parser("21"), Ok(("", "21")));
-/// assert_eq!(parser("a21c"), Ok(("a21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// assert_eq!(parser.parse_peek("21c"), Ok(("c", "21")));
+/// assert_eq!(parser.parse_peek("21"), Ok(("", "21")));
+/// assert_eq!(parser.parse_peek("a21c"), Ok(("a21c", "")));
+/// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::digit0;
-/// assert_eq!(digit0::<_, Error<_>>(Partial::new("21c")), Ok((Partial::new("c"), "21")));
-/// assert_eq!(digit0::<_, Error<_>>(Partial::new("a21c")), Ok((Partial::new("a21c"), "")));
-/// assert_eq!(digit0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(digit0::<_, Error<_>>.parse_peek(Partial::new("21c")), Ok((Partial::new("c"), "21")));
+/// assert_eq!(digit0::<_, Error<_>>.parse_peek(Partial::new("a21c")), Ok((Partial::new("a21c"), "")));
+/// assert_eq!(digit0::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn digit0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn digit0<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -392,7 +413,7 @@ where
         "digit0",
         take_while(0.., |c: <I as Stream>::Token| c.is_dec_digit()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes one or more ASCII numerical characters: 0-9
@@ -406,24 +427,26 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::digit1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     digit1(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     digit1.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("21c"), Ok(("c", "21")));
-/// assert_eq!(parser("c1"), Err(ErrMode::Backtrack(Error::new("c1", ErrorKind::Slice))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek("21c"), Ok(("c", "21")));
+/// assert_eq!(parser.parse_peek("c1"), Err(ErrMode::Backtrack(Error::new("c1", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::digit1;
-/// assert_eq!(digit1::<_, Error<_>>(Partial::new("21c")), Ok((Partial::new("c"), "21")));
-/// assert_eq!(digit1::<_, Error<_>>(Partial::new("c1")), Err(ErrMode::Backtrack(Error::new(Partial::new("c1"), ErrorKind::Slice))));
-/// assert_eq!(digit1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(digit1::<_, Error<_>>.parse_peek(Partial::new("21c")), Ok((Partial::new("c"), "21")));
+/// assert_eq!(digit1::<_, Error<_>>.parse_peek(Partial::new("c1")), Err(ErrMode::Backtrack(Error::new(Partial::new("c1"), ErrorKind::Slice))));
+/// assert_eq!(digit1::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// ## Parsing an integer
@@ -431,18 +454,19 @@ where
 /// You can use `digit1` in combination with [`Parser::try_map`][crate::Parser::try_map] to parse an integer:
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed, Parser};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, Parser};
 /// # use winnow::ascii::digit1;
-/// fn parser(input: &str) -> IResult<&str, u32> {
-///   digit1.try_map(str::parse).parse_peek(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<u32, Error<&'s str>> {
+///   digit1.try_map(str::parse).parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("416"), Ok(("", 416)));
-/// assert_eq!(parser("12b"), Ok(("b", 12)));
-/// assert!(parser("b").is_err());
+/// assert_eq!(parser.parse_peek("416"), Ok(("", 416)));
+/// assert_eq!(parser.parse_peek("12b"), Ok(("b", 12)));
+/// assert!(parser.parse_peek("b").is_err());
 /// ```
 #[inline(always)]
-pub fn digit1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn digit1<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -452,7 +476,7 @@ where
         "digit1",
         take_while(1.., |c: <I as Stream>::Token| c.is_dec_digit()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes zero or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -465,27 +489,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::ascii::hex_digit0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     hex_digit0(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     hex_digit0.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// assert_eq!(parser.parse_peek("21cZ"), Ok(("Z", "21c")));
+/// assert_eq!(parser.parse_peek("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::hex_digit0;
-/// assert_eq!(hex_digit0::<_, Error<_>>(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
-/// assert_eq!(hex_digit0::<_, Error<_>>(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
-/// assert_eq!(hex_digit0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit0::<_, Error<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
+/// assert_eq!(hex_digit0::<_, Error<_>>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(hex_digit0::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn hex_digit0<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -495,7 +521,7 @@ where
         "hex_digit0",
         take_while(0.., |c: <I as Stream>::Token| c.is_hex_digit()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes one or more ASCII hexadecimal numerical characters: 0-9, A-F, a-f
@@ -509,27 +535,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::hex_digit1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     hex_digit1(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     hex_digit1.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek("21cZ"), Ok(("Z", "21c")));
+/// assert_eq!(parser.parse_peek("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::hex_digit1;
-/// assert_eq!(hex_digit1::<_, Error<_>>(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
-/// assert_eq!(hex_digit1::<_, Error<_>>(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::Slice))));
-/// assert_eq!(hex_digit1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
+/// assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::Slice))));
+/// assert_eq!(hex_digit1::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn hex_digit1<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -539,7 +567,7 @@ where
         "hex_digit1",
         take_while(1.., |c: <I as Stream>::Token| c.is_hex_digit()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes zero or more octal characters: 0-7
@@ -553,27 +581,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::ascii::oct_digit0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     oct_digit0(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     oct_digit0.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// assert_eq!(parser.parse_peek("21cZ"), Ok(("cZ", "21")));
+/// assert_eq!(parser.parse_peek("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::oct_digit0;
-/// assert_eq!(oct_digit0::<_, Error<_>>(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
-/// assert_eq!(oct_digit0::<_, Error<_>>(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
-/// assert_eq!(oct_digit0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit0::<_, Error<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
+/// assert_eq!(oct_digit0::<_, Error<_>>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(oct_digit0::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn oct_digit0<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -583,7 +613,7 @@ where
         "oct_digit0",
         take_while(0.., |c: <I as Stream>::Token| c.is_oct_digit()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes one or more octal characters: 0-7
@@ -597,27 +627,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::oct_digit1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     oct_digit1(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     oct_digit1.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek("21cZ"), Ok(("cZ", "21")));
+/// assert_eq!(parser.parse_peek("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::oct_digit1;
-/// assert_eq!(oct_digit1::<_, Error<_>>(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
-/// assert_eq!(oct_digit1::<_, Error<_>>(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::Slice))));
-/// assert_eq!(oct_digit1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit1::<_, Error<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
+/// assert_eq!(oct_digit1::<_, Error<_>>.parse_peek(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::Slice))));
+/// assert_eq!(oct_digit1::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn oct_digit1<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -627,7 +659,7 @@ where
         "oct_digit0",
         take_while(1.., |c: <I as Stream>::Token| c.is_oct_digit()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes zero or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -641,27 +673,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::ascii::alphanumeric0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     alphanumeric0(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     alphanumeric0.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(parser("&Z21c"), Ok(("&Z21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// assert_eq!(parser.parse_peek("21cZ%1"), Ok(("%1", "21cZ")));
+/// assert_eq!(parser.parse_peek("&Z21c"), Ok(("&Z21c", "")));
+/// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alphanumeric0;
-/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
-/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial::new("&Z21c")), Ok((Partial::new("&Z21c"), "")));
-/// assert_eq!(alphanumeric0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric0::<_, Error<_>>.parse_peek(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
+/// assert_eq!(alphanumeric0::<_, Error<_>>.parse_peek(Partial::new("&Z21c")), Ok((Partial::new("&Z21c"), "")));
+/// assert_eq!(alphanumeric0::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn alphanumeric0<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -671,7 +705,7 @@ where
         "alphanumeric0",
         take_while(0.., |c: <I as Stream>::Token| c.is_alphanum()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes one or more ASCII numerical and alphabetic characters: 0-9, a-z, A-Z
@@ -685,27 +719,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::alphanumeric1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     alphanumeric1(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     alphanumeric1.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(parser("&H2"), Err(ErrMode::Backtrack(Error::new("&H2", ErrorKind::Slice))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek("21cZ%1"), Ok(("%1", "21cZ")));
+/// assert_eq!(parser.parse_peek("&H2"), Err(ErrMode::Backtrack(Error::new("&H2", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alphanumeric1;
-/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
-/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial::new("&H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("&H2"), ErrorKind::Slice))));
-/// assert_eq!(alphanumeric1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>.parse_peek(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
+/// assert_eq!(alphanumeric1::<_, Error<_>>.parse_peek(Partial::new("&H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("&H2"), ErrorKind::Slice))));
+/// assert_eq!(alphanumeric1::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn alphanumeric1<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -715,7 +751,7 @@ where
         "alphanumeric1",
         take_while(1.., |c: <I as Stream>::Token| c.is_alphanum()),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes zero or more spaces and tabs.
@@ -729,15 +765,16 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::space0;
-/// assert_eq!(space0::<_, Error<_>>(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
-/// assert_eq!(space0::<_, Error<_>>(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
-/// assert_eq!(space0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(space0::<_, Error<_>>.parse_peek(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
+/// assert_eq!(space0::<_, Error<_>>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(space0::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn space0<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -750,13 +787,13 @@ where
             matches!(ch, ' ' | '\t')
         }),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
-/// Recognizes one or more spaces and tabs.
+/// Recognizes zero or more spaces and tabs.
 ///
-/// *Complete version*: Will return an error if there's not enough input data,
-/// or the whole input if no terminating token is found (a non space character).
+/// *Complete version*: Will return the whole input if no terminating token is found (a non space
+/// character).
 ///
 /// *Partial version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there's not enough input data,
 /// or if no terminating token is found (a non space character).
@@ -764,27 +801,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::ascii::space1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     space1(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     space1.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(" \t21c"), Ok(("21c", " \t")));
+/// assert_eq!(parser.parse_peek("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::space1;
-/// assert_eq!(space1::<_, Error<_>>(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
-/// assert_eq!(space1::<_, Error<_>>(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::Slice))));
-/// assert_eq!(space1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(space1::<_, Error<_>>.parse_peek(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
+/// assert_eq!(space1::<_, Error<_>>.parse_peek(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::Slice))));
+/// assert_eq!(space1::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn space1<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -797,7 +836,7 @@ where
             matches!(ch, ' ' | '\t')
         }),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes zero or more spaces, tabs, carriage returns and line feeds.
@@ -811,27 +850,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::ascii::multispace0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     multispace0(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     multispace0.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// assert_eq!(parser.parse_peek(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
+/// assert_eq!(parser.parse_peek("Z21c"), Ok(("Z21c", "")));
+/// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::multispace0;
-/// assert_eq!(multispace0::<_, Error<_>>(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
-/// assert_eq!(multispace0::<_, Error<_>>(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
-/// assert_eq!(multispace0::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace0::<_, Error<_>>.parse_peek(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
+/// assert_eq!(multispace0::<_, Error<_>>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(multispace0::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace0<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn multispace0<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -844,7 +885,7 @@ where
             matches!(ch, ' ' | '\t' | '\r' | '\n')
         }),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Recognizes one or more spaces, tabs, carriage returns and line feeds.
@@ -858,27 +899,29 @@ where
 /// # Example
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::ascii::multispace1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     multispace1(input)
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     multispace1.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(parser("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
+/// assert_eq!(parser.parse_peek("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
 /// ```
 ///
 /// ```
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, IResult, error::Needed};
+/// # use winnow::prelude::*;
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::multispace1;
-/// assert_eq!(multispace1::<_, Error<_>>(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
-/// assert_eq!(multispace1::<_, Error<_>>(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::Slice))));
-/// assert_eq!(multispace1::<_, Error<_>>(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace1::<_, Error<_>>.parse_peek(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
+/// assert_eq!(multispace1::<_, Error<_>>.parse_peek(Partial::new("H2")), Err(ErrMode::Backtrack(Error::new(Partial::new("H2"), ErrorKind::Slice))));
+/// assert_eq!(multispace1::<_, Error<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace1<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+pub fn multispace1<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -891,7 +934,7 @@ where
             matches!(ch, ' ' | '\t' | '\r' | '\n')
         }),
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// Decode a decimal unsigned integer
@@ -904,49 +947,52 @@ where
 #[doc(alias = "u32")]
 #[doc(alias = "u64")]
 #[doc(alias = "u128")]
-pub fn dec_uint<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
+pub fn dec_uint<I, O, E: ParseError<I>>(input: &mut I) -> PResult<O, E>
 where
     I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
     O: Uint,
 {
-    trace("dec_uint", move |input: I| {
-        if input.eof_offset() == 0 {
-            if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-                return Err(ErrMode::Incomplete(Needed::new(1)));
-            } else {
-                return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+    trace(
+        "dec_uint",
+        unpeek(move |input: I| {
+            if input.eof_offset() == 0 {
+                if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
+                    return Err(ErrMode::Incomplete(Needed::new(1)));
+                } else {
+                    return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+                }
             }
-        }
 
-        let mut value = O::default();
-        for (offset, c) in input.iter_offsets() {
-            match c.as_char().to_digit(10) {
-                Some(d) => match value.checked_mul(10, sealed::SealedMarker).and_then(|v| {
-                    let d = d as u8;
-                    v.checked_add(d, sealed::SealedMarker)
-                }) {
-                    None => return Err(ErrMode::from_error_kind(input, ErrorKind::Verify)),
-                    Some(v) => value = v,
-                },
-                None => {
-                    if offset == 0 {
-                        return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
-                    } else {
-                        return Ok((input.peek_slice(offset).0, value));
+            let mut value = O::default();
+            for (offset, c) in input.iter_offsets() {
+                match c.as_char().to_digit(10) {
+                    Some(d) => match value.checked_mul(10, sealed::SealedMarker).and_then(|v| {
+                        let d = d as u8;
+                        v.checked_add(d, sealed::SealedMarker)
+                    }) {
+                        None => return Err(ErrMode::from_error_kind(input, ErrorKind::Verify)),
+                        Some(v) => value = v,
+                    },
+                    None => {
+                        if offset == 0 {
+                            return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+                        } else {
+                            return Ok((input.peek_slice(offset).0, value));
+                        }
                     }
                 }
             }
-        }
 
-        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        } else {
-            Ok((input.peek_finish().0, value))
-        }
-    })
-    .parse_peek(input)
+            if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
+                Err(ErrMode::Incomplete(Needed::new(1)))
+            } else {
+                Ok((input.peek_finish().0, value))
+            }
+        }),
+    )
+    .parse_next(input)
 }
 
 /// Metadata for parsing unsigned integers, see [`dec_uint`]
@@ -1057,61 +1103,64 @@ impl Uint for i128 {
 #[doc(alias = "i32")]
 #[doc(alias = "i64")]
 #[doc(alias = "i128")]
-pub fn dec_int<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
+pub fn dec_int<I, O, E: ParseError<I>>(input: &mut I) -> PResult<O, E>
 where
     I: StreamIsPartial,
     I: Stream,
     <I as Stream>::Token: AsChar + Copy,
     O: Int,
 {
-    trace("dec_int", move |input: I| {
-        fn sign(token: impl AsChar) -> bool {
-            let token = token.as_char();
-            token == '+' || token == '-'
-        }
-        let (input, sign) = opt(crate::token::one_of(sign).map(AsChar::as_char))
-            .map(|c| c != Some('-'))
-            .parse_peek(input)?;
-
-        if input.eof_offset() == 0 {
-            if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-                return Err(ErrMode::Incomplete(Needed::new(1)));
-            } else {
-                return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+    trace(
+        "dec_int",
+        unpeek(move |input: I| {
+            fn sign(token: impl AsChar) -> bool {
+                let token = token.as_char();
+                token == '+' || token == '-'
             }
-        }
+            let (input, sign) = opt(crate::token::one_of(sign).map(AsChar::as_char))
+                .map(|c| c != Some('-'))
+                .parse_peek(input)?;
 
-        let mut value = O::default();
-        for (offset, c) in input.iter_offsets() {
-            match c.as_char().to_digit(10) {
-                Some(d) => match value.checked_mul(10, sealed::SealedMarker).and_then(|v| {
-                    let d = d as u8;
-                    if sign {
-                        v.checked_add(d, sealed::SealedMarker)
-                    } else {
-                        v.checked_sub(d, sealed::SealedMarker)
-                    }
-                }) {
-                    None => return Err(ErrMode::from_error_kind(input, ErrorKind::Verify)),
-                    Some(v) => value = v,
-                },
-                None => {
-                    if offset == 0 {
-                        return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
-                    } else {
-                        return Ok((input.peek_slice(offset).0, value));
+            if input.eof_offset() == 0 {
+                if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
+                    return Err(ErrMode::Incomplete(Needed::new(1)));
+                } else {
+                    return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+                }
+            }
+
+            let mut value = O::default();
+            for (offset, c) in input.iter_offsets() {
+                match c.as_char().to_digit(10) {
+                    Some(d) => match value.checked_mul(10, sealed::SealedMarker).and_then(|v| {
+                        let d = d as u8;
+                        if sign {
+                            v.checked_add(d, sealed::SealedMarker)
+                        } else {
+                            v.checked_sub(d, sealed::SealedMarker)
+                        }
+                    }) {
+                        None => return Err(ErrMode::from_error_kind(input, ErrorKind::Verify)),
+                        Some(v) => value = v,
+                    },
+                    None => {
+                        if offset == 0 {
+                            return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+                        } else {
+                            return Ok((input.peek_slice(offset).0, value));
+                        }
                     }
                 }
             }
-        }
 
-        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        } else {
-            Ok((input.peek_finish().0, value))
-        }
-    })
-    .parse_peek(input)
+            if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
+                Err(ErrMode::Incomplete(Needed::new(1)))
+            } else {
+                Ok((input.peek_finish().0, value))
+            }
+        }),
+    )
+    .parse_next(input)
 }
 
 /// Metadata for parsing signed integers, see [`dec_int`]
@@ -1165,13 +1214,13 @@ impl Int for i128 {
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// use winnow::ascii::hex_uint;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u32> {
+/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<u32, Error<&'s [u8]>> {
 ///   hex_uint(s)
 /// }
 ///
-/// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
-/// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser(&b"ggg"[..]), Err(ErrMode::Backtrack(Error::new(&b"ggg"[..], ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
+/// assert_eq!(parser.parse_peek(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
+/// assert_eq!(parser.parse_peek(&b"ggg"[..]), Err(ErrMode::Backtrack(Error::new(&b"ggg"[..], ErrorKind::Slice))));
 /// ```
 ///
 /// ```rust
@@ -1180,16 +1229,16 @@ impl Int for i128 {
 /// # use winnow::Partial;
 /// use winnow::ascii::hex_uint;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+/// fn parser<'s>(s: &mut Partial<&'s [u8]>) -> PResult<u32, Error<Partial<&'s [u8]>>> {
 ///   hex_uint(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"01AE;"[..])), Ok((Partial::new(&b";"[..]), 0x01AE)));
-/// assert_eq!(parser(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Partial::new(&b"ggg"[..])), Err(ErrMode::Backtrack(Error::new(Partial::new(&b"ggg"[..]), ErrorKind::Slice))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"01AE;"[..])), Ok((Partial::new(&b";"[..]), 0x01AE)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"ggg"[..])), Err(ErrMode::Backtrack(Error::new(Partial::new(&b"ggg"[..]), ErrorKind::Slice))));
 /// ```
 #[inline]
-pub fn hex_uint<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
+pub fn hex_uint<I, O, E: ParseError<I>>(input: &mut I) -> PResult<O, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1197,53 +1246,56 @@ where
     <I as Stream>::Token: AsChar,
     <I as Stream>::Slice: AsBStr,
 {
-    trace("hex_uint", move |input: I| {
-        let invalid_offset = input
-            .offset_for(|c| {
-                let c = c.as_char();
-                !"0123456789abcdefABCDEF".contains(c)
-            })
-            .unwrap_or_else(|| input.eof_offset());
-        let max_nibbles = O::max_nibbles(sealed::SealedMarker);
-        let max_offset = input.offset_at(max_nibbles);
-        let offset = match max_offset {
-            Ok(max_offset) => {
-                if max_offset < invalid_offset {
-                    // Overflow
-                    return Err(ErrMode::from_error_kind(input, ErrorKind::Verify));
-                } else {
-                    invalid_offset
+    trace(
+        "hex_uint",
+        unpeek(move |input: I| {
+            let invalid_offset = input
+                .offset_for(|c| {
+                    let c = c.as_char();
+                    !"0123456789abcdefABCDEF".contains(c)
+                })
+                .unwrap_or_else(|| input.eof_offset());
+            let max_nibbles = O::max_nibbles(sealed::SealedMarker);
+            let max_offset = input.offset_at(max_nibbles);
+            let offset = match max_offset {
+                Ok(max_offset) => {
+                    if max_offset < invalid_offset {
+                        // Overflow
+                        return Err(ErrMode::from_error_kind(input, ErrorKind::Verify));
+                    } else {
+                        invalid_offset
+                    }
                 }
-            }
-            Err(_) => {
-                if <I as StreamIsPartial>::is_partial_supported()
-                    && input.is_partial()
-                    && invalid_offset == input.eof_offset()
-                {
-                    // Only the next byte is guaranteed required
-                    return Err(ErrMode::Incomplete(Needed::new(1)));
-                } else {
-                    invalid_offset
+                Err(_) => {
+                    if <I as StreamIsPartial>::is_partial_supported()
+                        && input.is_partial()
+                        && invalid_offset == input.eof_offset()
+                    {
+                        // Only the next byte is guaranteed required
+                        return Err(ErrMode::Incomplete(Needed::new(1)));
+                    } else {
+                        invalid_offset
+                    }
                 }
+            };
+            if offset == 0 {
+                // Must be at least one digit
+                return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
             }
-        };
-        if offset == 0 {
-            // Must be at least one digit
-            return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
-        }
-        let (remaining, parsed) = input.peek_slice(offset);
+            let (remaining, parsed) = input.peek_slice(offset);
 
-        let mut res = O::default();
-        for c in parsed.as_bstr() {
-            let nibble = *c as char;
-            let nibble = nibble.to_digit(16).unwrap_or(0) as u8;
-            let nibble = O::from(nibble);
-            res = (res << O::from(4)) + nibble;
-        }
+            let mut res = O::default();
+            for c in parsed.as_bstr() {
+                let nibble = *c as char;
+                let nibble = nibble.to_digit(16).unwrap_or(0) as u8;
+                let nibble = O::from(nibble);
+                res = (res << O::from(4)) + nibble;
+            }
 
-        Ok((remaining, res))
-    })
-    .parse_peek(input)
+            Ok((remaining, res))
+        }),
+    )
+    .parse_next(input)
 }
 
 /// Metadata for parsing hex numbers, see [`hex_uint`]
@@ -1303,14 +1355,14 @@ impl HexUint for u128 {
 /// # use winnow::error::Needed::Size;
 /// use winnow::ascii::float;
 ///
-/// fn parser(s: &str) -> IResult<&str, f64> {
+/// fn parser<'s>(s: &mut &'s str) -> PResult<f64, Error<&'s str>> {
 ///   float(s)
 /// }
 ///
-/// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
-/// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
-/// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek("11e-1"), Ok(("", 1.1)));
+/// assert_eq!(parser.parse_peek("123E-02"), Ok(("", 1.23)));
+/// assert_eq!(parser.parse_peek("123K-01"), Ok(("K-01", 123.0)));
+/// assert_eq!(parser.parse_peek("abc"), Err(ErrMode::Backtrack(Error::new("abc", ErrorKind::Tag))));
 /// ```
 ///
 /// ```rust
@@ -1320,20 +1372,20 @@ impl HexUint for u128 {
 /// # use winnow::Partial;
 /// use winnow::ascii::float;
 ///
-/// fn parser(s: Partial<&str>) -> IResult<Partial<&str>, f64> {
+/// fn parser<'s>(s: &mut Partial<&'s str>) -> PResult<f64, Error<Partial<&'s str>>> {
 ///   float(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new("11e-1 ")), Ok((Partial::new(" "), 1.1)));
-/// assert_eq!(parser(Partial::new("11e-1")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Partial::new("123E-02")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(Partial::new("123K-01")), Ok((Partial::new("K-01"), 123.0)));
-/// assert_eq!(parser(Partial::new("abc")), Err(ErrMode::Backtrack(Error::new(Partial::new("abc"), ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek(Partial::new("11e-1 ")), Ok((Partial::new(" "), 1.1)));
+/// assert_eq!(parser.parse_peek(Partial::new("11e-1")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new("123E-02")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new("123K-01")), Ok((Partial::new("K-01"), 123.0)));
+/// assert_eq!(parser.parse_peek(Partial::new("abc")), Err(ErrMode::Backtrack(Error::new(Partial::new("abc"), ErrorKind::Tag))));
 /// ```
 #[inline(always)]
 #[doc(alias = "f32")]
 #[doc(alias = "double")]
-pub fn float<I, O, E: ParseError<I>>(input: I) -> IResult<I, O, E>
+pub fn float<I, O, E: ParseError<I>>(input: &mut I) -> PResult<O, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1343,14 +1395,17 @@ where
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
 {
-    trace("float", move |input: I| {
-        let (i, s) = recognize_float_or_exceptions(input)?;
-        match s.parse_slice() {
-            Some(f) => Ok((i, f)),
-            None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
-        }
-    })
-    .parse_peek(input)
+    trace(
+        "float",
+        unpeek(move |input: I| {
+            let (i, s) = recognize_float_or_exceptions(input)?;
+            match s.parse_slice() {
+                Some(f) => Ok((i, f)),
+                None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
+            }
+        }),
+    )
+    .parse_next(input)
 }
 
 fn recognize_float_or_exceptions<I, E: ParseError<I>>(
@@ -1373,7 +1428,7 @@ where
     .parse_peek(input)
 }
 
-fn recognize_float<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Slice, E>
+fn recognize_float<I, E: ParseError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1391,7 +1446,7 @@ where
         opt((one_of(['e', 'E']), opt(one_of(['+', '-'])), cut_err(digit1))),
     )
         .recognize()
-        .parse_peek(input)
+        .parse_next(input)
 }
 
 /// Matches a byte string with escaped characters.
@@ -1403,6 +1458,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::ascii::digit1;
 /// # use winnow::prelude::*;
@@ -1418,6 +1474,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error, error::Needed, IResult};
 /// # use winnow::ascii::digit1;
 /// # use winnow::prelude::*;
@@ -1446,13 +1503,16 @@ where
     G: Parser<I, O2, Error>,
     Error: ParseError<I>,
 {
-    trace("escaped", move |input: I| {
-        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-            streaming_escaped_internal(input, &mut normal, control_char, &mut escapable)
-        } else {
-            complete_escaped_internal(input, &mut normal, control_char, &mut escapable)
-        }
-    })
+    trace(
+        "escaped",
+        unpeek(move |input: I| {
+            if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
+                streaming_escaped_internal(input, &mut normal, control_char, &mut escapable)
+            } else {
+                complete_escaped_internal(input, &mut normal, control_char, &mut escapable)
+            }
+        }),
+    )
 }
 
 fn streaming_escaped_internal<I, Error, F, G, O1, O2>(
@@ -1588,7 +1648,7 @@ where
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;
 ///
-/// fn parser(input: &str) -> IResult<&str, String> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<String, Error<&'s str>> {
 ///   escaped_transform(
 ///     alpha1,
 ///     '\\',
@@ -1597,11 +1657,11 @@ where
 ///       "\"".value("\""),
 ///       "n".value("\n"),
 ///     ))
-///   ).parse_peek(input)
+///   ).parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("ab\\\"cd"), Ok(("", String::from("ab\"cd"))));
-/// assert_eq!(parser("ab\\ncd"), Ok(("", String::from("ab\ncd"))));
+/// assert_eq!(parser.parse_peek("ab\\\"cd"), Ok(("", String::from("ab\"cd"))));
+/// assert_eq!(parser.parse_peek("ab\\ncd"), Ok(("", String::from("ab\ncd"))));
 /// ```
 ///
 /// ```
@@ -1614,7 +1674,7 @@ where
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;
 ///
-/// fn parser(input: Partial<&str>) -> IResult<Partial<&str>, String> {
+/// fn parser<'s>(input: &mut Partial<&'s str>) -> PResult<String, Error<Partial<&'s str>>> {
 ///   escaped_transform(
 ///     alpha1,
 ///     '\\',
@@ -1623,10 +1683,10 @@ where
 ///       "\"".value("\""),
 ///       "n".value("\n"),
 ///     ))
-///   ).parse_peek(input)
+///   ).parse_next(input)
 /// }
 ///
-/// assert_eq!(parser(Partial::new("ab\\\"cd\"")), Ok((Partial::new("\""), String::from("ab\"cd"))));
+/// assert_eq!(parser.parse_peek(Partial::new("ab\\\"cd\"")), Ok((Partial::new("\""), String::from("ab\"cd"))));
 /// ```
 #[inline(always)]
 pub fn escaped_transform<I, Error, F, G, Output>(
@@ -1643,13 +1703,26 @@ where
     G: Parser<I, <I as Stream>::Slice, Error>,
     Error: ParseError<I>,
 {
-    trace("escaped_transform", move |input: I| {
-        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-            streaming_escaped_transform_internal(input, &mut normal, control_char, &mut transform)
-        } else {
-            complete_escaped_transform_internal(input, &mut normal, control_char, &mut transform)
-        }
-    })
+    trace(
+        "escaped_transform",
+        unpeek(move |input: I| {
+            if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
+                streaming_escaped_transform_internal(
+                    input,
+                    &mut normal,
+                    control_char,
+                    &mut transform,
+                )
+            } else {
+                complete_escaped_transform_internal(
+                    input,
+                    &mut normal,
+                    control_char,
+                    &mut transform,
+                )
+            }
+        }),
+    )
 }
 
 fn streaming_escaped_transform_internal<I, Error, F, G, Output>(

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::IResult;
 
 mod complete {
     use super::*;
@@ -1130,7 +1131,7 @@ mod partial {
         }
 
         fn cnt(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-            length_count(number, "abc").parse_peek(i)
+            length_count(unpeek(number), "abc").parse_peek(i)
         }
 
         assert_eq!(
@@ -1171,7 +1172,7 @@ mod partial {
         }
 
         fn take(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-            length_data(number).parse_peek(i)
+            length_data(unpeek(number)).parse_peek(i)
         }
 
         assert_eq!(

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -48,7 +48,7 @@ pub trait Alt<I, O, E> {
 pub fn alt<I: Stream, O, E: ParseError<I>, List: Alt<I, O, E>>(
     mut l: List,
 ) -> impl Parser<I, O, E> {
-    trace("alt", move |i: I| l.choice(i))
+    trace("alt", unpeek(move |i: I| l.choice(i)))
 }
 
 /// Helper trait for the [permutation()] combinator.
@@ -109,7 +109,7 @@ pub trait Permutation<I, O, E> {
 pub fn permutation<I: Stream, O, E: ParseError<I>, List: Permutation<I, O, E>>(
     mut l: List,
 ) -> impl Parser<I, O, E> {
-    trace("permutation", move |i: I| l.permutation(i))
+    trace("permutation", unpeek(move |i: I| l.permutation(i)))
 }
 
 macro_rules! alt_trait(

--- a/src/combinator/parser.rs
+++ b/src/combinator/parser.rs
@@ -1,7 +1,6 @@
 use crate::error::{ContextError, ErrMode, ErrorKind, FromExternalError, ParseError};
 use crate::lib::std::borrow::Borrow;
 use crate::lib::std::ops::Range;
-use crate::parser::parser;
 use crate::stream::StreamIsPartial;
 use crate::stream::{Location, Stream};
 use crate::trace::trace;
@@ -366,15 +365,14 @@ where
 {
     #[inline]
     fn parse_next(&mut self, input: &mut I) -> PResult<O, E> {
-        trace(
-            "complete_err",
-            parser(|input: &mut I| match (self.f).parse_next(input) {
+        trace("complete_err", |input: &mut I| {
+            match (self.f).parse_next(input) {
                 Err(ErrMode::Incomplete(_)) => {
                     Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Complete))
                 }
                 rest => rest,
-            }),
-        )
+            }
+        })
         .parse_next(input)
     }
 }
@@ -834,15 +832,12 @@ where
         let name = format!("context={:?}", self.context);
         #[cfg(not(feature = "debug"))]
         let name = "context";
-        trace(
-            name,
-            parser(move |i: &mut I| {
-                let start = i.clone();
-                (self.parser)
-                    .parse_next(i)
-                    .map_err(|err| err.map(|err| err.add_context(start, self.context.clone())))
-            }),
-        )
+        trace(name, move |i: &mut I| {
+            let start = i.clone();
+            (self.parser)
+                .parse_next(i)
+                .map_err(|err| err.map(|err| err.add_context(start, self.context.clone())))
+        })
         .parse_next(i)
     }
 }

--- a/src/combinator/sequence.rs
+++ b/src/combinator/sequence.rs
@@ -35,10 +35,13 @@ where
     F: Parser<I, O1, E>,
     G: Parser<I, O2, E>,
 {
-    trace("preceded", move |input: I| {
-        let (input, _) = first.parse_peek(input)?;
-        second.parse_peek(input)
-    })
+    trace(
+        "preceded",
+        unpeek(move |input: I| {
+            let (input, _) = first.parse_peek(input)?;
+            second.parse_peek(input)
+        }),
+    )
 }
 
 /// Sequence two parsers, only returning the output of the first.
@@ -73,10 +76,13 @@ where
     F: Parser<I, O1, E>,
     G: Parser<I, O2, E>,
 {
-    trace("terminated", move |input: I| {
-        let (input, o1) = first.parse_peek(input)?;
-        second.parse_peek(input).map(|(i, _)| (i, o1))
-    })
+    trace(
+        "terminated",
+        unpeek(move |input: I| {
+            let (input, o1) = first.parse_peek(input)?;
+            second.parse_peek(input).map(|(i, _)| (i, o1))
+        }),
+    )
 }
 
 /// Sequence three parsers, only returning the values of the first and third.
@@ -113,11 +119,14 @@ where
     G: Parser<I, O2, E>,
     H: Parser<I, O3, E>,
 {
-    trace("separated_pair", move |input: I| {
-        let (input, o1) = first.parse_peek(input)?;
-        let (input, _) = sep.parse_peek(input)?;
-        second.parse_peek(input).map(|(i, o2)| (i, (o1, o2)))
-    })
+    trace(
+        "separated_pair",
+        unpeek(move |input: I| {
+            let (input, o1) = first.parse_peek(input)?;
+            let (input, _) = sep.parse_peek(input)?;
+            second.parse_peek(input).map(|(i, o2)| (i, (o1, o2)))
+        }),
+    )
 }
 
 /// Sequence three parsers, only returning the output of the second.
@@ -156,9 +165,12 @@ where
     G: Parser<I, O2, E>,
     H: Parser<I, O3, E>,
 {
-    trace("delimited", move |input: I| {
-        let (input, _) = first.parse_peek(input)?;
-        let (input, o2) = second.parse_peek(input)?;
-        third.parse_peek(input).map(|(i, _)| (i, o2))
-    })
+    trace(
+        "delimited",
+        unpeek(move |input: I| {
+            let (input, _) = first.parse_peek(input)?;
+            let (input, o2) = second.parse_peek(input)?;
+            third.parse_peek(input).map(|(i, _)| (i, o2))
+        }),
+    )
 }

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -11,6 +11,7 @@ use crate::error::Needed;
 use crate::error::ParseError;
 use crate::stream::Stream;
 use crate::token::take;
+use crate::unpeek;
 use crate::IResult;
 use crate::Parser;
 use crate::Partial;
@@ -574,13 +575,19 @@ fn alt_test() {
     }
 
     fn alt1(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        alt((dont_work, dont_work)).parse_peek(i)
+        alt((unpeek(dont_work), unpeek(dont_work))).parse_peek(i)
     }
     fn alt2(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        alt((dont_work, work)).parse_peek(i)
+        alt((unpeek(dont_work), unpeek(work))).parse_peek(i)
     }
     fn alt3(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        alt((dont_work, dont_work, work2, dont_work)).parse_peek(i)
+        alt((
+            unpeek(dont_work),
+            unpeek(dont_work),
+            unpeek(work2),
+            unpeek(dont_work),
+        ))
+        .parse_peek(i)
     }
     //named!(alt1, alt!(dont_work | dont_work));
     //named!(alt2, alt!(dont_work | work));
@@ -932,13 +939,13 @@ fn infinite_many() {
 
     // should not go into an infinite loop
     fn multi0(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        repeat(0.., tst).parse_peek(i)
+        repeat(0.., unpeek(tst)).parse_peek(i)
     }
     let a = &b"abcdef"[..];
     assert_eq!(multi0(a), Ok((a, Vec::new())));
 
     fn multi1(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        repeat(1.., tst).parse_peek(i)
+        repeat(1.., unpeek(tst)).parse_peek(i)
     }
     let a = &b"abcdef"[..];
     assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ pub mod _tutorial;
 /// ```rust
 /// use winnow::prelude::*;
 ///
-/// fn parse_data(input: &str) -> IResult<&str, u64> {
+/// fn parse_data(input: &mut &str) -> PResult<u64> {
 ///     // ...
 /// #   winnow::ascii::dec_uint(input)
 /// }

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -11,6 +11,7 @@ use crate::error::ErrorKind;
 use crate::error::Needed;
 use crate::stream::AsChar;
 use crate::token::tag;
+use crate::unpeek;
 use crate::IResult;
 use crate::Parser;
 use crate::Partial;
@@ -556,7 +557,7 @@ fn partial_recognize_take_while0() {
         take_while(0.., AsChar::is_alphanum).parse_peek(i)
     }
     fn y(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        x.recognize().parse_peek(i)
+        unpeek(x).recognize().parse_peek(i)
     }
     assert_eq!(
         x(Partial::new(&b"ab."[..])),

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -53,8 +53,10 @@ pub fn trace<I: Stream, O, E>(
 ) -> impl Parser<I, O, E> {
     #[cfg(feature = "debug")]
     {
+        use crate::unpeek;
+
         let mut call_count = 0;
-        move |i: I| {
+        unpeek(move |i: I| {
             let depth = internals::Depth::new();
             let original = i.checkpoint();
             internals::start(*depth, &name, call_count, &i);
@@ -67,7 +69,7 @@ pub fn trace<I: Stream, O, E>(
             call_count += 1;
 
             res
-        }
+        })
     }
     #[cfg(not(feature = "debug"))]
     {

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -6,6 +6,7 @@ use winnow::combinator::repeat;
 use winnow::combinator::terminated;
 use winnow::error::{ErrorKind, ParseError};
 use winnow::prelude::*;
+use winnow::unpeek;
 use winnow::IResult;
 use winnow::Partial;
 
@@ -35,16 +36,16 @@ fn test1(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
 
 fn test2(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
     //terminated!(input, test1, fix_error!(CustomError, digit))
-    terminated(test1, digit).parse_peek(input)
+    terminated(unpeek(test1), digit).parse_peek(input)
 }
 
 fn test3(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
-    test1
+    unpeek(test1)
         .verify(|s: &str| s.starts_with("abcd"))
         .parse_peek(input)
 }
 
 #[cfg(feature = "alloc")]
 fn test4(input: Partial<&str>) -> IResult<Partial<&str>, Vec<&str>, CustomError> {
-    repeat(4, test1).parse_peek(input)
+    repeat(4, unpeek(test1)).parse_peek(input)
 }

--- a/tests/testsuite/float.rs
+++ b/tests/testsuite/float.rs
@@ -3,6 +3,7 @@ use winnow::combinator::alt;
 use winnow::combinator::delimited;
 use winnow::combinator::opt;
 use winnow::prelude::*;
+use winnow::unpeek;
 use winnow::IResult;
 
 use std::str;
@@ -19,7 +20,7 @@ fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
 }
 
 fn float(i: &[u8]) -> IResult<&[u8], f32> {
-    (opt(alt(("+", "-"))), unsigned_float)
+    (opt(alt(("+", "-"))), unpeek(unsigned_float))
         .map(|(sign, value)| {
             sign.and_then(|s| if s[0] == b'-' { Some(-1f32) } else { None })
                 .unwrap_or(1f32)

--- a/tests/testsuite/fnmut.rs
+++ b/tests/testsuite/fnmut.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "alloc")]
 
 use winnow::combinator::repeat;
+use winnow::unpeek;
 use winnow::Parser;
 
 #[test]
@@ -9,10 +10,13 @@ fn parse() {
     let mut counter = 0;
 
     let res = {
-        let mut parser = repeat::<_, _, Vec<_>, (), _>(0.., |i| {
-            counter += 1;
-            "abc".parse_peek(i)
-        });
+        let mut parser = repeat::<_, _, Vec<_>, (), _>(
+            0..,
+            unpeek(|i| {
+                counter += 1;
+                "abc".parse_peek(i)
+            }),
+        );
 
         parser.parse_peek("abcabcabcabc").unwrap()
     };
@@ -26,11 +30,14 @@ fn accumulate() {
     let mut v = Vec::new();
 
     let (_, count) = {
-        let mut parser = repeat::<_, _, usize, (), _>(0.., |i| {
-            let (i, o) = "abc".parse_peek(i)?;
-            v.push(o);
-            Ok((i, ()))
-        });
+        let mut parser = repeat::<_, _, usize, (), _>(
+            0..,
+            unpeek(|i| {
+                let (i, o) = "abc".parse_peek(i)?;
+                v.push(o);
+                Ok((i, ()))
+            }),
+        );
         parser.parse_peek("abcabcabcabc").unwrap()
     };
 

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -4,7 +4,7 @@
 
 use winnow::prelude::*;
 use winnow::Partial;
-use winnow::{error::ErrMode, error::ErrorKind, error::Needed, IResult};
+use winnow::{error::ErrMode, error::ErrorKind, error::Needed, unpeek, IResult};
 
 #[allow(dead_code)]
 struct Range {
@@ -29,11 +29,11 @@ mod parse_int {
         ascii::{digit1 as digit, space1 as space},
         combinator::opt,
         combinator::repeat,
-        IResult,
+        unpeek, IResult,
     };
 
     fn parse_ints(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<i32>> {
-        repeat(0.., spaces_or_int).parse_peek(input)
+        repeat(0.., unpeek(spaces_or_int)).parse_peek(input)
     }
 
     fn spaces_or_int(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
@@ -170,7 +170,7 @@ fn issue_848_overflow_incomplete_bits_to_bytes() {
     fn parser(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         use winnow::binary::bits::{bits, bytes};
 
-        bits(bytes(take)).parse_peek(i)
+        bits(bytes(unpeek(take))).parse_peek(i)
     }
     assert_eq!(
         parser(Partial::new(&b""[..])),

--- a/tests/testsuite/multiline.rs
+++ b/tests/testsuite/multiline.rs
@@ -4,7 +4,7 @@ use winnow::{
     ascii::{alphanumeric1 as alphanumeric, line_ending as eol},
     combinator::repeat,
     combinator::terminated,
-    IResult, Parser,
+    unpeek, IResult, Parser,
 };
 
 pub fn end_of_line(input: &str) -> IResult<&str, &str> {
@@ -16,11 +16,11 @@ pub fn end_of_line(input: &str) -> IResult<&str, &str> {
 }
 
 pub fn read_line(input: &str) -> IResult<&str, &str> {
-    terminated(alphanumeric, end_of_line).parse_peek(input)
+    terminated(alphanumeric, unpeek(end_of_line)).parse_peek(input)
 }
 
 pub fn read_lines(input: &str) -> IResult<&str, Vec<&str>> {
-    repeat(0.., read_line).parse_peek(input)
+    repeat(0.., unpeek(read_line)).parse_peek(input)
 }
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
I expected this to have worse performance...

This is a step towards #72

v0.4.7
```
json/basic/canada       time:   [10.272 ms 10.308 ms 10.347 ms]
json/verbose/canada     time:   [32.539 ms 32.714 ms 32.893 ms]
json/dispatch/canada    time:   [8.9747 ms 8.9926 ms 9.0118 ms]
json/streaming/canada   time:   [10.612 ms 10.667 ms 10.726 ms]
```

#277
```
json/basic/canada       time:   [9.6649 ms 9.6840 ms 9.7037 ms]
json/unit/canada        time:   [9.0364 ms 9.0944 ms 9.1513 ms]
json/verbose/canada     time:   [31.032 ms 31.072 ms 31.114 ms]
json/dispatch/canada    time:   [8.5341 ms 8.5538 ms 8.5749 ms]
json/streaming/canada   time:   [10.679 ms 10.707 ms 10.739 ms]
```

#278
```
json/basic/canada       time:   [10.700 ms 10.779 ms 10.865 ms]
json/unit/canada        time:   [8.8489 ms 8.8636 ms 8.8791 ms]
json/verbose/canada     time:   [33.240 ms 33.291 ms 33.344 ms]
json/dispatch/canada    time:   [8.8891 ms 8.9045 ms 8.9203 ms]
json/streaming/canada   time:   [9.9510 ms 9.9905 ms 10.033 ms]
```