### PR TITLE
chore: Correct ^ error position in unicode strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,8 @@ dependencies = [
  "snapbox",
  "term-transcript",
  "terminal_size",
+ "unicode-width",
+ "winnow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ std = ["alloc", "memchr?/std"]
 simd = ["dep:memchr"]
 debug = ["std", "dep:anstream", "dep:anstyle", "dep:is-terminal", "dep:terminal_size"]
 unstable-recover = []
+unicode-width = ["dep:unicode-width"]
 
 unstable-doc = ["alloc", "std", "simd", "unstable-recover"]
 
@@ -129,6 +130,7 @@ anstyle = { version = "1.0.1", optional = true }
 is-terminal = { version = "0.4.9", optional = true }
 memchr = { version = "2.5", optional = true, default-features = false }
 terminal_size = { version = "0.2.6", optional = true }
+unicode-width = {version = "0.1.13", optional = true}
 
 [dev-dependencies]
 doc-comment = "0.3"
@@ -141,6 +143,7 @@ circular = "0.3.0"
 rustc-hash = "1.1.0"
 automod = "1.0.14"
 annotate-snippets = "0.11.3"
+winnow = {path = ".", features = ["unicode-width"]}
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
# Problem

Given we have the following string:

```rust
let input = r#""Hello, 世界! 🌍\*""
```

Let's say that `\*` represents an invalid sequence. By default `^` error symbol would be misplaced in the standard output:

```sh
  |
7 |     "Hello, 世界! 🌍\*"
  |                ^
```

This happens because symbols like `世界🌍` have double width in fixed width fonts.

The more emojis precede an error, the more the error pointer shifts. It is confusing, especially if errors are displayed to the end user.

# Solution

Adds `unicode-width` feature, which calculates correct offset using `unicode-width` crate.

```sh
  |
7 |     "Hello, 世界! 🌍\*"
  |                    ^
```

Thank you for this great crate!