### PR TITLE
fix(stream): Rename Located to LocatingSlice 

### DIFF
--- a/src/_topic/stream.rs
+++ b/src/_topic/stream.rs
@@ -5,7 +5,7 @@
 //! - Improved debug output like [`Bytes`]
 //! - [`Stateful`] for passing state through your parser, like tracking recursion
 //!   depth
-//! - [`Located`] for looking up the absolute position of a token
+//! - [`LocatingSlice`] for looking up the absolute position of a token
 //!
 //! But that won't always cut it for your parser. For example, you might lex `&str` into
 //! a series of tokens and then want to parse a `TokenStream`.

--- a/src/_topic/why.rs
+++ b/src/_topic/why.rs
@@ -50,7 +50,7 @@
 //! - Some common parsers to help get started, like numbers
 //!
 //! For text formats, `winnow` includes:
-//! - [Tracking of spans][crate::Located]
+//! - [Tracking of spans][crate::LocatingSlice]
 //! - [A textual view when parsing as bytes][crate::BStr] in [trace]
 //! - Ability to evaluate directly, parse to an AST, or lex and parse the format
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub use error::PResult;
 pub use parser::*;
 pub use stream::BStr;
 pub use stream::Bytes;
-pub use stream::Located;
+pub use stream::LocatingSlice;
 pub use stream::Partial;
 pub use stream::Stateful;
 pub use stream::Str;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -358,14 +358,14 @@ pub trait Parser<I, O, E> {
     /// ```rust
     /// # use winnow::prelude::*;
     /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, stream::Stream};
-    /// use winnow::stream::Located;
+    /// use winnow::stream::LocatingSlice;
     /// use winnow::ascii::alpha1;
     /// use winnow::combinator::separated_pair;
     ///
     /// let mut parser = separated_pair(alpha1.span(), ',', alpha1.span());
     ///
-    /// assert_eq!(parser.parse(Located::new("abcd,efgh")), Ok((0..4, 5..9)));
-    /// assert_eq!(parser.parse_peek(Located::new("abcd;")),Err(ErrMode::Backtrack(InputError::new(Located::new("abcd;").peek_slice(4).0, ErrorKind::Tag))));
+    /// assert_eq!(parser.parse(LocatingSlice::new("abcd,efgh")), Ok((0..4, 5..9)));
+    /// assert_eq!(parser.parse_peek(LocatingSlice::new("abcd;")),Err(ErrMode::Backtrack(InputError::new(LocatingSlice::new("abcd;").peek_slice(4).0, ErrorKind::Tag))));
     /// ```
     #[inline(always)]
     fn span(self) -> Span<Self, I, O, E>
@@ -391,12 +391,12 @@ pub trait Parser<I, O, E> {
     /// ```rust
     /// # use winnow::prelude::*;
     /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, stream::Stream};
-    /// use winnow::stream::Located;
+    /// use winnow::stream::LocatingSlice;
     /// use winnow::ascii::alpha1;
     /// use winnow::token::literal;
     /// use winnow::combinator::separated_pair;
     ///
-    /// fn inner_parser<'s>(input: &mut Located<&'s str>) -> PResult<bool, InputError<Located<&'s str>>> {
+    /// fn inner_parser<'s>(input: &mut LocatingSlice<&'s str>) -> PResult<bool, InputError<LocatingSlice<&'s str>>> {
     ///     "1234".value(true).parse_next(input)
     /// }
     ///
@@ -404,16 +404,16 @@ pub trait Parser<I, O, E> {
     ///
     /// let mut consumed_parser = separated_pair(alpha1.value(1).with_span(), ',', alpha1.value(2).with_span());
     ///
-    /// assert_eq!(consumed_parser.parse(Located::new("abcd,efgh")), Ok(((1, 0..4), (2, 5..9))));
-    /// assert_eq!(consumed_parser.parse_peek(Located::new("abcd;")),Err(ErrMode::Backtrack(InputError::new(Located::new("abcd;").peek_slice(4).0, ErrorKind::Tag))));
+    /// assert_eq!(consumed_parser.parse(LocatingSlice::new("abcd,efgh")), Ok(((1, 0..4), (2, 5..9))));
+    /// assert_eq!(consumed_parser.parse_peek(LocatingSlice::new("abcd;")),Err(ErrMode::Backtrack(InputError::new(LocatingSlice::new("abcd;").peek_slice(4).0, ErrorKind::Tag))));
     ///
     /// // the second output (representing the consumed input)
     /// // should be the same as that of the `span` parser.
     /// let mut span_parser = inner_parser.span();
     /// let mut consumed_parser = inner_parser.with_span().map(|(output, consumed)| consumed);
     ///
-    /// assert_eq!(span_parser.parse_peek(Located::new("1234")), consumed_parser.parse_peek(Located::new("1234")));
-    /// assert_eq!(span_parser.parse_peek(Located::new("abcd")), consumed_parser.parse_peek(Located::new("abcd")));
+    /// assert_eq!(span_parser.parse_peek(LocatingSlice::new("1234")), consumed_parser.parse_peek(LocatingSlice::new("1234")));
+    /// assert_eq!(span_parser.parse_peek(LocatingSlice::new("abcd")), consumed_parser.parse_peek(LocatingSlice::new("abcd")));
     /// # }
     /// ```
     #[inline(always)]


### PR DESCRIPTION
In #512, we found that the current name is so general it makes it sound
like it applies in all cases but doesn't.

Trying to make it clear that this is limited in where it can apply.

This is cherry-picked from #649 