### PR TITLE
fix: Rename `tag` parsers to `literal` and `pattern`

### DIFF
--- a/benches/next_slice.rs
+++ b/benches/next_slice.rs
@@ -2,8 +2,8 @@ use criterion::black_box;
 
 use winnow::combinator::repeat;
 use winnow::prelude::*;
+use winnow::token::literal;
 use winnow::token::one_of;
-use winnow::token::tag;
 
 fn next_slice(c: &mut criterion::Criterion) {
     let mut group = c.benchmark_group("next_slice");
@@ -102,11 +102,11 @@ fn parser_ascii_one_of(input: &mut &str) -> PResult<usize> {
 }
 
 fn parser_ascii_tag_char(input: &mut &str) -> PResult<usize> {
-    repeat(0.., tag('h')).parse_next(input)
+    repeat(0.., literal('h')).parse_next(input)
 }
 
 fn parser_ascii_tag_str(input: &mut &str) -> PResult<usize> {
-    repeat(0.., tag("h")).parse_next(input)
+    repeat(0.., literal("h")).parse_next(input)
 }
 
 fn parser_utf8_char(input: &mut &str) -> PResult<usize> {
@@ -122,11 +122,11 @@ fn parser_utf8_one_of(input: &mut &str) -> PResult<usize> {
 }
 
 fn parser_utf8_tag_char(input: &mut &str) -> PResult<usize> {
-    repeat(0.., tag('🧑')).parse_next(input)
+    repeat(0.., literal('🧑')).parse_next(input)
 }
 
 fn parser_utf8_tag_str(input: &mut &str) -> PResult<usize> {
-    repeat(0.., tag("🧑")).parse_next(input)
+    repeat(0.., literal("🧑")).parse_next(input)
 }
 
 criterion::criterion_group!(benches, next_slice);

--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -52,7 +52,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static s
     .parse_next(input)
 }
 
-/// `tag(string)` generates a parser that recognizes the argument string.
+/// `literal(string)` generates a parser that recognizes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
 fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -59,7 +59,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static s
     .parse_next(input)
 }
 
-/// `tag(string)` generates a parser that recognizes the argument string.
+/// `literal(string)` generates a parser that recognizes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
 fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -53,7 +53,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static s
     .parse_next(input)
 }
 
-/// `tag(string)` generates a parser that recognizes the argument string.
+/// `literal(string)` generates a parser that recognizes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
 fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -11,7 +11,7 @@ use winnow::{
     error::StrContext,
     stream::Offset,
     token::one_of,
-    token::{tag, take_while},
+    token::{literal, take_while},
 };
 
 use std::cell::Cell;
@@ -80,7 +80,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
         println!("array()");
 
         let mut data = self.data();
