### PR TITLE
docs: Try to clear up some confusion

### DIFF
--- a/src/_tutorial/chapter_0.rs
+++ b/src/_tutorial/chapter_0.rs
@@ -25,11 +25,10 @@
 //!
 //! Parser combinators are great because:
 //!
-//! - The parsers are small and easy to write
-//! - The parsers components are easy to reuse (if they're general enough, please add them to winnow!)
-//! - The parsers components are easy to test separately (unit tests and property-based tests)
-//! - The parser combination code looks close to the grammar you would have written
-//! - You can build partial parsers, specific to the data you need at the moment, and ignore the rest
+//! - Individual parser functions are small, focused on one thing, ignoring the rest
+//! - You can write tests focused on individual parsers (unit tests and property-based tests)
+//!   in addition to testing the top-level parser as a whole.
+//! - Top-level parsing code looks close to the grammar you would have written
 
 #![allow(unused_imports)]
 use crate::_topic;

--- a/src/_tutorial/chapter_1.rs
+++ b/src/_tutorial/chapter_1.rs
@@ -1,17 +1,17 @@
 //! # Chapter 1: The Winnow Way
 //!
 //! First of all, we need to understand the way that winnow thinks about parsing.
-//! As discussed in the introduction, winnow lets us build simple parsers, and
-//! then combine them (using "combinators").
+//! As discussed in the introduction, winnow lets us compose more complex parsers from more simple
+//! ones (using "combinators").
 //!
-//! Let's discuss what a "parser" actually does. A parser takes an input and returns
+//! Let's discuss what a "parser" actually does. A parser takes an input and advances it until it returns
 //! a result, where:
 //!  - `Ok` indicates the parser successfully found what it was looking for; or
 //!  - `Err` indicates the parser could not find what it was looking for.
 //!
 //! Parsers do more than just return a binary "success"/"failure" code.
-//! On success, the parser will return the processed data. The input will be left pointing to
-//! data that still needs processing
+//! On success, the parser will return the processed data. The input will be advanced to the end of
+//! what was processed, pointing to what will be parsed next.
 //!
 //! If the parser failed, then there are multiple errors that could be returned.
 //! For simplicity, however, in the next chapters we will leave these unexplored.
@@ -43,7 +43,6 @@
 //! have to be the same type (consider the simple example where `I = &str`, and `O = u64` -- this
 //! parses a string into an unsigned integer.)
 //!
-//!
 //! # Let's write our first parser!
 //!
 //! The simplest parser we can write is one which successfully does nothing.
@@ -54,7 +53,7 @@
 //! This parser function should take in a `&str`:
 //!
 //!  - Since it is supposed to succeed, we know it will return the `Ok` variant.
-//!  - Since it does nothing to our input, the remaining input is the same as the input.
+//!  - Since it does nothing to our input, the input will be left where it started.
 //!  - Since it doesn't parse anything, it also should just return an empty string.
 //!
 //! ```rust

--- a/src/_tutorial/chapter_3.rs
+++ b/src/_tutorial/chapter_3.rs
@@ -1,9 +1,9 @@
 //! # Chapter 3: Sequencing and Alternatives
 //!
-//! In the last chapter, we saw how to create simple parsers using prebuilt parsers.
+//! In the last chapter, we saw how to create parsers using prebuilt parsers.
 //!
 //! In this chapter, we explore two other widely used features:
-//! alternatives and composition.
+//! sequencing and alternatives.
 //!
 //! ## Sequencing
 //!
@@ -111,7 +111,8 @@
 //! Sometimes, we might want to choose between two parsers; and we're happy with
 //! either being used.
 //!
-//! [`Stream::checkpoint`] helps us to retry parsing:
+//! To retry a parse result, we can save off a [`Stream::checkpoint`] and later restore the parser
+//! back to that position with [`Stream::reset`]:
 //! ```rust
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
@@ -119,7 +120,6 @@
 //!
 //! fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
 //!     let start = input.checkpoint();
-//!
 //!     if let Ok(output) = ("0b", parse_bin_digits).parse_next(input) {
 //!         return Ok(output);
 //!     }
@@ -182,7 +182,7 @@
 //! > `Result::Err` can lead to incorrect behavior. This will be clarified in later when covering
 //! > [error handling][`chapter_6`#errmode]
 //!
-//! [`opt`] is a basic building block for correctly handling retrying parsing:
+//! [`opt`] is a parser that encapsulates this pattern of "retry on failure":
 //! ```rust
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
@@ -239,7 +239,7 @@
 //! # }
 //! ```
 //!
-//! [`alt`] encapsulates this if/else-if ladder pattern, with the last case being the `else`:
+//! [`alt`] encapsulates this if/else-if ladder pattern, with the last case being the "else":
 //! ```rust
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
@@ -293,7 +293,7 @@
 //! # }
 //! ```
 //!
-//! > **Note:** [`empty`] and [`fail`] are parsers that might be useful in the `else` case.
+//! > **Note:** [`empty`] and [`fail`] are parsers that might be useful in the "else" case.
 //!
 //! Sometimes a giant if/else-if ladder can be slow and you'd rather have a `match` statement for
 //! branches of your parser that have unique prefixes. In this case, you can use the
@@ -315,8 +315,7 @@
 //!         _ => fail,
 //!     ).parse_next(input)
 //! }
-//!
-//! // ...
+//! #
 //! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
@@ -342,17 +341,17 @@
 //! #         ('a'..='f'),
 //! #     )).parse_next(input)
 //! # }
-//!
-//! fn main() {
-//!     let mut input = "0x1a2b Hello";
-//!
-//!     let digits = parse_digits.parse_next(&mut input).unwrap();
-//!
-//!     assert_eq!(input, " Hello");
-//!     assert_eq!(digits, "1a2b");
-//!
-//!     assert!(parse_digits(&mut "ghiWorld").is_err());
-//! }
+//! #
+//! # fn main() {
+//! #     let mut input = "0x1a2b Hello";
+//! #
+//! #     let digits = parse_digits.parse_next(&mut input).unwrap();
+//! #
+//! #     assert_eq!(input, " Hello");
+//! #     assert_eq!(digits, "1a2b");
+//! #
+//! #     assert!(parse_digits(&mut "ghiWorld").is_err());
+//! # }
 //! ```
 //!
 //! > **Note:** [`peek`] may be useful when [`dispatch`]ing from hints from each case's parser.

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -86,11 +86,10 @@ impl Caseless<&str> {
 /// assert_eq!(crlf::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn crlf<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn crlf<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    I: Compare<&'static str>,
+    Input: StreamIsPartial + Stream + Compare<&'static str>,
+    Error: ParserError<Input>,
 {
     trace("crlf", "\r\n").parse_next(input)
 }
@@ -131,16 +130,14 @@ where
 /// assert_eq!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("a\rbc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("\rbc"), ErrorKind::Tag ))));
 /// ```
 #[inline(always)]
-pub fn till_line_ending<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn till_line_ending<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    I: Compare<&'static str>,
-    I: FindSlice<(char, char)>,
-    <I as Stream>::Token: AsChar + Clone,
+    Input: StreamIsPartial + Stream + Compare<&'static str> + FindSlice<(char, char)>,
+    <Input as Stream>::Token: AsChar + Clone,
+    Error: ParserError<Input>,
 {
-    trace("till_line_ending", move |input: &mut I| {
-        if <I as StreamIsPartial>::is_partial_supported() {
+    trace("till_line_ending", move |input: &mut Input| {
+        if <Input as StreamIsPartial>::is_partial_supported() {
             till_line_ending_::<_, _, true>(input)
         } else {
             till_line_ending_::<_, _, false>(input)
@@ -213,11 +210,10 @@ where
 /// assert_eq!(line_ending::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn line_ending<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn line_ending<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    I: Compare<&'static str>,
+    Input: StreamIsPartial + Stream + Compare<&'static str>,
+    Error: ParserError<Input>,
 {
     trace("line_ending", alt(("\n", "\r\n"))).parse_next(input)
 }
@@ -293,11 +289,10 @@ where
 /// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn tab<I, Error: ParserError<I>>(input: &mut I) -> PResult<char, Error>
+pub fn tab<Input, Error>(input: &mut Input) -> PResult<char, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    I: Compare<char>,
+    Input: StreamIsPartial + Stream + Compare<char>,
+    Error: ParserError<Input>,
 {
     trace("tab", '\t').parse_next(input)
 }
@@ -335,11 +330,11 @@ where
 /// assert_eq!(alpha0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha0<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn alpha0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("alpha0", take_while(0.., AsChar::is_alpha)).parse_next(input)
 }
@@ -377,11 +372,11 @@ where
 /// assert_eq!(alpha1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha1<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn alpha1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("alpha1", take_while(1.., AsChar::is_alpha)).parse_next(input)
 }
@@ -420,11 +415,11 @@ where
 /// assert_eq!(digit0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn digit0<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn digit0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("digit0", take_while(0.., AsChar::is_dec_digit)).parse_next(input)
 }
@@ -479,11 +474,11 @@ where
 /// assert!(parser.parse_peek("b").is_err());
 /// ```
 #[inline(always)]
-pub fn digit1<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn digit1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("digit1", take_while(1.., AsChar::is_dec_digit)).parse_next(input)
 }
@@ -521,11 +516,11 @@ where
 /// assert_eq!(hex_digit0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit0<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn hex_digit0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("hex_digit0", take_while(0.., AsChar::is_hex_digit)).parse_next(input)
 }
@@ -564,11 +559,11 @@ where
 /// assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit1<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn hex_digit1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("hex_digit1", take_while(1.., AsChar::is_hex_digit)).parse_next(input)
 }
@@ -606,11 +601,12 @@ where
 /// assert_eq!(oct_digit0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit0<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn oct_digit0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial,
+    Input: Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("oct_digit0", take_while(0.., AsChar::is_oct_digit)).parse_next(input)
 }
@@ -648,11 +644,11 @@ where
 /// assert_eq!(oct_digit1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit1<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn oct_digit1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("oct_digit0", take_while(1.., AsChar::is_oct_digit)).parse_next(input)
 }
