### PR TITLE
fiix(stream)!: Relax super traits for `Stream`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Example: `winnow`:
 - Changed error type for `Parser::parse` to allow quality errors without requiring `E` to carry `I`
 - Removed `impl ContainsToken for &str` (e.g. `one_of("abc"`) since it takes 5x more time leading to easily avoidable slow downs
   - Instead use `['a', 'b', 'c']` or `'a'..='c'` (see [`08b3e57`](https://github.com/winnow-rs/winnow/pull/252/commits/08b3e57ad321a79615fa0c516b818af449c38076) for examples)
+- Changed `ParserError` and `FromExternalError` from accepting `I` to `&I`
 - Renamed `ParseError` to `ParserError`
 - Renamed `ContextError` to `AddContext`
 - Renamed `Error` to `InputError`

--- a/benches/number.rs
+++ b/benches/number.rs
@@ -52,10 +52,7 @@ fn float_str(c: &mut Criterion) {
 fn std_float(input: &mut &[u8]) -> PResult<f64> {
     match input.parse_slice() {
         Some(n) => Ok(n),
-        None => Err(ErrMode::from_error_kind(
-            <&[u8]>::clone(input),
-            ErrorKind::Slice,
-        )),
+        None => Err(ErrMode::from_error_kind(input, ErrorKind::Slice)),
     }
 }
 

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -9,12 +9,12 @@ pub enum CustomError<I> {
     Nom(I, ErrorKind),
 }
 
-impl<I> ParserError<I> for CustomError<I> {
-    fn from_error_kind(input: I, kind: ErrorKind) -> Self {
-        CustomError::Nom(input, kind)
+impl<I: Clone> ParserError<I> for CustomError<I> {
+    fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
+        CustomError::Nom(input.clone(), kind)
     }
 
-    fn append(self, _: I, _: ErrorKind) -> Self {
+    fn append(self, _: &I, _: ErrorKind) -> Self {
         self
     }
 }

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -30,7 +30,7 @@ fn incr(i: &mut &str) -> PResult<()> {
         // limit the number of recursions, the fuzzer keeps running into them
         if *l.borrow() >= 8192 {
             Err(winnow::error::ErrMode::from_error_kind(
-                <&str>::clone(i),
+                i,
                 winnow::error::ErrorKind::Many,
             ))
         } else {

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -16,10 +16,10 @@
 //!
 //! fn parse_prefix(input: &mut &str) -> PResult<char> {
 //!     let c = input.next_token().ok_or_else(|| {
-//!         ErrMode::from_error_kind(input.clone(), ErrorKind::Token)
+//!         ErrMode::from_error_kind(input, ErrorKind::Token)
 //!     })?;
 //!     if c != '0' {
-//!         return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Verify));
+//!         return Err(ErrMode::from_error_kind(input, ErrorKind::Verify));
 //!     }
 //!     Ok(c)
 //! }
@@ -95,11 +95,11 @@
 //! fn parse_prefix<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //!     let expected = "0x";
 //!     if input.len() < expected.len() {
-//!         return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Slice));
+//!         return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
 //!     }
 //!     let actual = input.next_slice(expected.len());
 //!     if actual != expected {
-//!         return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Verify));
+//!         return Err(ErrMode::from_error_kind(input, ErrorKind::Verify));
 //!     }
 //!     Ok(actual)
 //! }

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1589,6 +1589,7 @@ where
         }
     }
 
+    input.reset(start);
     Ok(input.finish())
 }
 

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1518,8 +1518,8 @@ where
     while input.eof_offset() > 0 {
         let current_len = input.eof_offset();
 
-        match normal.parse_next(input) {
-            Ok(_) => {
+        match opt(normal.by_ref()).parse_next(input)? {
+            Some(_) => {
                 if input.eof_offset() == 0 {
                     return Err(ErrMode::Incomplete(Needed::Unknown));
                 } else if input.eof_offset() == current_len {
@@ -1528,7 +1528,7 @@ where
                     return Ok(input.next_slice(offset));
                 }
             }
-            Err(ErrMode::Backtrack(_)) => {
+            None => {
                 if input.peek_token().expect("eof_offset > 0").1.as_char() == control_char {
                     let next = control_char.len_utf8();
                     let _ = input.next_slice(next);
@@ -1541,9 +1541,6 @@ where
                     input.reset(start);
                     return Ok(input.next_slice(offset));
                 }
-            }
-            Err(e) => {
-                return Err(e);
             }
         }
     }
@@ -1570,8 +1567,8 @@ where
     while input.eof_offset() > 0 {
         let current_len = input.eof_offset();
 
-        match normal.parse_next(input) {
-            Ok(_) => {
+        match opt(normal.by_ref()).parse_next(input)? {
+            Some(_) => {
                 // return if we consumed everything or if the normal parser
                 // does not consume anything
                 if input.eof_offset() == 0 {
@@ -1583,7 +1580,7 @@ where
                     return Ok(input.next_slice(offset));
                 }
             }
-            Err(ErrMode::Backtrack(_)) => {
+            None => {
                 if input.peek_token().expect("eof_offset > 0").1.as_char() == control_char {
                     let next = control_char.len_utf8();
                     let _ = input.next_slice(next);
@@ -1597,9 +1594,6 @@ where
                     input.reset(start);
                     return Ok(input.next_slice(offset));
                 }
-            }
-            Err(e) => {
-                return Err(e);
             }
         }
     }
@@ -1709,8 +1703,8 @@ where
 
     while input.eof_offset() > 0 {
         let current_len = input.eof_offset();
-        match normal.parse_next(input) {
-            Ok(o) => {
+        match opt(normal.by_ref()).parse_next(input)? {
+            Some(o) => {
                 res.accumulate(o);
                 if input.eof_offset() == 0 {
                     return Err(ErrMode::Incomplete(Needed::Unknown));
@@ -1718,7 +1712,7 @@ where
                     return Ok(res);
                 }
             }
-            Err(ErrMode::Backtrack(_)) => {
+            None => {
                 if input.peek_token().expect("eof_offset > 0").1.as_char() == control_char {
                     let next = control_char.len_utf8();
                     let _ = input.next_slice(next);
@@ -1731,7 +1725,6 @@ where
                     return Ok(res);
                 }
             }
-            Err(e) => return Err(e),
         }
     }
     Err(ErrMode::Incomplete(Needed::Unknown))
@@ -1757,8 +1750,8 @@ where
     while input.eof_offset() > 0 {
         let current_len = input.eof_offset();
 
-        match normal.parse_next(input) {
-            Ok(o) => {
+        match opt(normal.by_ref()).parse_next(input)? {
+            Some(o) => {
                 res.accumulate(o);
                 if input.eof_offset() == 0 {
                     return Ok(res);
@@ -1766,7 +1759,7 @@ where
                     return Ok(res);
                 }
             }
-            Err(ErrMode::Backtrack(_)) => {
+            None => {
                 if input.peek_token().expect("eof_offset > 0").1.as_char() == control_char {
                     let next = control_char.len_utf8();
                     let _ = input.next_slice(next);
@@ -1779,7 +1772,6 @@ where
                     return Ok(res);
                 }
             }
-            Err(e) => return Err(e),
         }
     }
     Ok(res)

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -143,7 +143,7 @@ where
                     }
                     CompareResult::Incomplete | CompareResult::Error => {
                         let e: ErrorKind = ErrorKind::Tag;
-                        return Err(ErrMode::from_error_kind(input.clone(), e));
+                        return Err(ErrMode::from_error_kind(input, e));
                     }
                 }
             }
@@ -956,7 +956,7 @@ where
             if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
                 return Err(ErrMode::Incomplete(Needed::new(1)));
             } else {
-                return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Slice));
+                return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
             }
         }
 
@@ -967,12 +967,12 @@ where
                     let d = d as u8;
                     v.checked_add(d, sealed::SealedMarker)
                 }) {
-                    None => return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Verify)),
+                    None => return Err(ErrMode::from_error_kind(input, ErrorKind::Verify)),
                     Some(v) => value = v,
                 },
                 None => {
                     if offset == 0 {
-                        return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Slice));
+                        return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
                     } else {
                         let _ = input.next_slice(offset);
                         return Ok(value);
@@ -1119,7 +1119,7 @@ where
             if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
                 return Err(ErrMode::Incomplete(Needed::new(1)));
             } else {
-                return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Slice));
+                return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
             }
         }
 
@@ -1134,12 +1134,12 @@ where
                         v.checked_sub(d, sealed::SealedMarker)
                     }
                 }) {
-                    None => return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Verify)),
+                    None => return Err(ErrMode::from_error_kind(input, ErrorKind::Verify)),
                     Some(v) => value = v,
                 },
                 None => {
                     if offset == 0 {
-                        return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Slice));
+                        return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
                     } else {
                         let _ = input.next_slice(offset);
                         return Ok(value);
@@ -1254,7 +1254,7 @@ where
             Ok(max_offset) => {
                 if max_offset < invalid_offset {
                     // Overflow
-                    return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Verify));
+                    return Err(ErrMode::from_error_kind(input, ErrorKind::Verify));
                 } else {
                     invalid_offset
                 }
