### PR TITLE
fix(ascii): Clarify till_line_ending is take_till 

### DIFF
--- a/examples/http/parser.rs
+++ b/examples/http/parser.rs
@@ -72,7 +72,7 @@ fn http_version<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
 
 fn message_header_value<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
     let _ = take_while(1.., is_horizontal_space).parse_next(input)?;
-    let data = take_while(1.., not_line_ending).parse_next(input)?;
+    let data = take_while(1.., till_line_ending).parse_next(input)?;
     let _ = line_ending.parse_next(input)?;
 
     Ok(data)
@@ -120,7 +120,7 @@ fn is_version(c: u8) -> bool {
     c.is_ascii_digit() || c == b'.'
 }
 
-fn not_line_ending(c: u8) -> bool {
+fn till_line_ending(c: u8) -> bool {
     c != b'\r' && c != b'\n'
 }
 

--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -73,7 +73,7 @@ fn http_version<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
 
 fn message_header_value<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
     let _ = take_while(1.., is_horizontal_space).parse_next(input)?;
-    let data = take_while(1.., not_line_ending).parse_next(input)?;
+    let data = take_while(1.., till_line_ending).parse_next(input)?;
     let _ = line_ending.parse_next(input)?;
 
     Ok(data)
@@ -121,7 +121,7 @@ fn is_version(c: u8) -> bool {
     c.is_ascii_digit() || c == b'.'
 }
 
-fn not_line_ending(c: u8) -> bool {
+fn till_line_ending(c: u8) -> bool {
     c != b'\r' && c != b'\n'
 }
 

--- a/examples/ini/parser_str.rs
+++ b/examples/ini/parser_str.rs
@@ -38,7 +38,7 @@ fn key_value<'s>(i: &mut Stream<'s>) -> PResult<(&'s str, &'s str)> {
     let _ = (opt(space), "=", opt(space)).parse_next(i)?;
     let val = take_till(0.., is_line_ending_or_comment).parse_next(i)?;
     let _ = opt(space).parse_next(i)?;
-    let _ = opt((";", not_line_ending)).parse_next(i)?;
+    let _ = opt((";", till_line_ending)).parse_next(i)?;
     let _ = opt(space_or_line_ending).parse_next(i)?;
 
     Ok((key, val))
@@ -48,7 +48,7 @@ fn is_line_ending_or_comment(chr: char) -> bool {
     chr == ';' || chr == '\n'
 }
 
-fn not_line_ending<'s>(i: &mut Stream<'s>) -> PResult<&'s str> {
+fn till_line_ending<'s>(i: &mut Stream<'s>) -> PResult<&'s str> {
     take_while(0.., |c| c != '\r' && c != '\n').parse_next(i)
 }
 

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -226,37 +226,37 @@ mod complete {
     }
 
     #[test]
-    fn is_not_line_ending_bytes() {
+    fn is_till_line_ending_bytes() {
         let a: &[u8] = b"ab12cd\nefgh";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(a),
+            till_line_ending::<_, InputError<_>>.parse_peek(a),
             Ok((&b"\nefgh"[..], &b"ab12cd"[..]))
         );
 
         let b: &[u8] = b"ab12cd\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(b),
+            till_line_ending::<_, InputError<_>>.parse_peek(b),
             Ok((&b"\nefgh\nijkl"[..], &b"ab12cd"[..]))
         );
 
         let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(c),
+            till_line_ending::<_, InputError<_>>.parse_peek(c),
             Ok((&b"\r\nefgh\nijkl"[..], &b"ab12cd"[..]))
         );
 
         let d: &[u8] = b"ab12cd";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(d),
+            till_line_ending::<_, InputError<_>>.parse_peek(d),
             Ok((&[][..], d))
         );
     }
 
     #[test]
