### PR TITLE
fix: Rename `recognize` to `take` for consistency 

### DIFF
--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -52,7 +52,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static s
     .parse_next(input)
 }
 
-/// `literal(string)` generates a parser that recognizes the argument string.
+/// `literal(string)` generates a parser that takes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
 fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
@@ -75,7 +75,7 @@ fn boolean<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bo
     alt((parse_true, parse_false)).parse_next(input)
 }
 
-/// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
+/// This parser gathers all `char`s up into a `String`with a parse to take the double quote
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>(
     input: &mut Stream<'i>,

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -59,7 +59,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static s
     .parse_next(input)
 }
 
-/// `literal(string)` generates a parser that recognizes the argument string.
+/// `literal(string)` generates a parser that takes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
 fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
@@ -84,7 +84,7 @@ fn false_<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<boo
     "false".value(false).parse_next(input)
 }
 
-/// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
+/// This parser gathers all `char`s up into a `String`with a parse to take the double quote
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>(
     input: &mut Stream<'i>,

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -53,7 +53,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static s
     .parse_next(input)
 }
 
-/// `literal(string)` generates a parser that recognizes the argument string.
+/// `literal(string)` generates a parser that takes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
 fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
@@ -76,7 +76,7 @@ fn boolean<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bo
     alt((parse_true, parse_false)).parse_next(input)
 }
 
-/// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
+/// This parser gathers all `char`s up into a `String`with a parse to take the double quote
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>(
     input: &mut Stream<'i>,

--- a/examples/ndjson/parser.rs
+++ b/examples/ndjson/parser.rs
@@ -57,7 +57,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static s
     .parse_next(input)
 }
 
-/// `literal(string)` generates a parser that recognizes the argument string.
+/// `literal(string)` generates a parser that takes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
 fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
@@ -80,7 +80,7 @@ fn boolean<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bo
     alt((parse_true, parse_false)).parse_next(input)
 }
 
-/// This parser gathers all `char`s up into a `String`with a parse to recognize the double quote
+/// This parser gathers all `char`s up into a `String`with a parse to take the double quote
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, &'static str>>(
     input: &mut Stream<'i>,

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -116,16 +116,16 @@
 //!       one_of(|c: char| c.is_alpha() || c == '_'),
 //!       take_while(0.., |c: char| c.is_alphanum() || c == '_')
 //!   )
-//!   .recognize()
+//!   .take()
 //!   .parse_next(input)
 //! }
 //! ```
 //!
 //! Let's say we apply this to the identifier `hello_world123abc`. The first element of the tuple
-//! would uses [`one_of`][crate::token::one_of] which would recognize `h`. The tuple ensures that
+//! would uses [`one_of`][crate::token::one_of] which would take `h`. The tuple ensures that
 //! `ello_world123abc` will be piped to the next [`take_while`][crate::token::take_while] parser,
-//! which recognizes every remaining character. However, the tuple returns a tuple of the results
-//! of its sub-parsers. The [`recognize`][crate::Parser::recognize] parser produces a `&str` of the
+//! which takes every remaining character. However, the tuple returns a tuple of the results
+//! of its sub-parsers. The [`take`][crate::Parser::take] parser produces a `&str` of the
 //! input text that was parsed, which in this case is the entire `&str` `hello_world123abc`.
 //!
 //! ## Literal Values
@@ -166,7 +166,7 @@
 //!     alt(("0x", "0X")),
 //!     repeat(1..,
 //!       terminated(one_of(('0'..='9', 'a'..='f', 'A'..='F')), repeat(0.., '_').map(|()| ()))
-//!     ).map(|()| ()).recognize()
+//!     ).map(|()| ()).take()
 //!   ).parse_next(input)
 //! }
 //! ```
@@ -187,7 +187,7 @@
 //!     alt(("0x", "0X")),
 //!     repeat(1..,
 //!       terminated(one_of(('0'..='9', 'a'..='f', 'A'..='F')), repeat(0.., '_').map(|()| ()))
