### PR TITLE
Refactor `dispatch!`; fixes #344

### DIFF
--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -3,6 +3,8 @@ use crate::error::{ErrMode, ErrorKind, ParserError};
 use crate::stream::Stream;
 use crate::*;
 
+#[doc(hidden)]
+pub use crate::__dispatch_cases;
 #[doc(inline)]
 pub use crate::dispatch;
 

--- a/src/macros/dispatch.rs
+++ b/src/macros/dispatch.rs
@@ -39,17 +39,83 @@
 /// ```
 #[macro_export]
 #[doc(hidden)] // forced to be visible in intended location
+macro_rules! __dispatch_cases {
+    ([ ] $i:tt $initial:tt $($acc:tt)*) => {
+        match $initial {
+            $($acc)*
+        }
+    };
+    ([ $pat:pat $(if $pred:expr)? => $expr:expr $(,)? ] $i:tt $($acc:tt)*) => {
+        $crate::combinator::__dispatch_cases!([ ] $i $($acc)* $pat $(if $pred)? => $expr.parse_next($i),)
+    };
+    ([ $pat:pat $(if $pred:expr)? => $expr:expr, $($rest:tt)+ ] $i:tt $($acc:tt)*) => {
+        $crate::combinator::__dispatch_cases!([ $($rest)+ ] $i $($acc)* $pat $(if $pred)? => $expr.parse_next($i),)
+    };
+    // NOTE: Must be the last rule otherwise the `{ ... },` (trailing comma) will fail to parse.
+    ([ $pat:pat $(if $pred:expr)? => { $($body:tt)* } $($rest:tt)+ ] $i:tt $($acc:tt)*) => {
+        $crate::combinator::__dispatch_cases!([ $($rest)+ ] $i $($acc)* $pat $(if $pred)? => { $($body)* }.parse_next($i),)
+    };
+}
+
+#[macro_export]
+#[doc(hidden)] // forced to be visible in intended location
 macro_rules! dispatch {
-    ($match_parser: expr; $( $pat:pat $(if $pred:expr)? => $expr: expr ),+ $(,)? ) => {
-        $crate::combinator::trace("dispatch", move |i: &mut _|
-        {
+    ($match_parser:expr; $($cases:tt)+) => {
+        $crate::combinator::trace("dispatch", move |i: &mut _| {
             use $crate::Parser;
             let initial = $match_parser.parse_next(i)?;
-            match initial {
-                $(
-                    $pat $(if $pred)? => $expr.parse_next(i),
-                )*
-            }
+            $crate::combinator::__dispatch_cases!([ $($cases)+ ] i initial)
         })
+    };
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn parse_block_with_trailing_comma() {
+        use crate::combinator::{dispatch, empty, fail, preceded};
+        use crate::prelude::*;
+        use crate::token::any;
+
+        #[allow(unused)]
+        fn escaped(input: &mut &str) -> PResult<char> {
+            preceded('\\', escape_seq_char).parse_next(input)
+        }
+
+        #[allow(unused)]
+        fn escape_seq_char(input: &mut &str) -> PResult<char> {
+            dispatch! {any;
+                'b' => {
+                    empty.value('\u{8}')
+                },
+                'f' => empty.value('\u{c}'),
+                _ => fail::<_, char, _>,
+            }
+            .parse_next(input)
+        }
+    }
+
+    #[test]
+    fn parse_block_sans_trailing_comma() {
+        use crate::combinator::{dispatch, empty, fail, preceded};
+        use crate::prelude::*;
+        use crate::token::any;
+
+        #[allow(unused)]
+        fn escaped(input: &mut &str) -> PResult<char> {
+            preceded('\\', escape_seq_char).parse_next(input)
+        }
+
+        #[allow(unused)]
+        fn escape_seq_char(input: &mut &str) -> PResult<char> {
+            dispatch! {any;
+                'b' => {
+                    empty.value('\u{8}')
+                }
+                'f' => empty.value('\u{c}'),
+                _ => fail::<_, char, _>,
+            }
+            .parse_next(input)
+        }
     }
 }


### PR DESCRIPTION
This PR fixes #344.

There may be a simpler way to factor the rules but I couldn't find one easily.

The main reason for the complexity is that handling the trailing comma differently (depending on block or simple expression) requires separate rules. This is because alternation cannot be expressed in the rule patterns and the workaround is to use recursion.

Additionally, macros cannot expand in match arm positions, so an accumulator pattern must be used, rather than immediately expanding a match arm and then recursing.

This also has the potential to make the macro expansion for `dispatch` slower (particularly on very large branches, due to the inherent re-parsing of the token trees) but I haven't tested how much of an impact that has.