@@ -690,11 +686,11 @@ where
 /// assert_eq!(alphanumeric0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric0<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn alphanumeric0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("alphanumeric0", take_while(0.., AsChar::is_alphanum)).parse_next(input)
 }
@@ -732,11 +728,11 @@ where
 /// assert_eq!(alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric1<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn alphanumeric1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("alphanumeric1", take_while(1.., AsChar::is_alphanum)).parse_next(input)
 }
@@ -761,11 +757,11 @@ where
 /// assert_eq!(space0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space0<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn space0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar + Clone,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("space0", take_while(0.., AsChar::is_space)).parse_next(input)
 }
@@ -803,11 +799,11 @@ where
 /// assert_eq!(space1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space1<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn space1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar + Clone,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    Error: ParserError<Input>,
 {
     trace("space1", take_while(1.., AsChar::is_space)).parse_next(input)
 }
@@ -845,11 +841,11 @@ where
 /// assert_eq!(multispace0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace0<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn multispace0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar + Clone,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar + Clone,
+    Error: ParserError<Input>,
 {
     trace("multispace0", take_while(0.., (' ', '\t', '\r', '\n'))).parse_next(input)
 }
@@ -887,11 +883,11 @@ where
 /// assert_eq!(multispace1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace1<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+pub fn multispace1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Token: AsChar + Clone,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar + Clone,
+    Error: ParserError<Input>,
 {
     trace("multispace1", take_while(1.., (' ', '\t', '\r', '\n'))).parse_next(input)
 }
@@ -906,22 +902,22 @@ where
 #[doc(alias = "u32")]
 #[doc(alias = "u64")]
 #[doc(alias = "u128")]