@@ -1273,7 +1273,7 @@ where
         };
         if offset == 0 {
             // Must be at least one digit
-            return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Slice));
+            return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
         }
         let parsed = input.next_slice(offset);
 
@@ -1390,7 +1390,7 @@ where
     trace("float", move |input: &mut I| {
         let s = recognize_float_or_exceptions(input)?;
         s.parse_slice()
-            .ok_or_else(|| ErrMode::from_error_kind(input.clone(), ErrorKind::Verify))
+            .ok_or_else(|| ErrMode::from_error_kind(input, ErrorKind::Verify))
     })
     .parse_next(input)
 }

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1519,9 +1519,7 @@ where
 
         match opt(normal.by_ref()).parse_next(input)? {
             Some(_) => {
-                if input.eof_offset() == 0 {
-                    return Err(ErrMode::Incomplete(Needed::Unknown));
-                } else if input.eof_offset() == current_len {
+                if input.eof_offset() == current_len {
                     let offset = input.offset_from(&start);
                     input.reset(start);
                     return Ok(input.next_slice(offset));
@@ -1535,9 +1533,6 @@ where
                 .is_some()
                 {
                     let _ = escapable.parse_next(input)?;
-                    if input.eof_offset() == 0 {
-                        return Err(ErrMode::Incomplete(Needed::Unknown));
-                    }
                 } else {
                     let offset = input.offset_from(&start);
                     input.reset(start);
@@ -1571,12 +1566,7 @@ where
 
         match opt(normal.by_ref()).parse_next(input)? {
             Some(_) => {
-                // return if we consumed everything or if the normal parser
-                // does not consume anything
-                if input.eof_offset() == 0 {
-                    input.reset(start);
-                    return Ok(input.finish());
-                } else if input.eof_offset() == current_len {
+                if input.eof_offset() == current_len {
                     let offset = input.offset_from(&start);
                     input.reset(start);
                     return Ok(input.next_slice(offset));
@@ -1590,10 +1580,6 @@ where
                 .is_some()
                 {
                     let _ = escapable.parse_next(input)?;
-                    if input.eof_offset() == 0 {
-                        input.reset(start);
-                        return Ok(input.finish());
-                    }
                 } else {
                     let offset = input.offset_from(&start);
                     input.reset(start);
@@ -1711,9 +1697,7 @@ where
         match opt(normal.by_ref()).parse_next(input)? {
             Some(o) => {
                 res.accumulate(o);
-                if input.eof_offset() == 0 {
-                    return Err(ErrMode::Incomplete(Needed::Unknown));
-                } else if input.eof_offset() == current_len {
+                if input.eof_offset() == current_len {
                     return Ok(res);
                 }
             }
@@ -1726,9 +1710,6 @@ where
                 {
                     let o = transform.parse_next(input)?;
                     res.accumulate(o);
-                    if input.eof_offset() == 0 {
-                        return Err(ErrMode::Incomplete(Needed::Unknown));
-                    }
                 } else {
                     return Ok(res);
                 }
@@ -1761,9 +1742,7 @@ where
         match opt(normal.by_ref()).parse_next(input)? {
             Some(o) => {
                 res.accumulate(o);
-                if input.eof_offset() == 0 {
-                    return Ok(res);
-                } else if input.eof_offset() == current_len {
+                if input.eof_offset() == current_len {
                     return Ok(res);
                 }
             }
@@ -1776,9 +1755,6 @@ where
                 {
                     let o = transform.parse_next(input)?;
                     res.accumulate(o);
-                    if input.eof_offset() == 0 {
-                        return Ok(res);
-                    }
                 } else {
                     return Ok(res);
                 }

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -278,13 +278,13 @@ mod complete {
         let i = &b"g"[..];
         assert_parse!(
             hex_digit1.parse_peek(i),
-            Err(ErrMode::Backtrack(error_position!(i, ErrorKind::Slice)))
+            Err(ErrMode::Backtrack(error_position!(&i, ErrorKind::Slice)))
         );
 
         let i = &b"G"[..];
         assert_parse!(
             hex_digit1.parse_peek(i),
-            Err(ErrMode::Backtrack(error_position!(i, ErrorKind::Slice)))
+            Err(ErrMode::Backtrack(error_position!(&i, ErrorKind::Slice)))
         );
 
         assert!(AsChar::is_hex_digit(b'0'));
@@ -309,7 +309,7 @@ mod complete {
         let i = &b"8"[..];
         assert_parse!(
             oct_digit1.parse_peek(i),
-            Err(ErrMode::Backtrack(error_position!(i, ErrorKind::Slice)))
+            Err(ErrMode::Backtrack(error_position!(&i, ErrorKind::Slice)))
         );
 
         assert!(AsChar::is_oct_digit(b'0'));
@@ -367,14 +367,14 @@ mod complete {
         assert_parse!(
             crlf.parse_peek(&b"\r"[..]),
             Err(ErrMode::Backtrack(error_position!(
-                &b"\r"[..],
+                &&b"\r"[..],
                 ErrorKind::Tag
             )))
         );
         assert_parse!(
             crlf.parse_peek(&b"\ra"[..]),
             Err(ErrMode::Backtrack(error_position!(
-                &b"\ra"[..],
+                &&b"\ra"[..],
                 ErrorKind::Tag
             )))
         );
@@ -382,11 +382,11 @@ mod complete {
         assert_parse!(crlf.parse_peek("\r\na"), Ok(("a", "\r\n")));
         assert_parse!(
             crlf.parse_peek("\r"),
-            Err(ErrMode::Backtrack(error_position!("\r", ErrorKind::Tag)))
+            Err(ErrMode::Backtrack(error_position!(&"\r", ErrorKind::Tag)))
         );
         assert_parse!(
             crlf.parse_peek("\ra"),
-            Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::Tag)))
+            Err(ErrMode::Backtrack(error_position!(&"\ra", ErrorKind::Tag)))
         );
     }
 
@@ -403,14 +403,14 @@ mod complete {
         assert_parse!(
             line_ending.parse_peek(&b"\r"[..]),
             Err(ErrMode::Backtrack(error_position!(
-                &b"\r"[..],
+                &&b"\r"[..],
                 ErrorKind::Tag
             )))
         );
         assert_parse!(
             line_ending.parse_peek(&b"\ra"[..]),
             Err(ErrMode::Backtrack(error_position!(
-                &b"\ra"[..],
+                &&b"\ra"[..],
                 ErrorKind::Tag
             )))
         );
@@ -419,11 +419,11 @@ mod complete {
         assert_parse!(line_ending.parse_peek("\r\na"), Ok(("a", "\r\n")));
         assert_parse!(
             line_ending.parse_peek("\r"),
-            Err(ErrMode::Backtrack(error_position!("\r", ErrorKind::Tag)))
+            Err(ErrMode::Backtrack(error_position!(&"\r", ErrorKind::Tag)))
         );
         assert_parse!(
             line_ending.parse_peek("\ra"),
-            Err(ErrMode::Backtrack(error_position!("\ra", ErrorKind::Tag)))
+            Err(ErrMode::Backtrack(error_position!(&"\ra", ErrorKind::Tag)))
         );
     }
 
@@ -445,7 +445,7 @@ mod complete {
                     Ok((i, -n))
                 }
             }
-            None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
+            None => Err(ErrMode::from_error_kind(&i, ErrorKind::Verify)),
         }
     }
 
@@ -453,7 +453,7 @@ mod complete {
         let (i, s) = digit1.parse_peek(i)?;
         match s.parse_slice() {
             Some(n) => Ok((i, n)),
-            None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
+            None => Err(ErrMode::from_error_kind(&i, ErrorKind::Verify)),
         }
     }
 
@@ -484,7 +484,7 @@ mod complete {
         assert_parse!(
             hex_u32(&b";"[..]),
             Err(ErrMode::Backtrack(error_position!(
-                &b";"[..],
+                &&b";"[..],
                 ErrorKind::Slice
             )))
         );
@@ -495,14 +495,14 @@ mod complete {
         assert_parse!(
             hex_u32(&b"00c5a31be2;"[..]), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                &b"00c5a31be2;"[..],
+                &&b"00c5a31be2;"[..],
                 ErrorKind::Verify
             )))
         );
         assert_parse!(
             hex_u32(&b"c5a31be201;"[..]), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                &b"c5a31be201;"[..],
+                &&b"c5a31be201;"[..],
                 ErrorKind::Verify
             )))
         );
@@ -510,14 +510,14 @@ mod complete {
         assert_parse!(
             hex_u32(&b"ffffffffffffffff;"[..]), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                &b"ffffffffffffffff;"[..],
+                &&b"ffffffffffffffff;"[..],
                 ErrorKind::Verify
             )))
         );
         assert_parse!(
             hex_u32(&b"ffffffffffffffff"[..]), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                &b"ffffffffffffffff"[..],
+                &&b"ffffffffffffffff"[..],
                 ErrorKind::Verify
             )))
         );
@@ -670,16 +670,16 @@ mod complete {
         assert_eq!(
             esc(&b"AB\\"[..]),
             Err(ErrMode::Backtrack(error_position!(
-                &b""[..],
+                &&b""[..],
                 ErrorKind::Token
             )))
         );
         assert_eq!(
             esc(&b"AB\\A"[..]),
             Err(ErrMode::Backtrack(error_node_position!(
-                &b"AB\\A"[..],
+                &&b"AB\\A"[..],
                 ErrorKind::Token,
-                error_position!(&b"A"[..], ErrorKind::Verify)
+                error_position!(&&b"A"[..], ErrorKind::Verify)
             )))
         );
 
@@ -705,14 +705,14 @@ mod complete {
         assert_eq!(esc("ab\\\"12"), Ok(("12", "ab\\\"")));
         assert_eq!(
             esc("AB\\"),
-            Err(ErrMode::Backtrack(error_position!("", ErrorKind::Token)))
+            Err(ErrMode::Backtrack(error_position!(&"", ErrorKind::Token)))
         );
         assert_eq!(
             esc("AB\\A"),
             Err(ErrMode::Backtrack(error_node_position!(
-                "AB\\A",
+                &"AB\\A",
                 ErrorKind::Token,
-                error_position!("A", ErrorKind::Verify)
+                error_position!(&"A", ErrorKind::Verify)
             )))
         );
 
@@ -778,16 +778,16 @@ mod complete {
         assert_eq!(
             esc(&b"AB\\"[..]),
             Err(ErrMode::Backtrack(error_position!(
-                &b""[..],
+                &&b""[..],
                 ErrorKind::Tag
             )))
         );
         assert_eq!(
             esc(&b"AB\\A"[..]),
             Err(ErrMode::Backtrack(error_node_position!(
-                &b"AB\\A"[..],
+                &&b"AB\\A"[..],
                 ErrorKind::Eof,
-                error_position!(&b"A"[..], ErrorKind::Tag)
+                error_position!(&&b"A"[..], ErrorKind::Tag)
             )))
         );
 
@@ -834,14 +834,14 @@ mod complete {
         assert_eq!(esc("ab\\\"12"), Ok(("12", String::from("ab\""))));
         assert_eq!(
             esc("AB\\"),
-            Err(ErrMode::Backtrack(error_position!("", ErrorKind::Tag)))
+            Err(ErrMode::Backtrack(error_position!(&"", ErrorKind::Tag)))
         );
         assert_eq!(
             esc("AB\\A"),
             Err(ErrMode::Backtrack(error_node_position!(
-                "AB\\A",
+                &"AB\\A",
                 ErrorKind::Eof,
-                error_position!("A", ErrorKind::Tag)
+                error_position!(&"A", ErrorKind::Tag)
             )))
         );
 
@@ -1256,7 +1256,7 @@ mod partial {
         assert_parse!(
             hex_digit1.parse_peek(Partial::new(i)),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(i),
+                &Partial::new(i),
                 ErrorKind::Slice
             )))
         );
@@ -1265,7 +1265,7 @@ mod partial {
         assert_parse!(
             hex_digit1.parse_peek(Partial::new(i)),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(i),
+                &Partial::new(i),
                 ErrorKind::Slice
             )))
         );
@@ -1296,7 +1296,7 @@ mod partial {
         assert_parse!(
             oct_digit1.parse_peek(Partial::new(i)),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(i),
+                &Partial::new(i),
                 ErrorKind::Slice
             )))
         );
@@ -1368,7 +1368,7 @@ mod partial {
         assert_parse!(
             crlf.parse_peek(Partial::new(&b"\ra"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"\ra"[..]),
+                &Partial::new(&b"\ra"[..]),
                 ErrorKind::Tag
             )))
         );
