### PR TITLE
fix(stream): Correctly count offsets for non-byte slices 

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1300,7 +1300,7 @@ impl<'a, T> Offset for &'a [T] {
             fst <= snd,
             "`Offset::offset_to` only accepts slices of `self`"
         );
-        snd as usize - fst as usize
+        (snd as usize - fst as usize) / crate::lib::std::mem::size_of::<T>()
     }
 }
 

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -127,5 +127,5 @@ fn test_custom_slice() {
     let _ = input.next_token();
     let _ = input.next_token();
     let offset = input.offset_from(&start);
-    assert_eq!(offset, 16);
+    assert_eq!(offset, 2);
 }

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -114,3 +114,18 @@ fn test_partial_complete() {
     i.restore_partial(incomplete_state);
     assert!(i.is_partial(), "incomplete stream state should be restored");
 }
+
+#[test]
+fn test_custom_slice() {
+    type Token = usize;
+    type TokenSlice<'i> = &'i [Token];
+
+    let mut tokens: TokenSlice<'_> = &[1, 2, 3, 4];
+
+    let input = &mut tokens;
+    let start = input.checkpoint();
+    let _ = input.next_token();
+    let _ = input.next_token();
+    let offset = input.offset_from(&start);
+    assert_eq!(offset, 16);
+}


### PR DESCRIPTION
Fixes #339