### PR TITLE
feat(error): Add ParseError::into_error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -750,6 +750,12 @@ impl<I, E> ParseError<I, E> {
     pub fn inner(&self) -> &E {
         &self.inner
     }
+
+    /// The original [`ParserError`]
+    #[inline]
+    pub fn into_inner(self) -> E {
+        self.inner
+    }
 }
 
 impl<I, E> core::fmt::Display for ParseError<I, E>


### PR DESCRIPTION
Found this useful within cargo-smart-release where the extra details aren't needed

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
