### PR TITLE
refactor(binary): Move var definition close to use

### DIFF
--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -204,7 +204,6 @@ where
     if count == 0 {
         Ok(((input, bit_offset), 0u8.into()))
     } else {
-        let cnt = (count + bit_offset).div(BYTE);
         if input.eof_offset() * BYTE < count + bit_offset {
             if PARTIAL && input.is_partial() {
                 Err(ErrMode::Incomplete(Needed::new(count)))
@@ -215,6 +214,7 @@ where
                 ))
             }
         } else {
+            let cnt = (count + bit_offset).div(BYTE);
             let mut acc: O = 0_u8.into();
             let mut offset: usize = bit_offset;
             let mut remaining: usize = count;


### PR DESCRIPTION
It's not a big deal and compiler should be able to do this automatically, but this also reduces the scope of the definition.

See rust-bakery/nom#1683

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
