### PR TITLE
fix(trace)!: Fancy rendering for BStr / Bytes

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -493,6 +493,9 @@ pub trait Stream:
     ///
     /// May panic if an invalid [`Self::Checkpoint`] is provided
     fn reset(&mut self, checkpoint: Self::Checkpoint);
+
+    /// Return the inner-most stream
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug;
 }
 
 impl<'i, T> Stream for &'i [T]
@@ -551,6 +554,11 @@ where
     #[inline(always)]
     fn reset(&mut self, checkpoint: Self::Checkpoint) {
         *self = checkpoint.0;
+    }
+
+    #[inline(always)]
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug {
+        self
     }
 }
 
@@ -622,6 +630,11 @@ impl<'i> Stream for &'i str {
     fn reset(&mut self, checkpoint: Self::Checkpoint) {
         *self = checkpoint.0;
     }
+
+    #[inline(always)]
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug {
+        self
+    }
 }
 
 impl<'i> Stream for &'i Bytes {
@@ -682,6 +695,11 @@ impl<'i> Stream for &'i Bytes {
     fn reset(&mut self, checkpoint: Self::Checkpoint) {
         *self = checkpoint.0;
     }
+
+    #[inline(always)]
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug {
+        self
+    }
 }
 
 impl<'i> Stream for &'i BStr {
@@ -741,6 +759,11 @@ impl<'i> Stream for &'i BStr {
     #[inline(always)]
     fn reset(&mut self, checkpoint: Self::Checkpoint) {
         *self = checkpoint.0;
+    }
+
+    #[inline(always)]
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug {
+        self
     }
 }
 
@@ -814,6 +837,11 @@ where
     fn reset(&mut self, checkpoint: Self::Checkpoint) {
         self.0.reset(checkpoint.0 .0);
         self.1 = checkpoint.0 .1;
+    }
+
+    #[inline(always)]
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug {
+        &self.0
     }
 }
 
@@ -908,6 +936,11 @@ impl<I: Stream> Stream for Located<I> {
     fn reset(&mut self, checkpoint: Self::Checkpoint) {
         self.input.reset(checkpoint.0);
     }
+
+    #[inline(always)]
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug {
+        &self.input
+    }
 }
 
 impl<I: Stream, S: Clone + crate::lib::std::fmt::Debug> Stream for Stateful<I, S> {
@@ -956,6 +989,11 @@ impl<I: Stream, S: Clone + crate::lib::std::fmt::Debug> Stream for Stateful<I, S
     fn reset(&mut self, checkpoint: Self::Checkpoint) {
         self.input.reset(checkpoint.0);
     }
+
+    #[inline(always)]
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug {
+        &self.input
+    }
 }
 
 impl<I: Stream> Stream for Partial<I> {
@@ -1003,6 +1041,11 @@ impl<I: Stream> Stream for Partial<I> {
     #[inline(always)]
     fn reset(&mut self, checkpoint: Self::Checkpoint) {
         self.input.reset(checkpoint.0);
+    }
+
+    #[inline(always)]
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug {
+        &self.input
     }
 }
 

--- a/src/trace/internals.rs
+++ b/src/trace/internals.rs
@@ -87,13 +87,9 @@ pub fn start<I: Stream>(
     };
     let call_column = format!("{:depth$}> {name}{count}", "");
 
-    let eof_offset = input.eof_offset();
-    let offset = input.offset_at(input_width).unwrap_or(eof_offset);
-    let (_, slice) = input.peek_slice(offset);
-
     // The debug version of `slice` might be wider, either due to rendering one byte as two nibbles or
     // escaping in strings.
-    let mut debug_slice = format!("{:#?}", slice);
+    let mut debug_slice = format!("{:#?}", input.raw());
     let (debug_slice, eof) = if let Some(debug_offset) = debug_slice
         .char_indices()
         .enumerate()


### PR DESCRIPTION
BREAKING CHANGE: `Stream::raw` is a new required function

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
