### PR TITLE
fix(stream): Don't require Clone for Stateful's State

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -982,7 +982,7 @@ impl<I: Stream> Stream for Located<I> {
     }
 }
 
-impl<I: Stream, S: Clone + crate::lib::std::fmt::Debug> Stream for Stateful<I, S> {
+impl<I: Stream, S: crate::lib::std::fmt::Debug> Stream for Stateful<I, S> {
     type Token = <I as Stream>::Token;
     type Slice = <I as Stream>::Slice;
 
@@ -1435,7 +1435,7 @@ where
 impl<I, S> Offset<<Stateful<I, S> as Stream>::Checkpoint> for Stateful<I, S>
 where
     I: Stream,
-    S: Clone + crate::lib::std::fmt::Debug,
+    S: crate::lib::std::fmt::Debug,
 {
     #[inline(always)]
     fn offset_from(&self, other: &<Stateful<I, S> as Stream>::Checkpoint) -> usize {


### PR DESCRIPTION
I think this is a holdover from when we were more clone happy with streams.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
