### PR TITLE
docs: Be explicit on offset vs index

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1182,6 +1182,9 @@ impl<I, E> ParseError<I, E> {
     }
 
     /// The location in [`ParseError::input`] where parsing failed
+    ///
+    /// **Note:** This is an offset, not an index, and may point to the end of input
+    /// (`input.len() + 1`) on eof errors.
     #[inline]
     pub fn offset(&self) -> usize {
         self.offset

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1286,7 +1286,10 @@ where
 
 /// Useful functions to calculate the offset between slices and show a hexdump of a slice
 pub trait Offset<Start = Self> {
-    /// Offset between the first byte of `start` and the first byte of `self`
+    /// Offset between the first byte of `start` and the first byte of `self`a
+    ///
+    /// **Note:** This is an offset, not an index, and may point to the end of input
+    /// (`start.len() + 1`) when `self` is exhausted.
     fn offset_from(&self, start: &Start) -> usize;
 }
 


### PR DESCRIPTION
In particular, this calls out a problem when you conflate the two.

Fixes #341

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