-//!     ).map(|()| ()).recognize()
+//!     ).map(|()| ()).take()
 //!   ).try_map(
 //!     |out: &str| i64::from_str_radix(&str::replace(&out, "_", ""), 16)
 //!   ).parse_next(input)
@@ -212,7 +212,7 @@
 //!     alt(("0o", "0O")),
 //!     repeat(1..,
 //!       terminated(one_of('0'..='7'), repeat(0.., '_').map(|()| ()))
-//!     ).map(|()| ()).recognize()
+//!     ).map(|()| ()).take()
 //!   ).parse_next(input)
 //! }
 //! ```
@@ -233,7 +233,7 @@
 //!     alt(("0b", "0B")),
 //!     repeat(1..,
 //!       terminated(one_of('0'..='1'), repeat(0.., '_').map(|()| ()))
-//!     ).map(|()| ()).recognize()
+//!     ).map(|()| ()).take()
 //!   ).parse_next(input)
 //! }
 //! ```
@@ -252,7 +252,7 @@
 //!   repeat(1..,
 //!     terminated(one_of('0'..='9'), repeat(0.., '_').map(|()| ()))
 //!   ).map(|()| ())
-//!     .recognize()
+//!     .take()
 //!     .parse_next(input)
 //! }
 //! ```
@@ -284,7 +284,7 @@
 //!         opt(one_of(['+', '-'])),
 //!         decimal
 //!       ))
-//!     ).recognize()
+//!     ).take()
 //!     , // Case two: 42e42 and 42.42e42
 //!     (
 //!       decimal,
@@ -295,13 +295,13 @@
 //!       one_of(['e', 'E']),
 //!       opt(one_of(['+', '-'])),
 //!       decimal
-//!     ).recognize()
+//!     ).take()
 //!     , // Case three: 42. and 42.42
 //!     (
 //!       decimal,
 //!       '.',
 //!       opt(decimal)
-//!     ).recognize()
+//!     ).take()
 //!   )).parse_next(input)
 //! }
 //!
@@ -310,7 +310,7 @@
 //!     terminated(one_of('0'..='9'), repeat(0.., '_').map(|()| ()))
 //!   ).
 //!   map(|()| ())
-//!     .recognize()
+//!     .take()
 //!     .parse_next(input)
 //! }
 //! ```

--- a/src/_tutorial/chapter_5.rs
+++ b/src/_tutorial/chapter_5.rs
@@ -201,7 +201,7 @@
 //!
 //! If you look closely at [`repeat`], it isn't collecting directly into a [`Vec`] but
 //! anything that implements the [`Accumulate`] trait to gather the results. This lets us make more complex parsers than we did in
-//! [`chapter_2`] by accumulating the results into a `()` and [`recognize`][Parser::recognize]-ing the captured input:
+//! [`chapter_2`] by accumulating the results into a `()` and [`take`][Parser::take]-ing the captured input:
 //! ```rust
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
@@ -210,8 +210,8 @@
 //! # use winnow::combinator::fail;
 //! # use winnow::combinator::separated;
 //! #
-//! fn recognize_list<'s>(input: &mut &'s str) -> PResult<&'s str> {
-//!     parse_list.recognize().parse_next(input)
+//! fn take_list<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//!     parse_list.take().parse_next(input)
 //! }
 //!
 //! fn parse_list(input: &mut &str) -> PResult<()> {
@@ -257,7 +257,7 @@
 //! fn main() {
 //!     let mut input = "0x1a2b,0x3c4d,0x5e6f Hello";
 //!
