### PR TITLE
fix(stream)!: Open the door for UTF-8 caseless comparisons 

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -162,11 +162,10 @@ where
         }
         Err(_) => input.finish(),
     };
-    if input.compare("\r") == CompareResult::Ok {
+    if matches!(input.compare("\r"), CompareResult::Ok(_)) {
         let comp = input.compare("\r\n");
         match comp {
-            //FIXME: calculate the right index
-            CompareResult::Ok => {}
+            CompareResult::Ok(_) => {}
             CompareResult::Incomplete if PARTIAL && input.is_partial() => {
                 return Err(ErrMode::Incomplete(Needed::Unknown));
             }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2048,7 +2048,11 @@ where
 #[derive(Debug, Eq, PartialEq)]
 pub enum CompareResult {
     /// Comparison was successful
-    Ok,
+    ///
+    /// `usize` is the end of the successful match within the buffer.
+    /// This is most relevant for caseless UTF-8 where `Compare::compare`'s parameter might be a different
+    /// length than the match within the buffer.
+    Ok(usize),
     /// We need more data to be sure
     Incomplete,
     /// Comparison failed
@@ -2069,7 +2073,7 @@ impl<'a, 'b> Compare<&'b [u8]> for &'a [u8] {
         } else if self.len() < t.slice_len() {
             CompareResult::Incomplete
         } else {
-            CompareResult::Ok
+            CompareResult::Ok(t.slice_len())
         }
     }
 }
@@ -2086,7 +2090,7 @@ impl<'a, 'b> Compare<AsciiCaseless<&'b [u8]>> for &'a [u8] {
         } else if self.len() < t.slice_len() {
             CompareResult::Incomplete
         } else {
-            CompareResult::Ok
+            CompareResult::Ok(t.slice_len())
         }
     }
 }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -162,7 +162,7 @@ where
 {
     let tag_len = t.slice_len();
     match i.compare(t) {
-        CompareResult::Ok => Ok(i.next_slice(tag_len)),
+        CompareResult::Ok(len) => Ok(i.next_slice(len)),
         CompareResult::Incomplete if PARTIAL && i.is_partial() => {
             Err(ErrMode::Incomplete(Needed::new(tag_len - i.eof_offset())))
         }

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -670,6 +670,30 @@ fn partial_case_insensitive() {
             ErrorKind::Tag
         )))
     );
+
+    fn test3(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
+        tag(Caseless("k")).parse_peek(i)
+    }
+
+    assert_eq!(
+        test3(Partial::new("K")),
+        Err(ErrMode::Backtrack(error_position!(
+            &Partial::new("K"),
+            ErrorKind::Tag
+        )))
+    );
+
+    fn test4(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
+        tag(Caseless("K")).parse_peek(i)
+    }
+
+    assert_eq!(
+        test4(Partial::new("k")),
+        Err(ErrMode::Backtrack(error_position!(
+            &Partial::new("k"),
+            ErrorKind::Tag
+        )))
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #414

BREAKING CHANGE: `CompareResult::Ok` now has a `usize` for the lenght of
the match content in the Stream.