### PR TITLE
Fix minor typos

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -423,7 +423,8 @@ pub trait Stream: Offset<<Self as Stream>::Checkpoint> + crate::lib::std::fmt::D
 
     /// Iterate with the offset from the current location
     fn iter_offsets(&self) -> Self::IterOffsets;
-    /// Returns the offaet to the end of the input
+
+    /// Returns the offset to the end of the input
     fn eof_offset(&self) -> usize;
 
     /// Split off the next token from the input

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -19,7 +19,7 @@ compile_error!("`debug` requires `std`");
 
 /// Trace the execution of the parser
 ///
-/// Note that [`Parser::context` also provides high level trace information.
+/// Note that [`Parser::context`] also provides high level trace information.
 ///
 /// See [`trace` module][self] for more details.
 ///


### PR DESCRIPTION
I've seen a few typos browsing the docs. I've seen more, but those are the one I can find right now.