### PR TITLE
Don't split input over multiple lines in debug view.

### DIFF
--- a/src/combinator/debug/internals.rs
+++ b/src/combinator/debug/internals.rs
@@ -146,7 +146,7 @@ pub fn start<I: Stream>(
 
     // The debug version of `slice` might be wider, either due to rendering one byte as two nibbles or
     // escaping in strings.
-    let mut debug_slice = format!("{:#?}", input.raw());
+    let mut debug_slice = format!("{:?}", input.raw());
     let (debug_slice, eof) = if let Some(debug_offset) = debug_slice
         .char_indices()
         .enumerate()


### PR DESCRIPTION
If the Input type is a slice, using `{:#?}` will insert newlines into
the debug view. This messes up the output, which is counting charecters
to fill a single line.

Before:

```
> alt                                                      | [
    Call @ 0..4,
    Ident
 > separated_foldl1                                        | [
    Call @ 0..4,
    Ident
  > separated_foldl1                                       | [
    Call @ 0..4,
    Ident
   > separated_foldl1                                      | [
    Call @ 0..4,
    Ident
    > separated_foldl1                                     | [
    Call @ 0..4,
    Ident
     > separated_foldl1                                    | [
    Call @ 0..4,
    Ident
      > separated_foldl1                                   | [
    Call @ 0..4,
    Ident
       > alt                                               | [
    Call @ 0..4,
    Ident
        > alt                                              | [
    Call @ 0..4,
    Ident
         > one_of                                          | [
    Call @ 0..4,
    Ident
          > any                                            | [
    Call @ 0..4,
    Ident
```

After:

```
> alt                                                      | [Call @ 0..4, Ident @ 5..19,
 > separated_foldl1                                        | [Call @ 0..4, Ident @ 5..19,
  > separated_foldl1                                       | [Call @ 0..4, Ident @ 5..19,
   > separated_foldl1                                      | [Call @ 0..4, Ident @ 5..19,
    > separated_foldl1                                     | [Call @ 0..4, Ident @ 5..19,
     > separated_foldl1                                    | [Call @ 0..4, Ident @ 5..19,
      > separated_foldl1                                   | [Call @ 0..4, Ident @ 5..19,
       > alt                                               | [Call @ 0..4, Ident @ 5..19,
        > alt                                              | [Call @ 0..4, Ident @ 5..19,
         > one_of                                          | [Call @ 0..4, Ident @ 5..19,
          > any                                            | [Call @ 0..4, Ident @ 5..19,
```

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
