### PR TITLE
feat: Add `Parser::value_with` convenience method

### DIFF
--- a/src/combinator/parser.rs
+++ b/src/combinator/parser.rs
@@ -490,6 +490,47 @@ where
     }
 }
 
+/// Implementation of [`Parser::value_with`]
+pub struct ValueWith<P, F, I, O, O2, E>
+where
+    P: Parser<I, O, E>,
+    F: FnMut() -> O2,
+{
+    parser: P,
+    generator: F,
+    i: core::marker::PhantomData<I>,
+    o: core::marker::PhantomData<O>,
+    e: core::marker::PhantomData<E>,
+}
+
+impl<P, F, I, O, O2, E> ValueWith<P, F, I, O, O2, E>
+where
+    P: Parser<I, O, E>,
+    F: FnMut() -> O2,
+{
+    #[inline(always)]
+    pub(crate) fn new(parser: P, generator: F) -> Self {
+        Self {
+            parser,
+            generator,
+            i: Default::default(),
+            o: Default::default(),
+            e: Default::default(),
+        }
+    }
+}
+
+impl<P, F, I, O, O2, E> Parser<I, O2, E> for ValueWith<P, F, I, O, O2, E>
+where
+    P: Parser<I, O, E>,
+    F: FnMut() -> O2,
+{
+    #[inline]
+    fn parse_next(&mut self, input: &mut I) -> PResult<O2, E> {
+        (self.parser).parse_next(input).map(|_| (self.generator)())
+    }
+}
+
 /// Implementation of [`Parser::default_value`]
 pub struct DefaultValue<F, I, O, O2, E>
 where

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -178,6 +178,31 @@ pub trait Parser<I, O, E> {
         Value::new(self, val)
     }
 
+    /// Produce a value by calling the provided generator function
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// use winnow::ascii::alpha1;
+    /// # fn main() {
+    ///
+    /// let mut parser = alpha1.value_with(|| 1234);
+    ///
+    /// assert_eq!(parser.parse_peek("abcd"), Ok(("", 1234)));
+    /// assert_eq!(parser.parse_peek("123abcd;"), Err(ErrMode::Backtrack(InputError::new("123abcd;", ErrorKind::Slice))));
+    /// # }
+    /// ```
+    #[doc(alias = "to_with")]
+    #[inline(always)]
+    fn value_with<F, O2>(self, f: F) -> ValueWith<Self, F, I, O, O2, E>
+    where
+        Self: core::marker::Sized,
+        F: FnMut() -> O2,
+    {
+        ValueWith::new(self, f)
+    }
+
     /// Produce a type's default value
     ///
     /// # Example


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

I hope this is simple enough to not warrant an issue, this PR adds a method `value_with` to `Parser` that takes a generator function `FnMut() -> O2` and returns a new parser much like `p.value(x)` but without the bound `O2: Clone`.

This also lets us replace the implementation of `.default_value()` to be `ValueWith::new(self, Default::default)`, but it would also change the signature to return `ValueWith<Self, impl Fn() -> O2, I, O, O2, E>`, so I figured I won't change that yet.
        

