### PR TITLE
feat(error): `TreeError` to trace full error path

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -89,7 +89,7 @@ impl Needed {
     }
 }
 
-/// The `Err` enum indicates the parser was not successful
+/// Add parse error state to [`ParserError`]s
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
 pub enum ErrMode<E> {


### PR DESCRIPTION
gix was using `VerboseError` with a converted input type to easily dump parse state in tests for easier debugging.

This seemed like a nifty enough of an idea that I generalized it, building on ideas from `nom-supreme`