-//!     let digits = recognize_list.parse_next(&mut input).unwrap();
+//!     let digits = take_list.parse_next(&mut input).unwrap();
 //!
 //!     assert_eq!(input, " Hello");
 //!     assert_eq!(digits, "0x1a2b,0x3c4d,0x5e6f");

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1132,7 +1132,7 @@ where
 {
     trace("dec_uint", move |input: &mut Input| {
         alt(((one_of('1'..='9'), digit0).void(), one_of('0').void()))
-            .recognize()
+            .take()
             .verify_map(|s: <Input as Stream>::Slice| {
                 let s = s.as_bstr();
                 // SAFETY: Only 7-bit ASCII characters are parsed
@@ -1222,7 +1222,7 @@ where
             _ => fail,
         });
         alt(((sign, one_of('1'..='9'), digit0).void(), one_of('0').void()))
-            .recognize()
+            .take()
             .verify_map(|s: <Input as Stream>::Slice| {
                 let s = s.as_bstr();
                 // SAFETY: Only 7-bit ASCII characters are parsed
@@ -1491,7 +1491,7 @@ where
     Error: ParserError<Input>,
 {
     trace("float", move |input: &mut Input| {
-        let s = recognize_float_or_exceptions(input)?;
+        let s = take_float_or_exceptions(input)?;
         s.parse_slice()
             .ok_or_else(|| ErrMode::from_error_kind(input, ErrorKind::Verify))
     })
@@ -1499,9 +1499,7 @@ where
 }
 
 #[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
-fn recognize_float_or_exceptions<I, E: ParserError<I>>(
-    input: &mut I,
-) -> PResult<<I as Stream>::Slice, E>
+fn take_float_or_exceptions<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1512,24 +1510,24 @@ where
     I: AsBStr,
 {
     alt((
-        recognize_float,
+        take_float,
         crate::token::literal(Caseless("nan")),
         (
             opt(one_of(['+', '-'])),
             crate::token::literal(Caseless("infinity")),
         )
-            .recognize(),
+            .take(),
         (
             opt(one_of(['+', '-'])),
             crate::token::literal(Caseless("inf")),
         )
-            .recognize(),
+            .take(),
     ))
     .parse_next(input)
 }
 
 #[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
-fn recognize_float<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+fn take_float<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1546,7 +1544,7 @@ where
         )),
         opt((one_of(['e', 'E']), opt(one_of(['+', '-'])), cut_err(digit1))),
     )
-        .recognize()
+        .take()
         .parse_next(input)
 }
 

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -620,7 +620,7 @@ mod complete {
 
     #[cfg(feature = "std")]
     fn parse_f64(i: &str) -> IResult<&str, f64, ()> {
-        match recognize_float_or_exceptions.parse_peek(i) {
+        match take_float_or_exceptions.parse_peek(i) {
             Err(e) => Err(e),
             Ok((i, s)) => {
                 if s.is_empty() {

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -37,7 +37,7 @@ pub trait Alt<I, O, E> {
 ///   alt((alpha1, digit1)).parse_peek(input)
 /// };
 ///
-/// // the first parser, alpha1, recognizes the input
+/// // the first parser, alpha1, takes the input
 /// assert_eq!(parser("abc"), Ok(("", "abc")));
 ///
 /// // the first parser returns an error, so alt tries the second one
@@ -87,7 +87,7 @@ pub trait Permutation<I, O, E> {
 ///   permutation((alpha1, digit1)).parse_peek(input)
 /// }
 ///
-/// // permutation recognizes alphabetic characters then digit
+/// // permutation takes alphabetic characters then digit
 /// assert_eq!(parser("abc123"), Ok(("", ("abc", "123"))));
 ///
 /// // but also in inverse order

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Basic elements
 //!
-//! Those are used to recognize the lowest level elements of your grammar, like, "here is a dot", or "here is an big endian integer".
+//! Those are used to take a series of tokens for the lowest level elements of your grammar, like, "here is a dot", or "here is an big endian integer".
 //!
 //! | combinator | usage | input | new input | output | comment |
 //! |---|---|---|---|---|---|
@@ -64,8 +64,8 @@
 //! - [`not`]: Returns a result only if the embedded parser returns `Backtrack` or `Incomplete`. Does not consume the input
 //! - [`opt`]: Make the underlying parser optional
 //! - [`peek`]: Returns a result without consuming the input
-//! - [`Parser::recognize`]: If the child parser was successful, return the consumed input as the produced value
-//! - [`Parser::with_recognized`]: If the child parser was successful, return a tuple of the consumed input and the produced output.
+//! - [`Parser::take`]: If the child parser was successful, return the consumed input as the produced value
+//! - [`Parser::with_taken`]: If the child parser was successful, return a tuple of the consumed input and the produced output.
 //! - [`Parser::span`]: If the child parser was successful, return the location of the consumed input as the produced value
 //! - [`Parser::with_span`]: If the child parser was successful, return a tuple of the location of the consumed input and the produced output.
 //! - [`Parser::verify`]: Returns the result of the child parser if it satisfies a verification function

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -15,9 +15,9 @@ use crate::Parser;
 /// This stops before `n` when the parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
 /// [`cut_err`][crate::combinator::cut_err].
 ///
-/// To recognize a series of tokens, [`Accumulate`] into a `()`
+/// To take a series of tokens, [`Accumulate`] into a `()`
 /// (e.g. with [`.map(|()| ())`][Parser::map])
-/// and then [`Parser::recognize`].
+/// and then [`Parser::take`].
 ///
 /// **Warning:** If the parser passed to `repeat` accepts empty inputs
 /// (like `alpha0` or `digit0`), `repeat` will return an error,
@@ -452,9 +452,9 @@ where
 ///
 /// `f` keeps going so long as `g` produces [`ErrMode::Backtrack`]. To instead chain an error up, see [`cut_err`][crate::combinator::cut_err].
 ///
-/// To recognize a series of tokens, [`Accumulate`] into a `()`
+/// To take a series of tokens, [`Accumulate`] into a `()`
 /// (e.g. with [`.map(|()| ())`][Parser::map])
-/// and then [`Parser::recognize`].
+/// and then [`Parser::take`].
 ///
 /// See also
 /// - [`take_till`][crate::token::take_till] for recognizing up-to a member of a [set of tokens][crate::stream::ContainsToken]
@@ -612,9 +612,9 @@ where
 /// This stops when either parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
 /// [`cut_err`][crate::combinator::cut_err].
 ///
-/// To recognize a series of tokens, [`Accumulate`] into a `()`
+/// To take a series of tokens, [`Accumulate`] into a `()`
 /// (e.g. with [`.map(|()| ())`][Parser::map])
-/// and then [`Parser::recognize`].
+/// and then [`Parser::take`].
 ///
 /// **Warning:** If the separator parser accepts empty inputs
 /// (like `alpha0` or `digit0`), `separated` will return an error,

--- a/src/combinator/parser.rs
+++ b/src/combinator/parser.rs
@@ -579,9 +579,13 @@ where
     }
 }
 
+/// Replaced with [`Take`]
+#[deprecated(since = "0.6.14", note = "Replaced with `Take`")]
+pub type Recognize<F, I, O, E> = Take<F, I, O, E>;
+
 /// Implementation of [`Parser::recognize`]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
-pub struct Recognize<F, I, O, E>
+pub struct Take<F, I, O, E>
 where
     F: Parser<I, O, E>,
     I: Stream,
@@ -592,7 +596,7 @@ where
     e: core::marker::PhantomData<E>,
 }
 
-impl<F, I, O, E> Recognize<F, I, O, E>
+impl<F, I, O, E> Take<F, I, O, E>
 where
     F: Parser<I, O, E>,
     I: Stream,
@@ -608,7 +612,7 @@ where
     }
 }
 
-impl<I, O, E, F> Parser<I, <I as Stream>::Slice, E> for Recognize<F, I, O, E>
+impl<I, O, E, F> Parser<I, <I as Stream>::Slice, E> for Take<F, I, O, E>
 where
     F: Parser<I, O, E>,
     I: Stream,
@@ -628,9 +632,13 @@ where
     }
 }
 
+/// Replaced with [`WithTaken`]
+#[deprecated(since = "0.6.14", note = "Replaced with `WithTaken`")]
+pub type WithRecognized<F, I, O, E> = WithTaken<F, I, O, E>;
+
 /// Implementation of [`Parser::with_recognized`]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
-pub struct WithRecognized<F, I, O, E>
+pub struct WithTaken<F, I, O, E>
 where
     F: Parser<I, O, E>,
     I: Stream,
@@ -641,7 +649,7 @@ where
     e: core::marker::PhantomData<E>,
 }
 
-impl<F, I, O, E> WithRecognized<F, I, O, E>
+impl<F, I, O, E> WithTaken<F, I, O, E>
 where
     F: Parser<I, O, E>,
     I: Stream,
@@ -657,7 +665,7 @@ where
     }
 }
 