-        match tag::<_, _, ()>("[").parse_next(&mut data) {
+        match literal::<_, _, ()>("[").parse_next(&mut data) {
             Err(_) => None,
             Ok(_) => {
                 println!("[");
@@ -104,7 +104,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                         }
                     }
 
-                    if tag::<_, _, ()>("]").parse_next(&mut data).is_ok() {
+                    if literal::<_, _, ()>("]").parse_next(&mut data).is_ok() {
                         println!("]");
                         v.offset(data);
                         done = true;
@@ -114,7 +114,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                     if first {
                         first = false;
                     } else {
-                        match tag::<_, _, ()>(",").parse_next(&mut data) {
+                        match literal::<_, _, ()>(",").parse_next(&mut data) {
                             Ok(_) => {
                                 println!(",");
                                 v.offset(data);
@@ -137,7 +137,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
     pub fn object(&self) -> Option<impl Iterator<Item = (&'a str, JsonValue<'a, 'b>)>> {
         println!("object()");
         let mut data = self.data();
-        match tag::<_, _, ()>("{").parse_next(&mut data) {
+        match literal::<_, _, ()>("{").parse_next(&mut data) {
             Err(_) => None,
             Ok(_) => {
                 self.offset(data);
@@ -163,7 +163,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                         }
                     }
 
-                    if tag::<_, _, ()>("}").parse_next(&mut data).is_ok() {
+                    if literal::<_, _, ()>("}").parse_next(&mut data).is_ok() {
                         println!("}}");
                         v.offset(data);
                         done = true;
@@ -173,7 +173,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                     if first {
                         first = false;
                     } else {
-                        match tag::<_, _, ()>(",").parse_next(&mut data) {
+                        match literal::<_, _, ()>(",").parse_next(&mut data) {
                             Ok(_) => {
                                 println!(",");
                                 v.offset(data);
@@ -189,7 +189,7 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
                         Ok(key) => {
                             v.offset(data);
 
-                            match tag::<_, _, ()>(":").parse_next(&mut data) {
+                            match literal::<_, _, ()>(":").parse_next(&mut data) {
                                 Err(_) => None,
                                 Ok(_) => {
                                     v.offset(data);

--- a/examples/ndjson/parser.rs
+++ b/examples/ndjson/parser.rs
@@ -57,7 +57,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static s
     .parse_next(input)
 }
 
-/// `tag(string)` generates a parser that recognizes the argument string.
+/// `literal(string)` generates a parser that recognizes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
 fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -75,14 +75,14 @@
 //!
 //! ### `/* C-style comments */`
 //!
-//! Inline comments surrounded with sentinel tags `(*` and `*)`. This version returns an output of `()`
+//! Inline comments surrounded with sentinel literals `(*` and `*)`. This version returns an output of `()`
 //! and does not handle nested comments.
 //!
 //! ```rust
 //! use winnow::prelude::*;
 //! use winnow::{
 //!   error::ParserError,
-//!   token::{tag, take_until},
+//!   token::take_until,
 //! };
 //!
 //! pub fn pinline_comment<'a, E: ParserError<&'a str>>(i: &mut &'a str) -> PResult<(), E> {
@@ -159,7 +159,6 @@
 //!   combinator::{repeat},
 //!   combinator::{preceded, terminated},
 //!   token::one_of,
-//!   token::tag,
 //! };
 //!
 //! fn hexadecimal<'s>(input: &mut &'s str) -> PResult<&'s str> { // <'a, E: ParserError<&'a str>>
@@ -181,7 +180,6 @@
 //!   combinator::{repeat},
 //!   combinator::{preceded, terminated},
 //!   token::one_of,
-//!   token::tag,
 //! };
 //!
 //! fn hexadecimal_value(input: &mut &str) -> PResult<i64> {
@@ -207,7 +205,6 @@
 //!   combinator::{repeat},
 //!   combinator::{preceded, terminated},
 //!   token::one_of,
-//!   token::tag,
 //! };
 //!
 //! fn octal<'s>(input: &mut &'s str) -> PResult<&'s str> {
@@ -229,7 +226,6 @@
 //!   combinator::{repeat},
 //!   combinator::{preceded, terminated},
 //!   token::one_of,
-//!   token::tag,
 //! };
 //!
 //! fn binary<'s>(input: &mut &'s str) -> PResult<&'s str> {

--- a/src/_topic/stream.rs
+++ b/src/_topic/stream.rs
@@ -18,7 +18,6 @@
 //! The goal is to define parsers with this signature: `&mut MyStream -> PResult<Output>`.
 //! ```rust
 //! # use winnow::prelude::*;
-//! # use winnow::token::tag;
 //! # type MyStream<'i> = &'i str;
 //! # type Output<'i> = &'i str;
 //! fn parser<'s>(i: &mut MyStream<'s>) -> PResult<Output<'s>> {

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -135,12 +135,12 @@
 //! # }
 //! ```
 //!
-//! In `winnow`, we call this type of parser a [`tag`]. See [`token`] for additional individual
+//! In `winnow`, we call this type of parser a [`literal`]. See [`token`] for additional individual
 //! and token-slice parsers.
 //!
 //! ## Character Classes
 //!
-//! Selecting a single `char` or a [`tag`] is fairly limited. Sometimes, you will want to select one of several
+//! Selecting a single `char` or a [`literal`] is fairly limited. Sometimes, you will want to select one of several
 //! `chars` of a specific class, like digits. For this, we use the [`one_of`] parser:
 //!
 //! ```rust
@@ -237,8 +237,8 @@ use crate::stream::ContainsToken;
 use crate::stream::Stream;
 use crate::token;
 use crate::token::any;
+use crate::token::literal;
 use crate::token::one_of;
-use crate::token::tag;
 use crate::token::take_while;
 use crate::Parser;
 use std::ops::RangeInclusive;

--- a/src/_tutorial/chapter_3.rs
+++ b/src/_tutorial/chapter_3.rs
@@ -70,7 +70,7 @@
 //! }
 //! ```
 //!
-//! Frequently, you won't care about the tag and you can instead use one of the provided combinators,
+//! Frequently, you won't care about the literal and you can instead use one of the provided combinators,
 //! like [`preceded`]:
 //! ```rust
 //! # use winnow::prelude::*;

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1375,13 +1375,17 @@ where
 {
     alt((
         recognize_float,
-        crate::token::tag(Caseless("nan")),
+        crate::token::literal(Caseless("nan")),
         (
             opt(one_of(['+', '-'])),
-            crate::token::tag(Caseless("infinity")),
+            crate::token::literal(Caseless("infinity")),
         )
             .recognize(),
-        (opt(one_of(['+', '-'])), crate::token::tag(Caseless("inf"))).recognize(),
+        (
+            opt(one_of(['+', '-'])),
+            crate::token::literal(Caseless("inf")),
+        )
+            .recognize(),
     ))
     .parse_next(input)
 }
@@ -1570,7 +1574,7 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use std::str::from_utf8;
-/// use winnow::token::tag;
+/// use winnow::token::literal;
 /// use winnow::ascii::escaped_transform;
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;
@@ -1596,7 +1600,7 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use std::str::from_utf8;
 /// # use winnow::Partial;
-/// use winnow::token::tag;
+/// use winnow::token::literal;
 /// use winnow::ascii::escaped_transform;
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -302,7 +302,8 @@ where
 #[inline(always)]
 #[doc(alias = "literal")]
 #[doc(alias = "just")]
-pub fn tag<I, O, C, E: ParserError<(I, usize)>>(
+#[doc(alias = "tag")]
+pub fn pattern<I, O, C, E: ParserError<(I, usize)>>(
     pattern: O,
     count: C,
 ) -> impl Parser<(I, usize), O, E>
@@ -312,7 +313,7 @@ where
     O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
 {
     let count = count.to_usize();
-    trace("tag", move |input: &mut (I, usize)| {
+    trace("pattern", move |input: &mut (I, usize)| {
         let start = input.checkpoint();
 
         take(count).parse_next(input).and_then(|o| {
@@ -327,6 +328,16 @@ where
             }
         })
     })
+}
+
+/// Deprecated, replaced with [`pattern`]
+pub fn tag<I, O, C, E: ParserError<(I, usize)>>(p: O, count: C) -> impl Parser<(I, usize), O, E>
+where
+    I: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
+    C: ToUsize,
+    O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
+{
+    pattern(p, count)
 }
 
 /// Parses one specific bit as a bool.

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -254,7 +254,7 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
 /// # use winnow::error::{InputError, ErrorKind};
-/// use winnow::binary::bits::tag;
+/// use winnow::binary::bits::pattern;
 ///
 /// type Stream<'i> = &'i Bytes;
 ///
@@ -265,8 +265,8 @@ where
 /// /// Compare the lowest `count` bits of `input` against the lowest `count` bits of `pattern`.
 /// /// Return Ok and the matching section of `input` if there's a match.
 /// /// Return Err if there's no match.
-/// fn parser(pattern: u8, count: u8, input: (Stream<'_>, usize)) -> IResult<(Stream<'_>, usize), u8> {
-///     tag(pattern, count).parse_peek(input)
+/// fn parser(bits: u8, count: u8, input: (Stream<'_>, usize)) -> IResult<(Stream<'_>, usize), u8> {
+///     pattern(bits, count).parse_peek(input)
 /// }
 ///
 /// // The lowest 4 bits of 0b00001111 match the lowest 4 bits of 0b11111111.
@@ -331,6 +331,7 @@ where
 }
 
 /// Deprecated, replaced with [`pattern`]
+#[deprecated(since = "0.5.38", note = "Replaced with `pattern`")]
 pub fn tag<I, O, C, E: ParserError<(I, usize)>>(p: O, count: C) -> impl Parser<(I, usize), O, E>
 where
     I: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,

--- a/src/binary/bits/tests.rs
+++ b/src/binary/bits/tests.rs
@@ -114,27 +114,27 @@ fn test_take_partial_0() {
 }
 
 #[test]
-fn test_tag_partial_ok() {
+fn test_pattern_partial_ok() {
     let input = Partial::new(&[0b00011111][..]);
     let offset = 0usize;
     let bits_to_take = 4usize;
-    let value_to_tag = 0b0001;
+    let value_to_pattern = 0b0001;
 
     let result: crate::IResult<(_, usize), usize> =
-        tag(value_to_tag, bits_to_take).parse_peek((input, offset));
+        pattern(value_to_pattern, bits_to_take).parse_peek((input, offset));
 
-    assert_eq!(result, Ok(((input, bits_to_take), value_to_tag)));
+    assert_eq!(result, Ok(((input, bits_to_take), value_to_pattern)));
 }
 
 #[test]
-fn test_tag_partial_err() {
+fn test_pattern_partial_err() {
     let input = Partial::new(&[0b00011111][..]);
     let offset = 0usize;
     let bits_to_take = 4usize;
-    let value_to_tag = 0b1111;
+    let value_to_pattern = 0b1111;
 
     let result: crate::IResult<(_, usize), usize> =
-        tag(value_to_tag, bits_to_take).parse_peek((input, offset));
+        pattern(value_to_pattern, bits_to_take).parse_peek((input, offset));
 
     assert_eq!(
         result,

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -2408,7 +2408,6 @@ where
 /// use winnow::Bytes;
 /// use winnow::binary::be_u16;
 /// use winnow::binary::length_take;
-/// use winnow::token::tag;
 ///
 /// type Stream<'i> = Partial<&'i Bytes>;
 ///
@@ -2456,7 +2455,6 @@ where
 /// use winnow::Bytes;
 /// use winnow::binary::be_u16;
 /// use winnow::binary::length_and_then;
-/// use winnow::token::tag;
 ///
 /// type Stream<'i> = Partial<&'i Bytes>;
 ///
@@ -2514,7 +2512,6 @@ where
 /// use winnow::Bytes;
 /// use winnow::binary::u8;
 /// use winnow::binary::length_repeat;
-/// use winnow::token::tag;
 ///
 /// type Stream<'i> = &'i Bytes;
 ///

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -338,7 +338,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// use winnow::{combinator::iterator, IResult, token::tag, ascii::alpha1, combinator::terminated};
+/// use winnow::{combinator::iterator, IResult, ascii::alpha1, combinator::terminated};
 /// use std::collections::HashMap;
 ///
 /// let data = "abc|defg|hijkl|mnopqr|123";

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -10,11 +10,11 @@
 //! |---|---|---|---|---|---|
 //! | [`one_of`][crate::token::one_of] | `one_of(['a', 'b', 'c'])` |  `"abc"` |  `"bc"` | `Ok('a')` |Matches one of the provided characters (works with non ASCII characters too)|
 //! | [`none_of`][crate::token::none_of] | `none_of(['a', 'b', 'c'])` |  `"xyab"` |  `"yab"` | `Ok('x')` |Matches anything but the provided characters|
-//! | [`tag`][crate::token::tag] | `"hello"` |  `"hello world"` |  `" world"` | `Ok("hello")` |Recognizes a specific suite of characters or bytes (see also [`Caseless`][crate::ascii::Caseless])|
+//! | [`literal`][crate::token::literal] | `"hello"` |  `"hello world"` |  `" world"` | `Ok("hello")` |Recognizes a specific suite of characters or bytes (see also [`Caseless`][crate::ascii::Caseless])|
 //! | [`take`][crate::token::take] | `take(4)` |  `"hello"` |  `"o"` | `Ok("hell")` |Takes a specific number of bytes or characters|
 //! | [`take_while`][crate::token::take_while] | `take_while(0.., is_alphabetic)` |  `"abc123"` |  `"123"` | `Ok("abc")` |Returns the longest list of bytes for which the provided pattern matches.|
 //! | [`take_till`][crate::token::take_till] | `take_till(0.., is_alphabetic)` |  `"123abc"` |  `"abc"` | `Ok("123")` |Returns the longest list of bytes or characters until the provided pattern matches. `take_till1` does the same, but must return at least one character. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(0.., \|c\| !f(c))`|
-//! | [`take_until`][crate::token::take_until] | `take_until(0.., "world")` |  `"Hello world"` |  `"world"` | `Ok("Hello ")` |Returns the longest list of bytes or characters until the provided tag is found.|
+//! | [`take_until`][crate::token::take_until] | `take_until(0.., "world")` |  `"Hello world"` |  `"world"` | `Ok("Hello ")` |Returns the longest list of bytes or characters until the provided literal is found.|
 //!
 //! ## Choice combinators
 //!
@@ -40,7 +40,7 @@
 //! | combinator | usage | input | new input | output | comment |
 //! |---|---|---|---|---|---|
 //! | [`repeat`] | `repeat(1..=3, "ab")` | `"ababc"` | `"c"` | `Ok(vec!["ab", "ab"])` |Applies the parser between m and n times (n included) and returns the list of results in a Vec|
-//! | [`repeat_till`] | `repeat_till(0.., tag( "ab" ), tag( "ef" ))` | `"ababefg"` | `"g"` | `Ok((vec!["ab", "ab"], "ef"))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
+//! | [`repeat_till`] | `repeat_till(0.., literal( "ab" ), literal( "ef" ))` | `"ababefg"` | `"g"` | `Ok((vec!["ab", "ab"], "ef"))` |Applies the first parser until the second applies. Returns a tuple containing the list of results from the first in a Vec and the result of the second|
 //! | [`separated`] | `separated(1..=3, "ab", ",")` | `"ab,ab,ab."` | `"."` | `Ok(vec!["ab", "ab", "ab"])` |Applies the parser and separator between m and n times (n included) and returns the list of results in a Vec|
 //! | [`Repeat::fold`] | `repeat(1..=2, be_u8).fold(\|\| 0, \|acc, item\| acc + item)` | `[1, 2, 3]` | `[3]` | `Ok(3)` |Applies the parser between m and n times (n included) and folds the list of return value|
 //!
@@ -152,7 +152,7 @@
 //! - [`bits`][crate::binary::bits::bits]: Transforms the current input type (byte slice `&[u8]`) to a bit stream on which bit specific parsers and more general combinators can be applied
 //! - [`bytes`][crate::binary::bits::bytes]: Transforms its bits stream input back into a byte slice for the underlying parser
 //! - [`take`][crate::binary::bits::take]: Take a set number of bits
-//! - [`tag`][crate::binary::bits::tag]: Check if a set number of bits matches a pattern
+//! - [`pattern`][crate::binary::bits::pattern]: Check if a set number of bits matches a pattern
 //! - [`bool`][crate::binary::bits::bool]: Match any one bit
 
 mod branch;

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -34,7 +34,6 @@ use crate::Parser;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   repeat(0.., "abc").parse_peek(s)
@@ -53,7 +52,6 @@ use crate::Parser;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   repeat(1.., "abc").parse_peek(s)
@@ -72,7 +70,6 @@ use crate::Parser;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   repeat(2, "abc").parse_peek(s)
@@ -92,7 +89,6 @@ use crate::Parser;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   repeat(0..=2, "abc").parse_peek(s)
@@ -176,7 +172,6 @@ where
     /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
-    /// use winnow::token::tag;
     ///
     /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
     ///   repeat(
@@ -202,7 +197,6 @@ where
     /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
-    /// use winnow::token::tag;
     ///
     /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
     ///   repeat(
@@ -228,7 +222,6 @@ where
     /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
-    /// use winnow::token::tag;
     ///
     /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
     ///   repeat(
@@ -462,7 +455,6 @@ where
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat_till;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, (Vec<&str>, &str)> {
 ///   repeat_till(0.., "abc", "end").parse_peek(s)
@@ -617,7 +609,6 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   separated(0.., "abc", "|").parse_peek(s)
@@ -637,7 +628,6 @@ where
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   separated(1.., "abc", "|").parse_peek(s)
@@ -657,7 +647,6 @@ where
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   separated(2, "abc", "|").parse_peek(s)
@@ -677,7 +666,6 @@ where
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
 ///   separated(0..=2, "abc", "|").parse_peek(s)
@@ -1121,7 +1109,6 @@ where
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::fill;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, [&str; 2]> {
 ///   let mut buf = ["", ""];

--- a/src/combinator/sequence.rs
+++ b/src/combinator/sequence.rs
@@ -21,7 +21,6 @@ pub use crate::seq;
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::preceded;
-/// use winnow::token::tag;
 ///
 /// let mut parser = preceded("abc", "efg");
 ///
@@ -61,7 +60,6 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::terminated;
-/// use winnow::token::tag;
 ///
 /// let mut parser = terminated("abc", "efg");
 ///
@@ -102,7 +100,6 @@ where
 /// # use winnow::error::Needed::Size;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_pair;
-/// use winnow::token::tag;
 ///
 /// let mut parser = separated_pair("abc", "|", "efg");
 ///
@@ -145,7 +142,6 @@ where
 /// # use winnow::error::Needed::Size;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::delimited;
-/// use winnow::token::tag;
 ///
 /// let mut parser = delimited("(", "abc", ")");
 ///

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -186,20 +186,20 @@ fn opt_test() {
 
 #[test]
 fn peek_test() {
-    fn peek_tag(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
+    fn peek_literal(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         peek("abcd").parse_peek(i)
     }
 
     assert_eq!(
-        peek_tag(Partial::new(&b"abcdef"[..])),
+        peek_literal(Partial::new(&b"abcdef"[..])),
         Ok((Partial::new(&b"abcdef"[..]), &b"abcd"[..]))
     );
     assert_eq!(
-        peek_tag(Partial::new(&b"ab"[..])),
+        peek_literal(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        peek_tag(Partial::new(&b"xxx"[..])),
+        peek_literal(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Tag

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,7 +42,7 @@ use crate::stream::{Recover, Recoverable};
 ///
 /// Additionally, some basic types implement `Parser` as well, including
 /// - `u8` and `char`, see [`winnow::token::one_of`][crate::token::one_of]
-/// - `&[u8]` and `&str`, see [`winnow::token::tag`][crate::token::tag]
+/// - `&[u8]` and `&str`, see [`winnow::token::literal`][crate::token::literal]
 pub trait Parser<I, O, E> {
     /// Parse all of `input`, generating `O` from it
     #[inline]
@@ -285,7 +285,7 @@ pub trait Parser<I, O, E> {
     /// # use winnow::prelude::*;
     /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError};
     /// use winnow::ascii::{alpha1};
-    /// use winnow::token::tag;
+    /// use winnow::token::literal;
     /// use winnow::combinator::separated_pair;
     ///
     /// fn inner_parser<'s>(input: &mut &'s str) -> PResult<bool, InputError<&'s str>> {
@@ -357,7 +357,7 @@ pub trait Parser<I, O, E> {
     /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, stream::Stream};
     /// use winnow::stream::Located;
     /// use winnow::ascii::alpha1;
-    /// use winnow::token::tag;
+    /// use winnow::token::literal;
     /// use winnow::combinator::separated_pair;
     ///
     /// fn inner_parser<'s>(input: &mut Located<&'s str>) -> PResult<bool, InputError<Located<&'s str>>> {
@@ -771,7 +771,7 @@ where
     }
 }
 
-/// This is a shortcut for [`tag`][crate::token::tag].
+/// This is a shortcut for [`literal`][crate::token::literal].
 ///
 /// # Example
 /// ```rust
@@ -796,11 +796,11 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        crate::token::tag(*self).parse_next(i)
+        crate::token::literal(*self).parse_next(i)
     }
 }
 
-/// This is a shortcut for [`tag`][crate::token::tag].
+/// This is a shortcut for [`literal`][crate::token::literal].
 ///
 /// # Example
 /// ```rust
@@ -828,11 +828,11 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        crate::token::tag(*self).parse_next(i)
+        crate::token::literal(*self).parse_next(i)
     }
 }
 
-/// This is a shortcut for [`tag`][crate::token::tag].
+/// This is a shortcut for [`literal`][crate::token::literal].
 ///
 /// # Example
 /// ```rust
@@ -857,11 +857,11 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        crate::token::tag(*self).parse_next(i)
+        crate::token::literal(*self).parse_next(i)
     }
 }
 
-/// This is a shortcut for [`tag`][crate::token::tag].
+/// This is a shortcut for [`literal`][crate::token::literal].
 ///
 /// # Example
 /// ```rust
@@ -890,11 +890,11 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        crate::token::tag(*self).parse_next(i)
+        crate::token::literal(*self).parse_next(i)
     }
 }
 
-/// This is a shortcut for [`tag`][crate::token::tag].
+/// This is a shortcut for [`literal`][crate::token::literal].
 ///
 /// # Example
 /// ```rust
@@ -919,11 +919,11 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        crate::token::tag(*self).parse_next(i)
+        crate::token::literal(*self).parse_next(i)
     }
 }
 
-/// This is a shortcut for [`tag`][crate::token::tag].
+/// This is a shortcut for [`literal`][crate::token::literal].
 ///
 /// # Example
 /// ```rust
@@ -951,7 +951,7 @@ where
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<<I as Stream>::Slice, E> {
-        crate::token::tag(*self).parse_next(i)
+        crate::token::literal(*self).parse_next(i)
     }
 }
 

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -3,7 +3,7 @@ use proptest::prelude::*;
 
 use crate::error::ErrMode::Backtrack;
 use crate::error::{ErrorKind, InputError};
-use crate::token::tag;
+use crate::token::literal;
 use crate::{
     combinator::{separated, separated_pair},
     PResult, Parser,
@@ -151,78 +151,78 @@ fn test_custom_slice() {
 }
 
 #[test]
-fn test_tag_support_char() {
+fn test_literal_support_char() {
     assert_eq!(
-        tag::<_, _, InputError<_>>('π').parse_peek("π"),
+        literal::<_, _, InputError<_>>('π').parse_peek("π"),
         Ok(("", "π"))
     );
     assert_eq!(
-        tag::<_, _, InputError<_>>('π').parse_peek("π3.14"),
+        literal::<_, _, InputError<_>>('π').parse_peek("π3.14"),
         Ok(("3.14", "π"))
     );
 
     assert_eq!(
-        tag::<_, _, InputError<_>>("π").parse_peek("π3.14"),
+        literal::<_, _, InputError<_>>("π").parse_peek("π3.14"),
         Ok(("3.14", "π"))
     );
 
     assert_eq!(
-        tag::<_, _, InputError<_>>('-').parse_peek("π"),
+        literal::<_, _, InputError<_>>('-').parse_peek("π"),
         Err(Backtrack(InputError::new("π", ErrorKind::Tag)))
     );
 
     assert_eq!(
-        tag::<_, Partial<&[u8]>, InputError<_>>('π').parse_peek(Partial::new(b"\xCF\x80")),
+        literal::<_, Partial<&[u8]>, InputError<_>>('π').parse_peek(Partial::new(b"\xCF\x80")),
         Ok((Partial::new(Default::default()), "π".as_bytes()))
     );
     assert_eq!(
-        tag::<_, &[u8], InputError<_>>('π').parse_peek(b"\xCF\x80"),
+        literal::<_, &[u8], InputError<_>>('π').parse_peek(b"\xCF\x80"),
         Ok((Default::default(), "π".as_bytes()))
     );
 
     assert_eq!(
-        tag::<_, Partial<&[u8]>, InputError<_>>('π').parse_peek(Partial::new(b"\xCF\x803.14")),
+        literal::<_, Partial<&[u8]>, InputError<_>>('π').parse_peek(Partial::new(b"\xCF\x803.14")),
         Ok((Partial::new(&b"3.14"[..]), "π".as_bytes()))
     );
     assert_eq!(
-        tag::<_, &[u8], InputError<_>>('π').parse_peek(b"\xCF\x80"),
+        literal::<_, &[u8], InputError<_>>('π').parse_peek(b"\xCF\x80"),
         Ok((Default::default(), "π".as_bytes()))
     );
 
     assert_eq!(
-        tag::<_, &[u8], InputError<_>>('π').parse_peek(b"\xCF\x803.14"),
+        literal::<_, &[u8], InputError<_>>('π').parse_peek(b"\xCF\x803.14"),
         Ok((&b"3.14"[..], "π".as_bytes()))
     );
 
     assert_eq!(
-        tag::<_, &[u8], InputError<_>>(AsciiCaseless('a')).parse_peek(b"ABCxyz"),
+        literal::<_, &[u8], InputError<_>>(AsciiCaseless('a')).parse_peek(b"ABCxyz"),
         Ok((&b"BCxyz"[..], &b"A"[..]))
     );
 
     assert_eq!(
-        tag::<_, &[u8], InputError<_>>('a').parse_peek(b"ABCxyz"),
+        literal::<_, &[u8], InputError<_>>('a').parse_peek(b"ABCxyz"),
         Err(Backtrack(InputError::new(&b"ABCxyz"[..], ErrorKind::Tag)))
     );
 
     assert_eq!(
-        tag::<_, &[u8], InputError<_>>(AsciiCaseless('π')).parse_peek(b"\xCF\x803.14"),
+        literal::<_, &[u8], InputError<_>>(AsciiCaseless('π')).parse_peek(b"\xCF\x803.14"),
         Ok((&b"3.14"[..], "π".as_bytes()))
     );
 
     assert_eq!(
-        tag::<_, _, InputError<_>>(AsciiCaseless('🧑')).parse_peek("🧑你好"),
+        literal::<_, _, InputError<_>>(AsciiCaseless('🧑')).parse_peek("🧑你好"),
         Ok(("你好", "🧑"))
     );
 
     let mut buffer = [0; 4];
     let input = '\u{241b}'.encode_utf8(&mut buffer);
     assert_eq!(
-        tag::<_, &[u8], InputError<_>>(AsciiCaseless('␛')).parse_peek(input.as_bytes()),
+        literal::<_, &[u8], InputError<_>>(AsciiCaseless('␛')).parse_peek(input.as_bytes()),
         Ok((&b""[..], [226, 144, 155].as_slice()))
     );
 
     assert_eq!(
-        tag::<_, &[u8], InputError<_>>('-').parse_peek(b"\xCF\x80"),
+        literal::<_, &[u8], InputError<_>>('-').parse_peek(b"\xCF\x80"),
         Err(Backtrack(InputError::new(&b"\xCF\x80"[..], ErrorKind::Tag)))
     );
 }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -76,7 +76,7 @@ where
 
 /// Recognizes a literal
 ///
-/// The input data will be compared to the tag combinator's argument and will return the part of
+/// The input data will be compared to the literal combinator's argument and will return the part of
 /// the input that matches the argument
 ///
 /// It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern
@@ -88,7 +88,6 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
-/// use winnow::token::tag;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
 ///   "Hello".parse_peek(s)
@@ -103,7 +102,6 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::Partial;
-/// use winnow::token::tag;
 ///
 /// fn parser(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
 ///   "Hello".parse_peek(s)
@@ -118,11 +116,11 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// use winnow::token::tag;
+/// use winnow::token::literal;
 /// use winnow::ascii::Caseless;
 ///
 /// fn parser(s: &str) -> IResult<&str, &str> {
-///   tag(Caseless("hello")).parse_peek(s)
+///   literal(Caseless("hello")).parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
@@ -152,6 +150,7 @@ where
 }
 
 /// Deprecated, replaced with [`literal`]
+#[deprecated(since = "0.5.38", note = "Replaced with `literal`")]
 pub fn tag<T, I, Error: ParserError<I>>(tag: T) -> impl Parser<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
@@ -170,12 +169,12 @@ where
     I: Stream + Compare<T>,
     T: SliceLen,
 {
-    let tag_len = t.slice_len();
+    let literal_len = t.slice_len();
     match i.compare(t) {
         CompareResult::Ok(len) => Ok(i.next_slice(len)),
-        CompareResult::Incomplete if PARTIAL && i.is_partial() => {
-            Err(ErrMode::Incomplete(Needed::new(tag_len - i.eof_offset())))
-        }
+        CompareResult::Incomplete if PARTIAL && i.is_partial() => Err(ErrMode::Incomplete(
+            Needed::new(literal_len - i.eof_offset()),
+        )),
         CompareResult::Incomplete | CompareResult::Error => {
             let e: ErrorKind = ErrorKind::Tag;
             Err(ErrMode::from_error_kind(i, e))

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -132,10 +132,10 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Tag))));
 /// ```
 #[inline(always)]
-#[doc(alias = "literal")]
+#[doc(alias = "tag")]
 #[doc(alias = "bytes")]
 #[doc(alias = "just")]
-pub fn tag<T, I, Error: ParserError<I>>(tag: T) -> impl Parser<I, <I as Stream>::Slice, Error>
+pub fn literal<T, I, Error: ParserError<I>>(tag: T) -> impl Parser<I, <I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + Compare<T>,
@@ -144,14 +144,24 @@ where
     trace("tag", move |i: &mut I| {
         let t = tag.clone();
         if <I as StreamIsPartial>::is_partial_supported() {
-            tag_::<_, _, _, true>(i, t)
+            literal_::<_, _, _, true>(i, t)
         } else {
-            tag_::<_, _, _, false>(i, t)
+            literal_::<_, _, _, false>(i, t)
         }
     })
 }
 
-fn tag_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
+/// Deprecated, replaced with [`literal`]
+pub fn tag<T, I, Error: ParserError<I>>(tag: T) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream + Compare<T>,
+    T: SliceLen + Clone,
+{
+    literal(tag)
+}
+
+fn literal_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
     i: &mut I,
     t: T,
 ) -> PResult<<I as Stream>::Slice, Error>

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -10,7 +10,7 @@ use crate::error::ErrorKind;
 use crate::error::InputError;
 use crate::error::Needed;
 use crate::stream::AsChar;
-use crate::token::tag;
+use crate::token::literal;
 use crate::unpeek;
 use crate::IResult;
 use crate::Parser;
@@ -98,9 +98,9 @@ fn complete_take_until() {
 }
 
 #[test]
-fn complete_tag_case_insensitive() {
+fn complete_literal_case_insensitive() {
     fn caseless_bytes(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        tag(Caseless("ABcd")).parse_peek(i)
+        literal(Caseless("ABcd")).parse_peek(i)
     }
     assert_eq!(
         caseless_bytes(&b"aBCdefgh"[..]),
@@ -137,7 +137,7 @@ fn complete_tag_case_insensitive() {
     );
 
     fn caseless_str(i: &str) -> IResult<&str, &str> {
-        tag(Caseless("ABcd")).parse_peek(i)
+        literal(Caseless("ABcd")).parse_peek(i)
     }
     assert_eq!(caseless_str("aBCdefgh"), Ok(("efgh", "aBCd")));
     assert_eq!(caseless_str("abcdefgh"), Ok(("efgh", "abcd")));
@@ -159,7 +159,7 @@ fn complete_tag_case_insensitive() {
     );
 
     fn matches_kelvin(i: &str) -> IResult<&str, &str> {
-        tag(Caseless("k")).parse_peek(i)
+        literal(Caseless("k")).parse_peek(i)
     }
     assert_eq!(
         matches_kelvin("K"),
@@ -167,7 +167,7 @@ fn complete_tag_case_insensitive() {
     );
 
     fn is_kelvin(i: &str) -> IResult<&str, &str> {
-        tag(Caseless("K")).parse_peek(i)
+        literal(Caseless("K")).parse_peek(i)
     }
     assert_eq!(
         is_kelvin("k"),
@@ -176,12 +176,12 @@ fn complete_tag_case_insensitive() {
 }
 
 #[test]
-fn complete_tag_fixed_size_array() {
+fn complete_literal_fixed_size_array() {
     fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        tag([0x42]).parse_peek(i)
+        literal([0x42]).parse_peek(i)
     }
     fn test2(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        tag(&[0x42]).parse_peek(i)
+        literal(&[0x42]).parse_peek(i)
     }
 
     let input = &[0x42, 0x00][..];
@@ -190,9 +190,9 @@ fn complete_tag_fixed_size_array() {
 }
 
 #[test]
-fn complete_tag_char() {
+fn complete_literal_char() {
     fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        tag('B').parse_peek(i)
+        literal('B').parse_peek(i)
     }
     assert_eq!(test(&[0x42, 0x00][..]), Ok((&b"\x00"[..], &b"\x42"[..])));
     assert_eq!(
@@ -205,9 +205,9 @@ fn complete_tag_char() {
 }
 
 #[test]
-fn complete_tag_byte() {
+fn complete_literal_byte() {
     fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        tag(b'B').parse_peek(i)
+        literal(b'B').parse_peek(i)
     }
     assert_eq!(test(&[0x42, 0x00][..]), Ok((&b"\x00"[..], &b"\x42"[..])));
     assert_eq!(
@@ -723,9 +723,9 @@ fn partial_recognize_take_while0() {
 }
 
 #[test]
-fn partial_tag_case_insensitive() {
+fn partial_literal_case_insensitive() {
     fn caseless_bytes(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        tag(Caseless("ABcd")).parse_peek(i)
+        literal(Caseless("ABcd")).parse_peek(i)
     }
     assert_eq!(
         caseless_bytes(Partial::new(&b"aBCdefgh"[..])),
@@ -759,7 +759,7 @@ fn partial_tag_case_insensitive() {
     );
 
     fn caseless_str(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        tag(Caseless("ABcd")).parse_peek(i)
+        literal(Caseless("ABcd")).parse_peek(i)
     }
     assert_eq!(
         caseless_str(Partial::new("aBCdefgh")),
@@ -793,7 +793,7 @@ fn partial_tag_case_insensitive() {
     );
 
     fn matches_kelvin(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        tag(Caseless("k")).parse_peek(i)
+        literal(Caseless("k")).parse_peek(i)
     }
     assert_eq!(
         matches_kelvin(Partial::new("K")),
@@ -804,7 +804,7 @@ fn partial_tag_case_insensitive() {
     );
 
     fn is_kelvin(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        tag(Caseless("K")).parse_peek(i)
+        literal(Caseless("K")).parse_peek(i)
     }
     assert_eq!(
         is_kelvin(Partial::new("k")),
@@ -816,12 +816,12 @@ fn partial_tag_case_insensitive() {
 }
 
 #[test]
-fn partial_tag_fixed_size_array() {
+fn partial_literal_fixed_size_array() {
     fn test(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        tag([0x42]).parse_peek(i)
+        literal([0x42]).parse_peek(i)
     }
     fn test2(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        tag(&[0x42]).parse_peek(i)
+        literal(&[0x42]).parse_peek(i)
     }
     let input = Partial::new(&[0x42, 0x00][..]);
     assert_eq!(test(input), Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..])));

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -126,15 +126,15 @@ fn issue_655() {
 #[cfg(feature = "alloc")]
 fn issue_717(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     use winnow::combinator::separated;
-    use winnow::token::{tag, take_till};
+    use winnow::token::{literal, take_till};
 
-    separated(0.., take_till(1.., [0x0u8]), tag([0x0])).parse_peek(i)
+    separated(0.., take_till(1.., [0x0u8]), literal([0x0])).parse_peek(i)
 }
 
 mod issue_647 {
     use super::*;
     use winnow::combinator::separated;
-    use winnow::token::tag;
+    use winnow::token::literal;
     use winnow::{binary::be_f64, error::ErrMode, IResult};
     pub type Stream<'a> = winnow::Partial<&'a [u8]>;
 
@@ -149,7 +149,7 @@ mod issue_647 {
         input: Stream<'a>,
         _cs: &f64,
     ) -> Result<(Stream<'a>, Vec<f64>), ErrMode<InputError<Stream<'a>>>> {
-        separated(0.., be_f64.complete_err(), tag(",").complete_err()).parse_peek(input)
+        separated(0.., be_f64.complete_err(), literal(",").complete_err()).parse_peek(input)
     }
 
     fn data(input: Stream<'_>) -> IResult<Stream<'_>, Data> {
@@ -264,10 +264,10 @@ fn issue_1459_clamp_capacity() {
 
 #[test]
 fn issue_1617_count_parser_returning_zero_size() {
-    use winnow::{combinator::repeat, token::tag};
+    use winnow::{combinator::repeat, token::literal};
 
     // previously, `repeat()` panicked if the parser had type `O = ()`
-    let parser = tag::<_, _, InputError<&str>>("abc").map(|_| ());
+    let parser = literal::<_, _, InputError<&str>>("abc").map(|_| ());
     // shouldn't panic
     let result = repeat(3, parser)
         .parse_peek("abcabcabcdef")

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -4,7 +4,7 @@ mod test {
     use winnow::Parser;
     use winnow::Partial;
     #[cfg(feature = "alloc")]
-    use winnow::{combinator::alt, combinator::repeat, token::tag};
+    use winnow::{combinator::alt, combinator::repeat, token::literal};
     use winnow::{
         error::ErrMode,
         error::{ErrorKind, InputError},
@@ -13,7 +13,7 @@ mod test {
     };
 
     #[test]
-    fn tag_succeed_str() {
+    fn literal_succeed_str() {
         const INPUT: &str = "Hello World!";
         fn test(input: &str) -> IResult<&str, &str> {
             "Hello".parse_peek(input)
@@ -21,17 +21,20 @@ mod test {
 
         match test(INPUT) {
             Ok((extra, output)) => {
-                assert!(extra == " World!", "Parser `tag` consumed leftover input.");
+                assert!(
+                    extra == " World!",
+                    "Parser `literal` consumed leftover input."
+                );
                 assert!(
                     output == "Hello",
-                    "Parser `tag` doesn't return the tag it matched on success. \
+                    "Parser `literal` doesn't return the literal it matched on success. \
            Expected `{}`, got `{}`.",
                     "Hello",
                     output
                 );
             }
             other => panic!(
-                "Parser `tag` didn't succeed when it should have. \
+                "Parser `literal` didn't succeed when it should have. \
          Got `{:?}`.",
                 other
             ),
@@ -39,7 +42,7 @@ mod test {
     }
 
     #[test]
-    fn tag_incomplete_str() {
+    fn literal_incomplete_str() {
         const INPUT: &str = "Hello";
 
         let res: IResult<_, _, InputError<_>> = "Hello World!".parse_peek(Partial::new(INPUT));
@@ -47,7 +50,7 @@ mod test {
             Err(ErrMode::Incomplete(_)) => (),
             other => {
                 panic!(
-                    "Parser `tag` didn't require more input when it should have. \
+                    "Parser `literal` didn't require more input when it should have. \
            Got `{:?}`.",
                     other
                 );
@@ -56,7 +59,7 @@ mod test {
     }
 
     #[test]
-    fn tag_error_str() {
+    fn literal_error_str() {
         const INPUT: &str = "Hello World!";
 
         let res: IResult<_, _, InputError<_>> = "Random".parse_peek(INPUT);
@@ -64,7 +67,7 @@ mod test {
             Err(ErrMode::Backtrack(_)) => (),
             other => {
                 panic!(
-                    "Parser `tag` didn't fail when it should have. Got `{:?}`.`",
+                    "Parser `literal` didn't fail when it should have. Got `{:?}`.`",
                     other
                 );
             }
@@ -73,9 +76,9 @@ mod test {
 
     #[cfg(feature = "alloc")]
     #[test]
-    fn tag_case_insensitive_str() {
+    fn literal_case_insensitive_str() {
         fn test(i: &str) -> IResult<&str, &str> {
-            tag(Caseless("ABcd")).parse_peek(i)
+            literal(Caseless("ABcd")).parse_peek(i)
         }
         assert_eq!(test("aBCdefgh"), Ok(("efgh", "aBCd")));
         assert_eq!(test("abcdefgh"), Ok(("efgh", "abcd")));


### PR DESCRIPTION
`tag` refers to specific patterns in binary parsing (tag-length-value encoding).  `literal` and `pattern` are a bit more universally applicable.