### PR TITLE
fix(partial): Clarify Needed::Size is for offset, not tokens

### DIFF
--- a/src/binary/bits/tests.rs
+++ b/src/binary/bits/tests.rs
@@ -59,7 +59,7 @@ fn test_incomplete_bits() {
 
     assert!(result.is_err());
     let error = result.err().unwrap();
-    assert_eq!("Parsing requires 2 bytes/chars", error.to_string());
+    assert_eq!("Parsing requires 2 more data", error.to_string());
 }
 
 #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,9 @@ pub type PResult<O, E = ContextError> = Result<O, ErrMode<E>>;
 pub enum Needed {
     /// Needs more data, but we do not know how much
     Unknown,
-    /// Contains the required data size in bytes
+    /// Contains a lower bound on the buffer offset needed to finish parsing
+    ///
+    /// For byte/`&str` streams, this translates to bytes
     Size(NonZeroUsize),
 }
 
@@ -253,7 +255,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ErrMode::Incomplete(Needed::Size(u)) => write!(f, "Parsing requires {u} bytes/chars"),
+            ErrMode::Incomplete(Needed::Size(u)) => write!(f, "Parsing requires {u} more data"),
             ErrMode::Incomplete(Needed::Unknown) => write!(f, "Parsing requires more data"),
             ErrMode::Cut(c) => write!(f, "Parsing Failure: {c:?}"),
             ErrMode::Backtrack(c) => write!(f, "Parsing Error: {c:?}"),


### PR DESCRIPTION
Inspired by #578

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
