### PR TITLE
Add impl `ErrorConvert` for `ContextError`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -711,6 +711,13 @@ impl crate::lib::std::fmt::Display for ContextError<StrContext> {
     }
 }
 
+impl<C> ErrorConvert<ContextError<C>> for ContextError<C> {
+    #[inline]
+    fn convert(self) -> ContextError<C> {
+        self
+    }
+}
+
 /// Additional parse context for [`ContextError`] added via [`Parser::context`]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]


### PR DESCRIPTION
Quick fix for #498

I didn't touch TreeError because I couldn't see a particularly easy way of converting input types on it other than rewriting the entire tree which seemed a bit over the top.

I added the `InputError` -> `ContextError` conversion because I could rather than because I needed it, I can remove it if you don't want it.