### PR TITLE
fix(token): Be consistent on `take_until("")`

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -3479,6 +3479,7 @@ fn memchr3(token: (u8, u8, u8), slice: &[u8]) -> Option<usize> {
 #[inline(always)]
 fn memmem(slice: &[u8], literal: &[u8]) -> Option<crate::lib::std::ops::Range<usize>> {
     match literal.len() {
+        0 => Some(0..0),
         1 => memchr(literal[0], slice).map(|i| i..i + 1),
         _ => memmem_(slice, literal),
     }
@@ -3487,6 +3488,7 @@ fn memmem(slice: &[u8], literal: &[u8]) -> Option<crate::lib::std::ops::Range<us
 #[inline(always)]
 fn memmem2(slice: &[u8], literal: (&[u8], &[u8])) -> Option<crate::lib::std::ops::Range<usize>> {
     match (literal.0.len(), literal.1.len()) {
+        (0, _) | (_, 0) => Some(0..0),
         (1, 1) => memchr2((literal.0[0], literal.1[0]), slice).map(|i| i..i + 1),
         _ => memmem2_(slice, literal),
     }
@@ -3498,6 +3500,7 @@ fn memmem3(
     literal: (&[u8], &[u8], &[u8]),
 ) -> Option<crate::lib::std::ops::Range<usize>> {
     match (literal.0.len(), literal.1.len(), literal.2.len()) {
+        (0, _, _) | (_, 0, _) | (_, _, 0) => Some(0..0),
         (1, 1, 1) => memchr3((literal.0[0], literal.1[0], literal.2[0]), slice).map(|i| i..i + 1),
         _ => memmem3_(slice, literal),
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -3478,19 +3478,17 @@ fn memchr3(token: (u8, u8, u8), slice: &[u8]) -> Option<usize> {
 
 #[inline(always)]
 fn memmem(slice: &[u8], literal: &[u8]) -> Option<crate::lib::std::ops::Range<usize>> {
-    if literal.len() == 1 {
-        memchr(literal[0], slice).map(|i| i..i + 1)
-    } else {
-        memmem_(slice, literal)
+    match literal.len() {
+        1 => memchr(literal[0], slice).map(|i| i..i + 1),
+        _ => memmem_(slice, literal),
     }
 }
 
 #[inline(always)]
 fn memmem2(slice: &[u8], literal: (&[u8], &[u8])) -> Option<crate::lib::std::ops::Range<usize>> {
-    if literal.0.len() == 1 && literal.1.len() == 1 {
-        memchr2((literal.0[0], literal.1[0]), slice).map(|i| i..i + 1)
-    } else {
-        memmem2_(slice, literal)
+    match (literal.0.len(), literal.1.len()) {
+        (1, 1) => memchr2((literal.0[0], literal.1[0]), slice).map(|i| i..i + 1),
+        _ => memmem2_(slice, literal),
     }
 }
 
@@ -3499,10 +3497,9 @@ fn memmem3(
     slice: &[u8],
     literal: (&[u8], &[u8], &[u8]),
 ) -> Option<crate::lib::std::ops::Range<usize>> {
-    if literal.0.len() == 1 && literal.1.len() == 1 && literal.2.len() == 1 {
-        memchr3((literal.0[0], literal.1[0], literal.2[0]), slice).map(|i| i..i + 1)
-    } else {
-        memmem3_(slice, literal)
+    match (literal.0.len(), literal.1.len(), literal.2.len()) {
+        (1, 1, 1) => memchr3((literal.0[0], literal.1[0], literal.2[0]), slice).map(|i| i..i + 1),
+        _ => memmem3_(slice, literal),
     }
 }
 

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -102,12 +102,6 @@ fn complete_take_until_empty() {
     fn take_until_empty(i: &str) -> IResult<&str, &str> {
         take_until(0, "").parse_peek(i)
     }
-    #[cfg(not(feature = "simd"))]
-    assert_eq!(
-        take_until_empty(""),
-        Err(ErrMode::Backtrack(error_position!(&"", ErrorKind::Slice)))
-    );
-    #[cfg(feature = "simd")]
     assert_eq!(take_until_empty(""), Ok(("", "")));
     assert_eq!(take_until_empty("end"), Ok(("end", "")));
 }

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -98,6 +98,21 @@ fn complete_take_until() {
 }
 
 #[test]
+fn complete_take_until_empty() {
+    fn take_until_empty(i: &str) -> IResult<&str, &str> {
+        take_until(0, "").parse_peek(i)
+    }
+    #[cfg(not(feature = "simd"))]
+    assert_eq!(
+        take_until_empty(""),
+        Err(ErrMode::Backtrack(error_position!(&"", ErrorKind::Slice)))
+    );
+    #[cfg(feature = "simd")]
+    assert_eq!(take_until_empty(""), Ok(("", "")));
+    assert_eq!(take_until_empty("end"), Ok(("end", "")));
+}
+
+#[test]
 fn complete_literal_case_insensitive() {
     fn caseless_bytes(i: &[u8]) -> IResult<&[u8], &[u8]> {
         literal(Caseless("ABcd")).parse_peek(i)


### PR DESCRIPTION
We aren't consistent on empty buffers between `simd` and not.

Fixes #489