### PR TITLE
docs(tut): Add cross ref to chapter 6

### DIFF
--- a/src/_tutorial/chapter_7.rs
+++ b/src/_tutorial/chapter_7.rs
@@ -567,6 +567,9 @@
 //! - Correctly reporting columns with unicode
 //! - Conforming to a specific layout
 //!
+//! As a reminder [`chapter_6`] demonstrated how to convert a [`PResult`] to a standard
+//! Rust [`Result`], and this section assumes that has been done.
+//!
 //! For example, to get rustc-like errors with [`annotate-snippets`](https://crates.io/crates/annotate-snippets):
 //! ```rust
 //! # use winnow::prelude::*;
@@ -712,6 +715,7 @@
 #![allow(unused_imports)]
 use super::chapter_1;
 use super::chapter_3;
+use super::chapter_6;
 use crate::combinator::alt;
 use crate::combinator::cut_err;
 use crate::combinator::fail;


### PR DESCRIPTION
This helps when users try to use the docs as a reference to solve their issue at hand (as opposed to reading in order and remembering everything).

Related to discussion #544

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
