### PR TITLE
Fix documentation for space1 combinator

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -942,7 +942,7 @@ where
     trace("space0", take_while(0.., AsChar::is_space)).parse_next(input)
 }
 
-/// Recognizes zero or more spaces and tabs.
+/// Recognizes one or more spaces and tabs.
 ///
 /// *Complete version*: Will return the whole input if no terminating token is found (a non space
 /// character).


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
No issue because obvious bug: "zero or more" should be "one or more" for the `space1` combinator.