### PR TITLE
Update command in chapter 8

### DIFF
--- a/src/_tutorial/chapter_8.rs
+++ b/src/_tutorial/chapter_8.rs
@@ -1,7 +1,7 @@
 //! # Chapter 8: Debugging
 //!
 //! When things inevitably go wrong, you can introspect the parsing state by running your test case
-//! with `--features debug`:
+//! with `--features winnow/debug`:
 //! ![Trace output from string example](https://raw.githubusercontent.com/winnow-rs/winnow/main/assets/trace.svg "Example output")
 //!
 //! You can extend your own parsers to show up by wrapping their body with


### PR DESCRIPTION
While trying to run tests with the debug feature using the tutorial's command, I encountered an error:

```bash
$ cargo test --features debug
error: none of the selected packages contains these features: debug
```

After some investigation and learning how features in cargo work, I found that using `cargo test --features winnow/debug` resolved the issue. I recommend updating the tutorial to include this command to avoid future confusion for other users.