### PR TITLE
feat!: Add ParserError, AsChar, ContainsToken, Stream to prelude

### DIFF
--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -3,7 +3,6 @@ use criterion::black_box;
 use winnow::combinator::opt;
 use winnow::prelude::*;
 use winnow::stream::AsChar;
-use winnow::stream::Stream as _;
 use winnow::token::one_of;
 
 fn iter(c: &mut criterion::Criterion) {

--- a/examples/ndjson/main.rs
+++ b/examples/ndjson/main.rs
@@ -7,7 +7,6 @@ use winnow::error::ErrMode;
 use winnow::error::Needed;
 use winnow::prelude::*;
 use winnow::stream::Offset;
-use winnow::stream::Stream as _;
 
 fn main() -> Result<(), lexopt::Error> {
     let args = Args::parse()?;

--- a/src/_topic/nom.rs
+++ b/src/_topic/nom.rs
@@ -70,7 +70,7 @@
 //!
 //! To save and restore from intermediate states, [`Stream::checkpoint`] and [`Stream::reset`] can help:
 //! ```rust
-//! use winnow::stream::Stream as _;
+//! use winnow::prelude::*;
 //! # let mut i = "";
 //! # let i = &mut i;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,10 @@ pub mod _tutorial;
 /// }
 /// ```
 pub mod prelude {
+    pub use crate::error::ParserError as _;
+    pub use crate::stream::AsChar as _;
+    pub use crate::stream::ContainsToken as _;
+    pub use crate::stream::Stream as _;
     pub use crate::stream::StreamIsPartial as _;
     pub use crate::IResult;
     pub use crate::PResult;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -3265,7 +3265,7 @@ pub trait AsChar {
     /// # Example
     ///
     /// ```
-    /// use winnow::stream::AsChar as _;
+    /// use winnow::prelude::*;
     ///
     /// assert_eq!('a'.as_char(), 'a');
     /// assert_eq!(u8::MAX.as_char(), std::char::from_u32(u8::MAX as u32).unwrap());


### PR DESCRIPTION
Searching my projects, these are the ones I tend to see used and shouldn't cause much of a problem

Fixes #647

BREAKING CHANGE: These will cause unused import warnings when importing both the prelude and the trait

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