-    fn is_not_line_ending_str() {
+    fn is_till_line_ending_str() {
         let f = "βèƒôřè\rÂßÇáƒƭèř";
         assert_eq!(
-            not_line_ending.parse_peek(f),
+            till_line_ending.parse_peek(f),
             Err(ErrMode::Backtrack(InputError::new(
                 &f[12..],
                 ErrorKind::Tag
@@ -265,7 +265,7 @@ mod complete {
 
         let g2: &str = "ab12cd";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(g2),
+            till_line_ending::<_, InputError<_>>.parse_peek(g2),
             Ok(("", g2))
         );
     }
@@ -327,7 +327,7 @@ mod complete {
     #[test]
     fn full_line_windows() {
         fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
-            (not_line_ending, line_ending).parse_peek(i)
+            (till_line_ending, line_ending).parse_peek(i)
         }
         let input = b"abc\r\n";
         let output = take_full_line(input);
@@ -337,7 +337,7 @@ mod complete {
     #[test]
     fn full_line_unix() {
         fn take_full_line(i: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
-            (not_line_ending, line_ending).parse_peek(i)
+            (till_line_ending, line_ending).parse_peek(i)
         }
         let input = b"abc\n";
         let output = take_full_line(input);
@@ -1221,37 +1221,37 @@ mod partial {
     }
 
     #[test]
-    fn is_not_line_ending_bytes() {
+    fn is_till_line_ending_bytes() {
         let a: &[u8] = b"ab12cd\nefgh";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(Partial::new(a)),
+            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(a)),
             Ok((Partial::new(&b"\nefgh"[..]), &b"ab12cd"[..]))
         );
 
         let b: &[u8] = b"ab12cd\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(Partial::new(b)),
+            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(b)),
             Ok((Partial::new(&b"\nefgh\nijkl"[..]), &b"ab12cd"[..]))
         );
 
         let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(Partial::new(c)),
+            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(c)),
             Ok((Partial::new(&b"\r\nefgh\nijkl"[..]), &b"ab12cd"[..]))
         );
 
         let d: &[u8] = b"ab12cd";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(Partial::new(d)),
+            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(d)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
 
     #[test]
-    fn is_not_line_ending_str() {
+    fn is_till_line_ending_str() {
         let f = "βèƒôřè\rÂßÇáƒƭèř";
         assert_eq!(
-            not_line_ending.parse_peek(Partial::new(f)),
+            till_line_ending.parse_peek(Partial::new(f)),
             Err(ErrMode::Backtrack(InputError::new(
                 Partial::new(&f[12..]),
                 ErrorKind::Tag
@@ -1260,7 +1260,7 @@ mod partial {
 
         let g2: &str = "ab12cd";
         assert_eq!(
-            not_line_ending::<_, InputError<_>>.parse_peek(Partial::new(g2)),
+            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(g2)),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
     }
@@ -1338,7 +1338,7 @@ mod partial {
     fn full_line_windows() {
         #[allow(clippy::type_complexity)]
         fn take_full_line(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8])> {
-            (not_line_ending, line_ending).parse_peek(i)
+            (till_line_ending, line_ending).parse_peek(i)
         }
         let input = b"abc\r\n";
         let output = take_full_line(Partial::new(input));
@@ -1352,7 +1352,7 @@ mod partial {
     fn full_line_unix() {
         #[allow(clippy::type_complexity)]
         fn take_full_line(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8])> {
-            (not_line_ending, line_ending).parse_peek(i)
+            (till_line_ending, line_ending).parse_peek(i)
         }
         let input = b"abc\n";
         let output = take_full_line(Partial::new(input));

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -92,7 +92,7 @@
 //! - [`crlf`][crate::ascii::crlf]: Recognizes the string `\r\n`
 //! - [`line_ending`][crate::ascii::line_ending]: Recognizes an end of line (both `\n` and `\r\n`)
 //! - [`newline`][crate::ascii::newline]: Matches a newline character `\n`
-//! - [`not_line_ending`][crate::ascii::not_line_ending]: Recognizes a string of any char except `\r` or `\n`
+//! - [`till_line_ending`][crate::ascii::till_line_ending]: Recognizes a string of any char except `\r` or `\n`
 //! - [`rest`]: Return the remaining input
 //!
 //! - [`alpha0`][crate::ascii::alpha0]: Recognizes zero or more lowercase and uppercase alphabetic characters: `[a-zA-Z]`. [`alpha1`][crate::ascii::alpha1] does the same but returns at least one character

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -95,11 +95,11 @@ fn take_till0_issue() {
 
 #[test]
 fn issue_655() {
-    use winnow::ascii::{line_ending, not_line_ending};
+    use winnow::ascii::{line_ending, till_line_ending};
     fn twolines(i: Partial<&str>) -> IResult<Partial<&str>, (&str, &str)> {
-        let (i, l1) = not_line_ending.parse_peek(i)?;
+        let (i, l1) = till_line_ending.parse_peek(i)?;
         let (i, _) = line_ending.parse_peek(i)?;
-        let (i, l2) = not_line_ending.parse_peek(i)?;
+        let (i, l2) = till_line_ending.parse_peek(i)?;
         let (i, _) = line_ending.parse_peek(i)?;
 
         Ok((i, (l1, l2)))


### PR DESCRIPTION
The `not_*` naming schema is confusing that its "all characters up to".

My hope is this rename will clarify that.  I left out `take` for
brevity.