### PR TITLE
fix: Loosen `Clone` bound for tokens to `Copy`

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -228,7 +228,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Clone,
 {
-    trace("newline", '\n'.map(|c: <I as Stream>::Token| c.as_char())).parse_next(input)
+    trace("newline", '\n'.map(AsChar::as_char)).parse_next(input)
 }
 
 /// Matches a tab character `'\t'`.
@@ -268,7 +268,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Clone,
 {
-    trace("tab", '\t'.map(|c: <I as Stream>::Token| c.as_char())).parse_next(input)
+    trace("tab", '\t'.map(AsChar::as_char)).parse_next(input)
 }
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: `'a'..='z'`, `'A'..='Z'`
@@ -310,11 +310,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "alpha0",
-        take_while(0.., |c: <I as Stream>::Token| c.is_alpha()),
-    )
-    .parse_next(input)
+    trace("alpha0", take_while(0.., AsChar::is_alpha)).parse_next(input)
 }
 
 /// Recognizes one or more lowercase and uppercase ASCII alphabetic characters: `'a'..='z'`, `'A'..='Z'`
@@ -356,11 +352,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "alpha1",
-        take_while(1.., |c: <I as Stream>::Token| c.is_alpha()),
-    )
-    .parse_next(input)
+    trace("alpha1", take_while(1.., AsChar::is_alpha)).parse_next(input)
 }
 
 /// Recognizes zero or more ASCII numerical characters: `'0'..='9'`
@@ -403,11 +395,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "digit0",
-        take_while(0.., |c: <I as Stream>::Token| c.is_dec_digit()),
-    )
-    .parse_next(input)
+    trace("digit0", take_while(0.., AsChar::is_dec_digit)).parse_next(input)
 }
 
 /// Recognizes one or more ASCII numerical characters: `'0'..='9'`
@@ -466,11 +454,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "digit1",
-        take_while(1.., |c: <I as Stream>::Token| c.is_dec_digit()),
-    )
-    .parse_next(input)
+    trace("digit1", take_while(1.., AsChar::is_dec_digit)).parse_next(input)
 }
 
 /// Recognizes zero or more ASCII hexadecimal numerical characters: `'0'..='9'`, `'A'..='F'`,
@@ -512,11 +496,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "hex_digit0",
-        take_while(0.., |c: <I as Stream>::Token| c.is_hex_digit()),
-    )
-    .parse_next(input)
+    trace("hex_digit0", take_while(0.., AsChar::is_hex_digit)).parse_next(input)
 }
 
 /// Recognizes one or more ASCII hexadecimal numerical characters: `'0'..='9'`, `'A'..='F'`,
@@ -559,11 +539,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "hex_digit1",
-        take_while(1.., |c: <I as Stream>::Token| c.is_hex_digit()),
-    )
-    .parse_next(input)
+    trace("hex_digit1", take_while(1.., AsChar::is_hex_digit)).parse_next(input)
 }
 
 /// Recognizes zero or more octal characters: `'0'..='7'`
@@ -605,11 +581,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "oct_digit0",
-        take_while(0.., |c: <I as Stream>::Token| c.is_oct_digit()),
-    )
-    .parse_next(input)
+    trace("oct_digit0", take_while(0.., AsChar::is_oct_digit)).parse_next(input)
 }
 
 /// Recognizes one or more octal characters: `'0'..='7'`
@@ -651,11 +623,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "oct_digit0",
-        take_while(1.., |c: <I as Stream>::Token| c.is_oct_digit()),
-    )
-    .parse_next(input)
+    trace("oct_digit0", take_while(1.., AsChar::is_oct_digit)).parse_next(input)
 }
 
 /// Recognizes zero or more ASCII numerical and alphabetic characters: `'a'..='z'`, `'A'..='Z'`, `'0'..='9'`
@@ -697,11 +665,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "alphanumeric0",
-        take_while(0.., |c: <I as Stream>::Token| c.is_alphanum()),
-    )
-    .parse_next(input)
+    trace("alphanumeric0", take_while(0.., AsChar::is_alphanum)).parse_next(input)
 }
 
 /// Recognizes one or more ASCII numerical and alphabetic characters: `'a'..='z'`, `'A'..='Z'`, `'0'..='9'`
@@ -743,11 +707,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar,
 {
-    trace(
-        "alphanumeric1",
-        take_while(1.., |c: <I as Stream>::Token| c.is_alphanum()),
-    )
-    .parse_next(input)
+    trace("alphanumeric1", take_while(1.., AsChar::is_alphanum)).parse_next(input)
 }
 
 /// Recognizes zero or more spaces and tabs.
@@ -776,14 +736,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Clone,
 {
-    trace(
-        "space0",
-        take_while(0.., |c: <I as Stream>::Token| {
-            let ch = c.as_char();
-            matches!(ch, ' ' | '\t')
-        }),
-    )
-    .parse_next(input)
+    trace("space0", take_while(0.., AsChar::is_space)).parse_next(input)
 }
 
 /// Recognizes zero or more spaces and tabs.
