### PR TITLE
fix: Allow FnMut for parser predicates

### DIFF
--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -842,14 +842,14 @@ where
 pub fn separated_foldl1<I, O, O2, E, P, S, Op>(
     mut parser: P,
     mut sep: S,
-    op: Op,
+    mut op: Op,
 ) -> impl Parser<I, O, E>
 where
     I: Stream,
     P: Parser<I, O, E>,
     S: Parser<I, O2, E>,
     E: ParserError<I>,
-    Op: Fn(O, O2, O) -> O,
+    Op: FnMut(O, O2, O) -> O,
 {
     trace("separated_foldl1", move |i: &mut I| {
         let mut ol = parser.parse_next(i)?;
@@ -911,14 +911,14 @@ where
 pub fn separated_foldr1<I, O, O2, E, P, S, Op>(
     mut parser: P,
     mut sep: S,
-    op: Op,
+    mut op: Op,
 ) -> impl Parser<I, O, E>
 where
     I: Stream,
     P: Parser<I, O, E>,
     S: Parser<I, O2, E>,
     E: ParserError<I>,
-    Op: Fn(O, O2, O) -> O,
+    Op: FnMut(O, O2, O) -> O,
 {
     trace("separated_foldr1", move |i: &mut I| {
         let ol = parser.parse_next(i)?;

--- a/src/combinator/parser.rs
+++ b/src/combinator/parser.rs
@@ -35,7 +35,7 @@ where
 pub struct Map<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
-    G: Fn(O) -> O2,
+    G: FnMut(O) -> O2,
 {
     parser: F,
     map: G,
@@ -48,7 +48,7 @@ where
 impl<F, G, I, O, O2, E> Map<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
-    G: Fn(O) -> O2,
+    G: FnMut(O) -> O2,
 {
     #[inline(always)]
     pub(crate) fn new(parser: F, map: G) -> Self {
@@ -66,7 +66,7 @@ where
 impl<F, G, I, O, O2, E> Parser<I, O2, E> for Map<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
-    G: Fn(O) -> O2,
+    G: FnMut(O) -> O2,
 {
     #[inline]
     fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
@@ -393,7 +393,7 @@ where
 pub struct Verify<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
-    G: Fn(&O2) -> bool,
+    G: FnMut(&O2) -> bool,
     I: Stream,
     O: Borrow<O2>,
     O2: ?Sized,
@@ -410,7 +410,7 @@ where
 impl<F, G, I, O, O2, E> Verify<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
-    G: Fn(&O2) -> bool,
+    G: FnMut(&O2) -> bool,
     I: Stream,
     O: Borrow<O2>,
     O2: ?Sized,
@@ -432,7 +432,7 @@ where
 impl<F, G, I, O, O2, E> Parser<I, O, E> for Verify<F, G, I, O, O2, E>
 where
     F: Parser<I, O, E>,
-    G: Fn(&O2) -> bool,
+    G: FnMut(&O2) -> bool,
     I: Stream,
     O: Borrow<O2>,
     O2: ?Sized,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -382,7 +382,7 @@ pub trait Parser<I, O, E> {
     #[inline(always)]
     fn map<G, O2>(self, map: G) -> Map<Self, G, I, O, O2, E>
     where
-        G: Fn(O) -> O2,
+        G: FnMut(O) -> O2,
         Self: core::marker::Sized,
     {
         Map::new(self, map)
@@ -581,7 +581,7 @@ pub trait Parser<I, O, E> {
     fn verify<G, O2>(self, filter: G) -> Verify<Self, G, I, O, O2, E>
     where
         Self: core::marker::Sized,
-        G: Fn(&O2) -> bool,
+        G: FnMut(&O2) -> bool,
         I: Stream,
         O: crate::lib::std::borrow::Borrow<O2>,
         O2: ?Sized,


### PR DESCRIPTION
We inherited this inconsistency from nom

This still leaves out for token predicates but I think that should be fine.

See #392 for discussion on this.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
