### PR TITLE
docs: Highlight notes/warnings in a block

### DIFF
--- a/src/_topic/why.rs
+++ b/src/_topic/why.rs
@@ -2,9 +2,13 @@
 //!
 //! To answer this question, it will be useful to contrast this with other approaches to parsing.
 //!
+//! <div class="warning">
+//!
 //! **Note:** This will focus on principles and priorities. For a deeper and wider wider
 //! comparison with other Rust parser libraries, see
 //! [parse-rosetta-rs](https://github.com/rosetta-rs/parse-rosetta-rs).
+//!
+//! </div>
 //!
 //! ## Hand-written parsers
 //!

--- a/src/_tutorial/chapter_3.rs
+++ b/src/_tutorial/chapter_3.rs
@@ -178,9 +178,13 @@
 //! }
 //! ```
 //!
-//! > **Warning:** the above example is for illustrative purposes and relying on `Result::Ok` or
-//! > `Result::Err` can lead to incorrect behavior. This will be clarified in later when covering
-//! > [error handling][`chapter_7`#error-cuts]
+//! <div class="warning">
+//!
+//! **Warning:** the above example is for illustrative purposes and relying on `Result::Ok` or
+//! `Result::Err` can lead to incorrect behavior. This will be clarified in later when covering
+//! [error handling][`chapter_7`#error-cuts]
+//!
+//! </div>
 //!
 //! [`opt`] is a parser that encapsulates this pattern of "retry on failure":
 //! ```rust
@@ -293,7 +297,11 @@
 //! # }
 //! ```
 //!
-//! > **Note:** [`empty`] and [`fail`] are parsers that might be useful in the "else" case.
+//! <div class="warning">
+//!
+//! **Note:** [`empty`] and [`fail`] are parsers that might be useful in the "else" case.
+//!
+//! </div>
 //!
 //! Sometimes a giant if/else-if ladder can be slow and you'd rather have a `match` statement for
 //! branches of your parser that have unique prefixes. In this case, you can use the
@@ -354,7 +362,11 @@
 //! # }
 //! ```
 //!
-//! > **Note:** [`peek`] may be useful when [`dispatch`]ing from hints from each case's parser.
+//! <div class="warning">
+//!
+//! **Note:** [`peek`] may be useful when [`dispatch`]ing from hints from each case's parser.
+//!
+//! </div>
 //!
 //! See [`combinator`] for more alternative parsers.
 

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -80,8 +80,14 @@ where
 
 /// Convert a [`bits`] stream back into a byte stream
 ///
+/// <div class="warning">
+///
 /// **Warning:** A partial byte remaining in the input will be ignored and the given parser will
 /// start parsing at the next full byte.
+///
+/// </div>
+///
+/// # Examples
 ///
 /// ```
 /// use winnow::prelude::*;

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1210,7 +1210,11 @@ where
 
 /// Recognizes an unsigned 1 byte integer
 ///
+/// <div class="warning">
+///
 /// **Note:** that endianness does not apply to 1 byte numbers.
+///
+/// </div>
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///
@@ -1633,7 +1637,11 @@ where
 
 /// Recognizes a signed 1 byte integer
 ///
+/// <div class="warning">
+///
 /// **Note:** that endianness does not apply to 1 byte numbers.
+///
+/// </div>
 ///
 /// *Complete version*: returns an error if there is not enough input data
 ///

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -37,7 +37,11 @@ where
 
 /// Return the length of the remaining input.
 ///
+/// <div class="warning">
+///
 /// Note: this does not advance the [`Stream`]
+///
+/// </div>
 ///
 /// # Effective Signature
 ///
@@ -234,7 +238,11 @@ where
 
 /// Succeeds if the child parser returns an error.
 ///
+/// <div class="warning">
+///
 /// **Note:** This does not advance the [`Stream`]
+///
+/// </div>
 ///
 /// # Example
 ///
