### PR TITLE
Documentaion fix for repeat_till

### DIFF
--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -460,7 +460,7 @@ where
 /// `f` keeps going so long as `g` produces [`ErrMode::Backtrack`]. To instead chain an error up, see [`cut_err`][crate::combinator::cut_err].
 ///
 /// To take a series of tokens, [`Accumulate`] into a `()`
-/// (e.g. with [`.map(|()| ())`][Parser::map])
+/// (e.g. with [`.map(|((), _)| ())`][Parser::map])
 /// and then [`Parser::take`].
 ///
 /// See also


### PR DESCRIPTION
I tried to do `.map(|()| ())` as suggested in the repeat_til documentation for taking a series of tokens. This gave me a compiler error saying that I needed to put a tuple instead for the args in the map. Switching to `.map(|((), _)| ())` fixed my problem, accumulating the Accumulator into nothing and discarding the result of the combinator that repeat_till took.

This was a stumbling block for me, and I thought this tweak might make things easier for the next person.

<details><summary>If you need more context, here is the code I wrote when going through this experience.</summary>

``` rust

fn discard_junk(input: &mut Stream) -> PResult<()> {
    let mut parser = repeat_till(1.., take(1usize), peek(alt(("mul", "don't", "do"))))
        .map(|((), _)| ())
        .take()
        .void();
    parser.parse_next(input)
}

```
</details>

(I've been getting a lot of joy out of using winnow! Thank you for all the work you do.)

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
