### PR TITLE
perf(token): Speed up `take_until` under simd

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2684,7 +2684,35 @@ fn memchr(token: u8, slice: &[u8]) -> Option<usize> {
 #[cfg(feature = "simd")]
 #[inline(always)]
 fn memmem(slice: &[u8], tag: &[u8]) -> Option<usize> {
-    memchr::memmem::find(slice, tag)
+    if tag.len() > slice.len() {
+        return None;
+    }
+
+    let (&substr_first, substr_rest) = match tag.split_first() {
+        Some(split) => split,
+        // an empty substring is found at position 0
+        // This matches the behavior of str.find("").
+        None => return Some(0),
+    };
+
+    if substr_rest.is_empty() {
+        return memchr::memchr(substr_first, slice);
+    }
+
+    let mut offset = 0;
+    let haystack = &slice[..slice.len() - substr_rest.len()];
+
+    while let Some(position) = memchr::memchr(substr_first, &haystack[offset..]) {
+        offset += position;
+        let next_offset = offset + 1;
+        if &slice[next_offset..][..substr_rest.len()] == substr_rest {
+            return Some(offset);
+        }
+
+        offset = next_offset;
+    }
+
+    None
 }
 
 #[cfg(not(feature = "simd"))]


### PR DESCRIPTION
This reverts commit 489aa2ace0ce77790cf8d2aa3fc0fcf8a8f7ccb2.

PR #86 "FindSubstring<&[u8]>: make use of `memchr::memmem`"

When testing under gitoxide, it turned out this slowed down gitoxide-specific micro-benchmarks from ~170ns to ~240ns

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
