### PR TITLE
docs(tutorial): Clarify examples in chapter 5

### DIFF
--- a/src/_tutorial/chapter_5.rs
+++ b/src/_tutorial/chapter_5.rs
@@ -136,8 +136,8 @@
 //! # }
 //! ```
 //!
-//! You'll notice that the above allows trailing `,` when we intended to not support that. We can
-//! easily fix this by using [`separated`]:
+//! You'll notice that the above allows trailing `,`. However, if that's not desired, it
+//! can easily be fixed by using [`separated`] instead of [`repeat`]:
 //! ```rust
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
@@ -199,9 +199,22 @@
 //! }
 //! ```
 //!
-//! If you look closely at [`repeat`], it isn't collecting directly into a [`Vec`] but
-//! anything that implements the [`Accumulate`] trait to gather the results. This lets us make more complex parsers than we did in
-//! [`chapter_2`] by accumulating the results into a `()` and [`take`][Parser::take]-ing the captured input:
+//! If you look closely at [`separated`] and [`repeat`], they aren't limited to collecting
+//! the result into a [`Vec`], but rather anything that implements the [`Accumulate`] trait.
+//! [`Accumulate`] is for instance also implemented for [`HashSet`], [`String`] and `()`.
+//!
+//! This lets us build more complex parsers than we did in
+//! [`chapter_2`] by accumulating the results into a `()` and [`take`][Parser::take]-ing
+//! the consumed input.
+//!
+//! `take` works by
+//! 1. Creating a [`checkpoint`][Stream::checkpoint]
+//! 2. Running the inner parser, in our case the `parse_list` parser, which will advance the input
+//! 3. Returning the slice from the first checkpoint to the current position.
+//!
+//! Since the result of `parse_list` gets thrown away, we
+//! accumulates into a `()` to not waste work creating an unused `Vec`.
+//!
 //! ```rust
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
@@ -274,7 +287,9 @@ use crate::combinator;
 use crate::combinator::repeat;
 use crate::combinator::separated;
 use crate::stream::Accumulate;
+use crate::stream::Stream;
 use crate::Parser;
+use std::collections::HashSet;
 use std::vec::Vec;
 
 pub use super::chapter_4 as previous;


### PR DESCRIPTION
While going through the tutorial, I found the description on the last example of chapter 5 very confusing.

As a beginner, at this point of the tutorial I had the mental model that a Parser always consumes/advdances the input.
Suddenly `take` is introduced without any further info, which uses checkpoints under the hood.

And to make this even more confusing, the output of the `parse_list` parser is changed to "accumulat[e] the results into a `()`", which really doesn't make a lot of sense if you don't know that `take` doesn't care about the output of the contained parser due to the checkpoint logic.

There's really a lot of concepts to unwrap in this small piece of code and it took a bit of research to figure out why stuff worked the way it does.

I hope the new text is able to convey this knowledge in a better way.