### PR TITLE
feat(error): Backport additional names for items

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -357,6 +357,8 @@ pub trait ContextError<I, C = &'static str>: Sized {
     }
 }
 
+pub use ContextError as AddContext;
+
 /// Create a new error with an external error, from [`std::str::FromStr`]
 ///
 /// This trait is required by the [`Parser::try_map`] combinator.

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@
 //!
 //! Error types include:
 //! - `()`
+//! - [`ErrorKind`]
 //! - [`Error`]
 //! - [`VerboseError`]
 //! - [Custom errors][crate::_topic::error]

--- a/src/error.rs
+++ b/src/error.rs
@@ -385,6 +385,8 @@ pub struct Error<I> {
     pub kind: ErrorKind,
 }
 
+pub use Error as InputError;
+
 impl<I> Error<I> {
     /// Creates a new basic error
     pub fn new(input: I, kind: ErrorKind) -> Error<I> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -344,6 +344,8 @@ pub trait ParseError<I>: Sized {
     }
 }
 
+pub use ParseError as ParserError;
+
 /// Used by [`Parser::context`] to add custom data to error while backtracking
 ///
 /// May be implemented multiple times for different kinds of context.


### PR DESCRIPTION
This is to help the transition to 0.5 which has #282