### PR TITLE
Impl Accumulate for more HashMaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1438,7 @@ dependencies = [
  "lexopt",
  "memchr",
  "proptest",
+ "rustc-hash",
  "snapbox",
  "term-transcript",
  "terminal_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ term-transcript = "0.2.0"
 escargot = "0.5.7"
 snapbox = { version = "0.4.11", features = ["examples"] }
 circular = "0.3.0"
+rustc-hash = "1.1.0"
 
 [profile.bench]
 debug = true

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -1,7 +1,24 @@
 #[cfg(feature = "std")]
 use proptest::prelude::*;
 
+use crate::{
+    combinator::{separated0, separated_pair},
+    PResult, Parser,
+};
+
 use super::*;
+
+#[cfg(feature = "std")]
+#[test]
+fn test_fxhashmap_compiles() {
+    let input = "a=b";
+    fn pair(i: &mut &str) -> PResult<(char, char)> {
+        let out = separated_pair('a', '=', 'b').parse_next(i)?;
+        Ok(out)
+    }
+
+    let _: rustc_hash::FxHashMap<char, char> = separated0(pair, ',').parse(input).unwrap();
+}
 
 #[test]
 fn test_offset_u8() {


### PR DESCRIPTION
Currently Accumulate is only implemented for HashMap<K, V, RandomState>.

This generalizes the Accumulate impl to HashMap<K, V, S: BuildHasher + Default>.

See #356 
