### PR TITLE
Fix link to `dec_int` in the docs

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -104,7 +104,7 @@
 //! - [`oct_digit0`][crate::ascii::oct_digit0]: Recognizes zero or more octal characters: `[0-7]`. [`oct_digit1`][crate::ascii::oct_digit1] does the same but returns at least one character
 //!
 //! - [`float`][crate::ascii::float]: Parse a floating point number in a byte string
-//! - [`dec_int`][crate::ascii::dec_uint]: Decode a variable-width, decimal signed integer
+//! - [`dec_int`][crate::ascii::dec_int]: Decode a variable-width, decimal signed integer
 //! - [`dec_uint`][crate::ascii::dec_uint]: Decode a variable-width, decimal unsigned integer
 //! - [`hex_uint`][crate::ascii::hex_uint]: Decode a variable-width, hexadecimal integer
 //!


### PR DESCRIPTION
At the moment in [the docs about `combinator` module](https://docs.rs/winnow/latest/winnow/combinator/index.html) the entry for `dec_int` points to the page for  `dec_uint`. This small PR fixes that.

I'm not sure if it worth creating an issue for change so small, so I didn't create it 🙂 