### PR TITLE
chore(deps): bump anstream to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,29 +20,14 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
- "anstyle-wincon 1.0.1",
- "colorchoice",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon 3.0.3",
+ "anstyle-wincon",
  "colorchoice",
  "is_terminal_polyfill",
  "utf8parse",
@@ -74,22 +59,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1072,7 +1047,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ad8c7be18cc9ec7f4d7948ad6b9df0e04fc649663e3c0ed59f304ed17ca69e9"
 dependencies = [
- "anstream 0.6.14",
+ "anstream",
  "anstyle",
  "escargot",
  "normalize-line-endings",
@@ -1086,7 +1061,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f4c14672714436c09254801c934b203196a51182a5107fb76591c7cc56424d"
 dependencies = [
- "anstream 0.6.14",
+ "anstream",
 ]
 
 [[package]]
@@ -1373,15 +1348,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -1572,7 +1538,7 @@ name = "winnow"
 version = "0.6.20"
 dependencies = [
  "annotate-snippets",
- "anstream 0.3.2",
+ "anstream",
  "anstyle",
  "anyhow",
  "automod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ unstable-recover = []
 unstable-doc = ["alloc", "std", "simd", "unstable-recover"]
 
 [dependencies]
-anstream = { version = "0.3.2", optional = true }
+anstream = { version = "0.6.18", optional = true }
 anstyle = { version = "1.0.1", optional = true }
 is-terminal = { version = "0.4.9", optional = true }
 memchr = { version = "2.5", optional = true, default-features = false }


### PR DESCRIPTION
Fixes [`RUSTSEC-2024-0404`](https://rustsec.org/advisories/RUSTSEC-2024-0404.html)

[The changelog](https://github.com/rust-cli/anstyle/blob/main/crates/anstream/CHANGELOG.md) does not seem to contain anything breaking.
