### PR TITLE
fix(parser): Switch literal impl's from `one_of` to `literal`

### DIFF
--- a/assets/trace.svg
+++ b/assets/trace.svg
@@ -1,5 +1,5 @@
 <!-- Created with term-transcript v0.2.0 (https://github.com/slowli/term-transcript) -->
-<svg viewBox="0 0 720 768" width="720" height="768" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 720 552" width="720" height="552" xmlns="http://www.w3.org/2000/svg">
   <style>
     :root {
       --black: #1c1c1c; --i-black: #666666;
@@ -65,16 +65,13 @@
     .fg15 { color: var(--i-white); } .bg15 { background: var(--i-white); }
   </style>
   <rect width="100%" height="100%" y="0" rx="4.5" style="fill: var(--black);" />
-  <svg x="0" y="10" width="720" height="748" viewBox="0 0 720 748">
-    <foreignObject width="720" height="748">
+  <svg x="0" y="10" width="720" height="532" viewBox="0 0 720 532">
+    <foreignObject width="720" height="532">
       <div xmlns="http://www.w3.org/1999/xhtml" class="container">
         <div class="user-input"><pre><span class="prompt">$</span> ./string</pre></div>
         <div class="term-output"><pre>&gt; delimited                                         <span class="bold">|</span> <span class="underline">"\"abc\""</span><span class="fg6">∅</span>
- &gt; one_of                                           <span class="bold">|</span> <span class="underline">"\"abc\""</span><span class="fg6">∅</span>
-  &gt; any                                             <span class="bold">|</span> <span class="underline">"\"abc\""</span><span class="fg6">∅</span>
-<span class="fg2">  &lt; any                                            </span> <span class="bold">|</span> <span class="fg2">+1</span>
-<span class="fg2">  | verify                                         </span> <span class="bold">|</span> 
-<span class="fg2"> &lt; one_of                                          </span> <span class="bold">|</span> <span class="fg2">+1</span>
+ &gt; tag                                              <span class="bold">|</span> <span class="underline">"\"abc\""</span><span class="fg6">∅</span>
+<span class="fg2"> &lt; tag                                             </span> <span class="bold">|</span> <span class="fg2">+1</span>
  &gt; repeat_fold                                      <span class="bold">|</span> <span class="underline">"abc\""</span><span class="fg6">∅</span>
   &gt; alt                                             <span class="bold">|</span> <span class="underline">"abc\""</span><span class="fg6">∅</span>
    &gt; take_till                                      <span class="bold">|</span> <span class="underline">"abc\""</span><span class="fg6">∅</span>
@@ -85,26 +82,17 @@
    &gt; take_till                                      <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
 <span class="fg3">   &lt; take_till                                     </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
    &gt; preceded                                       <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
-    &gt; one_of                                        <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
-     &gt; any                                          <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
-<span class="fg2">     &lt; any                                         </span> <span class="bold">|</span> <span class="fg2">+1</span>
-<span class="fg3">     | verify                                      </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
-<span class="fg3">    &lt; one_of                                       </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
+    &gt; tag                                           <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
+<span class="fg3">    &lt; tag                                          </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
 <span class="fg3">   &lt; preceded                                      </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
    &gt; preceded                                       <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
-    &gt; one_of                                        <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
-     &gt; any                                          <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
-<span class="fg2">     &lt; any                                         </span> <span class="bold">|</span> <span class="fg2">+1</span>
-<span class="fg3">     | verify                                      </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
-<span class="fg3">    &lt; one_of                                       </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
+    &gt; tag                                           <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
+<span class="fg3">    &lt; tag                                          </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
 <span class="fg3">   &lt; preceded                                      </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
 <span class="fg3">  &lt; alt                                            </span> <span class="bold">|</span> <span class="fg3">backtrack</span>
 <span class="fg2"> &lt; repeat_fold                                     </span> <span class="bold">|</span> <span class="fg2">+3</span>
- &gt; one_of                                           <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
-  &gt; any                                             <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
-<span class="fg2">  &lt; any                                            </span> <span class="bold">|</span> <span class="fg2">+1</span>
-<span class="fg2">  | verify                                         </span> <span class="bold">|</span> 
-<span class="fg2"> &lt; one_of                                          </span> <span class="bold">|</span> <span class="fg2">+1</span>
+ &gt; tag                                              <span class="bold">|</span> <span class="underline">"\""</span><span class="fg6">∅</span>
+<span class="fg2"> &lt; tag                                             </span> <span class="bold">|</span> <span class="fg2">+1</span>
 <span class="fg2">&lt; delimited                                        </span> <span class="bold">|</span> <span class="fg2">+5</span>
 &gt; eof                                               <span class="bold">|</span> <span class="underline">""</span><span class="fg6">∅</span>
 <span class="fg2">&lt; eof                                              </span> <span class="bold">|</span> <span class="fg2">+0</span>

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -235,8 +235,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("\nc"), Ok(("c", '\n')));
-/// assert_eq!(parser.parse_peek("\r\nc"), Err(ErrMode::Backtrack(InputError::new("\r\nc", ErrorKind::Verify))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
+/// assert_eq!(parser.parse_peek("\r\nc"), Err(ErrMode::Backtrack(InputError::new("\r\nc", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// ```
@@ -245,7 +245,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::newline;
 /// assert_eq!(newline::<_, InputError<_>>.parse_peek(Partial::new("\nc")), Ok((Partial::new("c"), '\n')));
-/// assert_eq!(newline::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("\r\nc"), ErrorKind::Verify))));
+/// assert_eq!(newline::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("\r\nc"), ErrorKind::Tag))));
 /// assert_eq!(newline::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -253,9 +253,9 @@ pub fn newline<I, Error: ParserError<I>>(input: &mut I) -> PResult<char, Error>
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Clone,
+    I: Compare<char>,
 {
-    trace("newline", '\n'.map(AsChar::as_char)).parse_next(input)
+    trace("newline", '\n').parse_next(input)
 }
 
 /// Matches a tab character `'\t'`.
@@ -275,8 +275,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("\tc"), Ok(("c", '\t')));
-/// assert_eq!(parser.parse_peek("\r\nc"), Err(ErrMode::Backtrack(InputError::new("\r\nc", ErrorKind::Verify))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
+/// assert_eq!(parser.parse_peek("\r\nc"), Err(ErrMode::Backtrack(InputError::new("\r\nc", ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Tag))));
 /// ```
 ///
 /// ```
