### PR TITLE
fix: Deprecate signed Uint impls

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -965,6 +965,7 @@ impl Uint for u128 {
     }
 }
 
+/// Deprecated since v0.15.17
 impl Uint for i8 {
     fn checked_mul(self, by: u8, _: sealed::SealedMarker) -> Option<Self> {
         self.checked_mul(by as Self)
@@ -974,6 +975,7 @@ impl Uint for i8 {
     }
 }
 
+/// Deprecated since v0.15.17
 impl Uint for i16 {
     fn checked_mul(self, by: u8, _: sealed::SealedMarker) -> Option<Self> {
         self.checked_mul(by as Self)
@@ -983,6 +985,7 @@ impl Uint for i16 {
     }
 }
 
+/// Deprecated since v0.15.17
 impl Uint for i32 {
     fn checked_mul(self, by: u8, _: sealed::SealedMarker) -> Option<Self> {
         self.checked_mul(by as Self)
@@ -992,6 +995,7 @@ impl Uint for i32 {
     }
 }
 
+/// Deprecated since v0.15.17
 impl Uint for i64 {
     fn checked_mul(self, by: u8, _: sealed::SealedMarker) -> Option<Self> {
         self.checked_mul(by as Self)
@@ -1001,6 +1005,7 @@ impl Uint for i64 {
     }
 }
 
+/// Deprecated since v0.15.17
 impl Uint for i128 {
     fn checked_mul(self, by: u8, _: sealed::SealedMarker) -> Option<Self> {
         self.checked_mul(by as Self)


### PR DESCRIPTION
Inspired by #355

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
