### PR TITLE
feat(stream): Allow reseting streams to an absolute position

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -129,6 +129,21 @@ where
     }
 }
 
+impl<I> Located<I>
+where
+    I: Clone + Stream + Offset,
+{
+    /// Reset the stream to the start
+    ///
+    /// This is useful for formats that encode a graph with addresses relative to the start of the
+    /// input.
+    #[doc(alias = "fseek")]
+    pub fn reset_to_start(&mut self) {
+        let start = self.initial.checkpoint();
+        self.input.reset(&start);
+    }
+}
+
 impl<I> AsRef<I> for Located<I> {
     #[inline(always)]
     fn as_ref(&self) -> &I {


### PR DESCRIPTION
Inspired by #593 which is trying to use `winnow` for HDF5

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
