### PR TITLE
feat(token): Allow a byte to pass to tag

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2168,28 +2168,28 @@ impl<'a, 'b> Compare<AsciiCaseless<&'b str>> for &'a str {
 impl<'a> Compare<char> for &'a str {
     #[inline(always)]
     fn compare(&self, t: char) -> CompareResult {
-        self.compare(t.encode_utf8(&mut [0; 4]).as_bytes())
+        self.as_bytes().compare(t)
     }
 }
 
 impl<'a> Compare<AsciiCaseless<char>> for &'a str {
     #[inline(always)]
     fn compare(&self, t: AsciiCaseless<char>) -> CompareResult {
-        self.compare(AsciiCaseless(t.0.encode_utf8(&mut [0; 4]).as_bytes()))
+        self.as_bytes().compare(t)
     }
 }
 
 impl<'a, 'b> Compare<&'b [u8]> for &'a str {
     #[inline(always)]
     fn compare(&self, t: &'b [u8]) -> CompareResult {
-        AsBStr::as_bstr(self).compare(t)
+        self.as_bytes().compare(t)
     }
 }
 
 impl<'a, 'b> Compare<AsciiCaseless<&'b [u8]>> for &'a str {
     #[inline(always)]
     fn compare(&self, t: AsciiCaseless<&'b [u8]>) -> CompareResult {
-        AsBStr::as_bstr(self).compare(t)
+        self.as_bytes().compare(t)
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -427,49 +427,49 @@ impl<S: SliceLen> SliceLen for AsciiCaseless<S> {
 }
 
 impl<'a, T> SliceLen for &'a [T] {
-    #[inline]
+    #[inline(always)]
     fn slice_len(&self) -> usize {
         self.len()
     }
 }
 
 impl<T, const LEN: usize> SliceLen for [T; LEN] {
-    #[inline]
+    #[inline(always)]
     fn slice_len(&self) -> usize {
         self.len()
     }
 }
 
 impl<'a, T, const LEN: usize> SliceLen for &'a [T; LEN] {
-    #[inline]
+    #[inline(always)]
     fn slice_len(&self) -> usize {
         self.len()
     }
 }
 
 impl<'a> SliceLen for &'a str {
-    #[inline]
+    #[inline(always)]
     fn slice_len(&self) -> usize {
         self.len()
     }
 }
 
 impl SliceLen for char {
-    #[inline]
+    #[inline(always)]
     fn slice_len(&self) -> usize {
         self.len_utf8()
     }
 }
 
 impl<'a> SliceLen for &'a Bytes {
-    #[inline]
+    #[inline(always)]
     fn slice_len(&self) -> usize {
         self.len()
     }
 }
 
 impl<'a> SliceLen for &'a BStr {
-    #[inline]
+    #[inline(always)]
     fn slice_len(&self) -> usize {
         self.len()
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -2145,7 +2145,7 @@ impl<'a> Compare<char> for &'a [u8] {
 }
 
 impl<'a> Compare<AsciiCaseless<char>> for &'a [u8] {
-    #[inline]
+    #[inline(always)]
     fn compare(&self, t: AsciiCaseless<char>) -> CompareResult {
         self.compare(AsciiCaseless(t.0.encode_utf8(&mut [0; 4]).as_bytes()))
     }
@@ -2173,7 +2173,7 @@ impl<'a> Compare<char> for &'a str {
 }
 
 impl<'a> Compare<AsciiCaseless<char>> for &'a str {
-    #[inline]
+    #[inline(always)]
     fn compare(&self, t: AsciiCaseless<char>) -> CompareResult {
         self.compare(AsciiCaseless(t.0.encode_utf8(&mut [0; 4]).as_bytes()))
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -454,6 +454,13 @@ impl<'a> SliceLen for &'a str {
     }
 }
 
+impl SliceLen for u8 {
+    #[inline]
+    fn slice_len(&self) -> usize {
+        1
+    }
+}
+
 impl SliceLen for char {
     #[inline(always)]
     fn slice_len(&self) -> usize {
@@ -2137,6 +2144,28 @@ impl<'a, 'b> Compare<AsciiCaseless<&'b str>> for &'a [u8] {
     }
 }
 
+impl<'a> Compare<u8> for &'a [u8] {
+    #[inline]
+    fn compare(&self, t: u8) -> CompareResult {
+        match self.first().copied() {
+            Some(c) if t == c => CompareResult::Ok(t.slice_len()),
+            Some(_) => CompareResult::Error,
+            None => CompareResult::Incomplete,
+        }
+    }
+}
+
+impl<'a> Compare<AsciiCaseless<u8>> for &'a [u8] {
+    #[inline]
+    fn compare(&self, t: AsciiCaseless<u8>) -> CompareResult {
+        match self.first() {
+            Some(c) if t.0.eq_ignore_ascii_case(c) => CompareResult::Ok(t.slice_len()),
+            Some(_) => CompareResult::Error,
+            None => CompareResult::Incomplete,
+        }
+    }
+}
+
 impl<'a> Compare<char> for &'a [u8] {
     #[inline(always)]
     fn compare(&self, t: char) -> CompareResult {
@@ -2162,6 +2191,20 @@ impl<'a, 'b> Compare<AsciiCaseless<&'b str>> for &'a str {
     #[inline(always)]
     fn compare(&self, t: AsciiCaseless<&'b str>) -> CompareResult {
         self.as_bytes().compare(t.as_bytes())
+    }
+}
+
+impl<'a> Compare<u8> for &'a str {
+    #[inline(always)]
+    fn compare(&self, t: u8) -> CompareResult {
+        self.as_bytes().compare(t)
+    }
+}
+
+impl<'a> Compare<AsciiCaseless<u8>> for &'a str {
+    #[inline(always)]
+    fn compare(&self, t: AsciiCaseless<u8>) -> CompareResult {
+        self.as_bytes().compare(t)
     }
 }
 

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -205,6 +205,21 @@ fn complete_tag_char() {
 }
 
 #[test]
+fn complete_tag_byte() {
+    fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
+        tag(b'B').parse_peek(i)
+    }
+    assert_eq!(test(&[0x42, 0x00][..]), Ok((&b"\x00"[..], &b"\x42"[..])));
+    assert_eq!(
+        test(&[b'A', b'\0'][..]),
+        Err(ErrMode::Backtrack(error_position!(
+            &&b"A\0"[..],
+            ErrorKind::Tag
+        )))
+    );
+}
+
+#[test]
 fn partial_any_str() {
     use super::any;
     assert_eq!(

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -99,71 +99,78 @@ fn complete_take_until() {
 
 #[test]
 fn complete_tag_case_insensitive() {
-    fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    fn caseless_bytes(i: &[u8]) -> IResult<&[u8], &[u8]> {
         tag(Caseless("ABcd")).parse_peek(i)
     }
-    assert_eq!(test(&b"aBCdefgh"[..]), Ok((&b"efgh"[..], &b"aBCd"[..])));
-    assert_eq!(test(&b"abcdefgh"[..]), Ok((&b"efgh"[..], &b"abcd"[..])));
-    assert_eq!(test(&b"ABCDefgh"[..]), Ok((&b"efgh"[..], &b"ABCD"[..])));
     assert_eq!(
-        test(&b"ab"[..]),
+        caseless_bytes(&b"aBCdefgh"[..]),
+        Ok((&b"efgh"[..], &b"aBCd"[..]))
+    );
+    assert_eq!(
+        caseless_bytes(&b"abcdefgh"[..]),
+        Ok((&b"efgh"[..], &b"abcd"[..]))
+    );
+    assert_eq!(
+        caseless_bytes(&b"ABCDefgh"[..]),
+        Ok((&b"efgh"[..], &b"ABCD"[..]))
+    );
+    assert_eq!(
+        caseless_bytes(&b"ab"[..]),
         Err(ErrMode::Backtrack(error_position!(
             &&b"ab"[..],
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        test(&b"Hello"[..]),
+        caseless_bytes(&b"Hello"[..]),
         Err(ErrMode::Backtrack(error_position!(
             &&b"Hello"[..],
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        test(&b"Hel"[..]),
+        caseless_bytes(&b"Hel"[..]),
         Err(ErrMode::Backtrack(error_position!(
             &&b"Hel"[..],
             ErrorKind::Tag
         )))
     );
 
-    fn test2(i: &str) -> IResult<&str, &str> {
+    fn caseless_str(i: &str) -> IResult<&str, &str> {
         tag(Caseless("ABcd")).parse_peek(i)
     }
-    assert_eq!(test2("aBCdefgh"), Ok(("efgh", "aBCd")));
-    assert_eq!(test2("abcdefgh"), Ok(("efgh", "abcd")));
-    assert_eq!(test2("ABCDefgh"), Ok(("efgh", "ABCD")));
+    assert_eq!(caseless_str("aBCdefgh"), Ok(("efgh", "aBCd")));
+    assert_eq!(caseless_str("abcdefgh"), Ok(("efgh", "abcd")));
+    assert_eq!(caseless_str("ABCDefgh"), Ok(("efgh", "ABCD")));
     assert_eq!(
-        test2("ab"),
+        caseless_str("ab"),
         Err(ErrMode::Backtrack(error_position!(&"ab", ErrorKind::Tag)))
     );
     assert_eq!(
-        test2("Hello"),
+        caseless_str("Hello"),
         Err(ErrMode::Backtrack(error_position!(
             &"Hello",
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        test2("Hel"),
+        caseless_str("Hel"),
         Err(ErrMode::Backtrack(error_position!(&"Hel", ErrorKind::Tag)))
     );
 
-    fn test3(i: &str) -> IResult<&str, &str> {
+    fn matches_kelvin(i: &str) -> IResult<&str, &str> {
         tag(Caseless("k")).parse_peek(i)
     }
-
     assert_eq!(
-        test3("K"),
+        matches_kelvin("K"),
         Err(ErrMode::Backtrack(error_position!(&"K", ErrorKind::Tag)))
     );
 
-    fn test4(i: &str) -> IResult<&str, &str> {
+    fn is_kelvin(i: &str) -> IResult<&str, &str> {
         tag(Caseless("K")).parse_peek(i)
     }
-
     assert_eq!(
-        test4("k"),
+        is_kelvin("k"),
         Err(ErrMode::Backtrack(error_position!(&"k", ErrorKind::Tag)))
     );
 }
@@ -686,92 +693,90 @@ fn partial_recognize_take_while0() {
 
 #[test]
 fn partial_tag_case_insensitive() {
-    fn test(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
+    fn caseless_bytes(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         tag(Caseless("ABcd")).parse_peek(i)
     }
     assert_eq!(
-        test(Partial::new(&b"aBCdefgh"[..])),
+        caseless_bytes(Partial::new(&b"aBCdefgh"[..])),
         Ok((Partial::new(&b"efgh"[..]), &b"aBCd"[..]))
     );
     assert_eq!(
-        test(Partial::new(&b"abcdefgh"[..])),
+        caseless_bytes(Partial::new(&b"abcdefgh"[..])),
         Ok((Partial::new(&b"efgh"[..]), &b"abcd"[..]))
     );
     assert_eq!(
-        test(Partial::new(&b"ABCDefgh"[..])),
+        caseless_bytes(Partial::new(&b"ABCDefgh"[..])),
         Ok((Partial::new(&b"efgh"[..]), &b"ABCD"[..]))
     );
     assert_eq!(
-        test(Partial::new(&b"ab"[..])),
+        caseless_bytes(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        test(Partial::new(&b"Hello"[..])),
+        caseless_bytes(Partial::new(&b"Hello"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"Hello"[..]),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        test(Partial::new(&b"Hel"[..])),
+        caseless_bytes(Partial::new(&b"Hel"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"Hel"[..]),
             ErrorKind::Tag
         )))
     );
 
-    fn test2(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
+    fn caseless_str(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         tag(Caseless("ABcd")).parse_peek(i)
     }
     assert_eq!(
-        test2(Partial::new("aBCdefgh")),
+        caseless_str(Partial::new("aBCdefgh")),
         Ok((Partial::new("efgh"), "aBCd"))
     );
     assert_eq!(
-        test2(Partial::new("abcdefgh")),
+        caseless_str(Partial::new("abcdefgh")),
         Ok((Partial::new("efgh"), "abcd"))
     );
     assert_eq!(
-        test2(Partial::new("ABCDefgh")),
+        caseless_str(Partial::new("ABCDefgh")),
         Ok((Partial::new("efgh"), "ABCD"))
     );
     assert_eq!(
-        test2(Partial::new("ab")),
+        caseless_str(Partial::new("ab")),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        test2(Partial::new("Hello")),
+        caseless_str(Partial::new("Hello")),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new("Hello"),
             ErrorKind::Tag
         )))
     );
     assert_eq!(
-        test2(Partial::new("Hel")),
+        caseless_str(Partial::new("Hel")),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new("Hel"),
             ErrorKind::Tag
         )))
     );
 
-    fn test3(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
+    fn matches_kelvin(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         tag(Caseless("k")).parse_peek(i)
     }
-
     assert_eq!(
-        test3(Partial::new("K")),
+        matches_kelvin(Partial::new("K")),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new("K"),
             ErrorKind::Tag
         )))
     );
 
-    fn test4(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
+    fn is_kelvin(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
         tag(Caseless("K")).parse_peek(i)
     }
-
     assert_eq!(
-        test4(Partial::new("k")),
+        is_kelvin(Partial::new("k")),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new("k"),
             ErrorKind::Tag

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -183,9 +183,25 @@ fn complete_tag_fixed_size_array() {
     fn test2(i: &[u8]) -> IResult<&[u8], &[u8]> {
         tag(&[0x42]).parse_peek(i)
     }
+
     let input = &[0x42, 0x00][..];
     assert_eq!(test(input), Ok((&b"\x00"[..], &b"\x42"[..])));
     assert_eq!(test2(input), Ok((&b"\x00"[..], &b"\x42"[..])));
+}
+
+#[test]
+fn complete_tag_char() {
+    fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
+        tag('B').parse_peek(i)
+    }
+    assert_eq!(test(&[0x42, 0x00][..]), Ok((&b"\x00"[..], &b"\x42"[..])));
+    assert_eq!(
+        test(&[b'A', b'\0'][..]),
+        Err(ErrMode::Backtrack(error_position!(
+            &&b"A\0"[..],
+            ErrorKind::Tag
+        )))
+    );
 }
 
 #[test]

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -600,7 +600,6 @@ fn partial_recognize_take_while0() {
     );
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn partial_case_insensitive() {
     fn test(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {


### PR DESCRIPTION
In a way, this is split out of #428.  This is prep for `AsciiChar`