### PR TITLE
refactor(parser): Switch impl Parser for u8 from one_of to tag（Simplify debug trace output）

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -686,19 +686,21 @@ where
 ///     b'a'.parse_next(i)
 /// }
 /// assert_eq!(parser.parse_peek(&b"abc"[..]), Ok((&b"bc"[..], b'a')));
-/// assert_eq!(parser.parse_peek(&b" abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b" abc"[..], ErrorKind::Verify))));
-/// assert_eq!(parser.parse_peek(&b"bc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"bc"[..], ErrorKind::Verify))));
-/// assert_eq!(parser.parse_peek(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&b""[..], ErrorKind::Token))));
+/// assert_eq!(parser.parse_peek(&b" abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b" abc"[..], ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek(&b"bc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"bc"[..], ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&b""[..], ErrorKind::Tag))));
 /// ```
-impl<I, E> Parser<I, u8, E> for u8
+impl<'a, I, E> Parser<I, u8, E> for u8
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
+    I: StreamIsPartial + Compare<[u8; 1]>,
+    I: Stream<Slice = &'a [u8]>,
     E: ParserError<I>,
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<u8, E> {
-        crate::token::one_of(*self).parse_next(i)
+        crate::token::tag([*self])
+            .map(|x: &[u8]| x[0])
+            .parse_next(i)
     }
 }
 
@@ -1051,7 +1053,7 @@ mod tests {
             parser.parse_peek("123def"),
             Err(ErrMode::Backtrack(InputError::new(
                 "123def",
-                ErrorKind::Slice
+                ErrorKind::Slice,
             )))
         );
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -698,7 +698,7 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<u8, E> {
-        crate::token::tag([*self])
+        crate::token::tag([*self; 1])
             .map(|x: &[u8]| x[0])
             .parse_next(i)
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1694,19 +1694,6 @@ impl<'a, 'b, const LEN: usize> Compare<&'b [u8; LEN]> for &'a [u8] {
     }
 }
 
-impl<'a> Compare<u8> for &'a [u8] {
-    #[inline(always)]
-    fn compare(&self, t: u8) -> CompareResult {
-        self.compare([t; 1])
-    }
-
-    #[inline(always)]
-    #[allow(deprecated)]
-    fn compare_no_case(&self, t: u8) -> CompareResult {
-        self.compare_no_case([t; 1])
-    }
-}
-
 impl<'a, 'b, const LEN: usize> Compare<AsciiCaseless<&'b [u8; LEN]>> for &'a [u8] {
     #[inline(always)]
     fn compare(&self, t: AsciiCaseless<&'b [u8; LEN]>) -> CompareResult {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -381,6 +381,13 @@ impl SliceLen for char {
     }
 }
 
+impl SliceLen for u8 {
+    #[inline]
+    fn slice_len(&self) -> usize {
+        self.len()
+    }
+}
+
 impl<'a> SliceLen for &'a Bytes {
     #[inline]
     fn slice_len(&self) -> usize {
@@ -1684,6 +1691,19 @@ impl<'a, 'b, const LEN: usize> Compare<&'b [u8; LEN]> for &'a [u8] {
     #[allow(deprecated)]
     fn compare_no_case(&self, t: &'b [u8; LEN]) -> CompareResult {
         self.compare_no_case(&t[..])
+    }
+}
+
+impl<'a> Compare<u8> for &'a [u8] {
+    #[inline(always)]
+    fn compare(&self, t: u8) -> CompareResult {
+        self.compare([t; 1])
+    }
+
+    #[inline(always)]
+    #[allow(deprecated)]
+    fn compare_no_case(&self, t: u8) -> CompareResult {
+        self.compare_no_case([t; 1])
     }
 }
 


### PR DESCRIPTION
fix #427 

* rust code
```rust
use winnow::combinator::preceded;
use winnow::prelude::*;
use winnow::error::InputError;
fn main() {

    fn parser<'s, 'a>(i: &mut &'s [u8]) -> PResult<u8, InputError<&'s [u8]>> {
        preceded(b"hello", b'a').parse_next(i)
    }
    assert_eq!(parser.parse_peek(&b"helloabc"[..]), Ok((&b"bc"[..], b'a')));
}
```

* Modify the debug trace before modification
```diff
> preceded                                          | [
    104,
    101,
    1
 > tag                                              | [
    104,
    101,
    1
 < tag                                              | +5
+ > one_of                                           | [
+    97,
+   98,
+    99,
+  > any                                             | [
+    97,
+    98,
+    99,
+  < any                                             | +1
+  | verify                                          | 
+ < one_of                                           | +1
< preceded                                          | +6
```

* Debug trace after modification
```diff
> preceded                                          | [
    104,
    101,
    1
 > tag                                              | [
    104,
    101,
    1
 < tag                                              | +5
+ > tag                                              | [
+    97,
+    98,
+    99,
+ < tag                                              | +1
< preceded                                          | +6
```