@@ -1384,7 +1384,7 @@ mod partial {
         assert_parse!(
             crlf.parse_peek(Partial::new("\ra")),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new("\ra"),
+                &Partial::new("\ra"),
                 ErrorKind::Tag
             )))
         );
@@ -1407,7 +1407,7 @@ mod partial {
         assert_parse!(
             line_ending.parse_peek(Partial::new(&b"\ra"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"\ra"[..]),
+                &Partial::new(&b"\ra"[..]),
                 ErrorKind::Tag
             )))
         );
@@ -1427,7 +1427,7 @@ mod partial {
         assert_parse!(
             line_ending.parse_peek(Partial::new("\ra")),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new("\ra"),
+                &Partial::new("\ra"),
                 ErrorKind::Tag
             )))
         );
@@ -1451,7 +1451,7 @@ mod partial {
                     Ok((i, -n))
                 }
             }
-            None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
+            None => Err(ErrMode::from_error_kind(&i, ErrorKind::Verify)),
         }
     }
 
@@ -1459,7 +1459,7 @@ mod partial {
         let (i, s) = digit1.parse_peek(i)?;
         match s.parse_slice() {
             Some(n) => Ok((i, n)),
-            None => Err(ErrMode::from_error_kind(i, ErrorKind::Verify)),
+            None => Err(ErrMode::from_error_kind(&i, ErrorKind::Verify)),
         }
     }
 
@@ -1490,7 +1490,7 @@ mod partial {
         assert_parse!(
             hex_u32(Partial::new(&b";"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b";"[..]),
+                &Partial::new(&b";"[..]),
                 ErrorKind::Slice
             )))
         );
@@ -1513,14 +1513,14 @@ mod partial {
         assert_parse!(
             hex_u32(Partial::new(&b"00c5a31be2;"[..])), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"00c5a31be2;"[..]),
+                &Partial::new(&b"00c5a31be2;"[..]),
                 ErrorKind::Verify
             )))
         );
         assert_parse!(
             hex_u32(Partial::new(&b"c5a31be201;"[..])), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"c5a31be201;"[..]),
+                &Partial::new(&b"c5a31be201;"[..]),
                 ErrorKind::Verify
             )))
         );
@@ -1531,14 +1531,14 @@ mod partial {
         assert_parse!(
             hex_u32(Partial::new(&b"ffffffffffffffff;"[..])), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"ffffffffffffffff;"[..]),
+                &Partial::new(&b"ffffffffffffffff;"[..]),
                 ErrorKind::Verify
             )))
         );
         assert_parse!(
             hex_u32(Partial::new(&b"ffffffffffffffff"[..])), // overflow
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"ffffffffffffffff"[..]),
+                &Partial::new(&b"ffffffffffffffff"[..]),
                 ErrorKind::Verify
             )))
         );

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -123,7 +123,7 @@ where
                 Err(ErrMode::Incomplete(Needed::Size(sz))) => Err(match sz.get().checked_mul(8) {
                     Some(v) => ErrMode::Incomplete(Needed::new(v)),
                     None => ErrMode::Cut(E2::assert(
-                        i,
+                        &i,
                         "overflow in turning needed bytes into needed bits",
                     )),
                 }),
