### PR TITLE
alt_then

### DIFF
--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -78,13 +78,19 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::InputError,error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
-/// use winnow::combinator::alt_then;
+/// use winnow::combinator::{alt, alt_then};
 /// # fn main() {
 /// fn parser(input: &str) -> IResult<&str, (&str, &str)> {
 ///   alt_then(["aa", "a"], "ab").parse_peek(input)
 /// };
 ///
 /// assert_eq!(parser("aab"), Ok(("", ("a", "ab"))));
+///
+/// fn parser2(input: &str) -> IResult<&str, (&str, &str)> {
+///   alt_then(["1", "12", "123"], alt(["6", "56", "456"])).parse_peek(input)
+/// };
+///
+/// assert_eq!(parser2("123456"), Ok(("", ("123", "456"))));
 /// # }
 /// ```
 pub fn alt_then<Input: Stream, Output, Output2, Error, Alternatives>(

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -65,6 +65,20 @@ where
     trace("alt", move |i: &mut Input| alternatives.choice(i))
 }
 
+/// Run a parser from `alternatives` followed by `next`. Pick the first success.
+pub fn alt_then<Input: Stream, Output, Output2, Error, Alternatives>(
+    mut alternatives: Alternatives,
+    mut next: impl Parser<Input, Output2, Error>,
+) -> impl Parser<Input, (Output, Output2), Error>
+where
+    Alternatives: Alt<Input, Output, Error>,
+    Error: ParserError<Input>,
+{
+    trace("alt_then", move |i: &mut Input| {
+        alternatives.choice_then(&mut next, i)
+    })
+}
+
 /// Helper trait for the [`permutation()`] combinator.
 ///
 /// This trait is implemented for tuples of up to 21 elements

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -1,4 +1,4 @@
-use crate::combinator::trace;
+use crate::combinator::{empty, trace};
 use crate::error::{ErrMode, ErrorKind, ParserError};
 use crate::stream::Stream;
 use crate::*;
@@ -18,7 +18,13 @@ pub trait Alt<I, O, E> {
         input: &mut I,
     ) -> PResult<(O, O2), E>;
     /// Tests each parser in the tuple and returns the result of the first one that succeeds
-    fn choice(&mut self, input: &mut I) -> PResult<O, E>;
+    fn choice(&mut self, input: &mut I) -> PResult<O, E>
+    where
+        I: stream::Stream,
+    {
+        let (o, _) = self.choice_then(&mut empty, input)?;
+        Ok(o)
+    }
 }
 
 /// Pick the first successful parser

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -72,6 +72,21 @@ where
 }
 
 /// Run a parser from `alternatives` followed by `next`. Pick the first success.
+///
+/// # Example
+///
+/// ```rust
+/// # use winnow::{error::ErrMode, error::InputError,error::ErrorKind, error::Needed};
+/// # use winnow::prelude::*;
+/// use winnow::combinator::alt_then;
+/// # fn main() {
+/// fn parser(input: &str) -> IResult<&str, (&str, &str)> {
+///   alt_then(["aa", "a"], "ab").parse_peek(input)
+/// };
+///
+/// assert_eq!(parser("aab"), Ok(("", ("a", "ab"))));
+/// # }
+/// ```
 pub fn alt_then<Input: Stream, Output, Output2, Error, Alternatives>(
     mut alternatives: Alternatives,
     mut next: impl Parser<Input, Output2, Error>,

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -531,7 +531,6 @@ enum State<E> {
 pub fn empty<Input, Error>(_input: &mut Input) -> PResult<(), Error>
 where
     Input: Stream,
-    Error: ParserError<Input>,
 {
     Ok(())
 }


### PR DESCRIPTION
I couldn't find an easy way to implement this with the current combinators, so added the functionality to `Alt` trait

```rust
/// Run a parser from `alternatives` followed by `next`. Pick the first success.
pub fn alt_then<Input: Stream, Output, Output2, Error, Alternatives>(
    mut alternatives: Alternatives,
    mut next: impl Parser<Input, Output2, Error>,
) -> impl Parser<Input, (Output, Output2), Error>
where
    Alternatives: Alt<Input, Output, Error>,
    Error: ParserError<Input>,
```
