### PR TITLE
feat(comb): Allow arrays as input to `alt`

### DIFF
--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -13,6 +13,7 @@ use crate::stream::Stream;
 use crate::token::take;
 use crate::unpeek;
 use crate::IResult;
+use crate::PResult;
 use crate::Parser;
 use crate::Partial;
 
@@ -645,6 +646,28 @@ fn alt_incomplete() {
     assert_eq!(
         alt1(Partial::new(a)),
         Ok((Partial::new(&b"g"[..]), &b"def"[..]))
+    );
+}
+
+#[test]
+fn alt_array() {
+    fn alt1<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        alt(["a", "bc", "def"]).parse_next(i)
+    }
+
+    let i = &b"a"[..];
+    assert_eq!(alt1.parse_peek(i), Ok((&b""[..], (&b"a"[..]))));
+
+    let i = &b"bc"[..];
+    assert_eq!(alt1.parse_peek(i), Ok((&b""[..], (&b"bc"[..]))));
+
+    let i = &b"defg"[..];
+    assert_eq!(alt1.parse_peek(i), Ok((&b"g"[..], (&b"def"[..]))));
+
+    let i = &b"z"[..];
+    assert_eq!(
+        alt1.parse_peek(i),
+        Err(ErrMode::Backtrack(error_position!(&i, ErrorKind::Tag)))
     );
 }
 


### PR DESCRIPTION
Now that min-const-generics is stabilized, it's possible to (backwards-compatibly) write a version of `alt` that uses a const array as input instead of being limited to only tuples - this allows us to lift the 21-element limitation on tuples passed to `alt`.

Upstream: rust-bakery/nom#1556

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