@@ -202,7 +202,7 @@ where
                 Err(ErrMode::Incomplete(Needed::new(count)))
             } else {
                 Err(ErrMode::from_error_kind(
-                    (input, bit_offset),
+                    &(input, bit_offset),
                     ErrorKind::Eof,
                 ))
             }
@@ -313,7 +313,7 @@ where
             } else {
                 input.reset(start);
                 Err(ErrMode::Backtrack(E::from_error_kind(
-                    input.clone(),
+                    input,
                     ErrorKind::Tag,
                 )))
             }

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -47,7 +47,7 @@ pub fn bits<I, O, E1, E2, P>(mut parser: P) -> impl Parser<I, O, E2>
 where
     E1: ParserError<(I, usize)> + ErrorConvert<E2>,
     E2: ParserError<I>,
-    I: Stream,
+    I: Stream + Clone,
     P: Parser<(I, usize), O, E1>,
 {
     trace(
@@ -103,7 +103,7 @@ pub fn bytes<I, O, E1, E2, P>(mut parser: P) -> impl Parser<(I, usize), O, E2>
 where
     E1: ParserError<I> + ErrorConvert<E2>,
     E2: ParserError<(I, usize)>,
-    I: Stream<Token = u8>,
+    I: Stream<Token = u8> + Clone,
     P: Parser<I, O, E1>,
 {
     trace(
@@ -167,7 +167,7 @@ where
 #[inline(always)]
 pub fn take<I, O, C, E: ParserError<(I, usize)>>(count: C) -> impl Parser<(I, usize), O, E>
 where
-    I: Stream<Token = u8> + AsBytes + StreamIsPartial,
+    I: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
     C: ToUsize,
     O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
@@ -190,7 +190,7 @@ fn take_<I, O, E: ParserError<(I, usize)>, const PARTIAL: bool>(
 ) -> IResult<(I, usize), O, E>
 where
     I: StreamIsPartial,
-    I: Stream<Token = u8> + AsBytes,
+    I: Stream<Token = u8> + AsBytes + Clone,
     O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
 {
     if count == 0 {
@@ -299,7 +299,7 @@ pub fn tag<I, O, C, E: ParserError<(I, usize)>>(
     count: C,
 ) -> impl Parser<(I, usize), O, E>
 where
-    I: Stream<Token = u8> + AsBytes + StreamIsPartial,
+    I: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
     C: ToUsize,
     O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
@@ -347,7 +347,7 @@ where
 #[doc(alias = "any")]
 pub fn bool<I, E: ParserError<(I, usize)>>(input: &mut (I, usize)) -> PResult<bool, E>
 where
-    I: Stream<Token = u8> + AsBytes + StreamIsPartial,
+    I: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
 {
     trace("bool", |input: &mut (I, usize)| {
         let bit: u32 = take(1usize).parse_next(input)?;

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -2482,7 +2482,7 @@ where
 pub fn length_value<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl Parser<I, O, E>
 where
     I: StreamIsPartial,
-    I: Stream + UpdateSlice,
+    I: Stream + UpdateSlice + Clone,
     N: ToUsize,
     F: Parser<I, N, E>,
     G: Parser<I, O, E>,

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1270,7 +1270,7 @@ where
         if PARTIAL && input.is_partial() {
             ErrMode::Incomplete(Needed::new(1))
         } else {
-            ErrMode::Backtrack(E::from_error_kind(input.clone(), ErrorKind::Token))
+            ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Token))
         }
     })
 }

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -1150,14 +1150,14 @@ mod partial {
         assert_eq!(
             cnt(Partial::new(&b"xxx"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"xxx"[..]),
+                &Partial::new(&b"xxx"[..]),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
             cnt(Partial::new(&b"2abcxxx"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"xxx"[..]),
+                &Partial::new(&b"xxx"[..]),
                 ErrorKind::Tag
             )))
         );
@@ -1187,7 +1187,7 @@ mod partial {
         assert_eq!(
             take(Partial::new(&b"xxx"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"xxx"[..]),
+                &Partial::new(&b"xxx"[..]),
                 ErrorKind::Slice
             )))
         );
@@ -1215,14 +1215,14 @@ mod partial {
         assert_eq!(
             length_value_1(Partial::new(&i1)),
             Err(ErrMode::Backtrack(error_position!(
-                empty_complete,
+                &empty_complete,
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
             length_value_2(Partial::new(&i1)),
             Err(ErrMode::Backtrack(error_position!(
-                empty_complete,
+                &empty_complete,
                 ErrorKind::Token
             )))
         );
@@ -1234,14 +1234,14 @@ mod partial {
             assert_eq!(
                 length_value_1(Partial::new(&i2)),
                 Err(ErrMode::Backtrack(error_position!(
-                    middle_complete,
+                    &middle_complete,
                     ErrorKind::Slice
                 )))
             );
             assert_eq!(
                 length_value_2(Partial::new(&i2)),
                 Err(ErrMode::Backtrack(error_position!(
-                    empty_complete,
+                    &empty_complete,
                     ErrorKind::Token
                 )))
             );

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -157,7 +157,7 @@ macro_rules! alt_trait_inner(
     }
   });
   ($it:tt, $self:expr, $input:expr, $start:ident, $err:expr, $head:ident) => ({
-    Err(ErrMode::Backtrack($err.append($input.clone(), ErrorKind::Alt)))
+    Err(ErrMode::Backtrack($err.append($input, ErrorKind::Alt)))
   });
 );
 
@@ -209,8 +209,8 @@ macro_rules! permutation_trait_impl(
           // or errored on the remaining input
           if let Some(err) = err {
             // There are remaining parsers, and all errored on the remaining input
-            input.reset(start);
-            return Err(ErrMode::Backtrack(err.append(input.clone(), ErrorKind::Alt)));
+            input.reset(start.clone());
+            return Err(ErrMode::Backtrack(err.append(input, ErrorKind::Alt)));
           }
 
           // All parsers were applied

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -177,7 +177,7 @@ where
         if input.eof_offset() == 0 {
             Ok(input.next_slice(0))
         } else {
-            Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Eof))
+            Err(ErrMode::from_error_kind(input, ErrorKind::Eof))
         }
     })
     .parse_next(input)
@@ -209,7 +209,7 @@ where
     trace("not", move |input: &mut I| {
         let mut i = input.clone();
         match parser.parse_next(&mut i) {
-            Ok(_) => Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Not)),
+            Ok(_) => Err(ErrMode::from_error_kind(input, ErrorKind::Not)),
             Err(ErrMode::Backtrack(_)) => Ok(()),
             Err(e) => Err(e),
         }
@@ -481,7 +481,7 @@ pub fn success<I: Stream, O: Clone, E: ParserError<I>>(val: O) -> impl Parser<I,
 #[doc(alias = "unexpected")]
 pub fn fail<I: Stream, O, E: ParserError<I>>(i: &mut I) -> PResult<O, E> {
     trace("fail", |i: &mut I| {
-        Err(ErrMode::from_error_kind(i.clone(), ErrorKind::Fail))
+        Err(ErrMode::from_error_kind(i, ErrorKind::Fail))
     })
     .parse_next(i)
 }

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -146,8 +146,10 @@ where
     F: Parser<I, O, E>,
 {
     trace("peek", move |input: &mut I| {
-        let mut i = input.clone();
-        f.parse_next(&mut i)
+        let start = input.checkpoint();
+        let res = f.parse_next(input);
+        input.reset(start);
+        res
     })
 }
 
@@ -207,8 +209,10 @@ where
     F: Parser<I, O, E>,
 {
     trace("not", move |input: &mut I| {
-        let mut i = input.clone();
-        match parser.parse_next(&mut i) {
+        let start = input.checkpoint();
+        let res = parser.parse_next(input);
+        input.reset(start);
+        match res {
             Ok(_) => Err(ErrMode::from_error_kind(input, ErrorKind::Not)),
             Err(ErrMode::Backtrack(_)) => Ok(()),
             Err(e) => Err(e),

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -156,10 +156,7 @@ where
             Ok(o) => {
                 // infinite loop check: the parser must always consume
                 if i.eof_offset() == len {
-                    return Err(ErrMode::assert(
-                        i.clone(),
-                        "`repeat` parsers must always consume",
-                    ));
+                    return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
                 }
 
                 acc.accumulate(o);
@@ -176,7 +173,7 @@ where
     E: ParserError<I>,
 {
     match f.parse_next(i) {
-        Err(e) => Err(e.append(i.clone(), ErrorKind::Many)),
+        Err(e) => Err(e.append(i, ErrorKind::Many)),
         Ok(o) => {
             let mut acc = C::initial(None);
             acc.accumulate(o);
@@ -193,10 +190,7 @@ where
                     Ok(o) => {
                         // infinite loop check: the parser must always consume
                         if i.eof_offset() == len {
-                            return Err(ErrMode::assert(
-                                i.clone(),
-                                "`repeat` parsers must always consume",
-                            ));
+                            return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
                         }
 
                         acc.accumulate(o);
@@ -255,12 +249,12 @@ where
                 Err(ErrMode::Backtrack(_)) => {
                     i.reset(start);
                     match f.parse_next(i) {
-                        Err(e) => return Err(e.append(i.clone(), ErrorKind::Many)),
+                        Err(e) => return Err(e.append(i, ErrorKind::Many)),
                         Ok(o) => {
                             // infinite loop check: the parser must always consume
                             if i.eof_offset() == len {
                                 return Err(ErrMode::assert(
-                                    i.clone(),
+                                    i,
                                     "`repeat` parsers must always consume",
                                 ));
                             }
@@ -341,10 +335,7 @@ where
                 Ok(_) => {
                     // infinite loop check: the parser must always consume
                     if i.eof_offset() == len {
-                        return Err(ErrMode::assert(
-                            i.clone(),
-                            "sep parsers must always consume",
-                        ));
+                        return Err(ErrMode::assert(i, "sep parsers must always consume"));
                     }
 
                     match parser.parse_next(i) {
@@ -427,10 +418,7 @@ where
                 Ok(_) => {
                     // infinite loop check: the parser must always consume
                     if i.eof_offset() == len {
-                        return Err(ErrMode::assert(
-                            i.clone(),
-                            "sep parsers must always consume",
-                        ));
+                        return Err(ErrMode::assert(i, "sep parsers must always consume"));
                     }
 
                     match parser.parse_next(i) {
@@ -497,10 +485,7 @@ where
                 Ok(s) => {
                     // infinite loop check: the parser must always consume
                     if i.eof_offset() == len {
-                        return Err(ErrMode::assert(
-                            i.clone(),
-                            "`repeat` parsers must always consume",
-                        ));
+                        return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
                     }
 
                     match parser.parse_next(i) {
@@ -579,10 +564,7 @@ where
     E: ParserError<I>,
 {
     if min > max {
-        return Err(ErrMode::Cut(E::from_error_kind(
-            input.clone(),
-            ErrorKind::Many,
-        )));
+        return Err(ErrMode::Cut(E::from_error_kind(input, ErrorKind::Many)));
     }
 
     let mut res = C::initial(Some(min));
@@ -594,7 +576,7 @@ where
                 // infinite loop check: the parser must always consume
                 if input.eof_offset() == len {
                     return Err(ErrMode::assert(
-                        input.clone(),
+                        input,
                         "`repeat` parsers must always consume",
                     ));
                 }
@@ -603,7 +585,7 @@ where
             }
             Err(ErrMode::Backtrack(e)) => {
                 if count < min {
-                    return Err(ErrMode::Backtrack(e.append(input.clone(), ErrorKind::Many)));
+                    return Err(ErrMode::Backtrack(e.append(input, ErrorKind::Many)));
                 } else {
                     input.reset(start);
                     return Ok(res);
@@ -633,7 +615,7 @@ where
                 res.accumulate(o);
             }
             Err(e) => {
-                return Err(e.append(i.clone(), ErrorKind::Many));
+                return Err(e.append(i, ErrorKind::Many));
             }
         }
     }
@@ -682,7 +664,7 @@ where
                     *elem = o;
                 }
                 Err(e) => {
-                    return Err(e.append(i.clone(), ErrorKind::Many));
+                    return Err(e.append(i, ErrorKind::Many));
                 }
             }
         }
@@ -845,7 +827,7 @@ where
                 // infinite loop check: the parser must always consume
                 if input.eof_offset() == len {
                     return Err(ErrMode::assert(
-                        input.clone(),
+                        input,
                         "`repeat` parsers must always consume",
                     ));
                 }
@@ -878,7 +860,7 @@ where
 {
     let init = init();
     match f.parse_next(input) {
-        Err(ErrMode::Backtrack(_)) => Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Many)),
+        Err(ErrMode::Backtrack(_)) => Err(ErrMode::from_error_kind(input, ErrorKind::Many)),
         Err(e) => Err(e),
         Ok(o1) => {
             let mut acc = g(init, o1);
@@ -896,7 +878,7 @@ where
                         // infinite loop check: the parser must always consume
                         if input.eof_offset() == len {
                             return Err(ErrMode::assert(
-                                input.clone(),
+                                input,
                                 "`repeat` parsers must always consume",
                             ));
                         }
@@ -927,10 +909,7 @@ where
     E: ParserError<I>,
 {
     if min > max {
-        return Err(ErrMode::Cut(E::from_error_kind(
-            input.clone(),
-            ErrorKind::Many,
-        )));
+        return Err(ErrMode::Cut(E::from_error_kind(input, ErrorKind::Many)));
     }
 
     let mut acc = init();
@@ -942,7 +921,7 @@ where
                 // infinite loop check: the parser must always consume
                 if input.eof_offset() == len {
                     return Err(ErrMode::assert(
-                        input.clone(),
+                        input,
                         "`repeat` parsers must always consume",
                     ));
                 }
@@ -952,9 +931,7 @@ where
             //FInputXMError: handle failure properly
             Err(ErrMode::Backtrack(err)) => {
                 if count < min {
-                    return Err(ErrMode::Backtrack(
-                        err.append(input.clone(), ErrorKind::Many),
-                    ));
+                    return Err(ErrMode::Backtrack(err.append(input, ErrorKind::Many)));
                 } else {
                     input.reset(start);
                     break;

--- a/src/combinator/parser.rs
+++ b/src/combinator/parser.rs
@@ -617,7 +617,7 @@ where
 pub struct Span<F, I, O, E>
 where
     F: Parser<I, O, E>,
-    I: Clone + Location,
+    I: Stream + Location,
 {
     parser: F,
     i: core::marker::PhantomData<I>,
@@ -628,7 +628,7 @@ where
 impl<F, I, O, E> Span<F, I, O, E>
 where
     F: Parser<I, O, E>,
-    I: Clone + Location,
+    I: Stream + Location,
 {
     pub(crate) fn new(parser: F) -> Self {
         Self {
@@ -643,7 +643,7 @@ where
 impl<I, O, E, F> Parser<I, Range<usize>, E> for Span<F, I, O, E>
 where
     F: Parser<I, O, E>,
-    I: Clone + Location,
+    I: Stream + Location,
 {
     #[inline]
     fn parse_next(&mut self, input: &mut I) -> PResult<Range<usize>, E> {
@@ -660,7 +660,7 @@ where
 pub struct WithSpan<F, I, O, E>
 where
     F: Parser<I, O, E>,
-    I: Clone + Location,
+    I: Stream + Location,
 {
     parser: F,
     i: core::marker::PhantomData<I>,
@@ -671,7 +671,7 @@ where
 impl<F, I, O, E> WithSpan<F, I, O, E>
 where
     F: Parser<I, O, E>,
-    I: Clone + Location,
+    I: Stream + Location,
 {
     pub(crate) fn new(parser: F) -> Self {
         Self {
@@ -686,7 +686,7 @@ where
 impl<F, I, O, E> Parser<I, (O, Range<usize>), E> for WithSpan<F, I, O, E>
 where
     F: Parser<I, O, E>,
-    I: Clone + Location,
+    I: Stream + Location,
 {
     #[inline]
     fn parse_next(&mut self, input: &mut I) -> PResult<(O, Range<usize>), E> {

--- a/src/combinator/parser.rs
+++ b/src/combinator/parser.rs
@@ -123,7 +123,7 @@ where
         let o = self.parser.parse_next(input)?;
         let res = (self.map)(o).map_err(|err| {
             input.reset(start);
-            ErrMode::from_external_error(input.clone(), ErrorKind::Verify, err)
+            ErrMode::from_external_error(input, ErrorKind::Verify, err)
         });
         trace_result("verify", &res);
         res
@@ -179,7 +179,7 @@ where
         let o = self.parser.parse_next(input)?;
         let res = (self.map)(o).ok_or_else(|| {
             input.reset(start);
-            ErrMode::from_error_kind(input.clone(), ErrorKind::Verify)
+            ErrMode::from_error_kind(input, ErrorKind::Verify)
         });
         trace_result("verify", &res);
         res
@@ -289,7 +289,7 @@ where
         let o = self.p.parse_next(i)?;
         let res = o.parse_slice().ok_or_else(|| {
             i.reset(start);
-            ErrMode::from_error_kind(i.clone(), ErrorKind::Verify)
+            ErrMode::from_error_kind(i, ErrorKind::Verify)
         });
         trace_result("verify", &res);
         res
@@ -368,7 +368,7 @@ where
         trace("complete_err", |input: &mut I| {
             match (self.f).parse_next(input) {
                 Err(ErrMode::Incomplete(_)) => {
-                    Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Complete))
+                    Err(ErrMode::from_error_kind(input, ErrorKind::Complete))
                 }
                 rest => rest,
             }
@@ -432,7 +432,7 @@ where
         let o = self.parser.parse_next(input)?;
         let res = (self.filter)(o.borrow()).then_some(o).ok_or_else(|| {
             input.reset(start);
-            ErrMode::from_error_kind(input.clone(), ErrorKind::Verify)
+            ErrMode::from_error_kind(input, ErrorKind::Verify)
         });
         trace_result("verify", &res);
         res
@@ -833,10 +833,9 @@ where
         #[cfg(not(feature = "debug"))]
         let name = "context";
         trace(name, move |i: &mut I| {
-            let start = i.clone();
             (self.parser)
                 .parse_next(i)
-                .map_err(|err| err.map(|err| err.add_context(start, self.context.clone())))
+                .map_err(|err| err.map(|err| err.add_context(i, self.context.clone())))
         })
         .parse_next(i)
     }

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -35,7 +35,7 @@ fn eof_on_slices() {
     assert_parse!(
         res_not_over,
         Err(ErrMode::Backtrack(error_position!(
-            not_over,
+            &not_over,
             ErrorKind::Eof
         )))
     );
@@ -53,7 +53,7 @@ fn eof_on_strs() {
     assert_parse!(
         res_not_over,
         Err(ErrMode::Backtrack(error_position!(
-            not_over,
+            &not_over,
             ErrorKind::Eof
         )))
     );
@@ -90,11 +90,11 @@ impl From<u32> for CustomError {
 }
 
 impl<I> ParserError<I> for CustomError {
-    fn from_error_kind(_: I, _: ErrorKind) -> Self {
+    fn from_error_kind(_: &I, _: ErrorKind) -> Self {
         CustomError
     }
 
-    fn append(self, _: I, _: ErrorKind) -> Self {
+    fn append(self, _: &I, _: ErrorKind) -> Self {
         CustomError
     }
 }
@@ -200,7 +200,7 @@ fn peek_test() {
     assert_eq!(
         peek_tag(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx"[..]),
+            &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -215,7 +215,7 @@ fn not_test() {
     assert_eq!(
         not_aaa(Partial::new(&b"aaa"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"aaa"[..]),
+            &Partial::new(&b"aaa"[..]),
             ErrorKind::Not
         )))
     );
@@ -245,7 +245,7 @@ fn test_parser_verify() {
     assert_eq!(
         test(Partial::new(&b"bcdefg"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"bcdefg"[..]),
+            &Partial::new(&b"bcdefg"[..]),
             ErrorKind::Verify
         )))
     );
@@ -329,7 +329,7 @@ fn complete() {
     assert_eq!(
         res_a,
         Err(ErrMode::Backtrack(error_position!(
-            &b"mn"[..],
+            &&b"mn"[..],
             ErrorKind::Tag
         )))
     );
@@ -357,21 +357,21 @@ fn separated_pair_test() {
     assert_eq!(
         sep_pair_abc_def(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx"[..]),
+            &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         sep_pair_abc_def(Partial::new(&b"xxx,def"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx,def"[..]),
+            &Partial::new(&b"xxx,def"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         sep_pair_abc_def(Partial::new(&b"abc,xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx"[..]),
+            &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -398,21 +398,21 @@ fn preceded_test() {
     assert_eq!(
         preceded_abcd_efgh(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx"[..]),
+            &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         preceded_abcd_efgh(Partial::new(&b"xxxxdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxxxdef"[..]),
+            &Partial::new(&b"xxxxdef"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         preceded_abcd_efgh(Partial::new(&b"abcdxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx"[..]),
+            &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -439,21 +439,21 @@ fn terminated_test() {
     assert_eq!(
         terminated_abcd_efgh(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx"[..]),
+            &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         terminated_abcd_efgh(Partial::new(&b"xxxxdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxxxdef"[..]),
+            &Partial::new(&b"xxxxdef"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         terminated_abcd_efgh(Partial::new(&b"abcdxxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxxx"[..]),
+            &Partial::new(&b"xxxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -484,28 +484,28 @@ fn delimited_test() {
     assert_eq!(
         delimited_abc_def_ghi(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx"[..]),
+            &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         delimited_abc_def_ghi(Partial::new(&b"xxxdefghi"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxxdefghi"[..]),
+            &Partial::new(&b"xxxdefghi"[..]),
             ErrorKind::Tag
         ),))
     );
     assert_eq!(
         delimited_abc_def_ghi(Partial::new(&b"abcxxxghi"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxxghi"[..]),
+            &Partial::new(&b"xxxghi"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         delimited_abc_def_ghi(Partial::new(&b"abcdefxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx"[..]),
+            &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
@@ -543,11 +543,11 @@ fn alt_test() {
 
     #[cfg(feature = "alloc")]
     impl<I: Debug> ParserError<I> for ErrorStr {
-        fn from_error_kind(input: I, kind: ErrorKind) -> Self {
+        fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
             ErrorStr(format!("custom error message: ({:?}, {:?})", input, kind))
         }
 
-        fn append(self, input: I, kind: ErrorKind) -> Self {
+        fn append(self, input: &I, kind: ErrorKind) -> Self {
             ErrorStr(format!(
                 "custom error message: ({:?}, {:?}) - {:?}",
                 input, kind, self
@@ -591,7 +591,7 @@ fn alt_test() {
     assert_eq!(
         alt1(a),
         Err(ErrMode::Backtrack(error_node_position!(
-            a,
+            &a,
             ErrorKind::Alt,
             ErrorStr("abcd".to_string())
         )))
@@ -632,7 +632,7 @@ fn alt_incomplete() {
     assert_eq!(
         alt1(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(a),
+            &Partial::new(a),
             ErrorKind::Tag
         )))
     );
@@ -677,9 +677,9 @@ fn permutation_test() {
     assert_eq!(
         perm(Partial::new(d)),
         Err(ErrMode::Backtrack(error_node_position!(
-            Partial::new(&b"efgxyzabcdefghi"[..]),
+            &Partial::new(&b"efgxyzabcdefghi"[..]),
             ErrorKind::Alt,
-            error_position!(Partial::new(&b"xyzabcdefghi"[..]), ErrorKind::Tag)
+            error_position!(&Partial::new(&b"xyzabcdefghi"[..]), ErrorKind::Tag)
         )))
     );
 
@@ -759,7 +759,7 @@ fn separated0_empty_sep_test() {
     assert_eq!(
         empty_sep(Partial::new(i)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(i_err_pos),
+            &Partial::new(i_err_pos),
             ErrorKind::Assert
         )))
     );
@@ -791,7 +791,7 @@ fn separated1_test() {
     assert_eq!(
         multi(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(c),
+            &Partial::new(c),
             ErrorKind::Tag
         )))
     );
@@ -859,7 +859,7 @@ fn repeat0_empty_test() {
     assert_eq!(
         multi_empty(Partial::new(&b"abcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"abcdef"[..]),
+            &Partial::new(&b"abcdef"[..]),
             ErrorKind::Assert
         )))
     );
@@ -887,7 +887,7 @@ fn repeat1_test() {
     assert_eq!(
         multi(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(c),
+            &Partial::new(c),
             ErrorKind::Tag
         )))
     );
@@ -916,9 +916,9 @@ fn repeat_till_test() {
     assert_eq!(
         multi(&c[..]),
         Err(ErrMode::Backtrack(error_node_position!(
-            &c[..],
+            &&c[..],
             ErrorKind::Many,
-            error_position!(&c[..], ErrorKind::Tag)
+            error_position!(&&c[..], ErrorKind::Tag)
         )))
     );
 }
@@ -928,7 +928,7 @@ fn repeat_till_test() {
 fn infinite_many() {
     fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
         println!("input: {:?}", input);
-        Err(ErrMode::Backtrack(error_position!(input, ErrorKind::Tag)))
+        Err(ErrMode::Backtrack(error_position!(&input, ErrorKind::Tag)))
     }
 
     // should not go into an infinite loop
@@ -944,7 +944,7 @@ fn infinite_many() {
     let a = &b"abcdef"[..];
     assert_eq!(
         multi1(a),
-        Err(ErrMode::Backtrack(error_position!(a, ErrorKind::Tag)))
+        Err(ErrMode::Backtrack(error_position!(&a, ErrorKind::Tag)))
     );
 }
 
@@ -964,7 +964,7 @@ fn repeat_test() {
     assert_eq!(
         multi(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"ef"[..]),
+            &Partial::new(&b"ef"[..]),
             ErrorKind::Tag
         )))
     );
@@ -1012,21 +1012,21 @@ fn count_test() {
     assert_eq!(
         cnt_2(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxx"[..]),
+            &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         cnt_2(Partial::new(&b"xxxabcabcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxxabcabcdef"[..]),
+            &Partial::new(&b"xxxabcabcdef"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         cnt_2(Partial::new(&b"abcxxxabcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"xxxabcdef"[..]),
+            &Partial::new(&b"xxxabcdef"[..]),
             ErrorKind::Tag
         )))
     );
@@ -1081,10 +1081,10 @@ impl<I> From<(I, ErrorKind)> for NilError {
 }
 
 impl<I> ParserError<I> for NilError {
-    fn from_error_kind(_: I, _: ErrorKind) -> NilError {
+    fn from_error_kind(_: &I, _: ErrorKind) -> NilError {
         NilError
     }
-    fn append(self, _: I, _: ErrorKind) -> NilError {
+    fn append(self, _: &I, _: ErrorKind) -> NilError {
         NilError
     }
 }
@@ -1141,7 +1141,7 @@ fn fold_repeat0_empty_test() {
     assert_eq!(
         multi_empty(Partial::new(&b"abcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"abcdef"[..]),
+            &Partial::new(&b"abcdef"[..]),
             ErrorKind::Assert
         )))
     );
@@ -1173,7 +1173,7 @@ fn fold_repeat1_test() {
     assert_eq!(
         multi(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(c),
+            &Partial::new(c),
             ErrorKind::Many
         )))
     );
@@ -1203,7 +1203,7 @@ fn fold_repeat_test() {
     assert_eq!(
         multi(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"ef"[..]),
+            &Partial::new(&b"ef"[..]),
             ErrorKind::Tag
         )))
     );
@@ -1262,7 +1262,7 @@ fn repeat1_count_test() {
     assert_eq!(
         count1_nums(&b"hello"[..]),
         Err(ErrMode::Backtrack(error_position!(
-            &b"hello"[..],
+            &&b"hello"[..],
             ErrorKind::Slice
         )))
     );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -624,7 +624,7 @@ pub trait Parser<I, O, E> {
 impl<'a, I, O, E, F> Parser<I, O, E> for F
 where
     F: FnMut(&mut I) -> PResult<O, E> + 'a,
-    I: Clone,
+    I: Stream,
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -941,7 +941,7 @@ mod tests {
         assert_eq!(
             tuple_3(Partial::new(&b"abcdejk"[..])),
             Err(ErrMode::Backtrack(error_position!(
-                Partial::new(&b"jk"[..]),
+                &Partial::new(&b"jk"[..]),
                 ErrorKind::Tag
             )))
         );

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -405,9 +405,7 @@ where
 }
 
 /// Core definition for parser input state
-pub trait Stream:
-    Offset<<Self as Stream>::Checkpoint> + crate::lib::std::fmt::Debug + Sized
-{
+pub trait Stream: Offset<<Self as Stream>::Checkpoint> + crate::lib::std::fmt::Debug {
     /// The smallest unit being parsed
     ///
     /// Example: `u8` for `&[u8]` or `char` for `&str`

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -406,7 +406,7 @@ where
 
 /// Core definition for parser input state
 pub trait Stream:
-    Offset<<Self as Stream>::Checkpoint> + Offset + crate::lib::std::fmt::Debug + Sized
+    Offset<<Self as Stream>::Checkpoint> + crate::lib::std::fmt::Debug + Sized
 {
     /// The smallest unit being parsed
     ///

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -406,7 +406,7 @@ where
 
 /// Core definition for parser input state
 pub trait Stream:
-    Offset<<Self as Stream>::Checkpoint> + Offset + Clone + crate::lib::std::fmt::Debug
+    Offset<<Self as Stream>::Checkpoint> + Offset + crate::lib::std::fmt::Debug + Sized
 {
     /// The smallest unit being parsed
     ///
@@ -432,7 +432,10 @@ pub trait Stream:
     fn next_token(&mut self) -> Option<Self::Token>;
     /// Split off the next token from the input
     #[inline(always)]
-    fn peek_token(&self) -> Option<(Self, Self::Token)> {
+    fn peek_token(&self) -> Option<(Self, Self::Token)>
+    where
+        Self: Clone,
+    {
         let mut peek = self.clone();
         let token = peek.next_token()?;
         Some((peek, token))
@@ -466,7 +469,10 @@ pub trait Stream:
     fn next_slice(&mut self, offset: usize) -> Self::Slice;
     /// Split off a slice of tokens from the input
     #[inline(always)]
-    fn peek_slice(&self, offset: usize) -> (Self, Self::Slice) {
+    fn peek_slice(&self, offset: usize) -> (Self, Self::Slice)
+    where
+        Self: Clone,
+    {
         let mut peek = self.clone();
         let slice = peek.next_slice(offset);
         (peek, slice)
@@ -479,7 +485,10 @@ pub trait Stream:
     }
     /// Advance to the end of the stream
     #[inline(always)]
-    fn peek_finish(&self) -> (Self, Self::Slice) {
+    fn peek_finish(&self) -> (Self, Self::Slice)
+    where
+        Self: Clone,
+    {
         let mut peek = self.clone();
         let slice = peek.finish();
         (peek, slice)
@@ -769,7 +778,7 @@ impl<'i> Stream for &'i BStr {
 
 impl<I> Stream for (I, usize)
 where
-    I: Stream<Token = u8>,
+    I: Stream<Token = u8> + Clone,
 {
     type Token = bool;
     type Slice = (I::Slice, usize, usize);
@@ -853,7 +862,7 @@ pub struct BitOffsets<I> {
 
 impl<I> Iterator for BitOffsets<I>
 where
-    I: Stream<Token = u8>,
+    I: Stream<Token = u8> + Clone,
 {
     type Item = (usize, bool);
     fn next(&mut self) -> Option<Self::Item> {
@@ -868,7 +877,7 @@ where
 
 fn next_bit<I>(i: &mut (I, usize)) -> Option<bool>
 where
-    I: Stream<Token = u8>,
+    I: Stream<Token = u8> + Clone,
 {
     if i.eof_offset() == 0 {
         return None;
@@ -1351,7 +1360,7 @@ where
 
 impl<I> Offset<<(I, usize) as Stream>::Checkpoint> for (I, usize)
 where
-    I: Stream<Token = u8>,
+    I: Stream<Token = u8> + Clone,
 {
     #[inline(always)]
     fn offset_from(&self, other: &<(I, usize) as Stream>::Checkpoint) -> usize {

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -69,7 +69,7 @@ where
         if PARTIAL && input.is_partial() {
             ErrMode::Incomplete(Needed::new(1))
         } else {
-            ErrMode::from_error_kind(input.clone(), ErrorKind::Token)
+            ErrMode::from_error_kind(input, ErrorKind::Token)
         }
     })
 }
@@ -151,7 +151,7 @@ where
         }
         CompareResult::Incomplete | CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
-            Err(ErrMode::from_error_kind(i.clone(), e))
+            Err(ErrMode::from_error_kind(i, e))
         }
     }
 }
@@ -237,7 +237,7 @@ where
         }
         CompareResult::Incomplete | CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
-            Err(ErrMode::from_error_kind(i.clone(), e))
+            Err(ErrMode::from_error_kind(i, e))
         }
     }
 }
@@ -589,7 +589,7 @@ where
         .offset_for(predicate)
         .ok_or_else(|| ErrMode::Incomplete(Needed::new(1)))?;
     if offset == 0 {
-        Err(ErrMode::from_error_kind(input.clone(), e))
+        Err(ErrMode::from_error_kind(input, e))
     } else {
         Ok(input.next_slice(offset))
     }
@@ -630,7 +630,7 @@ where
         .offset_for(predicate)
         .unwrap_or_else(|| input.eof_offset());
     if offset == 0 {
-        Err(ErrMode::from_error_kind(input.clone(), e))
+        Err(ErrMode::from_error_kind(input, e))
     } else {
         Ok(input.next_slice(offset))
     }
@@ -648,14 +648,14 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     if n < m {
-        return Err(ErrMode::assert(input.clone(), "`m` should be <= `n`"));
+        return Err(ErrMode::assert(input, "`m` should be <= `n`"));
     }
 
     let mut final_count = 0;
     for (processed, (offset, token)) in input.iter_offsets().enumerate() {
         if !list.contains_token(token) {
             if processed < m {
-                return Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Slice));
+                return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
             } else {
                 return Ok(input.next_slice(offset));
             }
@@ -681,7 +681,7 @@ where
         if m <= final_count {
             Ok(input.finish())
         } else {
-            Err(ErrMode::from_error_kind(input.clone(), ErrorKind::Slice))
+            Err(ErrMode::from_error_kind(input, ErrorKind::Slice))
         }
     }
 }
@@ -903,7 +903,7 @@ where
     match i.offset_at(c) {
         Ok(offset) => Ok(i.next_slice(offset)),
         Err(e) if PARTIAL && i.is_partial() => Err(ErrMode::Incomplete(e)),
-        Err(_needed) => Err(ErrMode::from_error_kind(i.clone(), ErrorKind::Slice)),
+        Err(_needed) => Err(ErrMode::from_error_kind(i, ErrorKind::Slice)),
     }
 }
 
@@ -979,7 +979,7 @@ where
     match i.find_slice(t) {
         Some(offset) => Ok(i.next_slice(offset)),
         None if PARTIAL && i.is_partial() => Err(ErrMode::Incomplete(Needed::Unknown)),
-        None => Err(ErrMode::from_error_kind(i.clone(), ErrorKind::Slice)),
+        None => Err(ErrMode::from_error_kind(i, ErrorKind::Slice)),
     }
 }
 
@@ -1056,7 +1056,7 @@ where
 {
     match i.find_slice(t) {
         None if PARTIAL && i.is_partial() => Err(ErrMode::Incomplete(Needed::Unknown)),
-        None | Some(0) => Err(ErrMode::from_error_kind(i.clone(), ErrorKind::Slice)),
+        None | Some(0) => Err(ErrMode::from_error_kind(i, ErrorKind::Slice)),
         Some(offset) => Ok(i.next_slice(offset)),
     }
 }

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -38,7 +38,7 @@ fn model_complete_take_while_m_n(
 ) -> IResult<&str, &str> {
     if n < m {
         Err(crate::error::ErrMode::from_error_kind(
-            input,
+            &input,
             crate::error::ErrorKind::Slice,
         ))
     } else if m <= valid {
@@ -46,7 +46,7 @@ fn model_complete_take_while_m_n(
         Ok((&input[offset..], &input[0..offset]))
     } else {
         Err(crate::error::ErrMode::from_error_kind(
-            input,
+            &input,
             crate::error::ErrorKind::Slice,
         ))
     }
@@ -88,7 +88,7 @@ fn partial_one_of_test() {
     assert_eq!(
         f(Partial::new(b)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(b),
+            &Partial::new(b),
             ErrorKind::Verify
         )))
     );
@@ -111,7 +111,7 @@ fn char_byteslice() {
     assert_eq!(
         f(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(a),
+            &Partial::new(a),
             ErrorKind::Verify
         )))
     );
@@ -130,7 +130,7 @@ fn char_str() {
     assert_eq!(
         f(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(a),
+            &Partial::new(a),
             ErrorKind::Verify
         )))
     );
@@ -149,7 +149,7 @@ fn partial_none_of_test() {
     assert_eq!(
         f(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(a),
+            &Partial::new(a),
             ErrorKind::Verify
         )))
     );
@@ -173,7 +173,7 @@ fn partial_is_a() {
     let c = Partial::new(&b"cdef"[..]);
     assert_eq!(
         a_or_b(c),
-        Err(ErrMode::Backtrack(error_position!(c, ErrorKind::Slice)))
+        Err(ErrMode::Backtrack(error_position!(&c, ErrorKind::Slice)))
     );
 
     let d = Partial::new(&b"bacdef"[..]);
@@ -195,7 +195,7 @@ fn partial_is_not() {
     let c = Partial::new(&b"abab"[..]);
     assert_eq!(
         a_or_b(c),
-        Err(ErrMode::Backtrack(error_position!(c, ErrorKind::Slice)))
+        Err(ErrMode::Backtrack(error_position!(&c, ErrorKind::Slice)))
     );
 
     let d = Partial::new(&b"cdefba"[..]);
@@ -327,7 +327,7 @@ fn partial_take_while1() {
     assert_eq!(
         f(Partial::new(d)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(d),
+            &Partial::new(d),
             ErrorKind::Slice
         )))
     );
@@ -356,7 +356,7 @@ fn partial_take_while_m_n() {
     assert_eq!(
         x(Partial::new(f)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(f),
+            &Partial::new(f),
             ErrorKind::Slice
         )))
     );
@@ -398,7 +398,7 @@ fn partial_take_till1() {
     assert_eq!(
         f(Partial::new(b)),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(b),
+            &Partial::new(b),
             ErrorKind::Slice
         )))
     );
@@ -640,14 +640,14 @@ fn partial_case_insensitive() {
     assert_eq!(
         test(Partial::new(&b"Hello"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"Hello"[..]),
+            &Partial::new(&b"Hello"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         test(Partial::new(&b"Hel"[..])),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new(&b"Hel"[..]),
+            &Partial::new(&b"Hel"[..]),
             ErrorKind::Tag
         )))
     );
@@ -674,14 +674,14 @@ fn partial_case_insensitive() {
     assert_eq!(
         test2(Partial::new("Hello")),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new("Hello"),
+            &Partial::new("Hello"),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
         test2(Partial::new("Hel")),
         Err(ErrMode::Backtrack(error_position!(
-            Partial::new("Hel"),
+            &Partial::new("Hel"),
             ErrorKind::Tag
         )))
     );

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -20,11 +20,11 @@ impl<'a> From<(&'a str, ErrorKind)> for CustomError {
 }
 
 impl<'a> ParserError<Partial<&'a str>> for CustomError {
-    fn from_error_kind(_: Partial<&'a str>, kind: ErrorKind) -> Self {
+    fn from_error_kind(_: &Partial<&'a str>, kind: ErrorKind) -> Self {
         CustomError(format!("error code was: {:?}", kind))
     }
 
-    fn append(self, _: Partial<&'a str>, kind: ErrorKind) -> Self {
+    fn append(self, _: &Partial<&'a str>, kind: ErrorKind) -> Self {
         CustomError(format!("{:?}\nerror code was: {:?}", self, kind))
     }
 }


### PR DESCRIPTION
`Stream` no longer is required to be `Sized` and, in theory, should be object safe.

This also had the benefit of finding bugs in `escape` and `escape_transform` as well as cleaning up that code.