### PR TITLE
test(binary): Cover more cases

### DIFF
--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -797,6 +797,22 @@ mod partial {
     }
 
     #[test]
+    fn le_u16_tests() {
+        assert_parse!(
+            le_u16.parse_peek(Partial::new(&[0x00, 0x03][..])),
+            Ok((Partial::new(&b""[..]), 0x0300))
+        );
+        assert_parse!(
+            le_u16.parse_peek(Partial::new(&[b'a', b'b'][..])),
+            Ok((Partial::new(&b""[..]), 0x6261))
+        );
+        assert_parse!(
+            le_u16.parse_peek(Partial::new(&[0x01][..])),
+            Err(ErrMode::Incomplete(Needed::new(1)))
+        );
+    }
+
+    #[test]
     fn le_i8_tests() {
         assert_parse!(
             le_i8.parse_peek(Partial::new(&[0x00][..])),
@@ -865,6 +881,22 @@ mod partial {
         assert_parse!(
             le_i24.parse_peek(Partial::new(&[0xAA, 0xCB, 0xED][..])),
             Ok((Partial::new(&b""[..]), -1_193_046_i32))
+        );
+    }
+
+    #[test]
+    fn le_u32_test() {
+        assert_parse!(
+            le_u32.parse_peek(Partial::new(&[0x00, 0x03, 0x05, 0x07][..])),
+            Ok((Partial::new(&b""[..]), 0x07050300))
+        );
+        assert_parse!(
+            le_u32.parse_peek(Partial::new(&[b'a', b'b', b'c', b'd'][..])),
+            Ok((Partial::new(&b""[..]), 0x64636261))
+        );
+        assert_parse!(
+            le_u32.parse_peek(Partial::new(&[0x01][..])),
+            Err(ErrMode::Incomplete(Needed::new(3)))
         );
     }
 


### PR DESCRIPTION
Pulled from rust-bakery/nom#1769

I skipped the float ones because I didn't feel like adapting them to the `binary` mod.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
