### PR TITLE
docs: Separated takes a range, not separate m and n arguments

### DIFF
--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -342,8 +342,7 @@ where
 /// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Arguments
-/// * `m` The minimum number of iterations.
-/// * `n` The maximum number of iterations.
+/// * `range` The minimum and maximum number of iterations.
 /// * `parser` The parser that parses the elements of the list.
 /// * `sep` The parser that parses the separator between list elements.
 ///


### PR DESCRIPTION
The combination `separated` takes a range, not separate m and n arguments. Fix the documentation.