### PR TITLE
fix(combinator)!: add missing infinite loop check to repeat

### DIFF
--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -211,8 +211,14 @@ where
     let mut res = C::initial(Some(count));
 
     for _ in 0..count {
+        let len = i.eof_offset();
         match f.parse_next(i) {
             Ok(o) => {
+                // infinite loop check: the parser must always consume
+                if i.eof_offset() == len {
+                    return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
+                }
+
                 res.accumulate(o);
             }
             Err(e) => {


### PR DESCRIPTION
Add the missing infinite loop check to `repeat_n_` to make the error consistent.

As discussed in #365.