### PR TITLE
feat(combinator): add separated

### DIFF
--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -7,7 +7,7 @@ use winnow::{
     combinator::alt,
     combinator::cut_err,
     combinator::{delimited, preceded, separated_pair, terminated},
-    combinator::{fold_repeat, separated0},
+    combinator::{fold_repeat, separated},
     error::{AddContext, ParserError},
     token::{any, none_of, take, take_while},
 };
@@ -153,7 +153,7 @@ fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u1
         .parse_next(input)
 }
 
-/// Some combinators, like `separated0` or `repeat`, will call a parser repeatedly,
+/// Some combinators, like `separated` or `repeat`, will call a parser repeatedly,
 /// accumulating results in a `Vec`, until it encounters an error.
 /// If you want more control on the parser application, check out the `iterator`
 /// combinator (cf `examples/iterator.rs`)
@@ -162,7 +162,10 @@ fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>(
 ) -> PResult<Vec<JsonValue>, E> {
     preceded(
         ('[', ws),
-        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
+        cut_err(terminated(
+            separated(0.., json_value, (ws, ',', ws)),
+            (ws, ']'),
+        )),
     )
     .context("array")
     .parse_next(input)
@@ -173,7 +176,10 @@ fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>
 ) -> PResult<HashMap<String, JsonValue>, E> {
     preceded(
         ('{', ws),
-        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
+        cut_err(terminated(
+            separated(0.., key_value, (ws, ',', ws)),
+            (ws, '}'),
+        )),
     )
     .context("object")
     .parse_next(input)

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -10,7 +10,7 @@ use winnow::{
     combinator::success,
     combinator::{alt, dispatch},
     combinator::{delimited, preceded, separated_pair, terminated},
-    combinator::{fold_repeat, separated0},
+    combinator::{fold_repeat, separated},
     error::{AddContext, ParserError},
     token::{any, none_of, take, take_while},
 };
@@ -160,7 +160,7 @@ fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u1
         .parse_next(input)
 }
 
-/// Some combinators, like `separated0` or `repeat`, will call a parser repeatedly,
+/// Some combinators, like `separated` or `repeat`, will call a parser repeatedly,
 /// accumulating results in a `Vec`, until it encounters an error.
 /// If you want more control on the parser application, check out the `iterator`
 /// combinator (cf `examples/iterator.rs`)
