### PR TITLE
refactor: Update to new style of FnMut parsers

### DIFF
--- a/benches/contains_token.rs
+++ b/benches/contains_token.rs
@@ -18,48 +18,54 @@ fn contains_token(c: &mut criterion::Criterion) {
         group.throughput(criterion::Throughput::Bytes(len as u64));
 
         group.bench_with_input(criterion::BenchmarkId::new("slice", name), &len, |b, _| {
-            b.iter(|| black_box(parser_slice(black_box(sample)).unwrap()));
+            b.iter(|| black_box(parser_slice.parse_peek(black_box(sample)).unwrap()));
         });
         group.bench_with_input(criterion::BenchmarkId::new("array", name), &len, |b, _| {
-            b.iter(|| black_box(parser_array(black_box(sample)).unwrap()));
+            b.iter(|| black_box(parser_array.parse_peek(black_box(sample)).unwrap()));
         });
         group.bench_with_input(criterion::BenchmarkId::new("tuple", name), &len, |b, _| {
-            b.iter(|| black_box(parser_tuple(black_box(sample)).unwrap()));
+            b.iter(|| black_box(parser_tuple.parse_peek(black_box(sample)).unwrap()));
         });
         group.bench_with_input(
             criterion::BenchmarkId::new("closure-or", name),
             &len,
             |b, _| {
-                b.iter(|| black_box(parser_closure_or(black_box(sample)).unwrap()));
+                b.iter(|| black_box(parser_closure_or.parse_peek(black_box(sample)).unwrap()));
             },
         );
         group.bench_with_input(
             criterion::BenchmarkId::new("closure-matches", name),
             &len,
             |b, _| {
-                b.iter(|| black_box(parser_closure_matches(black_box(sample)).unwrap()));
+                b.iter(|| {
+                    black_box(
+                        parser_closure_matches
+                            .parse_peek(black_box(sample))
+                            .unwrap(),
+                    )
+                });
             },
         );
     }
     group.finish();
 }
 