-pub fn dec_uint<I, O, E: ParserError<I>>(input: &mut I) -> PResult<O, E>
+pub fn dec_uint<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Slice: AsBStr,
-    <I as Stream>::Token: AsChar + Clone,
-    O: Uint,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Slice: AsBStr,
+    <Input as Stream>::Token: AsChar + Clone,
+    Output: Uint,
+    Error: ParserError<Input>,
 {
-    trace("dec_uint", move |input: &mut I| {
+    trace("dec_uint", move |input: &mut Input| {
         alt(((one_of('1'..='9'), digit0).void(), one_of('0').void()))
             .recognize()
-            .verify_map(|s: <I as Stream>::Slice| {
+            .verify_map(|s: <Input as Stream>::Slice| {
                 let s = s.as_bstr();
                 // SAFETY: Only 7-bit ASCII characters are parsed
                 let s = unsafe { crate::lib::std::str::from_utf8_unchecked(s) };
-                O::try_from_dec_uint(s)
+                Output::try_from_dec_uint(s)
             })
             .parse_next(input)
     })
@@ -980,15 +976,15 @@ impl Uint for usize {
 #[doc(alias = "i32")]
 #[doc(alias = "i64")]
 #[doc(alias = "i128")]
-pub fn dec_int<I, O, E: ParserError<I>>(input: &mut I) -> PResult<O, E>
+pub fn dec_int<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    <I as Stream>::Slice: AsBStr,
-    <I as Stream>::Token: AsChar + Clone,
-    O: Int,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Slice: AsBStr,
+    <Input as Stream>::Token: AsChar + Clone,
+    Output: Int,
+    Error: ParserError<Input>,
 {
-    trace("dec_int", move |input: &mut I| {
+    trace("dec_int", move |input: &mut Input| {
         let sign = opt(dispatch! {any.map(AsChar::as_char);
             '+' => empty.value(true),
             '-' => empty.value(false),
@@ -996,11 +992,11 @@ where
         });
         alt(((sign, one_of('1'..='9'), digit0).void(), one_of('0').void()))
             .recognize()
-            .verify_map(|s: <I as Stream>::Slice| {
+            .verify_map(|s: <Input as Stream>::Slice| {
                 let s = s.as_bstr();
                 // SAFETY: Only 7-bit ASCII characters are parsed
                 let s = unsafe { crate::lib::std::str::from_utf8_unchecked(s) };
-                O::try_from_dec_int(s)
+                Output::try_from_dec_int(s)
             })
             .parse_next(input)
     })
@@ -1088,22 +1084,22 @@ impl Int for isize {
 /// assert_eq!(parser.parse_peek(Partial::new(&b"ggg"[..])), Err(ErrMode::Backtrack(InputError::new(Partial::new(&b"ggg"[..]), ErrorKind::Slice))));
 /// ```
 #[inline]
-pub fn hex_uint<I, O, E: ParserError<I>>(input: &mut I) -> PResult<O, E>
+pub fn hex_uint<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    O: HexUint,
-    <I as Stream>::Token: AsChar,
-    <I as Stream>::Slice: AsBStr,
+    Input: StreamIsPartial + Stream,
+    <Input as Stream>::Token: AsChar,
+    <Input as Stream>::Slice: AsBStr,
+    Output: HexUint,
+    Error: ParserError<Input>,
 {
-    trace("hex_uint", move |input: &mut I| {
+    trace("hex_uint", move |input: &mut Input| {
         let invalid_offset = input
             .offset_for(|c| {
                 let c = c.as_char();
                 !"0123456789abcdefABCDEF".contains(c)
             })
             .unwrap_or_else(|| input.eof_offset());
-        let max_nibbles = O::max_nibbles(sealed::SealedMarker);
+        let max_nibbles = Output::max_nibbles(sealed::SealedMarker);
         let max_offset = input.offset_at(max_nibbles);
         let offset = match max_offset {
             Ok(max_offset) => {
@@ -1115,7 +1111,7 @@ where
                 }
             }
             Err(_) => {
-                if <I as StreamIsPartial>::is_partial_supported()
+                if <Input as StreamIsPartial>::is_partial_supported()
                     && input.is_partial()
                     && invalid_offset == input.eof_offset()
                 {
@@ -1132,12 +1128,12 @@ where
         }
         let parsed = input.next_slice(offset);
 
-        let mut res = O::default();
+        let mut res = Output::default();
         for c in parsed.as_bstr() {
             let nibble = *c as char;
             let nibble = nibble.to_digit(16).unwrap_or(0) as u8;
-            let nibble = O::from(nibble);
-            res = (res << O::from(4)) + nibble;
+            let nibble = Output::from(nibble);
+            res = (res << Output::from(4)) + nibble;
         }
 
         Ok(res)
@@ -1233,18 +1229,15 @@ impl HexUint for u128 {
 #[doc(alias = "f32")]
 #[doc(alias = "double")]
 #[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
-pub fn float<I, O, E: ParserError<I>>(input: &mut I) -> PResult<O, E>
+pub fn float<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    I: Compare<Caseless<&'static str>>,
-    I: Compare<char>,
-    <I as Stream>::Slice: ParseSlice<O>,
-    <I as Stream>::Token: AsChar + Clone,
-    <I as Stream>::IterOffsets: Clone,
-    I: AsBStr,
+    Input: StreamIsPartial + Stream + Compare<Caseless<&'static str>> + Compare<char> + AsBStr,
+    <Input as Stream>::Slice: ParseSlice<Output>,
+    <Input as Stream>::Token: AsChar + Clone,
+    <Input as Stream>::IterOffsets: Clone,
+    Error: ParserError<Input>,
 {
-    trace("float", move |input: &mut I| {
+    trace("float", move |input: &mut Input| {
         let s = recognize_float_or_exceptions(input)?;
         s.parse_slice()
             .ok_or_else(|| ErrMode::from_error_kind(input, ErrorKind::Verify))
@@ -1345,21 +1338,19 @@ where
 /// assert_eq!(esc(Partial::new("12\\\"34;")), Ok((Partial::new(";"), "12\\\"34")));
 /// ```
 #[inline(always)]
-pub fn escaped<'a, I: 'a, Error, F, G, O1, O2>(
-    mut normal: F,
+pub fn escaped<'i, Input: 'i, Error, Normal, Escapable, NormalOutput, EscapableOutput>(
+    mut normal: Normal,
     control_char: char,
-    mut escapable: G,
-) -> impl Parser<I, <I as Stream>::Slice, Error>
+    mut escapable: Escapable,
+) -> impl Parser<Input, <Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    I: Compare<char>,
-    F: Parser<I, O1, Error>,
-    G: Parser<I, O2, Error>,
-    Error: ParserError<I>,
+    Input: StreamIsPartial + Stream + Compare<char>,
+    Normal: Parser<Input, NormalOutput, Error>,
+    Escapable: Parser<Input, EscapableOutput, Error>,
+    Error: ParserError<Input>,
 {
-    trace("escaped", move |input: &mut I| {
-        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
+    trace("escaped", move |input: &mut Input| {
+        if <Input as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             streaming_escaped_internal(input, &mut normal, control_char, &mut escapable)
         } else {
             complete_escaped_internal(input, &mut normal, control_char, &mut escapable)
@@ -1512,25 +1503,23 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new("ab\\\"cd\"")), Ok((Partial::new("\""), String::from("ab\"cd"))));
 /// ```
 #[inline(always)]
-pub fn escaped_transform<I, Error, F, G, Output>(
-    mut normal: F,
+pub fn escaped_transform<Input, Error, Normal, Escape, Output>(
+    mut normal: Normal,
     control_char: char,
-    mut transform: G,
-) -> impl Parser<I, Output, Error>
+    mut escape: Escape,
+) -> impl Parser<Input, Output, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    I: Compare<char>,
-    Output: crate::stream::Accumulate<<I as Stream>::Slice>,
-    F: Parser<I, <I as Stream>::Slice, Error>,
-    G: Parser<I, <I as Stream>::Slice, Error>,
-    Error: ParserError<I>,
+    Input: StreamIsPartial + Stream + Compare<char>,
+    Output: crate::stream::Accumulate<<Input as Stream>::Slice>,
+    Normal: Parser<Input, <Input as Stream>::Slice, Error>,
+    Escape: Parser<Input, <Input as Stream>::Slice, Error>,
+    Error: ParserError<Input>,
 {
-    trace("escaped_transform", move |input: &mut I| {
-        if <I as StreamIsPartial>::is_partial_supported() && input.is_partial() {
-            streaming_escaped_transform_internal(input, &mut normal, control_char, &mut transform)
+    trace("escaped_transform", move |input: &mut Input| {
+        if <Input as StreamIsPartial>::is_partial_supported() && input.is_partial() {
+            streaming_escaped_transform_internal(input, &mut normal, control_char, &mut escape)
         } else {
-            complete_escaped_transform_internal(input, &mut normal, control_char, &mut transform)
+            complete_escaped_transform_internal(input, &mut normal, control_char, &mut escape)
         }
     })
 }

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -46,17 +46,19 @@ const BYTE: usize = u8::BITS as usize;
 /// assert_eq!(parsed.0, 0x01);
 /// assert_eq!(parsed.1, 0x23);
 /// ```
-pub fn bits<I, O, E1, E2, P>(mut parser: P) -> impl Parser<I, O, E2>
+pub fn bits<Input, Output, BitError, ByteError, ParseNext>(
+    mut parser: ParseNext,
+) -> impl Parser<Input, Output, ByteError>
 where
-    E1: ParserError<(I, usize)> + ErrorConvert<E2>,
-    E2: ParserError<I>,
-    (I, usize): Stream,
-    I: Stream + Clone,
-    P: Parser<(I, usize), O, E1>,
+    BitError: ParserError<(Input, usize)> + ErrorConvert<ByteError>,
+    ByteError: ParserError<Input>,
+    (Input, usize): Stream,
+    Input: Stream + Clone,
+    ParseNext: Parser<(Input, usize), Output, BitError>,
 {
     trace(
         "bits",
-        unpeek(move |input: I| {
+        unpeek(move |input: Input| {
             match parser.parse_peek((input, 0)) {
                 Ok(((rest, offset), result)) => {
                     // If the next byte has been partially read, it will be sliced away as well.
@@ -106,16 +108,18 @@ where
 ///
 /// assert_eq!(parse(input), Ok(( stream(&[]), (0x01, 0x23, &[0xff, 0xff][..]) )));
 /// ```
-pub fn bytes<I, O, E1, E2, P>(mut parser: P) -> impl Parser<(I, usize), O, E2>
+pub fn bytes<Input, Output, ByteError, BitError, ParseNext>(
+    mut parser: ParseNext,
+) -> impl Parser<(Input, usize), Output, BitError>
 where
-    E1: ParserError<I> + ErrorConvert<E2>,
-    E2: ParserError<(I, usize)>,
-    I: Stream<Token = u8> + Clone,
-    P: Parser<I, O, E1>,
+    ByteError: ParserError<Input> + ErrorConvert<BitError>,
+    BitError: ParserError<(Input, usize)>,
+    Input: Stream<Token = u8> + Clone,
+    ParseNext: Parser<Input, Output, ByteError>,
 {
     trace(
         "bytes",
-        unpeek(move |(input, offset): (I, usize)| {
+        unpeek(move |(input, offset): (Input, usize)| {
             let (inner, _) = if offset % BYTE != 0 {
                 input.peek_slice(1 + offset / BYTE)
             } else {
@@ -130,7 +134,7 @@ where
                 Err(ErrMode::Incomplete(Needed::Size(sz))) => {
                     Err(match sz.get().checked_mul(BYTE) {
                         Some(v) => ErrMode::Incomplete(Needed::new(v)),
-                        None => ErrMode::Cut(E2::assert(
+                        None => ErrMode::Cut(BitError::assert(
                             &i,
                             "overflow in turning needed bytes into needed bits",
                         )),
@@ -174,17 +178,18 @@ where
 /// assert_eq!(parser((stream(&[0b00010010]), 0), 12), Err(winnow::error::ErrMode::Backtrack(InputError::new((stream(&[0b00010010]), 0), ErrorKind::Eof))));
 /// ```
 #[inline(always)]
-pub fn take<I, O, C, E: ParserError<(I, usize)>>(count: C) -> impl Parser<(I, usize), O, E>
+pub fn take<Input, Output, Count, Error>(count: Count) -> impl Parser<(Input, usize), Output, Error>
 where
-    I: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
-    C: ToUsize,
-    O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O>,
+    Input: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
+    Output: From<u8> + AddAssign + Shl<usize, Output = Output> + Shr<usize, Output = Output>,
+    Count: ToUsize,
+    Error: ParserError<(Input, usize)>,
 {
     let count = count.to_usize();
     trace(
         "take",
-        unpeek(move |input: (I, usize)| {
-            if <I as StreamIsPartial>::is_partial_supported() {
+        unpeek(move |input: (Input, usize)| {
+            if <Input as StreamIsPartial>::is_partial_supported() {
                 take_::<_, _, _, true>(input, count)
             } else {
                 take_::<_, _, _, false>(input, count)
@@ -304,17 +309,21 @@ where
 #[doc(alias = "literal")]
 #[doc(alias = "just")]
 #[doc(alias = "tag")]
-pub fn pattern<I, O, C, E: ParserError<(I, usize)>>(
-    pattern: O,
-    count: C,
-) -> impl Parser<(I, usize), O, E>
+pub fn pattern<Input, Output, Count, Error: ParserError<(Input, usize)>>(
+    pattern: Output,
+    count: Count,
+) -> impl Parser<(Input, usize), Output, Error>
 where
-    I: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
-    C: ToUsize,
-    O: From<u8> + AddAssign + Shl<usize, Output = O> + Shr<usize, Output = O> + PartialEq,
+    Input: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
+    Count: ToUsize,
+    Output: From<u8>
+        + AddAssign
+        + Shl<usize, Output = Output>
+        + Shr<usize, Output = Output>
+        + PartialEq,
 {
     let count = count.to_usize();
-    trace("pattern", move |input: &mut (I, usize)| {
+    trace("pattern", move |input: &mut (Input, usize)| {
         let start = input.checkpoint();
 
         take(count).parse_next(input).and_then(|o| {
@@ -322,7 +331,7 @@ where
                 Ok(o)
             } else {
                 input.reset(&start);
-                Err(ErrMode::Backtrack(E::from_error_kind(
+                Err(ErrMode::Backtrack(Error::from_error_kind(
                     input,
                     ErrorKind::Tag,
                 )))
@@ -355,11 +364,13 @@ where
 /// assert_eq!(parse((stream(&[0b10000000]), 1)), Ok(((stream(&[0b10000000]), 2), false)));
 /// ```
 #[doc(alias = "any")]
-pub fn bool<I, E: ParserError<(I, usize)>>(input: &mut (I, usize)) -> PResult<bool, E>
+pub fn bool<Input, Error: ParserError<(Input, usize)>>(
+    input: &mut (Input, usize),
+) -> PResult<bool, Error>
 where
-    I: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
+    Input: Stream<Token = u8> + AsBytes + StreamIsPartial + Clone,
 {
-    trace("bool", |input: &mut (I, usize)| {
+    trace("bool", |input: &mut (Input, usize)| {
         let bit: u32 = take(1usize).parse_next(input)?;
         Ok(bit != 0)
     })

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -68,10 +68,10 @@ pub enum Endianness {
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_u8<I, E: ParserError<I>>(input: &mut I) -> PResult<u8, E>
+pub fn be_u8<Input, Error>(input: &mut Input) -> PResult<u8, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    Error: ParserError<Input>,
 {
     u8(input)
 }
@@ -112,13 +112,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_u16<I, E: ParserError<I>>(input: &mut I) -> PResult<u16, E>
+pub fn be_u16<Input, Error>(input: &mut Input) -> PResult<u16, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_u16", move |input: &mut I| be_uint(input, 2)).parse_next(input)
+    trace("be_u16", move |input: &mut Input| be_uint(input, 2)).parse_next(input)
 }
 
 /// Recognizes a big endian unsigned 3 byte integer.
@@ -157,13 +157,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn be_u24<I, E: ParserError<I>>(input: &mut I) -> PResult<u32, E>
+pub fn be_u24<Input, Error>(input: &mut Input) -> PResult<u32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_u23", move |input: &mut I| be_uint(input, 3)).parse_next(input)
+    trace("be_u23", move |input: &mut Input| be_uint(input, 3)).parse_next(input)
 }
 
 /// Recognizes a big endian unsigned 4 bytes integer.
@@ -202,13 +202,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_u32<I, E: ParserError<I>>(input: &mut I) -> PResult<u32, E>
+pub fn be_u32<Input, Error>(input: &mut Input) -> PResult<u32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_u32", move |input: &mut I| be_uint(input, 4)).parse_next(input)
+    trace("be_u32", move |input: &mut Input| be_uint(input, 4)).parse_next(input)
 }
 
 /// Recognizes a big endian unsigned 8 bytes integer.
@@ -247,13 +247,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_u64<I, E: ParserError<I>>(input: &mut I) -> PResult<u64, E>
+pub fn be_u64<Input, Error>(input: &mut Input) -> PResult<u64, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_u64", move |input: &mut I| be_uint(input, 8)).parse_next(input)
+    trace("be_u64", move |input: &mut Input| be_uint(input, 8)).parse_next(input)
 }
 
 /// Recognizes a big endian unsigned 16 bytes integer.
@@ -292,26 +292,26 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn be_u128<I, E: ParserError<I>>(input: &mut I) -> PResult<u128, E>
+pub fn be_u128<Input, Error>(input: &mut Input) -> PResult<u128, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_u128", move |input: &mut I| be_uint(input, 16)).parse_next(input)
+    trace("be_u128", move |input: &mut Input| be_uint(input, 16)).parse_next(input)
 }
 
 #[inline]
-fn be_uint<I, Uint, E: ParserError<I>>(input: &mut I, bound: usize) -> PResult<Uint, E>
+fn be_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> PResult<Uint, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
     Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
+    Error: ParserError<Input>,
 {
     debug_assert_ne!(bound, 1, "to_be_uint needs extra work to avoid overflow");
     take(bound)
-        .map(|n: <I as Stream>::Slice| to_be_uint(n.as_bytes()))
+        .map(|n: <Input as Stream>::Slice| to_be_uint(n.as_bytes()))
         .parse_next(input)
 }
 
@@ -364,10 +364,10 @@ where
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_i8<I, E: ParserError<I>>(input: &mut I) -> PResult<i8, E>
+pub fn be_i8<Input, Error>(input: &mut Input) -> PResult<i8, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    Error: ParserError<Input>,
 {
     i8(input)
 }
@@ -408,13 +408,13 @@ where
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn be_i16<I, E: ParserError<I>>(input: &mut I) -> PResult<i16, E>
+pub fn be_i16<Input, Error>(input: &mut Input) -> PResult<i16, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_i16", move |input: &mut I| {
+    trace("be_i16", move |input: &mut Input| {
         be_uint::<_, u16, _>(input, 2).map(|n| n as i16)
     })
     .parse_next(input)
@@ -456,13 +456,13 @@ where
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_i24<I, E: ParserError<I>>(input: &mut I) -> PResult<i32, E>
+pub fn be_i24<Input, Error>(input: &mut Input) -> PResult<i32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_i24", move |input: &mut I| {
+    trace("be_i24", move |input: &mut Input| {
         be_uint::<_, u32, _>(input, 3).map(|n| {
             // Same as the unsigned version but we need to sign-extend manually here
             let n = if n & 0x80_00_00 != 0 {
@@ -512,13 +512,13 @@ where
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
-pub fn be_i32<I, E: ParserError<I>>(input: &mut I) -> PResult<i32, E>
+pub fn be_i32<Input, Error>(input: &mut Input) -> PResult<i32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_i32", move |input: &mut I| {
+    trace("be_i32", move |input: &mut Input| {
         be_uint::<_, u32, _>(input, 4).map(|n| n as i32)
     })
     .parse_next(input)
@@ -560,13 +560,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_i64<I, E: ParserError<I>>(input: &mut I) -> PResult<i64, E>
+pub fn be_i64<Input, Error>(input: &mut Input) -> PResult<i64, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_i64", move |input: &mut I| {
+    trace("be_i64", move |input: &mut Input| {
         be_uint::<_, u64, _>(input, 8).map(|n| n as i64)
     })
     .parse_next(input)
@@ -608,13 +608,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn be_i128<I, E: ParserError<I>>(input: &mut I) -> PResult<i128, E>
+pub fn be_i128<Input, Error>(input: &mut Input) -> PResult<i128, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_i128", move |input: &mut I| {
+    trace("be_i128", move |input: &mut Input| {
         be_uint::<_, u128, _>(input, 16).map(|n| n as i128)
     })
     .parse_next(input)
@@ -656,10 +656,10 @@ where
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_u8<I, E: ParserError<I>>(input: &mut I) -> PResult<u8, E>
+pub fn le_u8<Input, Error>(input: &mut Input) -> PResult<u8, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    Error: ParserError<Input>,
 {
     u8(input)
 }
@@ -700,13 +700,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_u16<I, E: ParserError<I>>(input: &mut I) -> PResult<u16, E>
+pub fn le_u16<Input, Error>(input: &mut Input) -> PResult<u16, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_u16", move |input: &mut I| le_uint(input, 2)).parse_next(input)
+    trace("le_u16", move |input: &mut Input| le_uint(input, 2)).parse_next(input)
 }
 
 /// Recognizes a little endian unsigned 3 byte integer.
@@ -745,13 +745,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn le_u24<I, E: ParserError<I>>(input: &mut I) -> PResult<u32, E>
+pub fn le_u24<Input, Error>(input: &mut Input) -> PResult<u32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_u24", move |input: &mut I| le_uint(input, 3)).parse_next(input)
+    trace("le_u24", move |input: &mut Input| le_uint(input, 3)).parse_next(input)
 }
 
 /// Recognizes a little endian unsigned 4 bytes integer.
@@ -790,13 +790,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_u32<I, E: ParserError<I>>(input: &mut I) -> PResult<u32, E>
+pub fn le_u32<Input, Error>(input: &mut Input) -> PResult<u32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_u32", move |input: &mut I| le_uint(input, 4)).parse_next(input)
+    trace("le_u32", move |input: &mut Input| le_uint(input, 4)).parse_next(input)
 }
 
 /// Recognizes a little endian unsigned 8 bytes integer.
@@ -835,13 +835,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_u64<I, E: ParserError<I>>(input: &mut I) -> PResult<u64, E>
+pub fn le_u64<Input, Error>(input: &mut Input) -> PResult<u64, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_u64", move |input: &mut I| le_uint(input, 8)).parse_next(input)
+    trace("le_u64", move |input: &mut Input| le_uint(input, 8)).parse_next(input)
 }
 
 /// Recognizes a little endian unsigned 16 bytes integer.
@@ -880,25 +880,25 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn le_u128<I, E: ParserError<I>>(input: &mut I) -> PResult<u128, E>
+pub fn le_u128<Input, Error>(input: &mut Input) -> PResult<u128, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_u128", move |input: &mut I| le_uint(input, 16)).parse_next(input)
+    trace("le_u128", move |input: &mut Input| le_uint(input, 16)).parse_next(input)
 }
 
 #[inline]
-fn le_uint<I, Uint, E: ParserError<I>>(input: &mut I, bound: usize) -> PResult<Uint, E>
+fn le_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> PResult<Uint, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
     Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
+    Error: ParserError<Input>,
 {
     take(bound)
-        .map(|n: <I as Stream>::Slice| to_le_uint(n.as_bytes()))
+        .map(|n: <Input as Stream>::Slice| to_le_uint(n.as_bytes()))
         .parse_next(input)
 }
 
@@ -951,10 +951,10 @@ where
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_i8<I, E: ParserError<I>>(input: &mut I) -> PResult<i8, E>
+pub fn le_i8<Input, Error>(input: &mut Input) -> PResult<i8, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    Error: ParserError<Input>,
 {
     i8(input)
 }
@@ -995,13 +995,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_i16<I, E: ParserError<I>>(input: &mut I) -> PResult<i16, E>
+pub fn le_i16<Input, Error>(input: &mut Input) -> PResult<i16, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_i16", move |input: &mut I| {
+    trace("le_i16", move |input: &mut Input| {
         le_uint::<_, u16, _>(input, 2).map(|n| n as i16)
     })
     .parse_next(input)
@@ -1043,13 +1043,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn le_i24<I, E: ParserError<I>>(input: &mut I) -> PResult<i32, E>
+pub fn le_i24<Input, Error>(input: &mut Input) -> PResult<i32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_i24", move |input: &mut I| {
+    trace("le_i24", move |input: &mut Input| {
         le_uint::<_, u32, _>(input, 3).map(|n| {
             // Same as the unsigned version but we need to sign-extend manually here
             let n = if n & 0x80_00_00 != 0 {
@@ -1099,13 +1099,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_i32<I, E: ParserError<I>>(input: &mut I) -> PResult<i32, E>
+pub fn le_i32<Input, Error>(input: &mut Input) -> PResult<i32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_i32", move |input: &mut I| {
+    trace("le_i32", move |input: &mut Input| {
         le_uint::<_, u32, _>(input, 4).map(|n| n as i32)
     })
     .parse_next(input)
@@ -1147,13 +1147,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_i64<I, E: ParserError<I>>(input: &mut I) -> PResult<i64, E>
+pub fn le_i64<Input, Error>(input: &mut Input) -> PResult<i64, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_i64", move |input: &mut I| {
+    trace("le_i64", move |input: &mut Input| {
         le_uint::<_, u64, _>(input, 8).map(|n| n as i64)
     })
     .parse_next(input)
@@ -1195,13 +1195,13 @@ where
 /// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn le_i128<I, E: ParserError<I>>(input: &mut I) -> PResult<i128, E>
+pub fn le_i128<Input, Error>(input: &mut Input) -> PResult<i128, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_i128", move |input: &mut I| {
+    trace("le_i128", move |input: &mut Input| {
         le_uint::<_, u128, _>(input, 16).map(|n| n as i128)
     })
     .parse_next(input)
@@ -1246,13 +1246,13 @@ where
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn u8<I, E: ParserError<I>>(input: &mut I) -> PResult<u8, E>
+pub fn u8<Input, Error>(input: &mut Input) -> PResult<u8, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    Error: ParserError<Input>,
 {
-    trace("u8", move |input: &mut I| {
-        if <I as StreamIsPartial>::is_partial_supported() {
+    trace("u8", move |input: &mut Input| {
+        if <Input as StreamIsPartial>::is_partial_supported() {
             u8_::<_, _, true>(input)
         } else {
             u8_::<_, _, false>(input)
@@ -1261,16 +1261,16 @@ where
     .parse_next(input)
 }
 
-fn u8_<I, E: ParserError<I>, const PARTIAL: bool>(input: &mut I) -> PResult<u8, E>
+fn u8_<Input, Error, const PARTIAL: bool>(input: &mut Input) -> PResult<u8, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    Error: ParserError<Input>,
 {
     input.next_token().ok_or_else(|| {
         if PARTIAL && input.is_partial() {
             ErrMode::Incomplete(Needed::new(1))
         } else {
-            ErrMode::Backtrack(E::from_error_kind(input, ErrorKind::Token))
+            ErrMode::Backtrack(Error::from_error_kind(input, ErrorKind::Token))
         }
     })
 }
@@ -1329,13 +1329,13 @@ where
 /// assert_eq!(le_u16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn u16<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, u16, E>
+pub fn u16<Input, Error>(endian: Endianness) -> impl Parser<Input, u16, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_u16,
             Endianness::Little => le_u16,
@@ -1401,13 +1401,13 @@ where
 /// assert_eq!(le_u24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn u24<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, u32, E>
+pub fn u24<Input, Error>(endian: Endianness) -> impl Parser<Input, u32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_u24,
             Endianness::Little => le_u24,
@@ -1473,13 +1473,13 @@ where
 /// assert_eq!(le_u32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn u32<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, u32, E>
+pub fn u32<Input, Error>(endian: Endianness) -> impl Parser<Input, u32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_u32,
             Endianness::Little => le_u32,
@@ -1545,13 +1545,13 @@ where
 /// assert_eq!(le_u64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn u64<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, u64, E>
+pub fn u64<Input, Error>(endian: Endianness) -> impl Parser<Input, u64, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_u64,
             Endianness::Little => le_u64,
@@ -1617,13 +1617,13 @@ where
 /// assert_eq!(le_u128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn u128<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, u128, E>
+pub fn u128<Input, Error>(endian: Endianness) -> impl Parser<Input, u128, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_u128,
             Endianness::Little => le_u128,
@@ -1674,13 +1674,13 @@ where
 /// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn i8<I, E: ParserError<I>>(input: &mut I) -> PResult<i8, E>
+pub fn i8<Input, Error>(input: &mut Input) -> PResult<i8, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    Error: ParserError<Input>,
 {
-    trace("i8", move |input: &mut I| {
-        if <I as StreamIsPartial>::is_partial_supported() {
+    trace("i8", move |input: &mut Input| {
+        if <Input as StreamIsPartial>::is_partial_supported() {
             u8_::<_, _, true>(input)
         } else {
             u8_::<_, _, false>(input)
@@ -1744,13 +1744,13 @@ where
 /// assert_eq!(le_i16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn i16<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, i16, E>
+pub fn i16<Input, Error>(endian: Endianness) -> impl Parser<Input, i16, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_i16,
             Endianness::Little => le_i16,
@@ -1816,13 +1816,13 @@ where
 /// assert_eq!(le_i24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn i24<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, i32, E>
+pub fn i24<Input, Error>(endian: Endianness) -> impl Parser<Input, i32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_i24,
             Endianness::Little => le_i24,
@@ -1888,13 +1888,13 @@ where
 /// assert_eq!(le_i32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn i32<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, i32, E>
+pub fn i32<Input, Error>(endian: Endianness) -> impl Parser<Input, i32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_i32,
             Endianness::Little => le_i32,
@@ -1960,13 +1960,13 @@ where
 /// assert_eq!(le_i64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn i64<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, i64, E>
+pub fn i64<Input, Error>(endian: Endianness) -> impl Parser<Input, i64, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_i64,
             Endianness::Little => le_i64,
@@ -2032,13 +2032,13 @@ where
 /// assert_eq!(le_i128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn i128<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, i128, E>
+pub fn i128<Input, Error>(endian: Endianness) -> impl Parser<Input, i128, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_i128,
             Endianness::Little => le_i128,
@@ -2087,13 +2087,13 @@ where
 /// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_f32<I, E: ParserError<I>>(input: &mut I) -> PResult<f32, E>
+pub fn be_f32<Input, Error>(input: &mut Input) -> PResult<f32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_f32", move |input: &mut I| {
+    trace("be_f32", move |input: &mut Input| {
         be_uint::<_, u32, _>(input, 4).map(f32::from_bits)
     })
     .parse_next(input)
@@ -2135,13 +2135,13 @@ where
 /// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_f64<I, E: ParserError<I>>(input: &mut I) -> PResult<f64, E>
+pub fn be_f64<Input, Error>(input: &mut Input) -> PResult<f64, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_f64", move |input: &mut I| {
+    trace("be_f64", move |input: &mut Input| {
         be_uint::<_, u64, _>(input, 8).map(f64::from_bits)
     })
     .parse_next(input)
@@ -2183,13 +2183,13 @@ where
 /// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_f32<I, E: ParserError<I>>(input: &mut I) -> PResult<f32, E>
+pub fn le_f32<Input, Error>(input: &mut Input) -> PResult<f32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("le_f32", move |input: &mut I| {
+    trace("le_f32", move |input: &mut Input| {
         le_uint::<_, u32, _>(input, 4).map(f32::from_bits)
     })
     .parse_next(input)
@@ -2231,13 +2231,13 @@ where
 /// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_f64<I, E: ParserError<I>>(input: &mut I) -> PResult<f64, E>
+pub fn le_f64<Input, Error>(input: &mut Input) -> PResult<f64, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    trace("be_f64", move |input: &mut I| {
+    trace("be_f64", move |input: &mut Input| {
         le_uint::<_, u64, _>(input, 8).map(f64::from_bits)
     })
     .parse_next(input)
@@ -2297,13 +2297,13 @@ where
 /// assert_eq!(le_f32(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn f32<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, f32, E>
+pub fn f32<Input, Error>(endian: Endianness) -> impl Parser<Input, f32, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_f32,
             Endianness::Little => le_f32,
@@ -2369,13 +2369,13 @@ where
 /// assert_eq!(le_f64(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
-pub fn f64<I, E: ParserError<I>>(endian: Endianness) -> impl Parser<I, f64, E>
+pub fn f64<Input, Error>(endian: Endianness) -> impl Parser<Input, f64, Error>
 where
-    I: StreamIsPartial,
-    I: Stream<Token = u8>,
-    <I as Stream>::Slice: AsBytes,
+    Input: StreamIsPartial + Stream<Token = u8>,
+    <Input as Stream>::Slice: AsBytes,
+    Error: ParserError<Input>,
 {
-    move |input: &mut I| {
+    move |input: &mut Input| {
         match endian {
             Endianness::Big => be_f64,
             Endianness::Little => le_f64,
@@ -2396,9 +2396,6 @@ where
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
 /// *Partial version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
-///
-/// # Arguments
-/// * `f` The parser to apply.
 ///
 /// # Example
 ///
@@ -2422,16 +2419,17 @@ where
 /// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
 /// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
-pub fn length_take<I, N, E, F>(mut f: F) -> impl Parser<I, <I as Stream>::Slice, E>
+pub fn length_take<Input, Count, Error, CountParser>(
+    mut count: CountParser,
+) -> impl Parser<Input, <Input as Stream>::Slice, Error>
 where
-    I: StreamIsPartial,
-    I: Stream,
-    N: ToUsize,
-    F: Parser<I, N, E>,
-    E: ParserError<I>,
+    Input: StreamIsPartial + Stream,
+    Count: ToUsize,
+    CountParser: Parser<Input, Count, Error>,
+    Error: ParserError<Input>,
 {
-    trace("length_take", move |i: &mut I| {
-        let length = f.parse_next(i)?;
+    trace("length_take", move |i: &mut Input| {
+        let length = count.parse_next(i)?;
 
         crate::token::take(length).parse_next(i)
     })
@@ -2442,10 +2440,6 @@ where
 /// *Complete version*: Returns an error if there is not enough input data.
 ///
 /// *Partial version*: Will return `Err(winnow::error::ErrMode::Incomplete(_))` if there is not enough data.
-///
-/// # Arguments
-/// * `f` The parser to apply.
-/// * `g` The parser to apply on the subslice.
 ///
 /// # Example
 ///
@@ -2476,20 +2470,22 @@ where
 /// assert_eq!(parser(stream(b"\x00\x03123123")), Err(ErrMode::Backtrack(InputError::new(complete_stream(&b"123"[..]), ErrorKind::Tag))));
 /// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
-pub fn length_and_then<I, O, N, E, F, G>(mut f: F, mut g: G) -> impl Parser<I, O, E>
+pub fn length_and_then<Input, Output, Count, Error, CountParser, ParseNext>(
+    mut count: CountParser,
+    mut parser: ParseNext,
+) -> impl Parser<Input, Output, Error>
 where
-    I: StreamIsPartial,
-    I: Stream + UpdateSlice + Clone,
-    N: ToUsize,
-    F: Parser<I, N, E>,
-    G: Parser<I, O, E>,
-    E: ParserError<I>,
+    Input: StreamIsPartial + Stream + UpdateSlice + Clone,
+    Count: ToUsize,
+    CountParser: Parser<Input, Count, Error>,
+    ParseNext: Parser<Input, Output, Error>,
+    Error: ParserError<Input>,
 {
-    trace("length_and_then", move |i: &mut I| {
-        let data = length_take(f.by_ref()).parse_next(i)?;
-        let mut data = I::update_slice(i.clone(), data);
+    trace("length_and_then", move |i: &mut Input| {
+        let data = length_take(count.by_ref()).parse_next(i)?;
+        let mut data = Input::update_slice(i.clone(), data);
         let _ = data.complete();
-        let o = g.by_ref().complete_err().parse_next(&mut data)?;
+        let o = parser.by_ref().complete_err().parse_next(&mut data)?;
         Ok(o)
     })
 }
@@ -2497,10 +2493,6 @@ where
 /// [`Accumulate`] a length-prefixed sequence of values ([TLV](https://en.wikipedia.org/wiki/Type-length-value))
 ///
 /// If the length represents token counts, see instead [`length_take`]
-///
-/// # Arguments
-/// * `f` The parser to apply to obtain the count.
-/// * `g` The parser to apply repeatedly.
 ///
 /// # Example
 ///
@@ -2530,18 +2522,21 @@ where
 /// assert_eq!(parser(stream(b"\x03123123123")), Err(ErrMode::Backtrack(InputError::new(stream(b"123123123"), ErrorKind::Tag))));
 /// # }
 /// ```
-pub fn length_repeat<I, O, C, N, E, F, G>(mut f: F, mut g: G) -> impl Parser<I, C, E>
+pub fn length_repeat<Input, Output, Accumulator, Count, Error, CountParser, ParseNext>(
+    mut count: CountParser,
+    mut parser: ParseNext,
+) -> impl Parser<Input, Accumulator, Error>
 where
-    I: Stream,
-    N: ToUsize,
-    C: Accumulate<O>,
-    F: Parser<I, N, E>,
-    G: Parser<I, O, E>,
-    E: ParserError<I>,
+    Input: Stream,
+    Count: ToUsize,
+    Accumulator: Accumulate<Output>,
+    CountParser: Parser<Input, Count, Error>,
+    ParseNext: Parser<Input, Output, Error>,
+    Error: ParserError<Input>,
 {
-    trace("length_repeat", move |i: &mut I| {
-        let n = f.parse_next(i)?;
+    trace("length_repeat", move |i: &mut Input| {
+        let n = count.parse_next(i)?;
         let n = n.to_usize();
-        repeat(n, g.by_ref()).parse_next(i)
+        repeat(n, parser.by_ref()).parse_next(i)
     })
 }

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -48,10 +48,14 @@ pub trait Alt<I, O, E> {
 /// # }
 /// ```
 #[doc(alias = "choice")]
-pub fn alt<I: Stream, O, E: ParserError<I>, List: Alt<I, O, E>>(
-    mut l: List,
-) -> impl Parser<I, O, E> {
-    trace("alt", move |i: &mut I| l.choice(i))
+pub fn alt<Input: Stream, Output, Error, Alternatives>(
+    mut alternatives: Alternatives,
+) -> impl Parser<Input, Output, Error>
+where
+    Alternatives: Alt<Input, Output, Error>,
+    Error: ParserError<Input>,
+{
+    trace("alt", move |i: &mut Input| alternatives.choice(i))
 }
 
 /// Helper trait for the [permutation()] combinator.

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -12,8 +12,8 @@
 //! | [`none_of`][crate::token::none_of] | `none_of(['a', 'b', 'c'])` |  `"xyab"` |  `"yab"` | `Ok('x')` |Matches anything but the provided characters|
 //! | [`literal`][crate::token::literal] | `"hello"` |  `"hello world"` |  `" world"` | `Ok("hello")` |Recognizes a specific suite of characters or bytes (see also [`Caseless`][crate::ascii::Caseless])|
 //! | [`take`][crate::token::take] | `take(4)` |  `"hello"` |  `"o"` | `Ok("hell")` |Takes a specific number of bytes or characters|
-//! | [`take_while`][crate::token::take_while] | `take_while(0.., is_alphabetic)` |  `"abc123"` |  `"123"` | `Ok("abc")` |Returns the longest slice of bytes or characters for which the provided pattern matches.|
-//! | [`take_till`][crate::token::take_till] | `take_till(0.., is_alphabetic)` |  `"123abc"` |  `"abc"` | `Ok("123")` |Returns a slice of bytes or characters until the provided pattern matches. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(0.., \|c\| !f(c))`|
+//! | [`take_while`][crate::token::take_while] | `take_while(0.., is_alphabetic)` |  `"abc123"` |  `"123"` | `Ok("abc")` |Returns the longest slice of bytes or characters for which the provided set of tokens matches.|
+//! | [`take_till`][crate::token::take_till] | `take_till(0.., is_alphabetic)` |  `"123abc"` |  `"abc"` | `Ok("123")` |Returns a slice of bytes or characters until the provided set of tokens matches. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(0.., \|c\| !f(c))`|
 //! | [`take_until`][crate::token::take_until] | `take_until(0.., "world")` |  `"Hello world"` |  `"world"` | `Ok("Hello ")` |Returns a slice of bytes or characters until the provided [literal][crate::token::literal] is found.|
 //!
 //! ## Choice combinators

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -14,7 +14,7 @@
 //! | [`take`][crate::token::take] | `take(4)` |  `"hello"` |  `"o"` | `Ok("hell")` |Takes a specific number of bytes or characters|
 //! | [`take_while`][crate::token::take_while] | `take_while(0.., is_alphabetic)` |  `"abc123"` |  `"123"` | `Ok("abc")` |Returns the longest slice of bytes or characters for which the provided pattern matches.|
 //! | [`take_till`][crate::token::take_till] | `take_till(0.., is_alphabetic)` |  `"123abc"` |  `"abc"` | `Ok("123")` |Returns a slice of bytes or characters until the provided pattern matches. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(0.., \|c\| !f(c))`|
-//! | [`take_until`][crate::token::take_until] | `take_until(0.., "world")` |  `"Hello world"` |  `"world"` | `Ok("Hello ")` |Returns a slice of bytes or characters until the provided literal is found.|
+//! | [`take_until`][crate::token::take_until] | `take_until(0.., "world")` |  `"Hello world"` |  `"world"` | `Ok("Hello ")` |Returns a slice of bytes or characters until the provided [literal][crate::token::literal] is found.|
 //!
 //! ## Choice combinators
 //!

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -8,12 +8,12 @@
 //!
 //! | combinator | usage | input | new input | output | comment |
 //! |---|---|---|---|---|---|
-//! | [`one_of`][crate::token::one_of] | `one_of(['a', 'b', 'c'])` |  `"abc"` |  `"bc"` | `Ok('a')` |Matches one of the provided characters (works with non ASCII characters too)|
-//! | [`none_of`][crate::token::none_of] | `none_of(['a', 'b', 'c'])` |  `"xyab"` |  `"yab"` | `Ok('x')` |Matches anything but the provided characters|
+//! | [`one_of`][crate::token::one_of] | `one_of(['a', 'b', 'c'])` |  `"abc"` |  `"bc"` | `Ok('a')` |Matches one of the provided [set of tokens][crate::stream::ContainsToken] (works with non ASCII characters too)|
+//! | [`none_of`][crate::token::none_of] | `none_of(['a', 'b', 'c'])` |  `"xyab"` |  `"yab"` | `Ok('x')` |Matches anything but one of the provided [set of tokens][crate::stream::ContainsToken]|
 //! | [`literal`][crate::token::literal] | `"hello"` |  `"hello world"` |  `" world"` | `Ok("hello")` |Recognizes a specific suite of characters or bytes (see also [`Caseless`][crate::ascii::Caseless])|
 //! | [`take`][crate::token::take] | `take(4)` |  `"hello"` |  `"o"` | `Ok("hell")` |Takes a specific number of bytes or characters|
-//! | [`take_while`][crate::token::take_while] | `take_while(0.., is_alphabetic)` |  `"abc123"` |  `"123"` | `Ok("abc")` |Returns the longest slice of bytes or characters for which the provided set of tokens matches.|
-//! | [`take_till`][crate::token::take_till] | `take_till(0.., is_alphabetic)` |  `"123abc"` |  `"abc"` | `Ok("123")` |Returns a slice of bytes or characters until the provided set of tokens matches. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(0.., \|c\| !f(c))`|
+//! | [`take_while`][crate::token::take_while] | `take_while(0.., is_alphabetic)` |  `"abc123"` |  `"123"` | `Ok("abc")` |Returns the longest slice of bytes or characters for which the provided [set of tokens][crate::stream::ContainsToken] matches.|
+//! | [`take_till`][crate::token::take_till] | `take_till(0.., is_alphabetic)` |  `"123abc"` |  `"abc"` | `Ok("123")` |Returns a slice of bytes or characters until the provided [set of tokens][crate::stream::ContainsToken] matches. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(0.., \|c\| !f(c))`|
 //! | [`take_until`][crate::token::take_until] | `take_until(0.., "world")` |  `"Hello world"` |  `"world"` | `Ok("Hello ")` |Returns a slice of bytes or characters until the provided [literal][crate::token::literal] is found.|
 //!
 //! ## Choice combinators

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -12,9 +12,9 @@
 //! | [`none_of`][crate::token::none_of] | `none_of(['a', 'b', 'c'])` |  `"xyab"` |  `"yab"` | `Ok('x')` |Matches anything but the provided characters|
 //! | [`literal`][crate::token::literal] | `"hello"` |  `"hello world"` |  `" world"` | `Ok("hello")` |Recognizes a specific suite of characters or bytes (see also [`Caseless`][crate::ascii::Caseless])|
 //! | [`take`][crate::token::take] | `take(4)` |  `"hello"` |  `"o"` | `Ok("hell")` |Takes a specific number of bytes or characters|
-//! | [`take_while`][crate::token::take_while] | `take_while(0.., is_alphabetic)` |  `"abc123"` |  `"123"` | `Ok("abc")` |Returns the longest list of bytes for which the provided pattern matches.|
-//! | [`take_till`][crate::token::take_till] | `take_till(0.., is_alphabetic)` |  `"123abc"` |  `"abc"` | `Ok("123")` |Returns the longest list of bytes or characters until the provided pattern matches. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(0.., \|c\| !f(c))`|
-//! | [`take_until`][crate::token::take_until] | `take_until(0.., "world")` |  `"Hello world"` |  `"world"` | `Ok("Hello ")` |Returns the longest list of bytes or characters until the provided literal is found.|
+//! | [`take_while`][crate::token::take_while] | `take_while(0.., is_alphabetic)` |  `"abc123"` |  `"123"` | `Ok("abc")` |Returns the longest slice of bytes or characters for which the provided pattern matches.|
+//! | [`take_till`][crate::token::take_till] | `take_till(0.., is_alphabetic)` |  `"123abc"` |  `"abc"` | `Ok("123")` |Returns a slice of bytes or characters until the provided pattern matches. This is the reverse behaviour from `take_while`: `take_till(f)` is equivalent to `take_while(0.., \|c\| !f(c))`|
+//! | [`take_until`][crate::token::take_until] | `take_until(0.., "world")` |  `"Hello world"` |  `"world"` | `Ok("Hello ")` |Returns a slice of bytes or characters until the provided literal is found.|
 //!
 //! ## Choice combinators
 //!

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -15,11 +15,6 @@ use crate::Parser;
 /// This stops before `n` when the parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
 /// [`cut_err`][crate::combinator::cut_err].
 ///
-/// # Arguments
-/// * `m` The minimum number of iterations.
-/// * `n` The maximum number of iterations.
-/// * `f` The parser to apply.
-///
 /// To recognize a series of tokens, [`Accumulate`] into a `()` and then [`Parser::recognize`].
 ///
 /// **Warning:** If the parser passed to `repeat` accepts empty inputs
@@ -111,15 +106,18 @@ use crate::Parser;
 #[doc(alias = "skip_many")]
 #[doc(alias = "skip_many1")]
 #[inline(always)]
-pub fn repeat<I, O, C, E, P>(range: impl Into<Range>, parser: P) -> Repeat<P, I, O, C, E>
+pub fn repeat<Input, Output, Accumulator, Error, ParseNext>(
+    occurrences: impl Into<Range>,
+    parser: ParseNext,
+) -> Repeat<ParseNext, Input, Output, Accumulator, Error>
 where
-    I: Stream,
-    C: Accumulate<O>,
-    P: Parser<I, O, E>,
-    E: ParserError<I>,
+    Input: Stream,
+    Accumulator: Accumulate<Output>,
+    ParseNext: Parser<Input, Output, Error>,
+    Error: ParserError<Input>,
 {
     Repeat {
-        range: range.into(),
+        occurrences: occurrences.into(),
         parser,
         i: Default::default(),
         o: Default::default(),
@@ -137,7 +135,7 @@ where
     C: Accumulate<O>,
     E: ParserError<I>,
 {
-    range: Range,
+    occurrences: Range,
     parser: P,
     i: core::marker::PhantomData<I>,
     o: core::marker::PhantomData<O>,
@@ -145,11 +143,11 @@ where
     e: core::marker::PhantomData<E>,
 }
 
-impl<P, I, O, E> Repeat<P, I, O, (), E>
+impl<ParseNext, Input, Output, Error> Repeat<ParseNext, Input, Output, (), Error>
 where
-    P: Parser<I, O, E>,
-    I: Stream,
-    E: ParserError<I>,
+    ParseNext: Parser<Input, Output, Error>,
+    Input: Stream,
+    Error: ParserError<Input>,
 {
     /// Repeats the embedded parser, calling `g` to gather the results
     ///
@@ -247,25 +245,29 @@ where
     #[doc(alias = "fold_many_m_n")]
     #[doc(alias = "fold_repeat")]
     #[inline(always)]
-    pub fn fold<H, G, R>(mut self, mut init: H, mut g: G) -> impl Parser<I, R, E>
+    pub fn fold<Init, Op, Result>(
+        mut self,
+        mut init: Init,
+        mut op: Op,
+    ) -> impl Parser<Input, Result, Error>
     where
-        G: FnMut(R, O) -> R,
-        H: FnMut() -> R,
+        Init: FnMut() -> Result,
+        Op: FnMut(Result, Output) -> Result,
     {
         let Range {
             start_inclusive,
             end_inclusive,
-        } = self.range;
-        trace("repeat_fold", move |i: &mut I| {
+        } = self.occurrences;
+        trace("repeat_fold", move |i: &mut Input| {
             match (start_inclusive, end_inclusive) {
-                (0, None) => fold_repeat0_(&mut self.parser, &mut init, &mut g, i),
-                (1, None) => fold_repeat1_(&mut self.parser, &mut init, &mut g, i),
+                (0, None) => fold_repeat0_(&mut self.parser, &mut init, &mut op, i),
+                (1, None) => fold_repeat1_(&mut self.parser, &mut init, &mut op, i),
                 (start, end) => fold_repeat_m_n_(
                     start,
                     end.unwrap_or(usize::MAX),
                     &mut self.parser,
                     &mut init,
-                    &mut g,
+                    &mut op,
                     i,
                 ),
             }
@@ -285,7 +287,7 @@ where
         let Range {
             start_inclusive,
             end_inclusive,
-        } = self.range;
+        } = self.occurrences;
         trace("repeat", move |i: &mut I| {
             match (start_inclusive, end_inclusive) {
                 (0, None) => repeat0_(&mut self.parser, i),
@@ -474,26 +476,32 @@ where
 /// # }
 /// ```
 #[doc(alias = "many_till0")]
-pub fn repeat_till<I, O, C, P, E, F, G>(
-    range: impl Into<Range>,
-    mut f: F,
-    mut g: G,
-) -> impl Parser<I, (C, P), E>
+pub fn repeat_till<Input, Output, Accumulator, Terminator, Error, ParseNext, TerminatorParser>(
+    occurrences: impl Into<Range>,
+    mut parse: ParseNext,
+    mut terminator: TerminatorParser,
+) -> impl Parser<Input, (Accumulator, Terminator), Error>
 where
-    I: Stream,
-    C: Accumulate<O>,
-    F: Parser<I, O, E>,
-    G: Parser<I, P, E>,
-    E: ParserError<I>,
+    Input: Stream,
+    Accumulator: Accumulate<Output>,
+    ParseNext: Parser<Input, Output, Error>,
+    TerminatorParser: Parser<Input, Terminator, Error>,
+    Error: ParserError<Input>,
 {
     let Range {
         start_inclusive,
         end_inclusive,
-    } = range.into();
-    trace("repeat_till", move |i: &mut I| {
+    } = occurrences.into();
+    trace("repeat_till", move |i: &mut Input| {
         match (start_inclusive, end_inclusive) {
-            (0, None) => repeat_till0_(&mut f, &mut g, i),
-            (start, end) => repeat_till_m_n_(start, end.unwrap_or(usize::MAX), &mut f, &mut g, i),
+            (0, None) => repeat_till0_(&mut parse, &mut terminator, i),
+            (start, end) => repeat_till_m_n_(
+                start,
+                end.unwrap_or(usize::MAX),
+                &mut parse,
+                &mut terminator,
+                i,
+            ),
         }
     })
 }
@@ -600,11 +608,6 @@ where
 /// This stops when either parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
 /// [`cut_err`][crate::combinator::cut_err].
 ///
-/// # Arguments
-/// * `range` The minimum and maximum number of iterations.
-/// * `parser` The parser that parses the elements of the list.
-/// * `sep` The parser that parses the separator between list elements.
-///
 /// **Warning:** If the separator parser accepts empty inputs
 /// (like `alpha0` or `digit0`), `separated` will return an error,
 /// to prevent going into an infinite loop.
@@ -692,23 +695,23 @@ where
 #[doc(alias = "separated_list1")]
 #[doc(alias = "separated_m_n")]
 #[inline(always)]
-pub fn separated<I, O, C, O2, E, P, S>(
-    range: impl Into<Range>,
-    mut parser: P,
-    mut separator: S,
-) -> impl Parser<I, C, E>
+pub fn separated<Input, Output, Accumulator, Sep, Error, ParseNext, SepParser>(
+    occurrences: impl Into<Range>,
+    mut parser: ParseNext,
+    mut separator: SepParser,
+) -> impl Parser<Input, Accumulator, Error>
 where
-    I: Stream,
-    C: Accumulate<O>,
-    P: Parser<I, O, E>,
-    S: Parser<I, O2, E>,
-    E: ParserError<I>,
+    Input: Stream,
+    Accumulator: Accumulate<Output>,
+    ParseNext: Parser<Input, Output, Error>,
+    SepParser: Parser<Input, Sep, Error>,
+    Error: ParserError<Input>,
 {
     let Range {
         start_inclusive,
         end_inclusive,
-    } = range.into();
-    trace("separated", move |input: &mut I| {
+    } = occurrences.into();
+    trace("separated", move |input: &mut Input| {
         match (start_inclusive, end_inclusive) {
             (0, None) => separated0_(&mut parser, &mut separator, input),
             (1, None) => separated1_(&mut parser, &mut separator, input),
@@ -1011,19 +1014,19 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
 /// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(InputError::new("def|abc", ErrorKind::Verify))));
 /// ```
-pub fn separated_foldl1<I, O, O2, E, P, S, Op>(
-    mut parser: P,
-    mut sep: S,
+pub fn separated_foldl1<Input, Output, Sep, Error, ParseNext, SepParser, Op>(
+    mut parser: ParseNext,
+    mut sep: SepParser,
     mut op: Op,
-) -> impl Parser<I, O, E>
+) -> impl Parser<Input, Output, Error>
 where
-    I: Stream,
-    P: Parser<I, O, E>,
-    S: Parser<I, O2, E>,
-    E: ParserError<I>,
-    Op: FnMut(O, O2, O) -> O,
+    Input: Stream,
+    ParseNext: Parser<Input, Output, Error>,
+    SepParser: Parser<Input, Sep, Error>,
+    Error: ParserError<Input>,
+    Op: FnMut(Output, Sep, Output) -> Output,
 {
-    trace("separated_foldl1", move |i: &mut I| {
+    trace("separated_foldl1", move |i: &mut Input| {
         let mut ol = parser.parse_next(i)?;
 
         loop {
@@ -1080,21 +1083,21 @@ where
 /// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(InputError::new("def|abc", ErrorKind::Verify))));
 /// ```
 #[cfg(feature = "alloc")]
-pub fn separated_foldr1<I, O, O2, E, P, S, Op>(
-    mut parser: P,
-    mut sep: S,
+pub fn separated_foldr1<Input, Output, Sep, Error, ParseNext, SepParser, Op>(
+    mut parser: ParseNext,
+    mut sep: SepParser,
     mut op: Op,
-) -> impl Parser<I, O, E>
+) -> impl Parser<Input, Output, Error>
 where
-    I: Stream,
-    P: Parser<I, O, E>,
-    S: Parser<I, O2, E>,
-    E: ParserError<I>,
-    Op: FnMut(O, O2, O) -> O,
+    Input: Stream,
+    ParseNext: Parser<Input, Output, Error>,
+    SepParser: Parser<Input, Sep, Error>,
+    Error: ParserError<Input>,
+    Op: FnMut(Output, Sep, Output) -> Output,
 {
-    trace("separated_foldr1", move |i: &mut I| {
+    trace("separated_foldr1", move |i: &mut Input| {
         let ol = parser.parse_next(i)?;
-        let all: crate::lib::std::vec::Vec<(O2, O)> =
+        let all: crate::lib::std::vec::Vec<(Sep, Output)> =
             repeat(0.., (sep.by_ref(), parser.by_ref())).parse_next(i)?;
         if let Some((s, or)) = all
             .into_iter()
@@ -1112,10 +1115,6 @@ where
 /// Repeats the embedded parser, filling the given slice with results.
 ///
 /// This parser fails if the input runs out before the given slice is full.
-///
-/// # Arguments
-/// * `f` The parser to apply.
-/// * `buf` The slice to fill
 ///
 /// # Example
 ///
@@ -1136,16 +1135,19 @@ where
 /// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Tag))));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", ["abc", "abc"])));
 /// ```
-pub fn fill<'a, I, O, E, F>(mut f: F, buf: &'a mut [O]) -> impl Parser<I, (), E> + 'a
+pub fn fill<'i, Input, Output, Error, ParseNext>(
+    mut parser: ParseNext,
+    buf: &'i mut [Output],
+) -> impl Parser<Input, (), Error> + 'i
 where
-    I: Stream + 'a,
-    F: Parser<I, O, E> + 'a,
-    E: ParserError<I> + 'a,
+    Input: Stream + 'i,
+    ParseNext: Parser<Input, Output, Error> + 'i,
+    Error: ParserError<Input> + 'i,
 {
-    trace("fill", move |i: &mut I| {
+    trace("fill", move |i: &mut Input| {
         for elem in buf.iter_mut() {
             let start = i.checkpoint();
-            match f.parse_next(i) {
+            match parser.parse_next(i) {
                 Ok(o) => {
                     *elem = o;
                 }

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -450,6 +450,10 @@ where
 ///
 /// To recognize a series of tokens, [`Accumulate`] into a `()` and then [`Parser::recognize`].
 ///
+/// See also
+/// - [`take_till`][crate::token::take_till] for recognizing up-to a [pattern][crate::stream::ContainsToken]
+/// - [`take_until`][crate::token::take_until] for recognizing up-to a [`literal`][crate::token::literal] (w/ optional simd optimizations)
+///
 /// # Example
 ///
 /// ```rust

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -451,7 +451,7 @@ where
 /// To recognize a series of tokens, [`Accumulate`] into a `()` and then [`Parser::recognize`].
 ///
 /// See also
-/// - [`take_till`][crate::token::take_till] for recognizing up-to a [pattern][crate::stream::ContainsToken]
+/// - [`take_till`][crate::token::take_till] for recognizing up-to a member of a [set of tokens][crate::stream::ContainsToken]
 /// - [`take_until`][crate::token::take_until] for recognizing up-to a [`literal`][crate::token::literal] (w/ optional simd optimizations)
 ///
 /// # Example

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -3227,13 +3227,12 @@ impl<'a> AsChar for &'a char {
 
 /// Check if a token is in a set of possible tokens
 ///
-/// This is generally implemented on patterns that a token may match and supports `u8` and `char`
-/// tokens along with the following patterns
+/// While this can be implemented manually, you can also build up sets using:
 /// - `b'c'` and `'c'`
-/// - `b""` and `""`
+/// - `b""`
 /// - `|c| true`
 /// - `b'a'..=b'z'`, `'a'..='z'` (etc for each [range type][std::ops])
-/// - `(pattern1, pattern2, ...)`
+/// - `(set1, set2, ...)`
 ///
 /// # Example
 ///

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -634,6 +634,8 @@ where
 
 /// Recognize the longest input slice (if any) till a [pattern][ContainsToken] is met.
 ///
+/// It doesn't consume the pattern.
+///
 /// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
 ///

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -800,9 +800,9 @@ where
     }
 }
 
-/// Recognize the input slice up to the first occurrence of the literal.
+/// Recognize the input slice up to the first occurrence of a [literal].
 ///
-/// It doesn't consume the pattern.
+/// It doesn't consume the literal.
 ///
 /// *Complete version*: It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Slice)))`
 /// if the pattern wasn't met.

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -639,6 +639,10 @@ where
 /// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
 ///
+/// See also
+/// - [`take_until`] for recognizing up-to a [`literal`] (w/ optional simd optimizations)
+/// - [`repeat_till`][crate::combinator::repeat_till] with [`Parser::recognize`] for recognizing up to a [`Parser`]
+///
 /// # Example
 ///
 /// ```rust
@@ -811,6 +815,10 @@ where
 ///
 /// *Partial version*: will return a `ErrMode::Incomplete(Needed::new(N))` if the input doesn't
 /// contain the pattern or if the input is smaller than the pattern.
+///
+/// See also
+/// - [`take_till`] for recognizing up-to a [pattern][ContainsToken]
+/// - [`repeat_till`][crate::combinator::repeat_till] with [`Parser::recognize`] for recognizing up to a [`Parser`]
 ///
 /// # Example
 ///

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -80,7 +80,7 @@ where
 /// The input data will be compared to the literal combinator's argument and will return the part of
 /// the input that matches the argument
 ///
-/// It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Tag)))` if the input doesn't match the pattern
+/// It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Tag)))` if the input doesn't match the literal
 ///
 /// **Note:** [`Parser`] is implemented for strings and byte strings as a convenience (complete
 /// only)
@@ -172,7 +172,7 @@ where
     }
 }
 
-/// Recognize a token that matches the [pattern][ContainsToken]
+/// Recognize a token that matches a [set of tokens][ContainsToken]
 ///
 /// **Note:** [`Parser`] is implemented as a convenience (complete
 /// only) for
@@ -234,7 +234,7 @@ where
     )
 }
 
-/// Recognize a token that does not match the [pattern][ContainsToken]
+/// Recognize a token that does not match a [set of tokens][ContainsToken]
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///
@@ -274,12 +274,12 @@ where
     )
 }
 
-/// Recognize the longest (m <= len <= n) input slice that matches the [pattern][ContainsToken]
+/// Recognize the longest (m <= len <= n) input slice that matches a [set of tokens][ContainsToken]
 ///
-/// It will return an `ErrMode::Backtrack(InputError::new(_, ErrorKind::Slice))` if the pattern wasn't met or is out
+/// It will return an `ErrMode::Backtrack(InputError::new(_, ErrorKind::Slice))` if the set of tokens wasn't met or is out
 /// of range (m <= len <= n).
 ///
-/// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))` if the pattern reaches the end of the input or is too short.
+/// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))` if a member of the set of tokens reaches the end of the input or is too short.
 ///
 /// To recognize a series of tokens, use [`repeat`][crate::combinator::repeat] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`].
 ///
@@ -632,9 +632,9 @@ where
     }
 }
 
-/// Recognize the longest input slice (if any) till a [pattern][ContainsToken] is met.
+/// Recognize the longest input slice (if any) till a member of a [set of tokens][ContainsToken] is found.
 ///
-/// It doesn't consume the pattern.
+/// It doesn't consume the terminating token from the set.
 ///
 /// *Partial version* will return a `ErrMode::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
@@ -811,13 +811,13 @@ where
 /// It doesn't consume the literal.
 ///
 /// *Complete version*: It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Slice)))`
-/// if the pattern wasn't met.
+/// if the literal wasn't met.
 ///
 /// *Partial version*: will return a `ErrMode::Incomplete(Needed::new(N))` if the input doesn't
-/// contain the pattern or if the input is smaller than the pattern.
+/// contain the literal or if the input is smaller than the literal.
 ///
 /// See also
-/// - [`take_till`] for recognizing up-to a [pattern][ContainsToken]
+/// - [`take_till`] for recognizing up-to a [set of tokens][ContainsToken]
 /// - [`repeat_till`][crate::combinator::repeat_till] with [`Parser::recognize`] for recognizing up to a [`Parser`]
 ///
 /// # Example

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -808,6 +808,8 @@ where
 
 /// Recognize the input slice up to the first occurrence of a [literal].
 ///
+/// Feature `simd` will enable the use of [`memchr`](https://docs.rs/memchr/latest/memchr/).
+///
 /// It doesn't consume the literal.
 ///
 /// *Complete version*: It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Slice)))`


### PR DESCRIPTION
Feedback

> And every time the docs say "this is simple" or "this is easy" etc., it's really discouraging if you are struggling to understand.

"simple" is meant to convey "basic".  To avoid the mismatch between the language and people's potential experience, I've tried to find other words.

> One example is take_till vs take_until. Semantically that means the same thing, and their descriptions on the doc's list of combinators, seem to say the same thing just with different words.

The naming has always bothered me but I still don't have a better idea.   We can at least cross-reference and clarify the distinctions

> Another is the phrase "the longest list of bytes/chars"; it feels ambiguous. Is there a chance it'll return some kind of shorter list? "longest" is a comparison, but it's not clear what the alternative outcome there is.

This is meant to convey "greedy".  For `take_while`, this is true.  However, `take_til` isn't greedy, so this was clarified

> Briefly looking at it again, chapters 0 and 1 made sense. Chapter 2 mostly made sense, but it started to become very code-heavy, with minimal explanation. Like for example, https://docs.rs/winnow/latest/winnow/_tutorial/chapter_2/index.html#tokens, the first code block is showing an example of how to process a single token, as noted in the text above it. But then in the next block, any and verify are introduced without any details of what they are or how they are relevant.

We're trying to step through the transformation from lower level code to higher level.  I've tried to adjust that section to be more explicitly about that transformation.  This also opened up an opportunity to call out the value of using a `Parser` is the helpers you can then use.