### PR TITLE
feat(comb): Allow 'alt' on array refs

### DIFF
--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -149,6 +149,31 @@ impl<const N: usize, I: Stream, O, E: ParserError<I>, P: Parser<I, O, E>> Alt<I,
     }
 }
 
+impl<I: Stream, O, E: ParserError<I>, P: Parser<I, O, E>> Alt<I, O, E> for &mut [P] {
+    fn choice(&mut self, input: &mut I) -> PResult<O, E> {
+        let mut error: Option<E> = None;
+
+        let start = input.checkpoint();
+        for branch in self.iter_mut() {
+            input.reset(&start);
+            match branch.parse_next(input) {
+                Err(ErrMode::Backtrack(e)) => {
+                    error = match error {
+                        Some(error) => Some(error.or(e)),
+                        None => Some(e),
+                    };
+                }
+                res => return res,
+            }
+        }
+
+        match error {
+            Some(e) => Err(ErrMode::Backtrack(e.append(input, &start, ErrorKind::Alt))),
+            None => Err(ErrMode::assert(input, "`alt` needs at least one parser")),
+        }
+    }
+}
+
 macro_rules! alt_trait(
   ($first:ident $second:ident $($id: ident)+) => (
     alt_trait!(__impl $first $second; $($id)+);

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -671,6 +671,22 @@ fn alt_array() {
 }
 
 #[test]
+fn alt_dynamic_array() {
+    fn alt1<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        alt(&mut ["a", "bc", "def"][..]).parse_next(i)
+    }
+
+    let a = &b"a"[..];
+    assert_eq!(alt1.parse_peek(a), Ok((&b""[..], (&b"a"[..]))));
+
+    let bc = &b"bc"[..];
+    assert_eq!(alt1.parse_peek(bc), Ok((&b""[..], (&b"bc"[..]))));
+
+    let defg = &b"defg"[..];
+    assert_eq!(alt1.parse_peek(defg), Ok((&b"g"[..], (&b"def"[..]))));
+}
+
+#[test]
 fn permutation_test() {
     #[allow(clippy::type_complexity)]
     fn perm(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8], &[u8])> {


### PR DESCRIPTION
This mirrors rust-bakery/nom#1754

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