-fn parser_slice(input: &str) -> IResult<&str, usize> {
+fn parser_slice(input: &mut &str) -> PResult<usize> {
     let contains = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'][..];
-    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_peek(input)
+    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_next(input)
 }
 
-fn parser_array(input: &str) -> IResult<&str, usize> {
+fn parser_array(input: &mut &str) -> PResult<usize> {
     let contains = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_peek(input)
+    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_next(input)
 }
 
-fn parser_tuple(input: &str) -> IResult<&str, usize> {
+fn parser_tuple(input: &mut &str) -> PResult<usize> {
     let contains = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9');
-    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_peek(input)
+    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_next(input)
 }
 
-fn parser_closure_or(input: &str) -> IResult<&str, usize> {
+fn parser_closure_or(input: &mut &str) -> PResult<usize> {
     let contains = |c: char| {
         c == '0'
             || c == '1'
@@ -72,12 +78,12 @@ fn parser_closure_or(input: &str) -> IResult<&str, usize> {
             || c == '8'
             || c == '9'
     };
-    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_peek(input)
+    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_next(input)
 }
 
-fn parser_closure_matches(input: &str) -> IResult<&str, usize> {
+fn parser_closure_matches(input: &mut &str) -> PResult<usize> {
     let contains = |c: char| matches!(c, '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9');
-    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_peek(input)
+    repeat(0.., alt((take_while(1.., contains), take_till1(contains)))).parse_next(input)
 }
 
 const CONTIGUOUS: &str = "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";

--- a/examples/arithmetic/bench.rs
+++ b/examples/arithmetic/bench.rs
@@ -1,5 +1,7 @@
 mod parser;
 
+use winnow::prelude::*;
+
 use parser::expr;
 
 #[allow(clippy::eq_op, clippy::erasing_op)]
@@ -7,11 +9,11 @@ fn arithmetic(c: &mut criterion::Criterion) {
     let data = "  2*2 / ( 5 - 1) + 3 / 4 * (2 - 7 + 567 *12 /2) + 3*(1+2*( 45 /2));";
 
     assert_eq!(
-        expr(data),
+        expr.parse_peek(data),
         Ok((";", 2 * 2 / (5 - 1) + 3 * (1 + 2 * (45 / 2)),))
     );
     c.bench_function("arithmetic", |b| {
-        b.iter(|| expr(data).unwrap());
+        b.iter(|| expr.parse_peek(data).unwrap());
     });
 }
 

--- a/examples/arithmetic/main.rs
+++ b/examples/arithmetic/main.rs
@@ -1,5 +1,4 @@
 use winnow::prelude::*;
-use winnow::unpeek;
 
 mod parser;
 mod parser_ast;
@@ -11,7 +10,7 @@ fn main() -> Result<(), lexopt::Error> {
 
     println!("{} =", input);
     match args.implementation {
-        Impl::Eval => match unpeek(parser::expr).parse(input) {
+        Impl::Eval => match parser::expr.parse(input) {
             Ok(result) => {
                 println!("  {}", result);
             }
@@ -19,7 +18,7 @@ fn main() -> Result<(), lexopt::Error> {
                 println!("  {}", err);
             }
         },
-        Impl::Ast => match unpeek(parser_ast::expr).parse(input) {
+        Impl::Ast => match parser_ast::expr.parse(input) {
             Ok(result) => {
                 println!("  {:#?}", result);
             }

--- a/examples/arithmetic/parser.rs
+++ b/examples/arithmetic/parser.rs
@@ -7,17 +7,16 @@ use winnow::{
     combinator::delimited,
     combinator::fold_repeat,
     token::one_of,
-    unpeek, IResult,
 };
 
 // Parser definition
 
-pub fn expr(i: &str) -> IResult<&str, i64> {
-    let (i, init) = term(i)?;
+pub fn expr(i: &mut &str) -> PResult<i64> {
+    let init = term.parse_next(i)?;
 
     fold_repeat(
         0..,
-        (one_of(['+', '-']), unpeek(term)),
+        (one_of(['+', '-']), term),
         move || init,
         |acc, (op, val): (char, i64)| {
             if op == '+' {
@@ -27,18 +26,18 @@ pub fn expr(i: &str) -> IResult<&str, i64> {
             }
         },
     )
-    .parse_peek(i)
+    .parse_next(i)
 }
 
 // We read an initial factor and for each time we find
 // a * or / operator followed by another factor, we do
 // the math by folding everything
-fn term(i: &str) -> IResult<&str, i64> {
-    let (i, init) = factor(i)?;
+fn term(i: &mut &str) -> PResult<i64> {
+    let init = factor.parse_next(i)?;
 
     fold_repeat(
         0..,
-        (one_of(['*', '/']), unpeek(factor)),
+        (one_of(['*', '/']), factor),
         move || init,
         |acc, (op, val): (char, i64)| {
             if op == '*' {
@@ -48,56 +47,56 @@ fn term(i: &str) -> IResult<&str, i64> {
             }
         },
     )
-    .parse_peek(i)
+    .parse_next(i)
 }
 
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.
 // If either str::from_utf8 or FromStr::from_str fail,
 // we fallback to the parens parser defined above
-fn factor(i: &str) -> IResult<&str, i64> {
+fn factor(i: &mut &str) -> PResult<i64> {
     delimited(
         spaces,
         alt((
             digits.try_map(FromStr::from_str),
-            delimited('(', unpeek(expr), ')'),
-            unpeek(parens),
+            delimited('(', expr, ')'),
+            parens,
         )),
         spaces,
     )
-    .parse_peek(i)
+    .parse_next(i)
 }
 
 // We parse any expr surrounded by parens, ignoring all whitespaces around those
-fn parens(i: &str) -> IResult<&str, i64> {
-    delimited('(', unpeek(expr), ')').parse_peek(i)
+fn parens(i: &mut &str) -> PResult<i64> {
+    delimited('(', expr, ')').parse_next(i)
 }
 
 #[test]
 fn factor_test() {
-    assert_eq!(factor("3"), Ok(("", 3)));
-    assert_eq!(factor(" 12"), Ok(("", 12)));
-    assert_eq!(factor("537  "), Ok(("", 537)));
-    assert_eq!(factor("  24   "), Ok(("", 24)));
+    assert_eq!(factor.parse_peek("3"), Ok(("", 3)));
+    assert_eq!(factor.parse_peek(" 12"), Ok(("", 12)));
+    assert_eq!(factor.parse_peek("537  "), Ok(("", 537)));
+    assert_eq!(factor.parse_peek("  24   "), Ok(("", 24)));
 }
 
 #[test]
 fn term_test() {
-    assert_eq!(term(" 12 *2 /  3"), Ok(("", 8)));
-    assert_eq!(term(" 2* 3  *2 *2 /  3"), Ok(("", 8)));
-    assert_eq!(term(" 48 /  3/2"), Ok(("", 8)));
+    assert_eq!(term.parse_peek(" 12 *2 /  3"), Ok(("", 8)));
+    assert_eq!(term.parse_peek(" 2* 3  *2 *2 /  3"), Ok(("", 8)));
+    assert_eq!(term.parse_peek(" 48 /  3/2"), Ok(("", 8)));
 }
 
 #[test]
 fn expr_test() {
-    assert_eq!(expr(" 1 +  2 "), Ok(("", 3)));
-    assert_eq!(expr(" 12 + 6 - 4+  3"), Ok(("", 17)));
-    assert_eq!(expr(" 1 + 2*3 + 4"), Ok(("", 11)));
+    assert_eq!(expr.parse_peek(" 1 +  2 "), Ok(("", 3)));
+    assert_eq!(expr.parse_peek(" 12 + 6 - 4+  3"), Ok(("", 17)));
+    assert_eq!(expr.parse_peek(" 1 + 2*3 + 4"), Ok(("", 11)));
 }
 
 #[test]
 fn parens_test() {
-    assert_eq!(expr(" (  2 )"), Ok(("", 2)));
-    assert_eq!(expr(" 2* (  3 + 4 ) "), Ok(("", 14)));
-    assert_eq!(expr("  2*2 / ( 5 - 1) + 3"), Ok(("", 4)));
+    assert_eq!(expr.parse_peek(" (  2 )"), Ok(("", 2)));
+    assert_eq!(expr.parse_peek(" 2* (  3 + 4 ) "), Ok(("", 14)));
+    assert_eq!(expr.parse_peek("  2*2 / ( 5 - 1) + 3"), Ok(("", 4)));
 }

--- a/examples/css/main.rs
+++ b/examples/css/main.rs
@@ -1,5 +1,4 @@
 use winnow::prelude::*;
-use winnow::unpeek;
 
 mod parser;
 
@@ -11,7 +10,7 @@ fn main() -> Result<(), lexopt::Error> {
     let input = args.input.as_deref().unwrap_or("#AAAAAA");
 
     println!("{} =", input);
-    match unpeek(hex_color).parse(input) {
+    match hex_color.parse(input) {
         Ok(result) => {
             println!("  {:?}", result);
         }
@@ -50,7 +49,7 @@ impl Args {
 #[test]
 fn parse_color() {
     assert_eq!(
-        hex_color("#2F14DF"),
+        hex_color.parse_peek("#2F14DF"),
         Ok((
             "",
             parser::Color {

--- a/examples/css/parser.rs
+++ b/examples/css/parser.rs
@@ -1,6 +1,5 @@
 use winnow::prelude::*;
 use winnow::token::take_while;
-use winnow::unpeek;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Color {
@@ -11,29 +10,22 @@ pub struct Color {
 
 impl std::str::FromStr for Color {
     // The error must be owned
-    type Err = winnow::error::Error<String>;
+    type Err = winnow::error::ErrorKind;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        unpeek(hex_color)
-            .parse(s)
-            .map_err(winnow::error::Error::into_owned)
+        hex_color.parse(s)
     }
 }
 
-pub fn hex_color(input: &str) -> IResult<&str, Color> {
-    let (input, _) = "#".parse_peek(input)?;
-    let (input, (red, green, blue)) = (
-        unpeek(hex_primary),
-        unpeek(hex_primary),
-        unpeek(hex_primary),
-    )
-        .parse_peek(input)?;
+pub fn hex_color(input: &mut &str) -> PResult<Color> {
+    let _ = "#".parse_next(input)?;
+    let (red, green, blue) = (hex_primary, hex_primary, hex_primary).parse_next(input)?;
 
-    Ok((input, Color { red, green, blue }))
+    Ok(Color { red, green, blue })
 }
 
-fn hex_primary(input: &str) -> IResult<&str, u8> {
+fn hex_primary(input: &mut &str) -> PResult<u8> {
     take_while(2, |c: char| c.is_ascii_hexdigit())
         .try_map(|input| u8::from_str_radix(input, 16))
-        .parse_peek(input)
+        .parse_next(input)
 }

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -1,7 +1,7 @@
 use winnow::error::ErrMode;
 use winnow::error::ErrorKind;
 use winnow::error::ParseError;
-use winnow::IResult;
+use winnow::prelude::*;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum CustomError<I> {
@@ -19,7 +19,7 @@ impl<I> ParseError<I> for CustomError<I> {
     }
 }
 
-pub fn parse(_input: &str) -> IResult<&str, &str, CustomError<&str>> {
+pub fn parse<'s>(_input: &mut &'s str) -> PResult<&'s str, CustomError<&'s str>> {
     Err(ErrMode::Backtrack(CustomError::MyError))
 }
 
@@ -27,13 +27,11 @@ fn main() {}
 
 #[cfg(test)]
 mod tests {
-    use super::parse;
-    use super::CustomError;
-    use winnow::error::ErrMode;
+    use super::*;
 
     #[test]
     fn it_works() {
-        let err = parse("").unwrap_err();
+        let err = parse.parse_next(&mut "").unwrap_err();
         match err {
             ErrMode::Backtrack(e) => assert_eq!(e, CustomError::MyError),
             _ => panic!("Unexpected error: {:?}", err),

--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -1,6 +1,5 @@
 use winnow::{
-    ascii::line_ending, combinator::repeat, stream::Partial, token::take_while, unpeek, IResult,
-    Parser,
+    ascii::line_ending, combinator::repeat, prelude::*, stream::Partial, token::take_while,
 };
 
 pub type Stream<'i> = Partial<&'i [u8]>;
@@ -25,12 +24,11 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
     let mut buf = Partial::new(data);
     let mut v = Vec::new();
     loop {
-        match request(buf) {
-            Ok((b, r)) => {
-                buf = b;
+        match request(&mut buf) {
+            Ok(r) => {
                 v.push(r);
 
-                if b.is_empty() {
+                if buf.is_empty() {
                     //println!("{}", i);
                     break;
                 }
@@ -45,53 +43,50 @@ pub fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> {
     Some(v)
 }
 
-fn request(input: Stream<'_>) -> IResult<Stream<'_>, (Request<'_>, Vec<Header<'_>>)> {
-    let (input, req) = request_line(input)?;
-    let (input, h) = repeat(1.., unpeek(message_header)).parse_peek(input)?;
-    let (input, _) = line_ending.parse_peek(input)?;
+fn request<'s>(input: &mut Stream<'s>) -> PResult<(Request<'s>, Vec<Header<'s>>)> {
+    let req = request_line(input)?;
+    let h = repeat(1.., message_header).parse_next(input)?;
+    let _ = line_ending.parse_next(input)?;
 
-    Ok((input, (req, h)))
+    Ok((req, h))
 }
 
-fn request_line(input: Stream<'_>) -> IResult<Stream<'_>, Request<'_>> {
-    let (input, method) = take_while(1.., is_token).parse_peek(input)?;
-    let (input, _) = take_while(1.., is_space).parse_peek(input)?;
-    let (input, uri) = take_while(1.., is_not_space).parse_peek(input)?;
-    let (input, _) = take_while(1.., is_space).parse_peek(input)?;
-    let (input, version) = http_version(input)?;
-    let (input, _) = line_ending.parse_peek(input)?;
+fn request_line<'s>(input: &mut Stream<'s>) -> PResult<Request<'s>> {
+    let method = take_while(1.., is_token).parse_next(input)?;
+    let _ = take_while(1.., is_space).parse_next(input)?;
+    let uri = take_while(1.., is_not_space).parse_next(input)?;
+    let _ = take_while(1.., is_space).parse_next(input)?;
+    let version = http_version(input)?;
+    let _ = line_ending.parse_next(input)?;
 
-    Ok((
-        input,
-        Request {
-            method,
-            uri,
-            version,
-        },
-    ))
+    Ok(Request {
+        method,
+        uri,
+        version,
+    })
 }
 
-fn http_version(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-    let (input, _) = "HTTP/".parse_peek(input)?;
-    let (input, version) = take_while(1.., is_version).parse_peek(input)?;
+fn http_version<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
+    let _ = "HTTP/".parse_next(input)?;
+    let version = take_while(1.., is_version).parse_next(input)?;
 
-    Ok((input, version))
+    Ok(version)
 }
 
-fn message_header_value(input: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-    let (input, _) = take_while(1.., is_horizontal_space).parse_peek(input)?;
-    let (input, data) = take_while(1.., not_line_ending).parse_peek(input)?;
-    let (input, _) = line_ending.parse_peek(input)?;
+fn message_header_value<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
+    let _ = take_while(1.., is_horizontal_space).parse_next(input)?;
+    let data = take_while(1.., not_line_ending).parse_next(input)?;
+    let _ = line_ending.parse_next(input)?;
 
-    Ok((input, data))
+    Ok(data)
 }
 
-fn message_header(input: Stream<'_>) -> IResult<Stream<'_>, Header<'_>> {
-    let (input, name) = take_while(1.., is_token).parse_peek(input)?;
-    let (input, _) = ':'.parse_peek(input)?;
-    let (input, value) = repeat(1.., unpeek(message_header_value)).parse_peek(input)?;
+fn message_header<'s>(input: &mut Stream<'s>) -> PResult<Header<'s>> {
+    let name = take_while(1.., is_token).parse_next(input)?;
+    let _ = ':'.parse_next(input)?;
+    let value = repeat(1.., message_header_value).parse_next(input)?;
 
-    Ok((input, Header { name, value }))
+    Ok(Header { name, value })
 }
 
 #[rustfmt::skip]

--- a/examples/ini/main.rs
+++ b/examples/ini/main.rs
@@ -1,5 +1,4 @@
 use winnow::prelude::*;
-use winnow::unpeek;
 
 mod parser;
 mod parser_str;
@@ -10,7 +9,7 @@ fn main() -> Result<(), lexopt::Error> {
     let input = args.input.as_deref().unwrap_or("1 + 1");
 
     if args.binary {
-        match unpeek(parser::categories).parse(input.as_bytes()) {
+        match parser::categories.parse(input.as_bytes()) {
             Ok(result) => {
                 println!("  {:?}", result);
             }
@@ -19,7 +18,7 @@ fn main() -> Result<(), lexopt::Error> {
             }
         }
     } else {
-        match unpeek(parser_str::categories).parse(input) {
+        match parser_str::categories.parse(input) {
             Ok(result) => {
                 println!("  {:?}", result);
             }

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -66,7 +66,7 @@ fn main() {
         .map(|(k, v)| (k.to_uppercase(), v))
         .collect::<HashMap<_, _>>();
 
-    let parser_result: IResult<_, _> = winnow_it.finish();
+    let parser_result: PResult<(_, _), ()> = winnow_it.finish();
     let (remaining_input, ()) = parser_result.unwrap();
 
     // will print "iterator returned {"key1": "value1", "key3": "value3", "key2": "value2"}, remaining input is ';'"

--- a/examples/json/bench.rs
+++ b/examples/json/bench.rs
@@ -1,3 +1,4 @@
+use winnow::prelude::*;
 use winnow::Partial;
 
 mod json;
@@ -15,12 +16,12 @@ fn json_bench(c: &mut criterion::Criterion) {
         group.bench_with_input(criterion::BenchmarkId::new("basic", name), &len, |b, _| {
             type Error<'i> = winnow::error::Error<parser::Stream<'i>>;
 
-            b.iter(|| parser::json::<Error>(sample).unwrap());
+            b.iter(|| parser::json::<Error>.parse_peek(sample).unwrap());
         });
         group.bench_with_input(criterion::BenchmarkId::new("unit", name), &len, |b, _| {
             type Error<'i> = ();
 
-            b.iter(|| parser::json::<Error>(sample).unwrap());
+            b.iter(|| parser::json::<Error>.parse_peek(sample).unwrap());
         });
         group.bench_with_input(
             criterion::BenchmarkId::new("verbose", name),
@@ -28,7 +29,7 @@ fn json_bench(c: &mut criterion::Criterion) {
             |b, _| {
                 type Error<'i> = winnow::error::VerboseError<parser::Stream<'i>>;
 
-                b.iter(|| parser::json::<Error>(sample).unwrap());
+                b.iter(|| parser::json::<Error>.parse_peek(sample).unwrap());
             },
         );
         group.bench_with_input(
@@ -37,7 +38,7 @@ fn json_bench(c: &mut criterion::Criterion) {
             |b, _| {
                 type Error<'i> = winnow::error::Error<parser_dispatch::Stream<'i>>;
 
-                b.iter(|| parser_dispatch::json::<Error>(sample).unwrap());
+                b.iter(|| parser_dispatch::json::<Error>.parse_peek(sample).unwrap());
             },
         );
         group.bench_with_input(
@@ -46,7 +47,11 @@ fn json_bench(c: &mut criterion::Criterion) {
             |b, _| {
                 type Error<'i> = winnow::error::Error<parser_partial::Stream<'i>>;
 
-                b.iter(|| parser_partial::json::<Error>(Partial::new(sample)).unwrap());
+                b.iter(|| {
+                    parser_partial::json::<Error>
+                        .parse_peek(Partial::new(sample))
+                        .unwrap()
+                });
             },
         );
     }

--- a/examples/json/main.rs
+++ b/examples/json/main.rs
@@ -8,7 +8,6 @@ use winnow::error::convert_error;
 use winnow::error::Error;
 use winnow::error::VerboseError;
 use winnow::prelude::*;
-use winnow::unpeek;
 
 fn main() -> Result<(), lexopt::Error> {
     let args = Args::parse()?;
@@ -28,7 +27,7 @@ fn main() -> Result<(), lexopt::Error> {
     });
 
     if args.verbose {
-        match unpeek(parser::json::<VerboseError<&str>>).parse(data) {
+        match parser::json::<VerboseError<&str>>.parse(data) {
             Ok(json) => {
                 println!("{:#?}", json);
             }
@@ -42,8 +41,8 @@ fn main() -> Result<(), lexopt::Error> {
         }
     } else {
         let result = match args.implementation {
-            Impl::Naive => unpeek(parser::json::<Error<&str>>).parse(data),
-            Impl::Dispatch => unpeek(parser_dispatch::json::<Error<&str>>).parse(data),
+            Impl::Naive => parser::json::<Error<&str>>.parse(data),
+            Impl::Dispatch => parser_dispatch::json::<Error<&str>>.parse(data),
         };
         match result {
             Ok(json) => {

--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -10,7 +10,6 @@ use winnow::{
     combinator::{fold_repeat, separated0},
     error::{ContextError, ParseError},
     token::{any, none_of, take, take_while},
-    unpeek,
 };
 
 use crate::json::JsonValue;
@@ -20,8 +19,8 @@ pub type Stream<'i> = &'i str;
 /// The root element of a JSON parser is any value
 ///
 /// A parser has the following signature:
-/// `Stream -> IResult<Stream, Output, Error>`, with `IResult` defined as:
-/// `type IResult<I, O, E = (I, ErrorKind)> = Result<(I, O), Err<E>>;`
+/// `&mut Stream -> PResult<Output, Error>`, with `PResult` defined as:
+/// `type PResult<O, E = (I, ErrorKind)> = Result<O, Err<E>>;`
 ///
 /// most of the times you can ignore the error type and use the default (but this
 /// examples shows custom error types later on!)
@@ -30,41 +29,41 @@ pub type Stream<'i> = &'i str;
 /// the input type, work directly with `&[u8]`, or any other type that
 /// implements the required traits.
 pub fn json<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, JsonValue, E> {
-    delimited(unpeek(ws), unpeek(json_value), unpeek(ws)).parse_peek(input)
+    input: &mut Stream<'i>,
+) -> PResult<JsonValue, E> {
+    delimited(ws, json_value, ws).parse_next(input)
 }
 
 /// `alt` is a combinator that tries multiple parsers one by one, until
 /// one of them succeeds
 fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, JsonValue, E> {
+    input: &mut Stream<'i>,
+) -> PResult<JsonValue, E> {
     // `alt` combines the each value parser. It returns the result of the first
     // successful parser, or an error
     alt((
-        unpeek(null).value(JsonValue::Null),
-        unpeek(boolean).map(JsonValue::Boolean),
-        unpeek(string).map(JsonValue::Str),
+        null.value(JsonValue::Null),
+        boolean.map(JsonValue::Boolean),
+        string.map(JsonValue::Str),
         float.map(JsonValue::Num),
-        unpeek(array).map(JsonValue::Array),
-        unpeek(object).map(JsonValue::Object),
+        array.map(JsonValue::Array),
+        object.map(JsonValue::Object),
     ))
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// `tag(string)` generates a parser that recognizes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
-fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
+fn null<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
-    "null".parse_peek(input)
+    "null".parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
 /// success.
-fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
+fn boolean<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
     let parse_true = "true".value(true);
@@ -73,14 +72,14 @@ fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'
     // an error otherwise
     let parse_false = "false".value(false);
 
-    alt((parse_true, parse_false)).parse_peek(input)
+    alt((parse_true, parse_false)).parse_next(input)
 }
 
 /// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, String, E> {
+    input: &mut Stream<'i>,
+) -> PResult<String, E> {
     preceded(
         '\"',
         // `cut_err` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
@@ -88,7 +87,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_repeat(0.., unpeek(character), String::new, |mut string, c| {
+            fold_repeat(0.., character, String::new, |mut string, c| {
                 string.push(c);
                 string
             }),
@@ -98,13 +97,13 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
     // `context` lets you add a static string to errors to provide more information in the
     // error chain (to indicate which parser had an error)
     .context("string")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
-fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of('\"').parse_peek(input)?;
+fn character<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+    let c = none_of('\"').parse_next(input)?;
     if c == '\\' {
         alt((
             any.verify_map(|c| {
@@ -118,24 +117,22 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
                     _ => return None,
                 })
             }),
-            preceded('u', unpeek(unicode_escape)),
+            preceded('u', unicode_escape),
         ))
-        .parse_peek(input)
+        .parse_next(input)
     } else {
-        Ok((input, c))
+        Ok(c)
     }
 }
 
-fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, char, E> {
+fn unicode_escape<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
     alt((
         // Not a surrogate
-        unpeek(u16_hex)
+        u16_hex
             .verify(|cp| !(0xD800..0xE000).contains(cp))
             .map(|cp| cp as u32),
         // See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF for details
-        separated_pair(unpeek(u16_hex), "\\u", unpeek(u16_hex))
+        separated_pair(u16_hex, "\\u", u16_hex)
             .verify(|(high, low)| (0xD800..0xDC00).contains(high) && (0xDC00..0xE000).contains(low))
             .map(|(high, low)| {
                 let high_ten = (high as u32) - 0xD800;
@@ -147,13 +144,13 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
         // Could be probably replaced with .unwrap() or _unchecked due to the verify checks
         std::char::from_u32,
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
-fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, u16, E> {
+fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u16, E> {
     take(4usize)
         .verify_map(|s| u16::from_str_radix(s, 16).ok())
-        .parse_peek(input)
+        .parse_next(input)
 }
 
 /// Some combinators, like `separated0` or `many0`, will call a parser repeatedly,
@@ -161,51 +158,40 @@ fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'
 /// If you want more control on the parser application, check out the `iterator`
 /// combinator (cf `examples/iterator.rs`)
 fn array<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, Vec<JsonValue>, E> {
+    input: &mut Stream<'i>,
+) -> PResult<Vec<JsonValue>, E> {
     preceded(
-        ('[', unpeek(ws)),
-        cut_err(terminated(
-            separated0(unpeek(json_value), (unpeek(ws), ',', unpeek(ws))),
-            (unpeek(ws), ']'),
-        )),
+        ('[', ws),
+        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
     )
     .context("array")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, HashMap<String, JsonValue>, E> {
+    input: &mut Stream<'i>,
+) -> PResult<HashMap<String, JsonValue>, E> {
     preceded(
-        ('{', unpeek(ws)),
-        cut_err(terminated(
-            separated0(unpeek(key_value), (unpeek(ws), ',', unpeek(ws))),
-            (unpeek(ws), '}'),
-        )),
+        ('{', ws),
+        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
     )
     .context("object")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, (String, JsonValue), E> {
-    separated_pair(
-        unpeek(string),
-        cut_err((unpeek(ws), ':', unpeek(ws))),
-        unpeek(json_value),
-    )
-    .parse_peek(input)
+    input: &mut Stream<'i>,
+) -> PResult<(String, JsonValue), E> {
+    separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
 /// first we write parsers for the smallest elements (here a space character),
 /// then we'll combine them in larger parsers
-fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
+fn ws<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
     // Combinators like `take_while` return a function. That function is the
     // parser,to which we can pass the input
-    take_while(0.., WS).parse_peek(input)
+    take_while(0.., WS).parse_next(input)
 }
 
 const WS: &[char] = &[' ', '\t', '\r', '\n'];
@@ -222,24 +208,33 @@ mod test {
 
     #[test]
     fn json_string() {
-        assert_eq!(string::<Error<'_>>("\"\""), Ok(("", "".to_string())));
-        assert_eq!(string::<Error<'_>>("\"abc\""), Ok(("", "abc".to_string())));
         assert_eq!(
-            string::<Error<'_>>("\"abc\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0001\\u2014\u{2014}def\""),
+            string::<Error<'_>>.parse_peek("\"\""),
+            Ok(("", "".to_string()))
+        );
+        assert_eq!(
+            string::<Error<'_>>.parse_peek("\"abc\""),
+            Ok(("", "abc".to_string()))
+        );
+        assert_eq!(
+            string::<Error<'_>>
+                .parse_peek("\"abc\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0001\\u2014\u{2014}def\""),
             Ok(("", "abc\"\\/\x08\x0C\n\r\t\x01——def".to_string())),
         );
         assert_eq!(
-            string::<Error<'_>>("\"\\uD83D\\uDE10\""),
+            string::<Error<'_>>.parse_peek("\"\\uD83D\\uDE10\""),
             Ok(("", "😐".to_string()))
         );
 
-        assert!(string::<Error<'_>>("\"").is_err());
-        assert!(string::<Error<'_>>("\"abc").is_err());
-        assert!(string::<Error<'_>>("\"\\\"").is_err());
-        assert!(string::<Error<'_>>("\"\\u123\"").is_err());
-        assert!(string::<Error<'_>>("\"\\uD800\"").is_err());
-        assert!(string::<Error<'_>>("\"\\uD800\\uD800\"").is_err());
-        assert!(string::<Error<'_>>("\"\\uDC00\"").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"abc").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"\\\"").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"\\u123\"").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"\\uD800\"").is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek("\"\\uD800\\uD800\"")
+            .is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"\\uDC00\"").is_err());
     }
 
     #[test]
@@ -257,7 +252,7 @@ mod test {
             .collect(),
         );
 
-        assert_eq!(json::<Error<'_>>(input), Ok(("", expected)));
+        assert_eq!(json::<Error<'_>>.parse_peek(input), Ok(("", expected)));
     }
 
     #[test]
@@ -268,7 +263,7 @@ mod test {
 
         let expected = Array(vec![Num(42.0), Str("x".to_string())]);
 
-        assert_eq!(json::<Error<'_>>(input), Ok(("", expected)));
+        assert_eq!(json::<Error<'_>>.parse_peek(input), Ok(("", expected)));
     }
 
     #[test]
@@ -290,7 +285,7 @@ mod test {
   "#;
 
         assert_eq!(
-            json::<Error<'_>>(input),
+            json::<Error<'_>>.parse_peek(input),
             Ok((
                 "",
                 Object(

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -13,7 +13,6 @@ use winnow::{
     combinator::{fold_repeat, separated0},
     error::{ContextError, ParseError},
     token::{any, none_of, take, take_while},
-    unpeek,
 };
 
 use crate::json::JsonValue;
@@ -33,63 +32,63 @@ pub type Stream<'i> = &'i str;
 /// the input type, work directly with `&[u8]`, or any other type that
 /// implements the required traits.
 pub fn json<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, JsonValue, E> {
-    delimited(unpeek(ws), unpeek(json_value), unpeek(ws)).parse_peek(input)
+    input: &mut Stream<'i>,
+) -> PResult<JsonValue, E> {
+    delimited(ws, json_value, ws).parse_next(input)
 }
 
 /// `alt` is a combinator that tries multiple parsers one by one, until
 /// one of them succeeds
 fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, JsonValue, E> {
+    input: &mut Stream<'i>,
+) -> PResult<JsonValue, E> {
     // `dispatch` gives you `match`-like behavior compared to `alt` successively trying different
     // implementations.
     dispatch!(peek(any);
-        'n' => unpeek(null).value(JsonValue::Null),
-        't' => unpeek(true_).map(JsonValue::Boolean),
-        'f' => unpeek(false_).map(JsonValue::Boolean),
-        '"' => unpeek(string).map(JsonValue::Str),
+        'n' => null.value(JsonValue::Null),
+        't' => true_.map(JsonValue::Boolean),
+        'f' => false_.map(JsonValue::Boolean),
+        '"' => string.map(JsonValue::Str),
         '+' => float.map(JsonValue::Num),
         '-' => float.map(JsonValue::Num),
         '0'..='9' => float.map(JsonValue::Num),
-        '[' => unpeek(array).map(JsonValue::Array),
-        '{' => unpeek(object).map(JsonValue::Object),
+        '[' => array.map(JsonValue::Array),
+        '{' => object.map(JsonValue::Object),
         _ => fail,
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// `tag(string)` generates a parser that recognizes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
-fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
+fn null<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
-    "null".parse_peek(input)
+    "null".parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
 /// success.
-fn true_<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
+fn true_<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
-    "true".value(true).parse_peek(input)
+    "true".value(true).parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
 /// success.
-fn false_<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
+fn false_<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool, E> {
     // This is a parser that returns `false` if it sees the string "false", and
     // an error otherwise
-    "false".value(false).parse_peek(input)
+    "false".value(false).parse_next(input)
 }
 
 /// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, String, E> {
+    input: &mut Stream<'i>,
+) -> PResult<String, E> {
     preceded(
         '\"',
         // `cut_err` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
@@ -97,7 +96,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_repeat(0.., unpeek(character), String::new, |mut string, c| {
+            fold_repeat(0.., character, String::new, |mut string, c| {
                 string.push(c);
                 string
             }),
@@ -107,13 +106,13 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
     // `context` lets you add a static string to errors to provide more information in the
     // error chain (to indicate which parser had an error)
     .context("string")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
-fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of('\"').parse_peek(input)?;
+fn character<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+    let c = none_of('\"').parse_next(input)?;
     if c == '\\' {
         dispatch!(any;
           '"' => success('"'),
@@ -124,25 +123,23 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
           'n' => success('\n'),
           'r' => success('\r'),
           't' => success('\t'),
-          'u' => unpeek(unicode_escape),
+          'u' => unicode_escape,
           _ => fail,
         )
-        .parse_peek(input)
+        .parse_next(input)
     } else {
-        Ok((input, c))
+        Ok(c)
     }
 }
 
-fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, char, E> {
+fn unicode_escape<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
     alt((
         // Not a surrogate
-        unpeek(u16_hex)
+        u16_hex
             .verify(|cp| !(0xD800..0xE000).contains(cp))
             .map(|cp| cp as u32),
         // See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF for details
-        separated_pair(unpeek(u16_hex), "\\u", unpeek(u16_hex))
+        separated_pair(u16_hex, "\\u", u16_hex)
             .verify(|(high, low)| (0xD800..0xDC00).contains(high) && (0xDC00..0xE000).contains(low))
             .map(|(high, low)| {
                 let high_ten = (high as u32) - 0xD800;
@@ -154,13 +151,13 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
         // Could be probably replaced with .unwrap() or _unchecked due to the verify checks
         std::char::from_u32,
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
-fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, u16, E> {
+fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u16, E> {
     take(4usize)
         .verify_map(|s| u16::from_str_radix(s, 16).ok())
-        .parse_peek(input)
+        .parse_next(input)
 }
 
 /// Some combinators, like `separated0` or `many0`, will call a parser repeatedly,
@@ -168,51 +165,40 @@ fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'
 /// If you want more control on the parser application, check out the `iterator`
 /// combinator (cf `examples/iterator.rs`)
 fn array<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, Vec<JsonValue>, E> {
+    input: &mut Stream<'i>,
+) -> PResult<Vec<JsonValue>, E> {
     preceded(
-        ('[', unpeek(ws)),
-        cut_err(terminated(
-            separated0(unpeek(json_value), (unpeek(ws), ',', unpeek(ws))),
-            (unpeek(ws), ']'),
-        )),
+        ('[', ws),
+        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
     )
     .context("array")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, HashMap<String, JsonValue>, E> {
+    input: &mut Stream<'i>,
+) -> PResult<HashMap<String, JsonValue>, E> {
     preceded(
-        ('{', unpeek(ws)),
-        cut_err(terminated(
-            separated0(unpeek(key_value), (unpeek(ws), ',', unpeek(ws))),
-            (unpeek(ws), '}'),
-        )),
+        ('{', ws),
+        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
     )
     .context("object")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, (String, JsonValue), E> {
-    separated_pair(
-        unpeek(string),
-        cut_err((unpeek(ws), ':', unpeek(ws))),
-        unpeek(json_value),
-    )
-    .parse_peek(input)
+    input: &mut Stream<'i>,
+) -> PResult<(String, JsonValue), E> {
+    separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
 /// first we write parsers for the smallest elements (here a space character),
 /// then we'll combine them in larger parsers
-fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
+fn ws<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
     // Combinators like `take_while` return a function. That function is the
     // parser,to which we can pass the input
-    take_while(0.., WS).parse_peek(input)
+    take_while(0.., WS).parse_next(input)
 }
 
 const WS: &[char] = &[' ', '\t', '\r', '\n'];
@@ -229,24 +215,33 @@ mod test {
 
     #[test]
     fn json_string() {
-        assert_eq!(string::<Error<'_>>("\"\""), Ok(("", "".to_string())));
-        assert_eq!(string::<Error<'_>>("\"abc\""), Ok(("", "abc".to_string())));
         assert_eq!(
-            string::<Error<'_>>("\"abc\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0001\\u2014\u{2014}def\""),
+            string::<Error<'_>>.parse_peek("\"\""),
+            Ok(("", "".to_string()))
+        );
+        assert_eq!(
+            string::<Error<'_>>.parse_peek("\"abc\""),
+            Ok(("", "abc".to_string()))
+        );
+        assert_eq!(
+            string::<Error<'_>>
+                .parse_peek("\"abc\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0001\\u2014\u{2014}def\""),
             Ok(("", "abc\"\\/\x08\x0C\n\r\t\x01——def".to_string())),
         );
         assert_eq!(
-            string::<Error<'_>>("\"\\uD83D\\uDE10\""),
+            string::<Error<'_>>.parse_peek("\"\\uD83D\\uDE10\""),
             Ok(("", "😐".to_string()))
         );
 
-        assert!(string::<Error<'_>>("\"").is_err());
-        assert!(string::<Error<'_>>("\"abc").is_err());
-        assert!(string::<Error<'_>>("\"\\\"").is_err());
-        assert!(string::<Error<'_>>("\"\\u123\"").is_err());
-        assert!(string::<Error<'_>>("\"\\uD800\"").is_err());
-        assert!(string::<Error<'_>>("\"\\uD800\\uD800\"").is_err());
-        assert!(string::<Error<'_>>("\"\\uDC00\"").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"abc").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"\\\"").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"\\u123\"").is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"\\uD800\"").is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek("\"\\uD800\\uD800\"")
+            .is_err());
+        assert!(string::<Error<'_>>.parse_peek("\"\\uDC00\"").is_err());
     }
 
     #[test]
@@ -264,7 +259,7 @@ mod test {
             .collect(),
         );
 
-        assert_eq!(json::<Error<'_>>(input), Ok(("", expected)));
+        assert_eq!(json::<Error<'_>>.parse_peek(input), Ok(("", expected)));
     }
 
     #[test]
@@ -275,7 +270,7 @@ mod test {
 
         let expected = Array(vec![Num(42.0), Str("x".to_string())]);
 
-        assert_eq!(json::<Error<'_>>(input), Ok(("", expected)));
+        assert_eq!(json::<Error<'_>>.parse_peek(input), Ok(("", expected)));
     }
 
     #[test]
@@ -297,7 +292,7 @@ mod test {
   "#;
 
         assert_eq!(
-            json::<Error<'_>>(input),
+            json::<Error<'_>>.parse_peek(input),
             Ok((
                 "",
                 Object(

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -22,8 +22,8 @@ pub type Stream<'i> = &'i str;
 /// The root element of a JSON parser is any value
 ///
 /// A parser has the following signature:
-/// `Stream -> IResult<Stream, Output, Error>`, with `IResult` defined as:
-/// `type IResult<I, O, E = (I, ErrorKind)> = Result<(I, O), Err<E>>;`
+/// `&mut Stream -> PResult<Output, Error>`, with `PResult` defined as:
+/// `type PResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;`
 ///
 /// most of the times you can ignore the error type and use the default (but this
 /// examples shows custom error types later on!)

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -20,8 +20,8 @@ pub type Stream<'i> = Partial<&'i str>;
 /// The root element of a JSON parser is any value
 ///
 /// A parser has the following signature:
-/// `Stream -> IResult<Stream, Output, Error>`, with `IResult` defined as:
-/// `type IResult<I, O, E = (I, ErrorKind)> = Result<(I, O), Err<E>>;`
+/// `&mut Stream -> PResult<Output, Error>`, with `PResult` defined as:
+/// `type PResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;`
 ///
 /// most of the times you can ignore the error type and use the default (but this
 /// examples shows custom error types later on!)

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -11,7 +11,6 @@ use winnow::{
     error::{ContextError, ParseError},
     stream::Partial,
     token::{any, none_of, take, take_while},
-    unpeek,
 };
 
 use crate::json::JsonValue;
@@ -31,41 +30,41 @@ pub type Stream<'i> = Partial<&'i str>;
 /// the input type, work directly with `&[u8]`, or any other type that
 /// implements the required traits.
 pub fn json<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, JsonValue, E> {
-    delimited(unpeek(ws), unpeek(json_value), unpeek(ws_or_eof)).parse_peek(input)
+    input: &mut Stream<'i>,
+) -> PResult<JsonValue, E> {
+    delimited(ws, json_value, ws_or_eof).parse_next(input)
 }
 
 /// `alt` is a combinator that tries multiple parsers one by one, until
 /// one of them succeeds
 fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, JsonValue, E> {
+    input: &mut Stream<'i>,
+) -> PResult<JsonValue, E> {
     // `alt` combines the each value parser. It returns the result of the first
     // successful parser, or an error
     alt((
-        unpeek(null).value(JsonValue::Null),
-        unpeek(boolean).map(JsonValue::Boolean),
-        unpeek(string).map(JsonValue::Str),
+        null.value(JsonValue::Null),
+        boolean.map(JsonValue::Boolean),
+        string.map(JsonValue::Str),
         float.map(JsonValue::Num),
-        unpeek(array).map(JsonValue::Array),
-        unpeek(object).map(JsonValue::Object),
+        array.map(JsonValue::Array),
+        object.map(JsonValue::Object),
     ))
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// `tag(string)` generates a parser that recognizes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
-fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
+fn null<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
-    "null".parse_peek(input)
+    "null".parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
 /// success.
-fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
+fn boolean<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
     let parse_true = "true".value(true);
@@ -74,14 +73,14 @@ fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'
     // an error otherwise
     let parse_false = "false".value(false);
 
-    alt((parse_true, parse_false)).parse_peek(input)
+    alt((parse_true, parse_false)).parse_next(input)
 }
 
 /// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, String, E> {
+    input: &mut Stream<'i>,
+) -> PResult<String, E> {
     preceded(
         '\"',
         // `cut_err` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
@@ -89,7 +88,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_repeat(0.., unpeek(character), String::new, |mut string, c| {
+            fold_repeat(0.., character, String::new, |mut string, c| {
                 string.push(c);
                 string
             }),
@@ -99,13 +98,13 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
     // `context` lets you add a static string to errors to provide more information in the
     // error chain (to indicate which parser had an error)
     .context("string")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
-fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of('\"').parse_peek(input)?;
+fn character<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+    let c = none_of('\"').parse_next(input)?;
     if c == '\\' {
         alt((
             any.verify_map(|c| {
@@ -119,24 +118,22 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
                     _ => return None,
                 })
             }),
-            preceded('u', unpeek(unicode_escape)),
+            preceded('u', unicode_escape),
         ))
-        .parse_peek(input)
+        .parse_next(input)
     } else {
-        Ok((input, c))
+        Ok(c)
     }
 }
 
-fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, char, E> {
+fn unicode_escape<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
     alt((
         // Not a surrogate
-        unpeek(u16_hex)
+        u16_hex
             .verify(|cp| !(0xD800..0xE000).contains(cp))
             .map(|cp| cp as u32),
         // See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF for details
-        separated_pair(unpeek(u16_hex), "\\u", unpeek(u16_hex))
+        separated_pair(u16_hex, "\\u", u16_hex)
             .verify(|(high, low)| (0xD800..0xDC00).contains(high) && (0xDC00..0xE000).contains(low))
             .map(|(high, low)| {
                 let high_ten = (high as u32) - 0xD800;
@@ -148,13 +145,13 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
         // Could be probably replaced with .unwrap() or _unchecked due to the verify checks
         std::char::from_u32,
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
-fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, u16, E> {
+fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u16, E> {
     take(4usize)
         .verify_map(|s| u16::from_str_radix(s, 16).ok())
-        .parse_peek(input)
+        .parse_next(input)
 }
 
 /// Some combinators, like `separated0` or `many0`, will call a parser repeatedly,
@@ -162,56 +159,45 @@ fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'
 /// If you want more control on the parser application, check out the `iterator`
 /// combinator (cf `examples/iterator.rs`)
 fn array<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, Vec<JsonValue>, E> {
+    input: &mut Stream<'i>,
+) -> PResult<Vec<JsonValue>, E> {
     preceded(
-        ('[', unpeek(ws)),
-        cut_err(terminated(
-            separated0(unpeek(json_value), (unpeek(ws), ',', unpeek(ws))),
-            (unpeek(ws), ']'),
-        )),
+        ('[', ws),
+        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
     )
     .context("array")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, HashMap<String, JsonValue>, E> {
+    input: &mut Stream<'i>,
+) -> PResult<HashMap<String, JsonValue>, E> {
     preceded(
-        ('{', unpeek(ws)),
-        cut_err(terminated(
-            separated0(unpeek(key_value), (unpeek(ws), ',', unpeek(ws))),
-            (unpeek(ws), '}'),
-        )),
+        ('{', ws),
+        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
     )
     .context("object")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, (String, JsonValue), E> {
-    separated_pair(
-        unpeek(string),
-        cut_err((unpeek(ws), ':', unpeek(ws))),
-        unpeek(json_value),
-    )
-    .parse_peek(input)
+    input: &mut Stream<'i>,
+) -> PResult<(String, JsonValue), E> {
+    separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
 /// first we write parsers for the smallest elements (here a space character),
 /// then we'll combine them in larger parsers
-fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
+fn ws<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
     // Combinators like `take_while` return a function. That function is the
     // parser,to which we can pass the input
-    take_while(0.., WS).parse_peek(input)
+    take_while(0.., WS).parse_next(input)
 }
 
-fn ws_or_eof<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
+fn ws_or_eof<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
     rest.verify(|s: &str| s.chars().all(|c| WS.contains(&c)))
-        .parse_peek(input)
+        .parse_next(input)
 }
 
 const WS: &[char] = &[' ', '\t', '\r', '\n'];
@@ -229,15 +215,15 @@ mod test {
     #[test]
     fn json_string() {
         assert_eq!(
-            string::<Error<'_>>(Partial::new("\"\"")),
+            string::<Error<'_>>.parse_peek(Partial::new("\"\"")),
             Ok((Partial::new(""), "".to_string()))
         );
         assert_eq!(
-            string::<Error<'_>>(Partial::new("\"abc\"")),
+            string::<Error<'_>>.parse_peek(Partial::new("\"abc\"")),
             Ok((Partial::new(""), "abc".to_string()))
         );
         assert_eq!(
-            string::<Error<'_>>(Partial::new(
+            string::<Error<'_>>.parse_peek(Partial::new(
                 "\"abc\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0001\\u2014\u{2014}def\""
             )),
             Ok((
@@ -246,17 +232,29 @@ mod test {
             )),
         );
         assert_eq!(
-            string::<Error<'_>>(Partial::new("\"\\uD83D\\uDE10\"")),
+            string::<Error<'_>>.parse_peek(Partial::new("\"\\uD83D\\uDE10\"")),
             Ok((Partial::new(""), "😐".to_string()))
         );
 
-        assert!(string::<Error<'_>>(Partial::new("\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"abc")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\u123\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\uD800\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\uD800\\uD800\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\uDC00\"")).is_err());
+        assert!(string::<Error<'_>>.parse_peek(Partial::new("\"")).is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"abc"))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\\""))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\u123\""))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\uD800\""))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\uD800\\uD800\""))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\uDC00\""))
+            .is_err());
     }
 
     #[test]
@@ -275,7 +273,7 @@ mod test {
         );
 
         assert_eq!(
-            json::<Error<'_>>(Partial::new(input)),
+            json::<Error<'_>>.parse_peek(Partial::new(input)),
             Ok((Partial::new(""), expected))
         );
     }
@@ -289,7 +287,7 @@ mod test {
         let expected = Array(vec![Num(42.0), Str("x".to_string())]);
 
         assert_eq!(
-            json::<Error<'_>>(Partial::new(input)),
+            json::<Error<'_>>.parse_peek(Partial::new(input)),
             Ok((Partial::new(""), expected))
         );
     }
@@ -313,7 +311,7 @@ mod test {
   "#;
 
         assert_eq!(
-            json::<Error<'_>>(Partial::new(input)),
+            json::<Error<'_>>.parse_peek(Partial::new(input)),
             Ok((
                 Partial::new(""),
                 Object(

--- a/examples/ndjson/main.rs
+++ b/examples/ndjson/main.rs
@@ -5,6 +5,7 @@ use std::io::Read;
 use winnow::error::ErrMode;
 use winnow::error::Error;
 use winnow::error::Needed;
+use winnow::prelude::*;
 use winnow::stream::Offset;
 
 fn main() -> Result<(), lexopt::Error> {
@@ -38,7 +39,7 @@ fn main() -> Result<(), lexopt::Error> {
 
         loop {
             let input = parser::Stream::new(std::str::from_utf8(buffer.data()).map_err(to_lexopt)?);
-            match parser::ndjson::<Error<parser::Stream>>(input) {
+            match parser::ndjson::<Error<parser::Stream>>.parse_peek(input) {
                 Ok((remainder, value)) => {
                     println!("{:?}", value);
                     println!();

--- a/examples/ndjson/parser.rs
+++ b/examples/ndjson/parser.rs
@@ -12,7 +12,6 @@ use winnow::{
     error::{ContextError, ParseError},
     stream::Partial,
     token::{any, none_of, take, take_while},
-    unpeek,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -29,17 +28,13 @@ pub enum JsonValue {
 pub type Stream<'i> = Partial<&'i str>;
 
 pub fn ndjson<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, Option<JsonValue>, E> {
+    input: &mut Stream<'i>,
+) -> PResult<Option<JsonValue>, E> {
     alt((
-        terminated(
-            delimited(unpeek(ws), unpeek(json_value), unpeek(ws)),
-            line_ending,
-        )
-        .map(Some),
+        terminated(delimited(ws, json_value, ws), line_ending).map(Some),
         line_ending.value(None),
     ))
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 // --Besides `WS`, same as a regular json parser ----------------------------
@@ -47,33 +42,33 @@ pub fn ndjson<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static 
 /// `alt` is a combinator that tries multiple parsers one by one, until
 /// one of them succeeds
 fn json_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, JsonValue, E> {
+    input: &mut Stream<'i>,
+) -> PResult<JsonValue, E> {
     // `alt` combines the each value parser. It returns the result of the first
     // successful parser, or an error
     alt((
-        unpeek(null).value(JsonValue::Null),
-        unpeek(boolean).map(JsonValue::Boolean),
-        unpeek(string).map(JsonValue::Str),
+        null.value(JsonValue::Null),
+        boolean.map(JsonValue::Boolean),
+        string.map(JsonValue::Str),
         float.map(JsonValue::Num),
-        unpeek(array).map(JsonValue::Array),
-        unpeek(object).map(JsonValue::Object),
+        array.map(JsonValue::Array),
+        object.map(JsonValue::Object),
     ))
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// `tag(string)` generates a parser that recognizes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
-fn null<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
+fn null<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
-    "null".parse_peek(input)
+    "null".parse_next(input)
 }
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
 /// success.
-fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, bool, E> {
+fn boolean<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
     let parse_true = "true".value(true);
@@ -82,14 +77,14 @@ fn boolean<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'
     // an error otherwise
     let parse_false = "false".value(false);
 
-    alt((parse_true, parse_false)).parse_peek(input)
+    alt((parse_true, parse_false)).parse_next(input)
 }
 
 /// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, String, E> {
+    input: &mut Stream<'i>,
+) -> PResult<String, E> {
     preceded(
         '\"',
         // `cut_err` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
@@ -97,7 +92,7 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
         // right branch (since we found the `"` character) but encountered an error when
         // parsing the string
         cut_err(terminated(
-            fold_repeat(0.., unpeek(character), String::new, |mut string, c| {
+            fold_repeat(0.., character, String::new, |mut string, c| {
                 string.push(c);
                 string
             }),
@@ -107,13 +102,13 @@ fn string<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>
     // `context` lets you add a static string to errors to provide more information in the
     // error chain (to indicate which parser had an error)
     .context("string")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
-fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, char, E> {
-    let (input, c) = none_of('"').parse_peek(input)?;
+fn character<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+    let c = none_of('"').parse_next(input)?;
     if c == '\\' {
         alt((
             any.verify_map(|c| {
@@ -127,24 +122,22 @@ fn character<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream
                     _ => return None,
                 })
             }),
-            preceded('u', unpeek(unicode_escape)),
+            preceded('u', unicode_escape),
         ))
-        .parse_peek(input)
+        .parse_next(input)
     } else {
-        Ok((input, c))
+        Ok(c)
     }
 }
 
-fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, char, E> {
+fn unicode_escape<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
     alt((
         // Not a surrogate
-        unpeek(u16_hex)
+        u16_hex
             .verify(|cp| !(0xD800..0xE000).contains(cp))
             .map(|cp| cp as u32),
         // See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF for details
-        separated_pair(unpeek(u16_hex), "\\u", unpeek(u16_hex))
+        separated_pair(u16_hex, "\\u", u16_hex)
             .verify(|(high, low)| (0xD800..0xDC00).contains(high) && (0xDC00..0xE000).contains(low))
             .map(|(high, low)| {
                 let high_ten = (high as u32) - 0xD800;
@@ -156,13 +149,13 @@ fn unicode_escape<'i, E: ParseError<Stream<'i>>>(
         // Could be probably replaced with .unwrap() or _unchecked due to the verify checks
         std::char::from_u32,
     )
-    .parse_peek(input)
+    .parse_next(input)
 }
 
-fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, u16, E> {
+fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u16, E> {
     take(4usize)
         .verify_map(|s| u16::from_str_radix(s, 16).ok())
-        .parse_peek(input)
+        .parse_next(input)
 }
 
 /// Some combinators, like `separated0` or `many0`, will call a parser repeatedly,
@@ -170,51 +163,40 @@ fn u16_hex<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'
 /// If you want more control on the parser application, check out the `iterator`
 /// combinator (cf `examples/iterator.rs`)
 fn array<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, Vec<JsonValue>, E> {
+    input: &mut Stream<'i>,
+) -> PResult<Vec<JsonValue>, E> {
     preceded(
-        ('[', unpeek(ws)),
-        cut_err(terminated(
-            separated0(unpeek(json_value), (unpeek(ws), ',', unpeek(ws))),
-            (unpeek(ws), ']'),
-        )),
+        ('[', ws),
+        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
     )
     .context("array")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 fn object<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, HashMap<String, JsonValue>, E> {
+    input: &mut Stream<'i>,
+) -> PResult<HashMap<String, JsonValue>, E> {
     preceded(
-        ('{', unpeek(ws)),
-        cut_err(terminated(
-            separated0(unpeek(key_value), (unpeek(ws), ',', unpeek(ws))),
-            (unpeek(ws), '}'),
-        )),
+        ('{', ws),
+        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
     )
     .context("object")
-    .parse_peek(input)
+    .parse_next(input)
 }
 
 fn key_value<'i, E: ParseError<Stream<'i>> + ContextError<Stream<'i>, &'static str>>(
-    input: Stream<'i>,
-) -> IResult<Stream<'i>, (String, JsonValue), E> {
-    separated_pair(
-        unpeek(string),
-        cut_err((unpeek(ws), ':', unpeek(ws))),
-        unpeek(json_value),
-    )
-    .parse_peek(input)
+    input: &mut Stream<'i>,
+) -> PResult<(String, JsonValue), E> {
+    separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
 /// first we write parsers for the smallest elements (here a space character),
 /// then we'll combine them in larger parsers
-fn ws<'i, E: ParseError<Stream<'i>>>(input: Stream<'i>) -> IResult<Stream<'i>, &'i str, E> {
+fn ws<'i, E: ParseError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
     // Combinators like `take_while` return a function. That function is the
     // parser,to which we can pass the input
-    take_while(0.., WS).parse_peek(input)
+    take_while(0.., WS).parse_next(input)
 }
 
 const WS: &[char] = &[' ', '\t'];
@@ -232,15 +214,15 @@ mod test {
     #[test]
     fn json_string() {
         assert_eq!(
-            string::<Error<'_>>(Partial::new("\"\"")),
+            string::<Error<'_>>.parse_peek(Partial::new("\"\"")),
             Ok((Partial::new(""), "".to_string()))
         );
         assert_eq!(
-            string::<Error<'_>>(Partial::new("\"abc\"")),
+            string::<Error<'_>>.parse_peek(Partial::new("\"abc\"")),
             Ok((Partial::new(""), "abc".to_string()))
         );
         assert_eq!(
-            string::<Error<'_>>(Partial::new(
+            string::<Error<'_>>.parse_peek(Partial::new(
                 "\"abc\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0001\\u2014\u{2014}def\""
             )),
             Ok((
@@ -249,17 +231,29 @@ mod test {
             )),
         );
         assert_eq!(
-            string::<Error<'_>>(Partial::new("\"\\uD83D\\uDE10\"")),
+            string::<Error<'_>>.parse_peek(Partial::new("\"\\uD83D\\uDE10\"")),
             Ok((Partial::new(""), "😐".to_string()))
         );
 
-        assert!(string::<Error<'_>>(Partial::new("\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"abc")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\u123\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\uD800\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\uD800\\uD800\"")).is_err());
-        assert!(string::<Error<'_>>(Partial::new("\"\\uDC00\"")).is_err());
+        assert!(string::<Error<'_>>.parse_peek(Partial::new("\"")).is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"abc"))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\\""))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\u123\""))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\uD800\""))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\uD800\\uD800\""))
+            .is_err());
+        assert!(string::<Error<'_>>
+            .parse_peek(Partial::new("\"\\uDC00\""))
+            .is_err());
     }
 
     #[test]
@@ -279,7 +273,7 @@ mod test {
         );
 
         assert_eq!(
-            ndjson::<Error<'_>>(Partial::new(input)),
+            ndjson::<Error<'_>>.parse_peek(Partial::new(input)),
             Ok((Partial::new(""), Some(expected)))
         );
     }
@@ -294,7 +288,7 @@ mod test {
         let expected = Array(vec![Num(42.0), Str("x".to_string())]);
 
         assert_eq!(
-            ndjson::<Error<'_>>(Partial::new(input)),
+            ndjson::<Error<'_>>.parse_peek(Partial::new(input)),
             Ok((Partial::new(""), Some(expected)))
         );
     }
@@ -307,7 +301,7 @@ mod test {
 "#;
 
         assert_eq!(
-            ndjson::<Error<'_>>(Partial::new(input)),
+            ndjson::<Error<'_>>.parse_peek(Partial::new(input)),
             Ok((
                 Partial::new(""),
                 Some(Object(

--- a/examples/string/main.rs
+++ b/examples/string/main.rs
@@ -14,13 +14,12 @@
 mod parser;
 
 use winnow::prelude::*;
-use winnow::unpeek;
 
 fn main() -> Result<(), lexopt::Error> {
     let args = Args::parse()?;
 
     let data = args.input.as_deref().unwrap_or("\"abc\"");
-    let result = unpeek(parser::parse_string::<()>).parse(data);
+    let result = parser::parse_string::<()>.parse(data);
     match result {
         Ok(data) => println!("{}", data),
         Err(err) => println!("{:?}", err),

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -65,11 +65,11 @@
 //!   token::take_till1,
 //! };
 //!
-//! pub fn peol_comment<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, (), E>
+//! pub fn peol_comment<'a, E: ParseError<&'a str>>(i: &mut &'a str) -> PResult<(), E>
 //! {
 //!   ('%', take_till1(['\n', '\r']))
 //!     .void() // Output is thrown away.
-//!     .parse_peek(i)
+//!     .parse_next(i)
 //! }
 //! ```
 //!
@@ -85,14 +85,14 @@
 //!   token::{tag, take_until0},
 //! };
 //!
-//! pub fn pinline_comment<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, (), E> {
+//! pub fn pinline_comment<'a, E: ParseError<&'a str>>(i: &mut &'a str) -> PResult<(), E> {
 //!   (
 //!     "(*",
 //!     take_until0("*)"),
 //!     "*)"
 //!   )
 //!     .void() // Output is thrown away.
-//!     .parse_peek(i)
+//!     .parse_next(i)
 //! }
 //! ```
 //!
@@ -111,13 +111,13 @@
 //!   token::one_of,
 //! };
 //!
-//! pub fn identifier(input: &str) -> IResult<&str, &str> {
+//! pub fn identifier<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //!   (
 //!       one_of(|c: char| c.is_alpha() || c == '_'),
 //!       take_while(0.., |c: char| c.is_alphanum() || c == '_')
 //!   )
 //!   .recognize()
-//!   .parse_peek(input)
+//!   .parse_next(input)
 //! }
 //! ```
 //!
@@ -162,13 +162,13 @@
 //!   token::tag,
 //! };
 //!
-//! fn hexadecimal(input: &str) -> IResult<&str, &str> { // <'a, E: ParseError<&'a str>>
+//! fn hexadecimal<'s>(input: &mut &'s str) -> PResult<&'s str> { // <'a, E: ParseError<&'a str>>
 //!   preceded(
 //!     alt(("0x", "0X")),
 //!     repeat(1..,
 //!       terminated(one_of(('0'..='9', 'a'..='f', 'A'..='F')), repeat(0.., '_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
-//!   ).parse_peek(input)
+//!   ).parse_next(input)
 //! }
 //! ```
 //!
@@ -184,7 +184,7 @@
 //!   token::tag,
 //! };
 //!
-//! fn hexadecimal_value(input: &str) -> IResult<&str, i64> {
+//! fn hexadecimal_value(input: &mut &str) -> PResult<i64> {
 //!   preceded(
 //!     alt(("0x", "0X")),
 //!     repeat(1..,
@@ -192,7 +192,7 @@
 //!     ).map(|()| ()).recognize()
 //!   ).try_map(
 //!     |out: &str| i64::from_str_radix(&str::replace(&out, "_", ""), 16)
-//!   ).parse_peek(input)
+//!   ).parse_next(input)
 //! }
 //! ```
 //!
@@ -210,13 +210,13 @@
 //!   token::tag,
 //! };
 //!
-//! fn octal(input: &str) -> IResult<&str, &str> {
+//! fn octal<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //!   preceded(
 //!     alt(("0o", "0O")),
 //!     repeat(1..,
 //!       terminated(one_of('0'..='7'), repeat(0.., '_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
-//!   ).parse_peek(input)
+//!   ).parse_next(input)
 //! }
 //! ```
 //!
@@ -232,13 +232,13 @@
 //!   token::tag,
 //! };
 //!
-//! fn binary(input: &str) -> IResult<&str, &str> {
+//! fn binary<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //!   preceded(
 //!     alt(("0b", "0B")),
 //!     repeat(1..,
 //!       terminated(one_of('0'..='1'), repeat(0.., '_').map(|()| ()))
 //!     ).map(|()| ()).recognize()
-//!   ).parse_peek(input)
+//!   ).parse_next(input)
 //! }
 //! ```
 //!
@@ -253,12 +253,12 @@
 //!   token::one_of,
 //! };
 //!
-//! fn decimal(input: &str) -> IResult<&str, &str> {
+//! fn decimal<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //!   repeat(1..,
 //!     terminated(one_of('0'..='9'), repeat(0.., '_').map(|()| ()))
 //!   ).map(|()| ())
 //!     .recognize()
-//!     .parse_peek(input)
+//!     .parse_next(input)
 //! }
 //! ```
 //!

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -247,7 +247,6 @@
 //! ```rust
 //! use winnow::prelude::*;
 //! use winnow::{
-//!   IResult,
 //!   combinator::{repeat},
 //!   combinator::terminated,
 //!   token::one_of,

--- a/src/_topic/stream.rs
+++ b/src/_topic/stream.rs
@@ -13,7 +13,7 @@
 //! ## Implementing a custom stream
 //!
 //! Let's assume we have an input type we'll call `MyStream`. `MyStream` is a sequence of `MyItem` type.
-//! The goal is to define parsers with this signature: `MyStream -> IResult<MyStream, Output>`.
+//! The goal is to define parsers with this signature: `&mut MyStream -> PResult<Output>`.
 //!
 //! ```rust
 //! # use winnow::prelude::*;

--- a/src/_topic/stream.rs
+++ b/src/_topic/stream.rs
@@ -20,8 +20,8 @@
 //! # use winnow::token::tag;
 //! # type MyStream<'i> = &'i str;
 //! # type Output<'i> = &'i str;
-//! fn parser(i: MyStream<'_>) -> IResult<MyStream<'_>, Output<'_>> {
-//!     "test".parse_peek(i)
+//! fn parser<'s>(i: &mut MyStream<'s>) -> PResult<Output<'s>> {
+//!     "test".parse_next(i)
 //! }
 //! ```
 //!

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -93,7 +93,7 @@
 //! > If you have not programmed in a language where functions are values, the type signature of the
 //! > [`one_of`] function might be a surprise.
 //! > The function [`one_of`] *returns a function*. The function it returns is a
-//! > `Parser`, taking a `&str` and returning an `IResult`. This is a common pattern in winnow for
+//! > `Parser`, taking a `&str` and returning an `PResult`. This is a common pattern in winnow for
 //! > configurable or stateful parsers.
 //!
 //! Some of character classes are common enough that a named parser is provided, like with:

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::prelude::*;
 
 mod complete {
     use super::*;
@@ -241,7 +242,7 @@ mod complete {
         let f = "βèƒôřè\rÂßÇáƒƭèř";
         assert_eq!(
             not_line_ending.parse_peek(f),
-            Err(ErrMode::Backtrack(Error::new(f, ErrorKind::Tag)))
+            Err(ErrMode::Backtrack(Error::new(&f[12..], ErrorKind::Tag)))
         );
 
         let g2: &str = "ab12cd";
@@ -570,7 +571,7 @@ mod complete {
 
     #[cfg(feature = "std")]
     fn parse_f64(i: &str) -> IResult<&str, f64, ()> {
-        match super::recognize_float_or_exceptions(i) {
+        match super::recognize_float_or_exceptions.parse_peek(i) {
             Err(e) => Err(e),
             Ok((i, s)) => {
                 if s.is_empty() {
@@ -1213,7 +1214,7 @@ mod partial {
         assert_eq!(
             not_line_ending.parse_peek(Partial::new(f)),
             Err(ErrMode::Backtrack(Error::new(
-                Partial::new(f),
+                Partial::new(&f[12..]),
                 ErrorKind::Tag
             )))
         );

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::unpeek;
 use crate::IResult;
 
 mod complete {

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -11,7 +11,7 @@ pub use crate::dispatch;
 /// This trait is implemented for tuples of up to 21 elements
 pub trait Alt<I, O, E> {
     /// Tests each parser in the tuple and returns the result of the first one that succeeds
-    fn choice(&mut self, input: I) -> IResult<I, O, E>;
+    fn choice(&mut self, input: &mut I) -> PResult<O, E>;
 }
 
 /// Pick the first successful parser
@@ -48,7 +48,7 @@ pub trait Alt<I, O, E> {
 pub fn alt<I: Stream, O, E: ParseError<I>, List: Alt<I, O, E>>(
     mut l: List,
 ) -> impl Parser<I, O, E> {
-    trace("alt", unpeek(move |i: I| l.choice(i)))
+    trace("alt", move |i: &mut I| l.choice(i))
 }
 
 /// Helper trait for the [permutation()] combinator.
@@ -56,7 +56,7 @@ pub fn alt<I: Stream, O, E: ParseError<I>, List: Alt<I, O, E>>(
 /// This trait is implemented for tuples of up to 21 elements
 pub trait Permutation<I, O, E> {
     /// Tries to apply all parsers in the tuple in various orders until all of them succeed
-    fn permutation(&mut self, input: I) -> IResult<I, O, E>;
+    fn permutation(&mut self, input: &mut I) -> PResult<O, E>;
 }
 
 /// Applies a list of parsers in any order.
@@ -109,7 +109,7 @@ pub trait Permutation<I, O, E> {
 pub fn permutation<I: Stream, O, E: ParseError<I>, List: Permutation<I, O, E>>(
     mut l: List,
 ) -> impl Parser<I, O, E> {
-    trace("permutation", unpeek(move |i: I| l.permutation(i)))
+    trace("permutation", move |i: &mut I| l.permutation(i))
 }
 
 macro_rules! alt_trait(
@@ -130,13 +130,14 @@ macro_rules! alt_trait(
 macro_rules! alt_trait_impl(
   ($($id:ident)+) => (
     impl<
-      I: Clone, Output, Error: ParseError<I>,
+      I: Stream, Output, Error: ParseError<I>,
       $($id: Parser<I, Output, Error>),+
     > Alt<I, Output, Error> for ( $($id),+ ) {
 
-      fn choice(&mut self, input: I) -> IResult<I, Output, Error> {
-        match self.0.parse_peek(input.clone()) {
-          Err(ErrMode::Backtrack(e)) => alt_trait_inner!(1, self, input, e, $($id)+),
+      fn choice(&mut self, input: &mut I) -> PResult<Output, Error> {
+        let start = input.checkpoint();
+        match self.0.parse_next(input) {
+          Err(ErrMode::Backtrack(e)) => alt_trait_inner!(1, self, input, start, e, $($id)+),
           res => res,
         }
       }
@@ -145,26 +146,28 @@ macro_rules! alt_trait_impl(
 );
 
 macro_rules! alt_trait_inner(
-  ($it:tt, $self:expr, $input:expr, $err:expr, $head:ident $($id:ident)+) => (
-    match $self.$it.parse_peek($input.clone()) {
+  ($it:tt, $self:expr, $input:expr, $start:ident, $err:expr, $head:ident $($id:ident)+) => ({
+    $input.reset($start.clone());
+    match $self.$it.parse_next($input) {
       Err(ErrMode::Backtrack(e)) => {
         let err = $err.or(e);
-        succ!($it, alt_trait_inner!($self, $input, err, $($id)+))
+        succ!($it, alt_trait_inner!($self, $input, $start, err, $($id)+))
       }
       res => res,
     }
-  );
-  ($it:tt, $self:expr, $input:expr, $err:expr, $head:ident) => (
-    Err(ErrMode::Backtrack($err.append($input, ErrorKind::Alt)))
-  );
+  });
+  ($it:tt, $self:expr, $input:expr, $start:ident, $err:expr, $head:ident) => ({
+    $input.reset($start);
+    Err(ErrMode::Backtrack($err.append($input.clone(), ErrorKind::Alt)))
+  });
 );
 
 alt_trait!(Alt2 Alt3 Alt4 Alt5 Alt6 Alt7 Alt8 Alt9 Alt10 Alt11 Alt12 Alt13 Alt14 Alt15 Alt16 Alt17 Alt18 Alt19 Alt20 Alt21 Alt22);
 
 // Manually implement Alt for (A,), the 1-tuple type
 impl<I, O, E: ParseError<I>, A: Parser<I, O, E>> Alt<I, O, E> for (A,) {
-    fn choice(&mut self, input: I) -> IResult<I, O, E> {
-        self.0.parse_peek(input)
+    fn choice(&mut self, input: &mut I) -> PResult<O, E> {
+        self.0.parse_next(input)
     }
 }
 
@@ -191,27 +194,29 @@ macro_rules! permutation_trait(
 macro_rules! permutation_trait_impl(
   ($($name:ident $ty:ident $item:ident),+) => (
     impl<
-      I: Clone, $($ty),+ , Error: ParseError<I>,
+      I: Stream, $($ty),+ , Error: ParseError<I>,
       $($name: Parser<I, $ty, Error>),+
     > Permutation<I, ( $($ty),+ ), Error> for ( $($name),+ ) {
 
-      fn permutation(&mut self, mut input: I) -> IResult<I, ( $($ty),+ ), Error> {
+      fn permutation(&mut self, input: &mut I) -> PResult<( $($ty),+ ), Error> {
         let mut res = ($(Option::<$ty>::None),+);
 
         loop {
           let mut err: Option<Error> = None;
-          permutation_trait_inner!(0, self, input, res, err, $($name)+);
+          let start = input.checkpoint();
+          permutation_trait_inner!(0, self, input, start, res, err, $($name)+);
 
           // If we reach here, every iterator has either been applied before,
           // or errored on the remaining input
           if let Some(err) = err {
             // There are remaining parsers, and all errored on the remaining input
-            return Err(ErrMode::Backtrack(err.append(input, ErrorKind::Alt)));
+            input.reset(start);
+            return Err(ErrMode::Backtrack(err.append(input.clone(), ErrorKind::Alt)));
           }
 
           // All parsers were applied
           match res {
-            ($(Some($item)),+) => return Ok((input, ($($item),+))),
+            ($(Some($item)),+) => return Ok(($($item),+)),
             _ => unreachable!(),
           }
         }
@@ -221,11 +226,11 @@ macro_rules! permutation_trait_impl(
 );
 
 macro_rules! permutation_trait_inner(
-  ($it:tt, $self:expr, $input:ident, $res:expr, $err:expr, $head:ident $($id:ident)*) => (
+  ($it:tt, $self:expr, $input:ident, $start:ident, $res:expr, $err:expr, $head:ident $($id:ident)*) => (
     if $res.$it.is_none() {
-      match $self.$it.parse_peek($input.clone()) {
-        Ok((i, o)) => {
-          $input = i;
+      $input.reset($start.clone());
+      match $self.$it.parse_next($input) {
+        Ok(o) => {
           $res.$it = Some(o);
           continue;
         }
@@ -238,9 +243,9 @@ macro_rules! permutation_trait_inner(
         Err(e) => return Err(e),
       };
     }
-    succ!($it, permutation_trait_inner!($self, $input, $res, $err, $($id)*));
+    succ!($it, permutation_trait_inner!($self, $input, $start, $res, $err, $($id)*));
   );
-  ($it:tt, $self:expr, $input:ident, $res:expr, $err:expr,) => ();
+  ($it:tt, $self:expr, $input:ident, $start:ident, $res:expr, $err:expr,) => ();
 );
 
 permutation_trait!(

--- a/src/combinator/sequence.rs
+++ b/src/combinator/sequence.rs
@@ -35,13 +35,10 @@ where
     F: Parser<I, O1, E>,
     G: Parser<I, O2, E>,
 {
-    trace(
-        "preceded",
-        unpeek(move |input: I| {
-            let (input, _) = first.parse_peek(input)?;
-            second.parse_peek(input)
-        }),
-    )
+    trace("preceded", move |input: &mut I| {
+        let _ = first.parse_next(input)?;
+        second.parse_next(input)
+    })
 }
 
 /// Sequence two parsers, only returning the output of the first.
@@ -76,13 +73,10 @@ where
     F: Parser<I, O1, E>,
     G: Parser<I, O2, E>,
 {
-    trace(
-        "terminated",
-        unpeek(move |input: I| {
-            let (input, o1) = first.parse_peek(input)?;
-            second.parse_peek(input).map(|(i, _)| (i, o1))
-        }),
-    )
+    trace("terminated", move |input: &mut I| {
+        let o1 = first.parse_next(input)?;
+        second.parse_next(input).map(|_| o1)
+    })
 }
 
 /// Sequence three parsers, only returning the values of the first and third.
@@ -119,14 +113,11 @@ where
     G: Parser<I, O2, E>,
     H: Parser<I, O3, E>,
 {
-    trace(
-        "separated_pair",
-        unpeek(move |input: I| {
-            let (input, o1) = first.parse_peek(input)?;
-            let (input, _) = sep.parse_peek(input)?;
-            second.parse_peek(input).map(|(i, o2)| (i, (o1, o2)))
-        }),
-    )
+    trace("separated_pair", move |input: &mut I| {
+        let o1 = first.parse_next(input)?;
+        let _ = sep.parse_next(input)?;
+        second.parse_next(input).map(|o2| (o1, o2))
+    })
 }
 
 /// Sequence three parsers, only returning the output of the second.
@@ -165,12 +156,9 @@ where
     G: Parser<I, O2, E>,
     H: Parser<I, O3, E>,
 {
-    trace(
-        "delimited",
-        unpeek(move |input: I| {
-            let (input, _) = first.parse_peek(input)?;
-            let (input, o2) = second.parse_peek(input)?;
-            third.parse_peek(input).map(|(i, _)| (i, o2))
-        }),
-    )
+    trace("delimited", move |input: &mut I| {
+        let _ = first.parse_next(input)?;
+        let o2 = second.parse_next(input)?;
+        third.parse_next(input).map(|_| o2)
+    })
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@
 //! - Can be modified according to the user's needs, because some languages need a lot more information
 //! - Help thread-through the [stream][crate::stream]
 //!
-//! To abstract these needs away from the user, generally `winnow` parsers use the [`IResult`]
+//! To abstract these needs away from the user, generally `winnow` parsers use the [`PResult`]
 //! alias, rather than [`Result`][std::result::Result].  [`Parser::parse`] is a top-level operation
 //! that can help convert to a `Result` for integrating with your application's error reporting.
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,16 +40,16 @@
 #[macro_export]
 macro_rules! dispatch {
     ($match_parser: expr; $( $pat:pat $(if $pred:expr)? => $expr: expr ),+ $(,)? ) => {
-        $crate::trace::trace("dispatch", $crate::unpeek(move |i|
+        $crate::trace::trace("dispatch", move |i: &mut _|
         {
             use $crate::Parser;
-            let (i, initial) = $match_parser.parse_peek(i)?;
+            let initial = $match_parser.parse_next(i)?;
             match initial {
                 $(
-                    $pat $(if $pred)? => $expr.parse_peek(i),
+                    $pat $(if $pred)? => $expr.parse_next(i),
                 )*
             }
-        }))
+        })
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2422,13 +2422,13 @@ impl<'a> AsChar for &'a char {
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Error};
 /// # use winnow::token::take_while;
-/// fn hex_digit1(input: &str) -> IResult<&str, &str> {
-///     take_while(1.., ('a'..='f', 'A'..='F', '0'..='9')).parse_peek(input)
+/// fn hex_digit1<'s>(input: &mut &'s str) -> PResult<&'s str, Error<&'s str>> {
+///     take_while(1.., ('a'..='f', 'A'..='F', '0'..='9')).parse_next(input)
 /// }
 ///
-/// assert_eq!(hex_digit1("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(hex_digit1("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
-/// assert_eq!(hex_digit1(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
+/// assert_eq!(hex_digit1.parse_peek("21cZ"), Ok(("Z", "21c")));
+/// assert_eq!(hex_digit1.parse_peek("H2"), Err(ErrMode::Backtrack(Error::new("H2", ErrorKind::Slice))));
+/// assert_eq!(hex_digit1.parse_peek(""), Err(ErrMode::Backtrack(Error::new("", ErrorKind::Slice))));
 /// ```
 pub trait ContainsToken<T> {
     /// Returns true if self contains the token

--- a/src/trace/internals.rs
+++ b/src/trace/internals.rs
@@ -129,7 +129,7 @@ pub fn end(
     depth: usize,
     name: &dyn crate::lib::std::fmt::Display,
     count: usize,
-    consumed: Option<usize>,
+    consumed: usize,
     severity: Severity,
 ) {
     let gutter_style = anstyle::Style::new().bold();
@@ -146,7 +146,7 @@ pub fn end(
     let (status_style, status) = match severity {
         Severity::Success => {
             let style = anstyle::Style::new().fg_color(Some(anstyle::AnsiColor::Green.into()));
-            let status = format!("+{}", consumed.unwrap_or_default());
+            let status = format!("+{}", consumed);
             (style, status)
         }
         Severity::Backtrack => (

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -26,7 +26,7 @@ compile_error!("`debug` requires `std`");
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::{Error, ErrorKind}, error::Needed};
 /// # use winnow::token::take_while;
 /// # use winnow::stream::AsChar;
 /// # use winnow::prelude::*;

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -32,17 +32,17 @@ compile_error!("`debug` requires `std`");
 /// # use winnow::prelude::*;
 /// use winnow::trace::trace;
 ///
-/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+/// fn short_alpha<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8], Error<&'s [u8]>> {
 ///   trace("short_alpha",
 ///     take_while(3..=6, AsChar::is_alpha)
-///   ).parse_peek(s)
+///   ).parse_next(s)
 /// }
 ///
-/// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
-/// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Backtrack(Error::new(&b"ed"[..], ErrorKind::Slice))));
-/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::Slice))));
+/// assert_eq!(short_alpha.parse_peek(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(short_alpha.parse_peek(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
+/// assert_eq!(short_alpha.parse_peek(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert_eq!(short_alpha.parse_peek(b"ed"), Err(ErrMode::Backtrack(Error::new(&b"ed"[..], ErrorKind::Slice))));
+/// assert_eq!(short_alpha.parse_peek(b"12345"), Err(ErrMode::Backtrack(Error::new(&b"12345"[..], ErrorKind::Slice))));
 /// ```
 #[cfg_attr(not(feature = "debug"), allow(unused_variables))]
 #[cfg_attr(not(feature = "debug"), allow(unused_mut))]

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -53,23 +53,21 @@ pub fn trace<I: Stream, O, E>(
 ) -> impl Parser<I, O, E> {
     #[cfg(feature = "debug")]
     {
-        use crate::unpeek;
-
         let mut call_count = 0;
-        unpeek(move |i: I| {
+        move |i: &mut I| {
             let depth = internals::Depth::new();
             let original = i.checkpoint();
-            internals::start(*depth, &name, call_count, &i);
+            internals::start(*depth, &name, call_count, i);
 
-            let res = parser.parse_peek(i);
+            let res = parser.parse_next(i);
 
-            let consumed = res.as_ref().ok().map(|(i, _)| i.offset_from(&original));
+            let consumed = i.offset_from(&original);
             let severity = internals::Severity::with_result(&res);
             internals::end(*depth, &name, call_count, consumed, severity);
             call_count += 1;
 
             res
-        })
+        }
     }
     #[cfg(not(feature = "debug"))]
     {


### PR DESCRIPTION
Not all doc comments have been updated though

This is a step towards #72

v0.4.7
```
json/basic/canada       time:   [10.272 ms 10.308 ms 10.347 ms]
json/verbose/canada     time:   [32.539 ms 32.714 ms 32.893 ms]
json/dispatch/canada    time:   [8.9747 ms 8.9926 ms 9.0118 ms]
json/streaming/canada   time:   [10.612 ms 10.667 ms 10.726 ms]
```

#278
```
json/basic/canada       time:   [10.700 ms 10.779 ms 10.865 ms]
json/unit/canada        time:   [8.8489 ms 8.8636 ms 8.8791 ms]
json/verbose/canada     time:   [33.240 ms 33.291 ms 33.344 ms]
json/dispatch/canada    time:   [8.8891 ms 8.9045 ms 8.9203 ms]
json/streaming/canada   time:   [9.9510 ms 9.9905 ms 10.033 ms]
```

#279
```
```