### PR TITLE
Fixes `winnow::ascii::float` not matching `+inf` or `-inf`

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1367,8 +1367,12 @@ where
     alt((
         recognize_float,
         crate::token::tag_no_case("nan"),
-        crate::token::tag_no_case("infinity"),
-        crate::token::tag_no_case("inf"),
+        (
+            opt(one_of(['+', '-'])),
+            crate::token::tag_no_case("infinity"),
+        )
+            .recognize(),
+        (opt(one_of(['+', '-'])), crate::token::tag_no_case("inf")).recognize(),
     ))
     .parse_next(input)
 }

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -566,24 +566,17 @@ mod complete {
 
             println!("now parsing: {} -> {}", test, expected32);
 
-            if (test.starts_with('-') || test.starts_with('+')) && expected32.is_infinite() {
-                assert!(float::<_, f32, ()>.parse_peek(test.as_bytes()).is_err());
-                assert!(float::<_, f32, ()>.parse_peek(test).is_err());
-                assert!(float::<_, f64, ()>.parse_peek(test.as_bytes()).is_err());
-                assert!(float::<_, f64, ()>.parse_peek(test).is_err());
-            } else {
-                assert_parse!(
-                    float.parse_peek(test.as_bytes()),
-                    Ok((&b""[..], expected32))
-                );
-                assert_parse!(float.parse_peek(test), Ok(("", expected32)));
+            assert_parse!(
+                float.parse_peek(test.as_bytes()),
+                Ok((&b""[..], expected32))
+            );
+            assert_parse!(float.parse_peek(test), Ok(("", expected32)));
 
-                assert_parse!(
-                    float.parse_peek(test.as_bytes()),
-                    Ok((&b""[..], expected64))
-                );
-                assert_parse!(float.parse_peek(test), Ok(("", expected64)));
-            }
+            assert_parse!(
+                float.parse_peek(test.as_bytes()),
+                Ok((&b""[..], expected64))
+            );
+            assert_parse!(float.parse_peek(test), Ok(("", expected64)));
         }
 
         let remaining_exponent = "-1.234E-";

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -592,9 +592,27 @@ mod complete {
             Err(ErrMode::Cut(InputError::new("", ErrorKind::Slice)))
         );
 
-        let (i, nan) = float::<_, f32, ()>.parse_peek("NaN").unwrap();
-        assert!(nan.is_nan());
-        assert_eq!(i, "");
+        let nan_test_cases = ["nan", "NaN", "NAN"];
+
+        for test in nan_test_cases {
+            println!("now parsing: {}", test);
+
+            let (remaining, parsed) = float::<_, f32, ()>.parse_peek(test.as_bytes()).unwrap();
+            assert!(parsed.is_nan());
+            assert!(remaining.is_empty());
+
+            let (remaining, parsed) = float::<_, f32, ()>.parse_peek(test).unwrap();
+            assert!(parsed.is_nan());
+            assert!(remaining.is_empty());
+
+            let (remaining, parsed) = float::<_, f64, ()>.parse_peek(test.as_bytes()).unwrap();
+            assert!(parsed.is_nan());
+            assert!(remaining.is_empty());
+
+            let (remaining, parsed) = float::<_, f64, ()>.parse_peek(test).unwrap();
+            assert!(parsed.is_nan());
+            assert!(remaining.is_empty());
+        }
     }
 
     #[cfg(feature = "std")]

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -528,7 +528,7 @@ mod complete {
     #[test]
     #[cfg(feature = "std")]
     fn float_test() {
-        let mut test_cases = vec![
+        let test_cases = [
             "+3.14",
             "3.14",
             "-3.14",
@@ -548,7 +548,7 @@ mod complete {
             "0.00000000000000000087",
         ];
 
-        for test in test_cases.drain(..) {
+        for test in test_cases {
             let expected32 = str::parse::<f32>(test).unwrap();
             let expected64 = str::parse::<f64>(test).unwrap();
 

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -546,6 +546,18 @@ mod complete {
             "-1.234E-12",
             "-1.234e-12",
             "0.00000000000000000087",
+            "inf",
+            "Inf",
+            "infinity",
+            "Infinity",
+            "-inf",
+            "-Inf",
+            "-infinity",
+            "-Infinity",
+            "+inf",
+            "+Inf",
+            "+infinity",
+            "+Infinity",
         ];
 
         for test in test_cases {
@@ -554,17 +566,24 @@ mod complete {
 
             println!("now parsing: {} -> {}", test, expected32);
 
-            assert_parse!(
-                float.parse_peek(test.as_bytes()),
-                Ok((&b""[..], expected32))
-            );
-            assert_parse!(float.parse_peek(test), Ok(("", expected32)));
+            if (test.starts_with('-') || test.starts_with('+')) && expected32.is_infinite() {
+                assert!(float::<_, f32, ()>.parse_peek(test.as_bytes()).is_err());
+                assert!(float::<_, f32, ()>.parse_peek(test).is_err());
+                assert!(float::<_, f64, ()>.parse_peek(test.as_bytes()).is_err());
+                assert!(float::<_, f64, ()>.parse_peek(test).is_err());
+            } else {
+                assert_parse!(
+                    float.parse_peek(test.as_bytes()),
+                    Ok((&b""[..], expected32))
+                );
+                assert_parse!(float.parse_peek(test), Ok(("", expected32)));
 
-            assert_parse!(
-                float.parse_peek(test.as_bytes()),
-                Ok((&b""[..], expected64))
-            );
-            assert_parse!(float.parse_peek(test), Ok(("", expected64)));
+                assert_parse!(
+                    float.parse_peek(test.as_bytes()),
+                    Ok((&b""[..], expected64))
+                );
+                assert_parse!(float.parse_peek(test), Ok(("", expected64)));
+            }
         }
 
         let remaining_exponent = "-1.234E-";
@@ -575,13 +594,6 @@ mod complete {
 
         let (i, nan) = float::<_, f32, ()>.parse_peek("NaN").unwrap();
         assert!(nan.is_nan());
-        assert_eq!(i, "");
-
-        let (i, inf) = float::<_, f32, ()>.parse_peek("inf").unwrap();
-        assert!(inf.is_infinite());
-        assert_eq!(i, "");
-        let (i, inf) = float::<_, f32, ()>.parse_peek("infinity").unwrap();
-        assert!(inf.is_infinite());
         assert_eq!(i, "");
     }
 

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -554,19 +554,17 @@ mod complete {
 
             println!("now parsing: {} -> {}", test, expected32);
 
-            let larger = test.to_string();
-
             assert_parse!(
-                float.parse_peek(larger.as_bytes()),
+                float.parse_peek(test.as_bytes()),
                 Ok((&b""[..], expected32))
             );
-            assert_parse!(float.parse_peek(&larger[..]), Ok(("", expected32)));
+            assert_parse!(float.parse_peek(test), Ok(("", expected32)));
 
             assert_parse!(
-                float.parse_peek(larger.as_bytes()),
+                float.parse_peek(test.as_bytes()),
                 Ok((&b""[..], expected64))
             );
-            assert_parse!(float.parse_peek(&larger[..]), Ok(("", expected64)));
+            assert_parse!(float.parse_peek(test), Ok(("", expected64)));
         }
 
         let remaining_exponent = "-1.234E-";


### PR DESCRIPTION
Fixes `winnow::ascii::float` not matching any variants of `inf`/`infinite` prefixed by a `+`/`-` sign as mentioned in https://github.com/winnow-rs/winnow/issues/411.