### PR TITLE
perf(token): Speed up 'take_until' for str/char 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,10 @@ name = "contains_token"
 harness = false
 
 [[bench]]
+name = "find_slice"
+harness = false
+
+[[bench]]
 name = "iter"
 harness = false
 

--- a/benches/find_slice.rs
+++ b/benches/find_slice.rs
@@ -1,0 +1,50 @@
+use criterion::black_box;
+
+use winnow::combinator::repeat;
+use winnow::prelude::*;
+use winnow::token::take_until0;
+
+fn find_slice(c: &mut criterion::Criterion) {
+    let empty = "";
+    let start_byte = "\r".repeat(100);
+    let start_slice = "\r\n".repeat(100);
+    let small = format!("{:>10}\r\n", "").repeat(100);
+    let large = format!("{:>10000}\r\n", "").repeat(100);
+
+    let data = [
+        ("empty", (empty, empty)),
+        ("start", (&start_byte, &start_slice)),
+        ("medium", (&small, &small)),
+        ("large", (&large, &large)),
+    ];
+    let mut group = c.benchmark_group("find_slice");
+    for (name, samples) in data {
+        group.bench_with_input(
+            criterion::BenchmarkId::new("byte", name),
+            samples.0,
+            |b, sample| {
+                b.iter(|| black_box(parser_byte.parse_peek(black_box(sample)).unwrap()));
+            },
+        );
+
+        group.bench_with_input(
+            criterion::BenchmarkId::new("slice", name),
+            samples.1,
+            |b, sample| {
+                b.iter(|| black_box(parser_slice.parse_peek(black_box(sample)).unwrap()));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn parser_byte(input: &mut &str) -> PResult<usize> {
+    repeat(0.., (take_until0("\r"), "\r")).parse_next(input)
+}
+
+fn parser_slice(input: &mut &str) -> PResult<usize> {
+    repeat(0.., (take_until0("\r\n"), "\r\n")).parse_next(input)
+}
+
+criterion::criterion_group!(benches, find_slice);
+criterion::criterion_main!(benches);

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1901,14 +1901,16 @@ impl<'i, 's> FindSlice<&'s str> for &'i [u8] {
 impl<'i, 's> FindSlice<&'s str> for &'i str {
     #[inline(always)]
     fn find_slice(&self, substr: &'s str) -> Option<usize> {
-        self.find(substr)
+        self.as_bytes().find_slice(substr.as_bytes())
     }
 }
 
 impl<'i> FindSlice<char> for &'i str {
     #[inline(always)]
     fn find_slice(&self, substr: char) -> Option<usize> {
-        self.find(substr)
+        let mut b = [0; 4];
+        let substr = substr.encode_utf8(&mut b);
+        self.find_slice(&*substr)
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2796,42 +2796,33 @@ fn memchr(token: u8, slice: &[u8]) -> Option<usize> {
     slice.iter().position(|t| *t == token)
 }
 
-#[cfg(feature = "simd")]
 #[inline(always)]
 fn memmem(slice: &[u8], tag: &[u8]) -> Option<usize> {
-    if tag.len() > slice.len() {
-        return None;
+    if tag.len() == 1 {
+        memchr(tag[0], slice)
+    } else {
+        memmem_(slice, tag)
     }
+}
 
-    let (&substr_first, substr_rest) = match tag.split_first() {
-        Some(split) => split,
-        // an empty substring is found at position 0
-        // This matches the behavior of str.find("").
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn memmem_(slice: &[u8], tag: &[u8]) -> Option<usize> {
+    let &prefix = match tag.first() {
+        Some(x) => x,
         None => return Some(0),
     };
-
-    if substr_rest.is_empty() {
-        return memchr::memchr(substr_first, slice);
-    }
-
-    let mut offset = 0;
-    let haystack = &slice[..slice.len() - substr_rest.len()];
-
-    while let Some(position) = memchr::memchr(substr_first, &haystack[offset..]) {
-        offset += position;
-        let next_offset = offset + 1;
-        if &slice[next_offset..][..substr_rest.len()] == substr_rest {
-            return Some(offset);
+    #[allow(clippy::manual_find)] // faster this way
+    for i in memchr::memchr_iter(prefix, slice) {
+        if slice[i..].starts_with(tag) {
+            return Some(i);
         }
-
-        offset = next_offset;
     }
-
     None
 }
 
 #[cfg(not(feature = "simd"))]
-fn memmem(slice: &[u8], tag: &[u8]) -> Option<usize> {
+fn memmem_(slice: &[u8], tag: &[u8]) -> Option<usize> {
     for i in 0..slice.len() {
         let subslice = &slice[i..];
         if subslice.starts_with(tag) {


### PR DESCRIPTION
Before/after (with simd)
```
find_slice/byte/empty   time:   [8.6164 ns 9.0722 ns 9.5994 ns]
                        change: [-43.031% -39.731% -35.814%] (p = 0.00 < 0.05)
                        Performance has improved.
find_slice/slice/empty  time:   [8.9148 ns 9.4395 ns 9.9990 ns]
                        change: [-40.889% -36.871% -32.492%] (p = 0.00 < 0.05)
                        Performance has improved.
find_slice/byte/start   time:   [349.03 ns 382.08 ns 418.18 ns]
                        change: [-66.578% -63.083% -59.659%] (p = 0.00 < 0.05)
                        Performance has improved.
find_slice/slice/start  time:   [621.33 ns 662.95 ns 707.40 ns]
                        change: [-55.891% -51.971% -47.614%] (p = 0.00 < 0.05)
                        Performance has improved.
find_slice/byte/medium  time:   [535.01 ns 560.18 ns 586.97 ns]
                        change: [-68.347% -65.802% -62.864%] (p = 0.00 < 0.05)
                        Performance has improved.
find_slice/slice/medium time:   [681.00 ns 725.15 ns 772.02 ns]
                        change: [-58.167% -54.656% -50.939%] (p = 0.00 < 0.05)
                        Performance has improved.
find_slice/byte/large   time:   [12.233 µs 12.845 µs 13.494 µs]
                        change: [-97.200% -96.959% -96.698%] (p = 0.00 < 0.05)
                        Performance has improved.
find_slice/slice/large  time:   [12.739 µs 13.314 µs 13.912 µs]
                        change: [-91.483% -90.773% -90.011%] (p = 0.00 < 0.05)
                        Performance has improved.
```