-impl<F, I, O, E> Parser<I, (O, <I as Stream>::Slice), E> for WithRecognized<F, I, O, E>
+impl<F, I, O, E> Parser<I, (O, <I as Stream>::Slice), E> for WithTaken<F, I, O, E>
 where
     F: Parser<I, O, E>,
     I: Stream,

--- a/src/combinator/parser.rs
+++ b/src/combinator/parser.rs
@@ -583,7 +583,7 @@ where
 #[deprecated(since = "0.6.14", note = "Replaced with `Take`")]
 pub type Recognize<F, I, O, E> = Take<F, I, O, E>;
 
-/// Implementation of [`Parser::recognize`]
+/// Implementation of [`Parser::take`]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
 pub struct Take<F, I, O, E>
 where
@@ -624,8 +624,8 @@ where
             Ok(_) => {
                 let offset = input.offset_from(&checkpoint);
                 input.reset(&checkpoint);
-                let recognized = input.next_slice(offset);
-                Ok(recognized)
+                let taken = input.next_slice(offset);
+                Ok(taken)
             }
             Err(e) => Err(e),
         }
@@ -636,7 +636,7 @@ where
 #[deprecated(since = "0.6.14", note = "Replaced with `WithTaken`")]
 pub type WithRecognized<F, I, O, E> = WithTaken<F, I, O, E>;
 