@@ -825,14 +778,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Clone,
 {
-    trace(
-        "space1",
-        take_while(1.., |c: <I as Stream>::Token| {
-            let ch = c.as_char();
-            matches!(ch, ' ' | '\t')
-        }),
-    )
-    .parse_next(input)
+    trace("space1", take_while(1.., AsChar::is_space)).parse_next(input)
 }
 
 /// Recognizes zero or more spaces, tabs, carriage returns and line feeds.
@@ -874,14 +820,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Clone,
 {
-    trace(
-        "multispace0",
-        take_while(0.., |c: <I as Stream>::Token| {
-            let ch = c.as_char();
-            matches!(ch, ' ' | '\t' | '\r' | '\n')
-        }),
-    )
-    .parse_next(input)
+    trace("multispace0", take_while(0.., (' ', '\t', '\r', '\n'))).parse_next(input)
 }
 
 /// Recognizes one or more spaces, tabs, carriage returns and line feeds.
@@ -923,14 +862,7 @@ where
     I: Stream,
     <I as Stream>::Token: AsChar + Clone,
 {
-    trace(
-        "multispace1",
-        take_while(1.., |c: <I as Stream>::Token| {
-            let ch = c.as_char();
-            matches!(ch, ' ' | '\t' | '\r' | '\n')
-        }),
-    )
-    .parse_next(input)
+    trace("multispace1", take_while(1.., (' ', '\t', '\r', '\n'))).parse_next(input)
 }
 
 /// Decode a decimal unsigned integer (e.g. [`u32`])