@@ -505,7 +513,11 @@ enum State<E> {
 /// - [`Parser::default_value`]
 /// - [`Parser::map`]
 ///
+/// <div class="warning">
+///
 /// **Note:** This never advances the [`Stream`]
+///
+/// </div>
 ///
 /// # Example
 ///

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -1,6 +1,10 @@
 //! # List of parsers and combinators
 //!
+//! <div class="warning">
+//!
 //! **Note**: this list is meant to provide a nicer way to find a parser than reading through the documentation on docs.rs. Function combinators are organized in module so they are a bit easier to find.
+//!
+//! </div>
 //!
 //! ## Basic elements
 //!

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -19,9 +19,13 @@ use crate::Parser;
 /// (e.g. with [`.map(|()| ())`][Parser::map])
 /// and then [`Parser::take`].
 ///
+/// <div class="warning">
+///
 /// **Warning:** If the parser passed to `repeat` accepts empty inputs
 /// (like `alpha0` or `digit0`), `repeat` will return an error,
 /// to prevent going into an infinite loop.
+///
+/// </div>
 ///
 /// # Example
 ///
@@ -160,9 +164,13 @@ where
     /// * `g` The function that combines a result of `f` with
     ///       the current accumulator.
     ///
+    /// <div class="warning">
+    ///
     /// **Warning:** If the parser passed to `fold` accepts empty inputs
     /// (like `alpha0` or `digit0`), `fold_repeat` will return an error,
     /// to prevent going into an infinite loop.
+    ///
+    /// </div>
     ///
     /// # Example
     ///
@@ -615,9 +623,13 @@ where
 /// (e.g. with [`.map(|()| ())`][Parser::map])
 /// and then [`Parser::take`].
 ///
+/// <div class="warning">
+///
 /// **Warning:** If the separator parser accepts empty inputs
 /// (like `alpha0` or `digit0`), `separated` will return an error,
 /// to prevent going into an infinite loop.
+///
+/// </div>
 ///
 /// # Example
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,8 +57,12 @@ pub type PResult<O, E = ContextError> = Result<O, ErrMode<E>>;
 
 /// Contains information on needed data if a parser returned `Incomplete`
 ///
+/// <div class="warning">
+///
 /// **Note:** This is only possible for `Stream` that are [partial][`crate::stream::StreamIsPartial`],
 /// like [`Partial`][crate::Partial].
+///
+/// </div>
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Needed {
     /// Needs more data, but we do not know how much
@@ -350,8 +354,12 @@ pub trait ErrorConvert<E> {
 /// This is useful for testing of generic parsers to ensure the error happens at the right
 /// location.
 ///
+/// <div class="warning">
+///
 /// **Note:** [context][Parser::context] and inner errors (like from [`Parser::try_map`]) will be
 /// dropped.
+///
+/// </div>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct InputError<I: Clone> {
     /// The input stream, pointing to the location where the error occurred
@@ -1184,8 +1192,12 @@ impl<I, E> ParseError<I, E> {
 
     /// The location in [`ParseError::input`] where parsing failed
     ///
+    /// <div class="warning">
+    ///
     /// **Note:** This is an offset, not an index, and may point to the end of input
     /// (`input.len()`) on eof errors.
+    ///
+    /// </div>
     #[inline]
     pub fn offset(&self) -> usize {
         self.offset

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -669,12 +669,16 @@ pub trait Stream: Offset<<Self as Stream>::Checkpoint> + crate::lib::std::fmt::D
     fn offset_at(&self, tokens: usize) -> Result<usize, Needed>;
     /// Split off a slice of tokens from the input
     ///
-    /// **NOTE:** For inputs with variable width tokens, like `&str`'s `char`, `offset` might not correspond
+    /// <div class="warning">
+    ///
+    /// **Note:** For inputs with variable width tokens, like `&str`'s `char`, `offset` might not correspond
     /// with the number of tokens. To get a valid offset, use:
     /// - [`Stream::eof_offset`]
     /// - [`Stream::iter_offsets`]
     /// - [`Stream::offset_for`]
     /// - [`Stream::offset_at`]
+    ///
+    /// </div>
     ///
     /// # Panic
     ///
@@ -1835,8 +1839,12 @@ where
 pub trait Offset<Start = Self> {
     /// Offset between the first byte of `start` and the first byte of `self`a
     ///
+    /// <div class="warning">
+    ///
     /// **Note:** This is an offset, not an index, and may point to the end of input
     /// (`start.len()`) when `self` is exhausted.
+    ///
+    /// </div>
     fn offset_from(&self, start: &Start) -> usize;
 }
 
@@ -3208,8 +3216,12 @@ pub trait AsChar {
 
     /// Tests that self is an alphabetic character
     ///
+    /// <div class="warning">
+    ///
     /// **Warning:** for `&str` it matches alphabetic
     /// characters outside of the 52 ASCII letters
+    ///
+    /// </div>
     fn is_alpha(self) -> bool;
 
     /// Tests that self is an alphabetic character

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -93,8 +93,12 @@ where
 ///
 /// It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Tag)))` if the input doesn't match the literal
 ///
+/// <div class="warning">
+///
 /// **Note:** [`Parser`] is implemented for strings and byte strings as a convenience (complete
 /// only)
+///
+/// </div>
 ///
 /// # Effective Signature
 ///
@@ -199,10 +203,14 @@ where
 
 /// Recognize a token that matches a [set of tokens][ContainsToken]
 ///
+/// <div class="warning">
+///
 /// **Note:** [`Parser`] is implemented as a convenience (complete
 /// only) for
 /// - `u8`
 /// - `char`
+///
+/// </div>
 ///
 /// *Complete version*: Will return an error if there's not enough input data.
 ///


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