@@ -285,7 +285,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::tab;
 /// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("\tc")), Ok((Partial::new("c"), '\t')));
-/// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("\r\nc"), ErrorKind::Verify))));
+/// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("\r\nc"), ErrorKind::Tag))));
 /// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -293,9 +293,9 @@ pub fn tab<I, Error: ParserError<I>>(input: &mut I) -> PResult<char, Error>
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Clone,
+    I: Compare<char>,
 {
-    trace("tab", '\t'.map(AsChar::as_char)).parse_next(input)
+    trace("tab", '\t').parse_next(input)
 }
 
 /// Recognizes zero or more lowercase and uppercase ASCII alphabetic characters: `'a'..='z'`, `'A'..='Z'`
@@ -1346,6 +1346,7 @@ where
     I: StreamIsPartial,
     I: Stream,
     I: Compare<Caseless<&'static str>>,
+    I: Compare<char>,
     <I as Stream>::Slice: ParseSlice<O>,
     <I as Stream>::Token: AsChar + Clone,
     <I as Stream>::IterOffsets: Clone,
@@ -1367,6 +1368,7 @@ where
     I: StreamIsPartial,
     I: Stream,
     I: Compare<Caseless<&'static str>>,
+    I: Compare<char>,
     <I as Stream>::Token: AsChar + Clone,
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
@@ -1393,6 +1395,7 @@ fn recognize_float<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>
 where
     I: StreamIsPartial,
     I: Stream,
+    I: Compare<char>,
     <I as Stream>::Token: AsChar + Clone,
     <I as Stream>::IterOffsets: Clone,
     I: AsBStr,
@@ -1458,7 +1461,7 @@ pub fn escaped<'a, I: 'a, Error, F, G, O1, O2>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Clone,
+    I: Compare<char>,
     F: Parser<I, O1, Error>,
     G: Parser<I, O2, Error>,
     Error: ParserError<I>,
@@ -1481,7 +1484,7 @@ fn streaming_escaped_internal<I, Error, F, G, O1, O2>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: AsChar + Clone,
+    I: Compare<char>,
     F: Parser<I, O1, Error>,
     G: Parser<I, O2, Error>,
     Error: ParserError<I>,
@@ -1523,7 +1526,7 @@ fn complete_escaped_internal<'a, I: 'a, Error, F, G, O1, O2>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: crate::stream::AsChar + Clone,
+    I: Compare<char>,
     F: Parser<I, O1, Error>,
     G: Parser<I, O2, Error>,
     Error: ParserError<I>,