-/// Implementation of [`Parser::with_recognized`]
+/// Implementation of [`Parser::with_taken`]
 #[cfg_attr(nightly, warn(rustdoc::missing_doc_code_examples))]
 pub struct WithTaken<F, I, O, E>
 where
@@ -677,8 +677,8 @@ where
             Ok(result) => {
                 let offset = input.offset_from(&checkpoint);
                 input.reset(&checkpoint);
-                let recognized = input.next_slice(offset);
-                Ok((result, recognized))
+                let taken = input.next_slice(offset);
+                Ok((result, taken))
             }
             Err(e) => Err(e),
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -261,13 +261,25 @@ pub trait Parser<I, O, E> {
     /// # }
     /// ```
     #[doc(alias = "concat")]
+    #[doc(alias = "recognize")]
     #[inline(always)]
-    fn recognize(self) -> Recognize<Self, I, O, E>
+    fn take(self) -> Take<Self, I, O, E>
     where
         Self: core::marker::Sized,
         I: Stream,
     {
-        Recognize::new(self)
+        Take::new(self)
+    }
+
+    /// Replaced with [`Parser::take`]
+    #[inline(always)]
+    #[deprecated(since = "0.6.14", note = "Replaced with `Parser::take`")]
+    fn recognize(self) -> Take<Self, I, O, E>
+    where
+        Self: core::marker::Sized,
+        I: Stream,
+    {
+        Take::new(self)
     }
 
     /// Produce the consumed input with the output
@@ -307,13 +319,25 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(recognize_parser.parse_peek("abcd"), consumed_parser.parse_peek("abcd"));
     /// ```
     #[doc(alias = "consumed")]
+    #[doc(alias = "with_recognized")]
     #[inline(always)]
-    fn with_recognized(self) -> WithRecognized<Self, I, O, E>
+    fn with_taken(self) -> WithTaken<Self, I, O, E>
     where
         Self: core::marker::Sized,
         I: Stream,
     {
-        WithRecognized::new(self)
+        WithTaken::new(self)
+    }
+
+    /// Replaced with [`Parser::with_taken`]
+    #[inline(always)]
+    #[deprecated(since = "0.6.14", note = "Replaced with `Parser::with_taken`")]
+    fn with_recognized(self) -> WithTaken<Self, I, O, E>
+    where
+        Self: core::marker::Sized,
+        I: Stream,
+    {
+        WithTaken::new(self)
     }
 
     /// Produce the location of the consumed input as produced value.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -254,7 +254,7 @@ pub trait Parser<I, O, E> {
     /// use winnow::combinator::separated_pair;
     /// # fn main() {
     ///
-    /// let mut parser = separated_pair(alpha1, ',', alpha1).recognize();
+    /// let mut parser = separated_pair(alpha1, ',', alpha1).take();
     ///
     /// assert_eq!(parser.parse_peek("abcd,efgh"), Ok(("", "abcd,efgh")));
     /// assert_eq!(parser.parse_peek("abcd;"),Err(ErrMode::Backtrack(InputError::new(";", ErrorKind::Tag))));
@@ -284,7 +284,7 @@ pub trait Parser<I, O, E> {
 
     /// Produce the consumed input with the output
     ///
-    /// Functions similarly to [recognize][Parser::recognize] except it
+    /// Functions similarly to [take][Parser::take] except it
     /// returns the parser output as well.
     ///
     /// This can be useful especially in cases where the output is not the same type
@@ -305,18 +305,18 @@ pub trait Parser<I, O, E> {
     ///     "1234".value(true).parse_next(input)
     /// }
     ///
-    /// let mut consumed_parser = separated_pair(alpha1, ',', alpha1).value(true).with_recognized();
+    /// let mut consumed_parser = separated_pair(alpha1, ',', alpha1).value(true).with_taken();
     ///
     /// assert_eq!(consumed_parser.parse_peek("abcd,efgh1"), Ok(("1", (true, "abcd,efgh"))));
     /// assert_eq!(consumed_parser.parse_peek("abcd;"),Err(ErrMode::Backtrack(InputError::new(";", ErrorKind::Tag))));
     ///
     /// // the second output (representing the consumed input)
-    /// // should be the same as that of the `recognize` parser.
-    /// let mut recognize_parser = inner_parser.recognize();
-    /// let mut consumed_parser = inner_parser.with_recognized().map(|(output, consumed)| consumed);
+    /// // should be the same as that of the `take` parser.
+    /// let mut take_parser = inner_parser.take();
+    /// let mut consumed_parser = inner_parser.with_taken().map(|(output, consumed)| consumed);
     ///
-    /// assert_eq!(recognize_parser.parse_peek("1234"), consumed_parser.parse_peek("1234"));
-    /// assert_eq!(recognize_parser.parse_peek("abcd"), consumed_parser.parse_peek("abcd"));
+    /// assert_eq!(take_parser.parse_peek("1234"), consumed_parser.parse_peek("1234"));
+    /// assert_eq!(take_parser.parse_peek("abcd"), consumed_parser.parse_peek("abcd"));
     /// ```
     #[doc(alias = "consumed")]
     #[doc(alias = "with_recognized")]
@@ -398,11 +398,11 @@ pub trait Parser<I, O, E> {
     ///
     /// // the second output (representing the consumed input)
     /// // should be the same as that of the `span` parser.
-    /// let mut recognize_parser = inner_parser.span();
+    /// let mut span_parser = inner_parser.span();
     /// let mut consumed_parser = inner_parser.with_span().map(|(output, consumed)| consumed);
     ///
-    /// assert_eq!(recognize_parser.parse_peek(Located::new("1234")), consumed_parser.parse_peek(Located::new("1234")));
-    /// assert_eq!(recognize_parser.parse_peek(Located::new("abcd")), consumed_parser.parse_peek(Located::new("abcd")));
+    /// assert_eq!(span_parser.parse_peek(Located::new("1234")), consumed_parser.parse_peek(Located::new("1234")));
+    /// assert_eq!(span_parser.parse_peek(Located::new("abcd")), consumed_parser.parse_peek(Located::new("abcd")));
     /// # }
     /// ```
     #[inline(always)]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -399,7 +399,7 @@ impl<I: crate::lib::std::fmt::Debug, S: crate::lib::std::fmt::Debug> crate::lib:
 /// // but the complete parser will return an error
 /// assert_eq!(take_complete.parse_peek(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
 ///
-/// // the alpha0 function recognizes 0 or more alphabetic characters
+/// // the alpha0 function takes 0 or more alphabetic characters
 /// fn alpha0_partial<'s>(i: &mut Partial<&'s str>) -> PResult<&'s str, InputError<Partial<&'s str>>> {
 ///   ascii::alpha0.parse_next(i)
 /// }
@@ -408,12 +408,12 @@ impl<I: crate::lib::std::fmt::Debug, S: crate::lib::std::fmt::Debug> crate::lib:
 ///   ascii::alpha0.parse_next(i)
 /// }
 ///
-/// // if there's a clear limit to the recognized characters, both parsers work the same way
+/// // if there's a clear limit to the taken characters, both parsers work the same way
 /// assert_eq!(alpha0_partial.parse_peek(Partial::new("abcd;")), Ok((Partial::new(";"), "abcd")));
 /// assert_eq!(alpha0_complete.parse_peek("abcd;"), Ok((";", "abcd")));
 ///
 /// // but when there's no limit, the partial version returns `Incomplete`, because it cannot
-/// // know if more input data should be recognized. The whole input could be "abcd;", or
+/// // know if more input data should be taken. The whole input could be "abcd;", or
 /// // "abcde;"
 /// assert_eq!(alpha0_partial.parse_peek(Partial::new("abcd")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
@@ -3169,7 +3169,7 @@ pub trait AsChar {
 
     /// Tests that self is an alphabetic character
     ///
-    /// **Warning:** for `&str` it recognizes alphabetic
+    /// **Warning:** for `&str` it matches alphabetic
     /// characters outside of the 52 ASCII letters
     fn is_alpha(self) -> bool;
 

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -332,7 +332,7 @@ where
 ///
 /// *[Partial version][crate::_topic::partial]* will return a `ErrMode::Incomplete(Needed::new(1))` if a member of the set of tokens reaches the end of the input or is too short.
 ///
-/// To recognize a series of tokens, use [`repeat`][crate::combinator::repeat] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::recognize`].
+/// To take a series of tokens, use [`repeat`][crate::combinator::repeat] to [`Accumulate`][crate::stream::Accumulate] into a `()` and then [`Parser::take`].
 ///
 /// # Effective Signature
 ///
@@ -686,7 +686,7 @@ where
 ///
 /// See also
 /// - [`take_until`] for recognizing up-to a [`literal`] (w/ optional simd optimizations)
-/// - [`repeat_till`][crate::combinator::repeat_till] with [`Parser::recognize`] for recognizing up to a [`Parser`]
+/// - [`repeat_till`][crate::combinator::repeat_till] with [`Parser::take`] for taking tokens up to a [`Parser`]
 ///
 /// # Effective Signature
 ///
@@ -895,7 +895,7 @@ where
 ///
 /// See also
 /// - [`take_till`] for recognizing up-to a [set of tokens][ContainsToken]
-/// - [`repeat_till`][crate::combinator::repeat_till] with [`Parser::recognize`] for recognizing up to a [`Parser`]
+/// - [`repeat_till`][crate::combinator::repeat_till] with [`Parser::take`] for taking tokens up to a [`Parser`]
 ///
 /// # Effective Signature
 ///

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -398,16 +398,14 @@ fn partial_take_until_incomplete_s() {
 }
 
 #[test]
-fn partial_recognize() {
+fn partial_take() {
     use crate::ascii::{
         alpha1 as alpha, alphanumeric1 as alphanumeric, digit1 as digit, hex_digit1 as hex_digit,
         multispace1 as multispace, oct_digit1 as oct_digit, space1 as space,
     };
 
     fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        delimited("<!--", take(5_usize), "-->")
-            .recognize()
-            .parse_peek(i)
+        delimited("<!--", take(5_usize), "-->").take().parse_peek(i)
     }
     let r = x(Partial::new(&b"<!-- abc --> aaa"[..]));
     assert_eq!(r, Ok((Partial::new(&b" aaa"[..]), &b"<!-- abc -->"[..])));
@@ -415,43 +413,43 @@ fn partial_recognize() {
     let semicolon = &b";"[..];
 
     fn ya(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        alpha.recognize().parse_peek(i)
+        alpha.take().parse_peek(i)
     }
     let ra = ya(Partial::new(&b"abc;"[..]));
     assert_eq!(ra, Ok((Partial::new(semicolon), &b"abc"[..])));
 
     fn yd(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        digit.recognize().parse_peek(i)
+        digit.take().parse_peek(i)
     }
     let rd = yd(Partial::new(&b"123;"[..]));
     assert_eq!(rd, Ok((Partial::new(semicolon), &b"123"[..])));
 
     fn yhd(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        hex_digit.recognize().parse_peek(i)
+        hex_digit.take().parse_peek(i)
     }
     let rhd = yhd(Partial::new(&b"123abcDEF;"[..]));
     assert_eq!(rhd, Ok((Partial::new(semicolon), &b"123abcDEF"[..])));
 
     fn yod(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        oct_digit.recognize().parse_peek(i)
+        oct_digit.take().parse_peek(i)
     }
     let rod = yod(Partial::new(&b"1234567;"[..]));
     assert_eq!(rod, Ok((Partial::new(semicolon), &b"1234567"[..])));
 
     fn yan(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        alphanumeric.recognize().parse_peek(i)
+        alphanumeric.take().parse_peek(i)
     }
     let ran = yan(Partial::new(&b"123abc;"[..]));
     assert_eq!(ran, Ok((Partial::new(semicolon), &b"123abc"[..])));
 
     fn ys(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        space.recognize().parse_peek(i)
+        space.take().parse_peek(i)
     }
     let rs = ys(Partial::new(&b" \t;"[..]));
     assert_eq!(rs, Ok((Partial::new(semicolon), &b" \t"[..])));
 
     fn yms(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        multispace.recognize().parse_peek(i)
+        multispace.take().parse_peek(i)
     }
     let rms = yms(Partial::new(&b" \t\r\n;"[..]));
     assert_eq!(rms, Ok((Partial::new(semicolon), &b" \t\r\n"[..])));
@@ -714,12 +712,12 @@ fn partial_take_while_m_n_utf8_full_match_range() {
 
 #[test]
 #[cfg(feature = "std")]
-fn partial_recognize_take_while0() {
+fn partial_take_take_while0() {
     fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
         take_while(0.., AsChar::is_alphanum).parse_peek(i)
     }
     fn y(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        unpeek(x).recognize().parse_peek(i)
+        unpeek(x).take().parse_peek(i)
     }
     assert_eq!(
         x(Partial::new(&b"ab."[..])),

--- a/tests/testsuite/float.rs
+++ b/tests/testsuite/float.rs
@@ -14,7 +14,7 @@ fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
         delimited(digit, ".", opt(digit)),
         delimited(opt(digit), ".", digit),
     ))
-    .recognize();
+    .take();
     let float_str = float_bytes.try_map(str::from_utf8);
     float_str.try_map(FromStr::from_str).parse_peek(i)
 }

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -504,7 +504,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "alloc")]
-    fn recognize_is_a_str() {
+    fn take_is_a_str() {
         use winnow::prelude::*;
 
         let a = "aabbab";
@@ -512,7 +512,7 @@ mod test {
 
         fn f(i: &str) -> IResult<&str, &str> {
             repeat::<_, _, (), _, _>(1.., alt(("a", "b")))
-                .recognize()
+                .take()
                 .parse_peek(i)
         }
 


### PR DESCRIPTION
We can consider other names, like `capture`, in the future but for now, let's be consistent.

Fixes #488