### PR TITLE
doc: Add a blank line between paragraph and image

### DIFF
--- a/src/_tutorial/chapter_8.rs
+++ b/src/_tutorial/chapter_8.rs
@@ -2,6 +2,7 @@
 //!
 //! When things inevitably go wrong, you can introspect the parsing state by running your test case
 //! with `--features winnow/debug`:
+//!
 //! ![Trace output from string example](https://raw.githubusercontent.com/winnow-rs/winnow/main/assets/trace.svg "Example output")
 //!
 //! You can extend your own parsers to show up by wrapping their body with


### PR DESCRIPTION
This prevents the large image from appearing inline in the last line of
the paragraph.

Without this fix:

![image](https://github.com/winnow-rs/winnow/assets/162737/b367adcf-1ee3-425e-8dcc-b90eacc83ceb)