@@ -1625,7 +1628,7 @@ pub fn escaped_transform<I, Error, F, G, Output>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: crate::stream::AsChar + Clone,
+    I: Compare<char>,
     Output: crate::stream::Accumulate<<I as Stream>::Slice>,
     F: Parser<I, <I as Stream>::Slice, Error>,
     G: Parser<I, <I as Stream>::Slice, Error>,
@@ -1649,7 +1652,7 @@ fn streaming_escaped_transform_internal<I, Error, F, G, Output>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: crate::stream::AsChar + Clone,
+    I: Compare<char>,
     Output: crate::stream::Accumulate<<I as Stream>::Slice>,
     F: Parser<I, <I as Stream>::Slice, Error>,
     G: Parser<I, <I as Stream>::Slice, Error>,
@@ -1688,7 +1691,7 @@ fn complete_escaped_transform_internal<I, Error, F, G, Output>(
 where
     I: StreamIsPartial,
     I: Stream,
-    <I as Stream>::Token: crate::stream::AsChar + Clone,
+    I: Compare<char>,
     Output: crate::stream::Accumulate<<I as Stream>::Slice>,
     F: Parser<I, <I as Stream>::Slice, Error>,
     G: Parser<I, <I as Stream>::Slice, Error>,

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -111,7 +111,7 @@ pub trait Permutation<I, O, E> {
 ///
 /// // any parses 'a', then char('a') fails on 'b',
 /// // even though char('a') followed by any would succeed
-/// assert_eq!(parser("ab"), Err(ErrMode::Backtrack(InputError::new("b", ErrorKind::Verify))));
+/// assert_eq!(parser("ab"), Err(ErrMode::Backtrack(InputError::new("b", ErrorKind::Tag))));
 /// ```
 ///
 pub fn permutation<I: Stream, O, E: ParserError<I>, List: Permutation<I, O, E>>(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -727,19 +727,20 @@ where
 ///     b'a'.parse_next(i)
 /// }
 /// assert_eq!(parser.parse_peek(&b"abc"[..]), Ok((&b"bc"[..], b'a')));
-/// assert_eq!(parser.parse_peek(&b" abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b" abc"[..], ErrorKind::Verify))));
-/// assert_eq!(parser.parse_peek(&b"bc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"bc"[..], ErrorKind::Verify))));
-/// assert_eq!(parser.parse_peek(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&b""[..], ErrorKind::Token))));
+/// assert_eq!(parser.parse_peek(&b" abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b" abc"[..], ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek(&b"bc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"bc"[..], ErrorKind::Tag))));
+/// assert_eq!(parser.parse_peek(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&b""[..], ErrorKind::Tag))));
 /// ```
 impl<I, E> Parser<I, u8, E> for u8
 where
     I: StreamIsPartial,
-    I: Stream<Token = u8>,
+    I: Stream,
+    I: Compare<u8>,
     E: ParserError<I>,
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> PResult<u8, E> {
-        crate::token::one_of(*self).parse_next(i)
+        crate::token::literal(*self).value(*self).parse_next(i)
     }
 }
 

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -256,7 +256,7 @@ fn partial_one_of_test() {
 
 #[test]
 fn char_byteslice() {
-    fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
+    fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, char> {
         'c'.parse_peek(i)
     }
 
@@ -265,12 +265,12 @@ fn char_byteslice() {
         f(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(a),
-            ErrorKind::Verify
+            ErrorKind::Tag
         )))
     );
 
     let b = &b"cde"[..];
-    assert_eq!(f(Partial::new(b)), Ok((Partial::new(&b"de"[..]), b'c')));
+    assert_eq!(f(Partial::new(b)), Ok((Partial::new(&b"de"[..]), 'c')));
 }
 
 #[test]
@@ -284,7 +284,7 @@ fn char_str() {
         f(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(a),
-            ErrorKind::Verify
+            ErrorKind::Tag
         )))
     );
 


### PR DESCRIPTION
Originally, this was going to be done for performance reasons but when
comparing this to the previous commit, `tag(char)` / `char` slowed down
dramatically in the `next_slice` benchmark.

However, `json` benchmark was unchanged.  This also (slightly)
simplifies traces, is more direct in what it says, and does still speed
things up for UTF-8-exclusive `char`s, so going forward with it.

Fixes #418
Fixes #427

BREAKING CHANGE: `char` parers now always return `char` as the output
and now require `I: Compare<char>`

BREAKING CHANGE: `u8` parers now  require `I: Compare<u8>`