@@ -169,7 +169,10 @@ fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>(
 ) -> PResult<Vec<JsonValue>, E> {
     preceded(
         ('[', ws),
-        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
+        cut_err(terminated(
+            separated(0.., json_value, (ws, ',', ws)),
+            (ws, ']'),
+        )),
     )
     .context("array")
     .parse_next(input)
@@ -180,7 +183,10 @@ fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>
 ) -> PResult<HashMap<String, JsonValue>, E> {
     preceded(
         ('{', ws),
-        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
+        cut_err(terminated(
+            separated(0.., key_value, (ws, ',', ws)),
+            (ws, '}'),
+        )),
     )
     .context("object")
     .parse_next(input)

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -7,7 +7,7 @@ use winnow::{
     combinator::alt,
     combinator::{cut_err, rest},
     combinator::{delimited, preceded, separated_pair, terminated},
-    combinator::{fold_repeat, separated0},
+    combinator::{fold_repeat, separated},
     error::{AddContext, ParserError},
     stream::Partial,
     token::{any, none_of, take, take_while},
@@ -154,7 +154,7 @@ fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u1
         .parse_next(input)
 }
 
-/// Some combinators, like `separated0` or `repeat`, will call a parser repeatedly,
+/// Some combinators, like `separated` or `repeat`, will call a parser repeatedly,
 /// accumulating results in a `Vec`, until it encounters an error.
 /// If you want more control on the parser application, check out the `iterator`
 /// combinator (cf `examples/iterator.rs`)
@@ -163,7 +163,10 @@ fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>(
 ) -> PResult<Vec<JsonValue>, E> {
     preceded(
         ('[', ws),
-        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
+        cut_err(terminated(
+            separated(0.., json_value, (ws, ',', ws)),
+            (ws, ']'),
+        )),
     )
     .context("array")
     .parse_next(input)
@@ -174,7 +177,10 @@ fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>
 ) -> PResult<HashMap<String, JsonValue>, E> {
     preceded(
         ('{', ws),
-        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
+        cut_err(terminated(
+            separated(0.., key_value, (ws, ',', ws)),
+            (ws, '}'),
+        )),
     )
     .context("object")
     .parse_next(input)

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -5,7 +5,7 @@ use winnow::{
     ascii::{alphanumeric1 as alphanumeric, escaped, float},
     combinator::alt,
     combinator::cut_err,
-    combinator::separated0,
+    combinator::separated,
     combinator::{preceded, separated_pair, terminated},
     error::ParserError,
     error::StrContext,
@@ -233,7 +233,7 @@ fn array(i: &mut &str) -> PResult<()> {
     preceded(
         '[',
         cut_err(terminated(
-            separated0(value, preceded(sp, ',')),
+            separated(0.., value, preceded(sp, ',')),
             preceded(sp, ']'),
         )),
     )
@@ -249,7 +249,7 @@ fn hash(i: &mut &str) -> PResult<()> {
     preceded(
         '{',
         cut_err(terminated(
-            separated0(key_value, preceded(sp, ',')),
+            separated(0.., key_value, preceded(sp, ',')),
             preceded(sp, '}'),
         )),
     )

--- a/examples/ndjson/parser.rs
+++ b/examples/ndjson/parser.rs
@@ -8,7 +8,7 @@ use winnow::{
     combinator::alt,
     combinator::cut_err,
     combinator::{delimited, preceded, separated_pair, terminated},
-    combinator::{fold_repeat, separated0},
+    combinator::{fold_repeat, separated},
     error::{AddContext, ParserError},
     stream::Partial,
     token::{any, none_of, take, take_while},
@@ -158,7 +158,7 @@ fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u1
         .parse_next(input)
 }
 
-/// Some combinators, like `separated0` or `repeat`, will call a parser repeatedly,
+/// Some combinators, like `separated` or `repeat`, will call a parser repeatedly,
 /// accumulating results in a `Vec`, until it encounters an error.
 /// If you want more control on the parser application, check out the `iterator`
 /// combinator (cf `examples/iterator.rs`)
@@ -167,7 +167,10 @@ fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>(
 ) -> PResult<Vec<JsonValue>, E> {
     preceded(
         ('[', ws),
-        cut_err(terminated(separated0(json_value, (ws, ',', ws)), (ws, ']'))),
+        cut_err(terminated(
+            separated(0.., json_value, (ws, ',', ws)),
+            (ws, ']'),
+        )),
     )
     .context("array")
     .parse_next(input)
@@ -178,7 +181,10 @@ fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>
 ) -> PResult<HashMap<String, JsonValue>, E> {
     preceded(
         ('{', ws),
-        cut_err(terminated(separated0(key_value, (ws, ',', ws)), (ws, '}'))),
+        cut_err(terminated(
+            separated(0.., key_value, (ws, ',', ws)),
+            (ws, '}'),
+        )),
     )
     .context("object")
     .parse_next(input)

--- a/src/_tutorial/chapter_5.rs
+++ b/src/_tutorial/chapter_5.rs
@@ -137,17 +137,17 @@
 //! ```
 //!
 //! You'll notice that the above allows trailing `,` when we intended to not support that. We can
-//! easily fix this by using [`separated0`]:
+//! easily fix this by using [`separated`]:
 //! ```rust
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
 //! # use winnow::combinator::fail;
-//! use winnow::combinator::separated0;
+//! use winnow::combinator::separated;
 //!
 //! fn parse_list(input: &mut &str) -> PResult<Vec<usize>> {
-//!     separated0(parse_digits, ",").parse_next(input)
+//!     separated(0.., parse_digits, ",").parse_next(input)
 //! }
 //!
 //! // ...
@@ -208,14 +208,14 @@
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
 //! # use winnow::combinator::fail;
-//! # use winnow::combinator::separated0;
+//! # use winnow::combinator::separated;
 //! #
 //! fn recognize_list<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //!     parse_list.recognize().parse_next(input)
 //! }
 //!
 //! fn parse_list(input: &mut &str) -> PResult<()> {
-//!     separated0(parse_digits, ",").parse_next(input)
+//!     separated(0.., parse_digits, ",").parse_next(input)
 //! }
 //!
 //! # fn parse_digits(input: &mut &str) -> PResult<usize> {
@@ -272,7 +272,7 @@ use super::chapter_2;
 use super::chapter_3;
 use crate::combinator;
 use crate::combinator::repeat;
-use crate::combinator::separated0;
+use crate::combinator::separated;
 use crate::stream::Accumulate;
 use crate::Parser;
 use std::vec::Vec;

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -41,7 +41,7 @@
 //! |---|---|---|---|---|---|
 //! | [`repeat`] | `repeat(1..=3, "ab")` | `"ababc"` | `"c"` | `Ok(vec!["ab", "ab"])` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
 //! | [`repeat_till0`] | `repeat_till0(tag( "ab" ), tag( "ef" ))` | `"ababefg"` | `"g"` | `Ok((vec!["ab", "ab"], "ef"))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
-//! | [`separated0`] | `separated0("ab", ",")` | `"ab,ab,ab."` | `"."` | `Ok(vec!["ab", "ab", "ab"])` |`separated1` works like `separated0` but must returns at least one element|
+//! | [`separated`] | `separated(1..=3, "ab", ",")` | `"ab,ab,ab."` | `"."` | `Ok(vec!["ab", "ab", "ab"])` |Applies the parser and separator between m and n times (n included) and returns the list of results in a Vec|
 //! | [`fold_repeat`] | `fold_repeat(1..=2, be_u8, \|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `[3]` | `Ok(3)` |Applies the parser between m and n times (n included) and folds the list of return value|
 //!
 //! ## Partial related

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -513,7 +513,11 @@ where
     })
 }
 
-fn separated0_<I, O, C, O2, E, P, S>(parser: &mut P, sep: &mut S, i: &mut I) -> PResult<C, E>
+fn separated0_<I, O, C, O2, E, P, S>(
+    parser: &mut P,
+    separator: &mut S,
+    input: &mut I,
+) -> PResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -521,46 +525,46 @@ where
     S: Parser<I, O2, E>,
     E: ParserError<I>,
 {
-    let mut res = C::initial(None);
+    let mut acc = C::initial(None);
 
-    let start = i.checkpoint();
-    match parser.parse_next(i) {
+    let start = input.checkpoint();
+    match parser.parse_next(input) {
         Err(ErrMode::Backtrack(_)) => {
-            i.reset(start);
-            return Ok(res);
+            input.reset(start);
+            return Ok(acc);
         }
         Err(e) => return Err(e),
         Ok(o) => {
-            res.accumulate(o);
+            acc.accumulate(o);
         }
     }
 
     loop {
-        let start = i.checkpoint();
-        let len = i.eof_offset();
-        match sep.parse_next(i) {
+        let start = input.checkpoint();
+        let len = input.eof_offset();
+        match separator.parse_next(input) {
             Err(ErrMode::Backtrack(_)) => {
-                i.reset(start);
-                return Ok(res);
+                input.reset(start);
+                return Ok(acc);
             }
             Err(e) => return Err(e),
             Ok(_) => {
                 // infinite loop check
-                if i.eof_offset() == len {
+                if input.eof_offset() == len {
                     return Err(ErrMode::assert(
-                        i,
+                        input,
                         "`separated` separator parser must always consume",
                     ));
                 }
 
-                match parser.parse_next(i) {
+                match parser.parse_next(input) {
                     Err(ErrMode::Backtrack(_)) => {
-                        i.reset(start);
-                        return Ok(res);
+                        input.reset(start);
+                        return Ok(acc);
                     }
                     Err(e) => return Err(e),
                     Ok(o) => {
-                        res.accumulate(o);
+                        acc.accumulate(o);
                     }
                 }
             }
@@ -615,7 +619,11 @@ where
     })
 }
 
-fn separated1_<I, O, C, O2, E, P, S>(parser: &mut P, sep: &mut S, i: &mut I) -> PResult<C, E>
+fn separated1_<I, O, C, O2, E, P, S>(
+    parser: &mut P,
+    separator: &mut S,
+    input: &mut I,
+) -> PResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -623,42 +631,42 @@ where
     S: Parser<I, O2, E>,
     E: ParserError<I>,
 {
-    let mut res = C::initial(None);
+    let mut acc = C::initial(None);
 
     // Parse the first element
-    match parser.parse_next(i) {
+    match parser.parse_next(input) {
         Err(e) => return Err(e),
         Ok(o) => {
-            res.accumulate(o);
+            acc.accumulate(o);
         }
     }
 
     loop {
-        let start = i.checkpoint();
-        let len = i.eof_offset();
-        match sep.parse_next(i) {
+        let start = input.checkpoint();
+        let len = input.eof_offset();
+        match separator.parse_next(input) {
             Err(ErrMode::Backtrack(_)) => {
-                i.reset(start);
-                return Ok(res);
+                input.reset(start);
+                return Ok(acc);
             }
             Err(e) => return Err(e),
             Ok(_) => {
                 // infinite loop check
-                if i.eof_offset() == len {
+                if input.eof_offset() == len {
                     return Err(ErrMode::assert(
-                        i,
+                        input,
                         "`separated` separator parser must always consume",
                     ));
                 }
 
-                match parser.parse_next(i) {
+                match parser.parse_next(input) {
                     Err(ErrMode::Backtrack(_)) => {
-                        i.reset(start);
-                        return Ok(res);
+                        input.reset(start);
+                        return Ok(acc);
                     }
                     Err(e) => return Err(e),
                     Ok(o) => {
-                        res.accumulate(o);
+                        acc.accumulate(o);
                     }
                 }
             }

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -342,6 +342,138 @@ where
 /// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
+/// * `m` The minimum number of iterations.
+/// * `n` The maximum number of iterations.
+/// * `parser` The parser that parses the elements of the list.
+/// * `sep` The parser that parses the separator between list elements.
+///
+/// # Example
+///
+/// Zero or more repetitions:
+/// ```rust
+/// # #[cfg(feature = "std")] {
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::prelude::*;
+/// use winnow::combinator::separated;
+/// use winnow::token::tag;
+///
+/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+///   separated(0.., "abc", "|").parse_peek(s)
+/// }
+///
+/// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
+/// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
+/// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
+/// assert_eq!(parser(""), Ok(("", vec![])));
+/// assert_eq!(parser("def|abc"), Ok(("def|abc", vec![])));
+/// # }
+/// ```
+///
+/// One or more repetitions:
+/// ```rust
+/// # #[cfg(feature = "std")] {
+/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
+/// use winnow::combinator::separated;
+/// use winnow::token::tag;
+///
+/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+///   separated(1.., "abc", "|").parse_peek(s)
+/// }
+///
+/// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
+/// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
+/// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(InputError::new("def|abc", ErrorKind::Tag))));
+/// # }
+/// ```
+///
+/// Fixed number of repetitions:
+/// ```rust
+/// # #[cfg(feature = "std")] {
+/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
+/// use winnow::combinator::separated;
+/// use winnow::token::tag;
+///
+/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+///   separated(2, "abc", "|").parse_peek(s)
+/// }
+///
+/// assert_eq!(parser("abc|abc|abc"), Ok(("|abc", vec!["abc", "abc"])));
+/// assert_eq!(parser("abc123abc"), Err(ErrMode::Backtrack(InputError::new("123abc", ErrorKind::Tag))));
+/// assert_eq!(parser("abc|def"), Err(ErrMode::Backtrack(InputError::new("def", ErrorKind::Tag))));
+/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Tag))));
+/// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(InputError::new("def|abc", ErrorKind::Tag))));
+/// # }
+/// ```
+///
+/// Arbitrary repetitions:
+/// ```rust
+/// # #[cfg(feature = "std")] {
+/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::prelude::*;
+/// use winnow::combinator::separated;
+/// use winnow::token::tag;
+///
+/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+///   separated(0..=2, "abc", "|").parse_peek(s)
+/// }
+///
+/// assert_eq!(parser("abc|abc|abc"), Ok(("|abc", vec!["abc", "abc"])));
+/// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
+/// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
+/// assert_eq!(parser(""), Ok(("", vec![])));
+/// assert_eq!(parser("def|abc"), Ok(("def|abc", vec![])));
+/// # }
+/// ```
+#[doc(alias = "sep_by")]
+#[doc(alias = "sep_by1")]
+#[doc(alias = "separated_list0")]
+#[doc(alias = "separated_list1")]
+#[doc(alias = "separated_m_n")]
+#[inline(always)]
+pub fn separated<I, O, C, O2, E, P, S>(
+    range: impl Into<Range>,
+    mut parser: P,
+    mut separator: S,
+) -> impl Parser<I, C, E>
+where
+    I: Stream,
+    C: Accumulate<O>,
+    P: Parser<I, O, E>,
+    S: Parser<I, O2, E>,
+    E: ParserError<I>,
+{
+    let Range {
+        start_inclusive,
+        end_inclusive,
+    } = range.into();
+    trace("separated", move |input: &mut I| {
+        match (start_inclusive, end_inclusive) {
+            (0, None) => separated0_(&mut parser, &mut separator, input),
+            (1, None) => separated1_(&mut parser, &mut separator, input),
+            (start, end) if Some(start) == end => {
+                separated_n_(start, &mut parser, &mut separator, input)
+            }
+            (start, end) => separated_m_n_(
+                start,
+                end.unwrap_or(usize::MAX),
+                &mut parser,
+                &mut separator,
+                input,
+            ),
+        }
+    })
+}
+
+/// [`Accumulate`] the output of a parser, interleaved with `sep`
+///
+/// This stops when either parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
+/// [`cut_err`][crate::combinator::cut_err].
+///
+/// # Arguments
 /// * `parser` Parses the elements of the list.
 /// * `sep` Parses the separator between list elements.
 ///
@@ -367,6 +499,7 @@ where
 /// ```
 #[doc(alias = "sep_by")]
 #[doc(alias = "separated_list0")]
+#[deprecated(since = "0.5.19", note = "Replaced with `combinator::separated`")]
 pub fn separated0<I, O, C, O2, E, P, S>(mut parser: P, mut sep: S) -> impl Parser<I, C, E>
 where
     I: Stream,
@@ -376,49 +509,63 @@ where
     E: ParserError<I>,
 {
     trace("separated0", move |i: &mut I| {
-        let mut res = C::initial(None);
+        separated0_(&mut parser, &mut sep, i)
+    })
+}
 
+fn separated0_<I, O, C, O2, E, P, S>(parser: &mut P, sep: &mut S, i: &mut I) -> PResult<C, E>
+where
+    I: Stream,
+    C: Accumulate<O>,
+    P: Parser<I, O, E>,
+    S: Parser<I, O2, E>,
+    E: ParserError<I>,
+{
+    let mut res = C::initial(None);
+
+    let start = i.checkpoint();
+    match parser.parse_next(i) {
+        Err(ErrMode::Backtrack(_)) => {
+            i.reset(start);
+            return Ok(res);
+        }
+        Err(e) => return Err(e),
+        Ok(o) => {
+            res.accumulate(o);
+        }
+    }
+
+    loop {
         let start = i.checkpoint();
-        match parser.parse_next(i) {
+        let len = i.eof_offset();
+        match sep.parse_next(i) {
             Err(ErrMode::Backtrack(_)) => {
                 i.reset(start);
                 return Ok(res);
             }
             Err(e) => return Err(e),
-            Ok(o) => {
-                res.accumulate(o);
-            }
-        }
-
-        loop {
-            let start = i.checkpoint();
-            let len = i.eof_offset();
-            match sep.parse_next(i) {
-                Err(ErrMode::Backtrack(_)) => {
-                    i.reset(start);
-                    return Ok(res);
+            Ok(_) => {
+                // infinite loop check
+                if i.eof_offset() == len {
+                    return Err(ErrMode::assert(
+                        i,
+                        "`separated` separator parser must always consume",
+                    ));
                 }
-                Err(e) => return Err(e),
-                Ok(_) => {
-                    // infinite loop check: the parser must always consume
-                    if i.eof_offset() == len {
-                        return Err(ErrMode::assert(i, "sep parsers must always consume"));
-                    }
 
-                    match parser.parse_next(i) {
-                        Err(ErrMode::Backtrack(_)) => {
-                            i.reset(start);
-                            return Ok(res);
-                        }
-                        Err(e) => return Err(e),
-                        Ok(o) => {
-                            res.accumulate(o);
-                        }
+                match parser.parse_next(i) {
+                    Err(ErrMode::Backtrack(_)) => {
+                        i.reset(start);
+                        return Ok(res);
+                    }
+                    Err(e) => return Err(e),
+                    Ok(o) => {
+                        res.accumulate(o);
                     }
                 }
             }
         }
-    })
+    }
 }
 
 /// [`Accumulate`] the output of a parser, interleaved with `sep`
@@ -454,6 +601,7 @@ where
 /// ```
 #[doc(alias = "sep_by1")]
 #[doc(alias = "separated_list1")]
+#[deprecated(since = "0.5.19", note = "Replaced with `combinator::separated`")]
 pub fn separated1<I, O, C, O2, E, P, S>(mut parser: P, mut sep: S) -> impl Parser<I, C, E>
 where
     I: Stream,
@@ -463,45 +611,200 @@ where
     E: ParserError<I>,
 {
     trace("separated1", move |i: &mut I| {
-        let mut res = C::initial(None);
-
-        // Parse the first element
-        match parser.parse_next(i) {
-            Err(e) => return Err(e),
-            Ok(o) => {
-                res.accumulate(o);
-            }
-        }
-
-        loop {
-            let start = i.checkpoint();
-            let len = i.eof_offset();
-            match sep.parse_next(i) {
-                Err(ErrMode::Backtrack(_)) => {
-                    i.reset(start);
-                    return Ok(res);
-                }
-                Err(e) => return Err(e),
-                Ok(_) => {
-                    // infinite loop check: the parser must always consume
-                    if i.eof_offset() == len {
-                        return Err(ErrMode::assert(i, "sep parsers must always consume"));
-                    }
-
-                    match parser.parse_next(i) {
-                        Err(ErrMode::Backtrack(_)) => {
-                            i.reset(start);
-                            return Ok(res);
-                        }
-                        Err(e) => return Err(e),
-                        Ok(o) => {
-                            res.accumulate(o);
-                        }
-                    }
-                }
-            }
-        }
+        separated1_(&mut parser, &mut sep, i)
     })
+}
+
+fn separated1_<I, O, C, O2, E, P, S>(parser: &mut P, sep: &mut S, i: &mut I) -> PResult<C, E>
+where
+    I: Stream,
+    C: Accumulate<O>,
+    P: Parser<I, O, E>,
+    S: Parser<I, O2, E>,
+    E: ParserError<I>,
+{
+    let mut res = C::initial(None);
+
+    // Parse the first element
+    match parser.parse_next(i) {
+        Err(e) => return Err(e),
+        Ok(o) => {
+            res.accumulate(o);
+        }
+    }
+
+    loop {
+        let start = i.checkpoint();
+        let len = i.eof_offset();
+        match sep.parse_next(i) {
+            Err(ErrMode::Backtrack(_)) => {
+                i.reset(start);
+                return Ok(res);
+            }
+            Err(e) => return Err(e),
+            Ok(_) => {
+                // infinite loop check
+                if i.eof_offset() == len {
+                    return Err(ErrMode::assert(
+                        i,
+                        "`separated` separator parser must always consume",
+                    ));
+                }
+
+                match parser.parse_next(i) {
+                    Err(ErrMode::Backtrack(_)) => {
+                        i.reset(start);
+                        return Ok(res);
+                    }
+                    Err(e) => return Err(e),
+                    Ok(o) => {
+                        res.accumulate(o);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn separated_n_<I, O, C, O2, E, P, S>(
+    count: usize,
+    parser: &mut P,
+    separator: &mut S,
+    input: &mut I,
+) -> PResult<C, E>
+where
+    I: Stream,
+    C: Accumulate<O>,
+    P: Parser<I, O, E>,
+    S: Parser<I, O2, E>,
+    E: ParserError<I>,
+{
+    let mut acc = C::initial(Some(count));
+
+    if count == 0 {
+        return Ok(acc);
+    }
+
+    match parser.parse_next(input) {
+        Err(e) => {
+            return Err(e.append(input, ErrorKind::Many));
+        }
+        Ok(o) => {
+            acc.accumulate(o);
+        }
+    }
+
+    for _ in 1..count {
+        let len = input.eof_offset();
+        match separator.parse_next(input) {
+            Err(e) => {
+                return Err(e.append(input, ErrorKind::Many));
+            }
+            Ok(_) => {
+                // infinite loop check
+                if input.eof_offset() == len {
+                    return Err(ErrMode::assert(
+                        input,
+                        "`separated` separator parser must always consume",
+                    ));
+                }
+
+                match parser.parse_next(input) {
+                    Err(e) => {
+                        return Err(e.append(input, ErrorKind::Many));
+                    }
+                    Ok(o) => {
+                        acc.accumulate(o);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(acc)
+}
+
+fn separated_m_n_<I, O, C, O2, E, P, S>(
+    min: usize,
+    max: usize,
+    parser: &mut P,
+    separator: &mut S,
+    input: &mut I,
+) -> PResult<C, E>
+where
+    I: Stream,
+    C: Accumulate<O>,
+    P: Parser<I, O, E>,
+    S: Parser<I, O2, E>,
+    E: ParserError<I>,
+{
+    if min > max {
+        return Err(ErrMode::Cut(E::from_error_kind(input, ErrorKind::Many)));
+    }
+
+    let mut acc = C::initial(Some(min));
+
+    let start = input.checkpoint();
+    match parser.parse_next(input) {
+        Err(ErrMode::Backtrack(e)) => {
+            if min == 0 {
+                input.reset(start);
+                return Ok(acc);
+            } else {
+                return Err(ErrMode::Backtrack(e.append(input, ErrorKind::Many)));
+            }
+        }
+        Err(e) => return Err(e),
+        Ok(o) => {
+            acc.accumulate(o);
+        }
+    }
+
+    for index in 1..max {
+        let start = input.checkpoint();
+        let len = input.eof_offset();
+        match separator.parse_next(input) {
+            Err(ErrMode::Backtrack(e)) => {
+                if index < min {
+                    return Err(ErrMode::Backtrack(e.append(input, ErrorKind::Many)));
+                } else {
+                    input.reset(start);
+                    return Ok(acc);
+                }
+            }
+            Err(e) => {
+                return Err(e);
+            }
+            Ok(_) => {
+                // infinite loop check
+                if input.eof_offset() == len {
+                    return Err(ErrMode::assert(
+                        input,
+                        "`separated` separator parser must always consume",
+                    ));
+                }
+
+                match parser.parse_next(input) {
+                    Err(ErrMode::Backtrack(e)) => {
+                        if index < min {
+                            return Err(ErrMode::Backtrack(e.append(input, ErrorKind::Many)));
+                        } else {
+                            input.reset(start);
+                            return Ok(acc);
+                        }
+                    }
+                    Err(e) => {
+                        return Err(e);
+                    }
+                    Ok(o) => {
+                        acc.accumulate(o);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(acc)
 }
 
 /// Alternates between two parsers, merging the results (left associative)

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -717,13 +717,13 @@ fn permutation_test() {
 #[cfg(feature = "alloc")]
 fn separated0_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0("abcd", ",").parse_peek(i)
+        separated(0.., "abcd", ",").parse_peek(i)
     }
     fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0("", ",").parse_peek(i)
+        separated(0.., "", ",").parse_peek(i)
     }
     fn multi_longsep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0("abcd", "..").parse_peek(i)
+        separated(0.., "abcd", "..").parse_peek(i)
     }
 
     let a = &b"abcdef"[..];
@@ -773,7 +773,7 @@ fn separated0_test() {
 #[cfg_attr(debug_assertions, should_panic)]
 fn separated0_empty_sep_test() {
     fn empty_sep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated0("abc", "").parse_peek(i)
+        separated(0.., "abc", "").parse_peek(i)
     }
 
     let i = &b"abcabc"[..];
@@ -792,10 +792,10 @@ fn separated0_empty_sep_test() {
 #[cfg(feature = "alloc")]
 fn separated1_test() {
     fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated1("abcd", ",").parse_peek(i)
+        separated(1.., "abcd", ",").parse_peek(i)
     }
     fn multi_longsep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated1("abcd", "..").parse_peek(i)
+        separated(1.., "abcd", "..").parse_peek(i)
     }
 
     let a = &b"abcdef"[..];

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -2,7 +2,7 @@
 use proptest::prelude::*;
 
 use crate::{
-    combinator::{separated0, separated_pair},
+    combinator::{separated, separated_pair},
     PResult, Parser,
 };
 
@@ -17,7 +17,7 @@ fn test_fxhashmap_compiles() {
         Ok(out)
     }
 
-    let _: rustc_hash::FxHashMap<char, char> = separated0(pair, ',').parse(input).unwrap();
+    let _: rustc_hash::FxHashMap<char, char> = separated(0.., pair, ',').parse(input).unwrap();
 }
 
 #[test]

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -125,15 +125,15 @@ fn issue_655() {
 
 #[cfg(feature = "alloc")]
 fn issue_717(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    use winnow::combinator::separated0;
+    use winnow::combinator::separated;
     use winnow::token::{tag, take_till1};
 
-    separated0(take_till1([0x0u8]), tag([0x0])).parse_peek(i)
+    separated(0.., take_till1([0x0u8]), tag([0x0])).parse_peek(i)
 }
 
 mod issue_647 {
     use super::*;
-    use winnow::combinator::separated0;
+    use winnow::combinator::separated;
     use winnow::token::tag;
     use winnow::{binary::be_f64, error::ErrMode, IResult};
     pub type Stream<'a> = winnow::Partial<&'a [u8]>;
@@ -149,7 +149,7 @@ mod issue_647 {
         input: Stream<'a>,
         _cs: &f64,
     ) -> Result<(Stream<'a>, Vec<f64>), ErrMode<InputError<Stream<'a>>>> {
-        separated0(be_f64.complete_err(), tag(",").complete_err()).parse_peek(input)
+        separated(0.., be_f64.complete_err(), tag(",").complete_err()).parse_peek(input)
     }
 
     fn data(input: Stream<'_>) -> IResult<Stream<'_>, Data> {


### PR DESCRIPTION
This attempts to add a `separated` parser that accepts a range similar to `repeat`.

Towards #98.

I tried to copy as much logic as possible from existing code. I'm unfamiliar with the code and may have missed some things, e.g. checkpoint resets, infinite loop checks, or correct error types. Please double check carefully and feel free to edit if it can be improved.