@@ -1529,12 +1461,7 @@ where
                 }
             }
             None => {
-                if opt(one_of(|t: <I as Stream>::Token| {
-                    t.as_char() == control_char
-                }))
-                .parse_next(input)?
-                .is_some()
-                {
+                if opt(control_char).parse_next(input)?.is_some() {
                     let _ = escapable.parse_next(input)?;
                 } else {
                     let offset = input.offset_from(&start);
@@ -1576,12 +1503,7 @@ where
                 }
             }
             None => {
-                if opt(one_of(|t: <I as Stream>::Token| {
-                    t.as_char() == control_char
-                }))
-                .parse_next(input)?
-                .is_some()
-                {
+                if opt(control_char).parse_next(input)?.is_some() {
                     let _ = escapable.parse_next(input)?;
                 } else {
                     let offset = input.offset_from(&start);
@@ -1706,12 +1628,7 @@ where
                 }
             }
             None => {
-                if opt(one_of(|t: <I as Stream>::Token| {
-                    t.as_char() == control_char
-                }))
-                .parse_next(input)?
-                .is_some()
-                {
+                if opt(control_char).parse_next(input)?.is_some() {
                     let o = transform.parse_next(input)?;
                     res.accumulate(o);
                 } else {
@@ -1751,12 +1668,7 @@ where
                 }
             }
             None => {
-                if opt(one_of(|t: <I as Stream>::Token| {
-                    t.as_char() == control_char
-                }))
-                .parse_next(input)?
-                .is_some()
-                {
+                if opt(control_char).parse_next(input)?.is_some() {
                     let o = transform.parse_next(input)?;
                     res.accumulate(o);
                 } else {

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -226,7 +226,7 @@ pub fn newline<I, Error: ParserError<I>>(input: &mut I) -> PResult<char, Error>
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
 {
     trace("newline", '\n'.map(|c: <I as Stream>::Token| c.as_char())).parse_next(input)
 }
@@ -266,7 +266,7 @@ pub fn tab<I, Error: ParserError<I>>(input: &mut I) -> PResult<char, Error>
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
 {
     trace("tab", '\t'.map(|c: <I as Stream>::Token| c.as_char())).parse_next(input)
 }
@@ -774,7 +774,7 @@ pub fn space0<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Sli
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
 {
     trace(
         "space0",
@@ -823,7 +823,7 @@ pub fn space1<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Sli
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
 {
     trace(
         "space1",
@@ -872,7 +872,7 @@ pub fn multispace0<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
 {
     trace(
         "multispace0",
@@ -921,7 +921,7 @@ pub fn multispace1<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
 {
     trace(
         "multispace1",
@@ -947,7 +947,7 @@ pub fn dec_uint<I, O, E: ParserError<I>>(input: &mut I) -> PResult<O, E>
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
     O: Uint,
 {
     trace("dec_uint", move |input: &mut I| {
@@ -1102,7 +1102,7 @@ pub fn dec_int<I, O, E: ParserError<I>>(input: &mut I) -> PResult<O, E>
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
     O: Int,
 {
     trace("dec_int", move |input: &mut I| {
@@ -1376,13 +1376,14 @@ impl HexUint for u128 {
 #[inline(always)]
 #[doc(alias = "f32")]
 #[doc(alias = "double")]
+#[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
 pub fn float<I, O, E: ParserError<I>>(input: &mut I) -> PResult<O, E>
 where
     I: StreamIsPartial,
     I: Stream,
     I: Compare<&'static str>,
     <I as Stream>::Slice: ParseSlice<O>,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
 {
@@ -1394,6 +1395,7 @@ where
     .parse_next(input)
 }
 
+#[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
 fn recognize_float_or_exceptions<I, E: ParserError<I>>(
     input: &mut I,
 ) -> PResult<<I as Stream>::Slice, E>
@@ -1401,7 +1403,7 @@ where
     I: StreamIsPartial,
     I: Stream,
     I: Compare<&'static str>,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
 {
@@ -1414,12 +1416,13 @@ where
     .parse_next(input)
 }
 
+#[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
 fn recognize_float<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
     I: Compare<&'static str>,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
 {
@@ -1484,7 +1487,7 @@ pub fn escaped<'a, I: 'a, Error, F, G, O1, O2>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
     F: Parser<I, O1, Error>,
     G: Parser<I, O2, Error>,
     Error: ParserError<I>,
@@ -1507,7 +1510,7 @@ fn streaming_escaped_internal<I, Error, F, G, O1, O2>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
     F: Parser<I, O1, Error>,
     G: Parser<I, O2, Error>,
     Error: ParserError<I>,
@@ -1554,7 +1557,7 @@ fn complete_escaped_internal<'a, I: 'a, Error, F, G, O1, O2>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: crate::stream::AsChar + Copy,
+    <I as Stream>::Token: crate::stream::AsChar + Clone,
     F: Parser<I, O1, Error>,
     G: Parser<I, O2, Error>,
     Error: ParserError<I>,
@@ -1661,7 +1664,7 @@ pub fn escaped_transform<I, Error, F, G, Output>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: crate::stream::AsChar + Copy,
+    <I as Stream>::Token: crate::stream::AsChar + Clone,
     Output: crate::stream::Accumulate<<I as Stream>::Slice>,
     F: Parser<I, <I as Stream>::Slice, Error>,
     G: Parser<I, <I as Stream>::Slice, Error>,
@@ -1685,7 +1688,7 @@ fn streaming_escaped_transform_internal<I, Error, F, G, Output>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: crate::stream::AsChar + Copy,
+    <I as Stream>::Token: crate::stream::AsChar + Clone,
     Output: crate::stream::Accumulate<<I as Stream>::Slice>,
     F: Parser<I, <I as Stream>::Slice, Error>,
     G: Parser<I, <I as Stream>::Slice, Error>,
@@ -1729,7 +1732,7 @@ fn complete_escaped_transform_internal<I, Error, F, G, Output>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: crate::stream::AsChar + Copy,
+    <I as Stream>::Token: crate::stream::AsChar + Clone,
     Output: crate::stream::Accumulate<<I as Stream>::Slice>,
     F: Parser<I, <I as Stream>::Slice, Error>,
     G: Parser<I, <I as Stream>::Slice, Error>,

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -1222,7 +1222,7 @@ mod partial {
         let d: &[u8] = b"ab12cd";
         assert_eq!(
             not_line_ending::<_, InputError<_>>.parse_peek(Partial::new(d)),
-            Err(ErrMode::Incomplete(Needed::Unknown))
+            Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
 
@@ -1240,7 +1240,7 @@ mod partial {
         let g2: &str = "ab12cd";
         assert_eq!(
             not_line_ending::<_, InputError<_>>.parse_peek(Partial::new(g2)),
-            Err(ErrMode::Incomplete(Needed::Unknown))
+            Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -678,7 +678,7 @@ impl<I, E> Parser<I, <I as Stream>::Token, E> for char
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Copy,
+    <I as Stream>::Token: AsChar + Clone,
     E: ParserError<I>,
 {
     #[inline(always)]

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -295,12 +295,12 @@ pub fn one_of<I, T, Error: ParserError<I>>(list: T) -> impl Parser<I, <I as Stre
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: Copy,
+    <I as Stream>::Token: Clone,
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace(
         "one_of",
-        any.verify(move |t: &<I as Stream>::Token| list.contains_token(*t)),
+        any.verify(move |t: &<I as Stream>::Token| list.contains_token(t.clone())),
     )
 }
 
@@ -335,12 +335,12 @@ pub fn none_of<I, T, Error: ParserError<I>>(list: T) -> impl Parser<I, <I as Str
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: Copy,
+    <I as Stream>::Token: Clone,
     T: ContainsToken<<I as Stream>::Token>,
 {
     trace(
         "none_of",
-        any.verify(move |t: &<I as Stream>::Token| !list.contains_token(*t)),
+        any.verify(move |t: &<I as Stream>::Token| !list.contains_token(t.clone())),
     )
 }
 


### PR DESCRIPTION
This was inspired by #232.  I tried to remove the `Clone` bound completely but was running into compiler issues that were non-obvious.  The worst part is that inputs with costlier `Stream::Token::clone` calls will be in the inner-loop for `Stream::offset_for` for parers like `take_while`.