### PR TITLE
perf(stream): Ensure u8::slice_len is inlined

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -455,7 +455,7 @@ impl<'a> SliceLen for &'a str {
 }
 
 impl SliceLen for u8 {
-    #[inline]
+    #[inline(always)]
     fn slice_len(&self) -> usize {
         1
     }


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
