### PR TITLE
fix: De-emphasize `parse_peek`-related functionality

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1576,7 +1576,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed, error::IResult};
 /// # use winnow::ascii::digit1;
 /// # use winnow::prelude::*;
 /// use winnow::ascii::take_escaped;
@@ -1592,7 +1592,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed, error::IResult};
 /// # use winnow::ascii::digit1;
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -1,11 +1,11 @@
 use super::*;
-use crate::prelude::*;
 
 mod complete {
     use super::*;
     use crate::combinator::alt;
     use crate::error::ErrMode;
     use crate::error::ErrorKind;
+    use crate::error::IResult;
     use crate::error::InputError;
     use crate::stream::ParseSlice;
     use crate::token::none_of;
@@ -16,7 +16,7 @@ mod complete {
 
     macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, InputError<_>> = $left;
+      let res: $crate::error::IResult<_, _, InputError<_>> = $left;
       assert_eq!(res, $right);
     };
   );
@@ -956,14 +956,14 @@ mod complete {
 mod partial {
     use super::*;
     use crate::error::ErrorKind;
+    use crate::error::IResult;
     use crate::error::InputError;
     use crate::error::{ErrMode, Needed};
-    use crate::IResult;
     use crate::Partial;
 
     macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, InputError<_>> = $left;
+      let res: $crate::error::IResult<_, _, InputError<_>> = $left;
       assert_eq!(res, $right);
     };
   );

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -8,7 +8,7 @@ use crate::combinator::trace;
 use crate::error::{ErrMode, ErrorConvert, ErrorKind, Needed, ParserError};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
 use crate::stream::{Stream, StreamIsPartial, ToUsize};
-use crate::{error::IResult, unpeek, PResult, Parser};
+use crate::{error::IResult, PResult, Parser};
 
 /// Number of bits in a byte
 const BYTE: usize = u8::BITS as usize;
@@ -56,6 +56,8 @@ where
     Input: Stream + Clone,
     ParseNext: Parser<(Input, usize), Output, BitError>,
 {
+    #![allow(deprecated)]
+    use crate::unpeek;
     trace(
         "bits",
         unpeek(move |input: Input| {
@@ -124,6 +126,8 @@ where
     Input: Stream<Token = u8> + Clone,
     ParseNext: Parser<Input, Output, ByteError>,
 {
+    #![allow(deprecated)]
+    use crate::unpeek;
     trace(
         "bytes",
         unpeek(move |(input, offset): (Input, usize)| {
@@ -205,6 +209,8 @@ where
     Count: ToUsize,
     Error: ParserError<(Input, usize)>,
 {
+    #![allow(deprecated)]
+    use crate::unpeek;
     let count = count.to_usize();
     trace(
         "take",

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -8,7 +8,7 @@ use crate::combinator::trace;
 use crate::error::{ErrMode, ErrorConvert, ErrorKind, Needed, ParserError};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
 use crate::stream::{Stream, StreamIsPartial, ToUsize};
-use crate::{unpeek, IResult, PResult, Parser};
+use crate::{error::IResult, unpeek, PResult, Parser};
 
 /// Number of bits in a byte
 const BYTE: usize = u8::BITS as usize;
@@ -19,11 +19,11 @@ const BYTE: usize = u8::BITS as usize;
 ///
 /// # Example
 /// ```
-/// use winnow::prelude::*;
-/// use winnow::Bytes;
-/// use winnow::binary::bits::{bits, take};
-/// use winnow::error::InputError;
-///
+/// # use winnow::prelude::*;
+/// # use winnow::Bytes;
+/// # use winnow::binary::bits::{bits, take};
+/// # use winnow::error::InputError;
+/// # use winnow::error::IResult;
 /// type Stream<'i> = &'i Bytes;
 ///
 /// fn stream(b: &[u8]) -> Stream<'_> {
@@ -95,6 +95,7 @@ where
 /// use winnow::binary::bits::{bits, bytes, take};
 /// use winnow::token::rest;
 /// use winnow::error::InputError;
+/// use winnow::error::IResult;
 ///
 /// type Stream<'i> = &'i Bytes;
 ///
@@ -171,6 +172,7 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
 /// # use winnow::error::{InputError, ErrorKind};
+/// # use winnow::error::IResult;
 /// use winnow::binary::bits::take;
 ///
 /// type Stream<'i> = &'i Bytes;
@@ -290,6 +292,7 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
 /// # use winnow::error::{InputError, ErrorKind};
+/// # use winnow::error::IResult;
 /// use winnow::binary::bits::pattern;
 ///
 /// type Stream<'i> = &'i Bytes;
@@ -390,6 +393,7 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
 /// # use winnow::error::{InputError, ErrorKind};
+/// # use winnow::error::IResult;
 /// use winnow::binary::bits::bool;
 ///
 /// type Stream<'i> = &'i Bytes;

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -40,6 +40,7 @@ pub enum Endianness {
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -54,6 +55,7 @@ pub enum Endianness {
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -84,6 +86,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -98,6 +101,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -128,6 +132,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -142,6 +147,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -172,6 +178,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -186,6 +193,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -216,6 +224,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -230,6 +239,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -260,6 +270,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -274,6 +285,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -342,6 +354,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -356,6 +369,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -386,6 +400,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -400,6 +415,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -433,6 +449,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -447,6 +464,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -488,6 +506,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -502,6 +521,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -535,6 +555,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -549,6 +570,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -582,6 +604,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -596,6 +619,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -629,6 +653,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -643,6 +668,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -673,6 +699,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -687,6 +714,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -717,6 +745,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -731,6 +760,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -761,6 +791,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -775,6 +806,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -805,6 +837,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -819,6 +852,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -849,6 +883,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -863,6 +898,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -930,6 +966,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -944,6 +981,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -974,6 +1012,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -988,6 +1027,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -1021,6 +1061,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1035,6 +1076,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -1076,6 +1118,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1090,6 +1133,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -1123,6 +1167,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1137,6 +1182,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -1170,6 +1216,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1184,6 +1231,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -1223,6 +1271,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1237,6 +1286,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1292,6 +1342,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1313,6 +1364,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1363,6 +1415,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1384,6 +1437,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1434,6 +1488,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1455,6 +1510,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1505,6 +1561,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1526,6 +1583,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1576,6 +1634,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1597,6 +1656,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1650,6 +1710,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1664,6 +1725,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1706,6 +1768,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1727,6 +1790,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1777,6 +1841,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1798,6 +1863,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1848,6 +1914,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1869,6 +1936,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1919,6 +1987,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1940,6 +2009,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -1990,6 +2060,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2011,6 +2082,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2058,6 +2130,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::prelude::*;
@@ -2073,6 +2146,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -2106,6 +2180,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2120,6 +2195,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -2153,6 +2229,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2167,6 +2244,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -2200,6 +2278,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2214,6 +2293,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -2250,6 +2330,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2271,6 +2352,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2321,6 +2403,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2342,6 +2425,7 @@ where
 /// ```
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2393,6 +2477,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, stream::Partial};
 /// # use winnow::prelude::*;
 /// use winnow::Bytes;
@@ -2437,6 +2522,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed, stream::{Partial, StreamIsPartial}};
 /// # use winnow::prelude::*;
 /// use winnow::Bytes;
@@ -2490,6 +2576,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # #[cfg(feature = "std")] {
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -1,14 +1,14 @@
 use super::*;
 use crate::unpeek;
-use crate::IResult;
 
 mod complete {
     use super::*;
+    use crate::error::IResult;
     use crate::error::InputError;
 
     macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, InputError<_>> = $left;
+      let res: $crate::error::IResult<_, _, InputError<_>> = $left;
       assert_eq!(res, $right);
     };
   );
@@ -436,6 +436,7 @@ mod complete {
 mod partial {
     use super::*;
     use crate::error::ErrMode;
+    use crate::error::IResult;
     use crate::error::InputError;
     use crate::error::Needed;
     #[cfg(feature = "alloc")]
@@ -446,12 +447,11 @@ mod partial {
         binary::{be_u16, be_u8},
         error::ErrorKind,
         lib::std::str::{self, FromStr},
-        IResult,
     };
 
     macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
-      let res: $crate::IResult<_, _, InputError<_>> = $left;
+      let res: $crate::error::IResult<_, _, InputError<_>> = $left;
       assert_eq!(res, $right);
     };
   );

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::unpeek;
 
 mod complete {
     use super::*;
@@ -1156,38 +1155,38 @@ mod partial {
     #[test]
     #[cfg(feature = "alloc")]
     fn length_repeat_test() {
-        fn number(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+        fn number(i: &mut Partial<&[u8]>) -> PResult<u32> {
             digit
                 .try_map(str::from_utf8)
                 .try_map(FromStr::from_str)
-                .parse_peek(i)
+                .parse_next(i)
         }
 
-        fn cnt(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-            length_repeat(unpeek(number), "abc").parse_peek(i)
+        fn cnt<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+            length_repeat(number, "abc").parse_next(i)
         }
 
         assert_eq!(
-            cnt(Partial::new(&b"2abcabcabcdef"[..])),
+            cnt.parse_peek(Partial::new(&b"2abcabcabcdef"[..])),
             Ok((Partial::new(&b"abcdef"[..]), vec![&b"abc"[..], &b"abc"[..]]))
         );
         assert_eq!(
-            cnt(Partial::new(&b"2ab"[..])),
+            cnt.parse_peek(Partial::new(&b"2ab"[..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            cnt(Partial::new(&b"3abcab"[..])),
+            cnt.parse_peek(Partial::new(&b"3abcab"[..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            cnt(Partial::new(&b"xxx"[..])),
+            cnt.parse_peek(Partial::new(&b"xxx"[..])),
             Err(ErrMode::Backtrack(error_position!(
                 &Partial::new(&b"xxx"[..]),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            cnt(Partial::new(&b"2abcxxx"[..])),
+            cnt.parse_peek(Partial::new(&b"2abcxxx"[..])),
             Err(ErrMode::Backtrack(error_position!(
                 &Partial::new(&b"xxx"[..]),
                 ErrorKind::Literal
@@ -1243,34 +1242,34 @@ mod partial {
 
     #[test]
     fn length_take_test() {
-        fn number(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+        fn number(i: &mut Partial<&[u8]>) -> PResult<u32> {
             digit
                 .try_map(str::from_utf8)
                 .try_map(FromStr::from_str)
-                .parse_peek(i)
+                .parse_next(i)
         }
 
-        fn take(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-            length_take(unpeek(number)).parse_peek(i)
+        fn take<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+            length_take(number).parse_next(i)
         }
 
         assert_eq!(
-            take(Partial::new(&b"6abcabcabcdef"[..])),
+            take.parse_peek(Partial::new(&b"6abcabcabcdef"[..])),
             Ok((Partial::new(&b"abcdef"[..]), &b"abcabc"[..]))
         );
         assert_eq!(
-            take(Partial::new(&b"3ab"[..])),
+            take.parse_peek(Partial::new(&b"3ab"[..])),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            take(Partial::new(&b"xxx"[..])),
+            take.parse_peek(Partial::new(&b"xxx"[..])),
             Err(ErrMode::Backtrack(error_position!(
                 &Partial::new(&b"xxx"[..]),
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            take(Partial::new(&b"2abcxxx"[..])),
+            take.parse_peek(Partial::new(&b"2abcxxx"[..])),
             Ok((Partial::new(&b"cxxx"[..]), &b"ab"[..]))
         );
     }

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -28,6 +28,7 @@ pub trait Alt<I, O, E> {
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::InputError,error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::ascii::{alpha1, digit1};
@@ -79,6 +80,7 @@ pub trait Permutation<I, O, E> {
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode,error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::ascii::{alpha1, digit1};
@@ -102,6 +104,7 @@ pub trait Permutation<I, O, E> {
 /// The parsers are applied greedily: if there are multiple unapplied parsers
 /// that could parse the next slice of input, the first one is used.
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::permutation;

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -32,6 +32,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::opt;
@@ -71,7 +72,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, IResult};
+/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::IResult};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::cond;
 /// use winnow::ascii::alpha1;
@@ -112,7 +113,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::IResult};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::peek;
 /// use winnow::ascii::alpha1;
@@ -150,6 +151,7 @@ where
 ///
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::prelude::*;;
 /// pub fn eof<'i>(input: &mut &'i str) -> PResult<&'i str>
 /// # {
@@ -160,6 +162,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use std::str;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::combinator::eof;
@@ -197,7 +200,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::IResult};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::not;
 /// use winnow::ascii::alpha1;
@@ -238,6 +241,7 @@ where
 ///
 /// Without `cut_err`:
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::token::one_of;
 /// # use winnow::token::rest;
@@ -262,6 +266,7 @@ where
 ///
 /// With `cut_err`:
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::prelude::*;
 /// # use winnow::token::one_of;
@@ -325,6 +330,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::prelude::*;
 /// # use winnow::combinator::todo;
 ///
@@ -354,7 +360,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// use winnow::{combinator::iterator, IResult, ascii::alpha1, combinator::terminated};
+/// use winnow::{combinator::iterator, error::IResult, ascii::alpha1, combinator::terminated};
 /// use std::collections::HashMap;
 ///
 /// let data = "abc|defg|hijkl|mnopqr|123";
@@ -472,6 +478,7 @@ enum State<E> {
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::alt;
@@ -507,7 +514,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::IResult};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::fail;
 ///

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -32,6 +32,7 @@ use crate::Parser;
 /// Zero or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
@@ -50,6 +51,7 @@ use crate::Parser;
 /// One or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
@@ -68,6 +70,7 @@ use crate::Parser;
 /// Fixed number of repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
@@ -87,6 +90,7 @@ use crate::Parser;
 /// Arbitrary repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
@@ -176,6 +180,7 @@ where
     ///
     /// Zero or more repetitions:
     /// ```rust
+    /// # use winnow::error::IResult;
     /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
@@ -201,6 +206,7 @@ where
     ///
     /// One or more repetitions:
     /// ```rust
+    /// # use winnow::error::IResult;
     /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
@@ -226,6 +232,7 @@ where
     ///
     /// Arbitrary number of repetitions:
     /// ```rust
+    /// # use winnow::error::IResult;
     /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
@@ -475,6 +482,7 @@ where
 ///
 /// ```rust
 /// # #[cfg(feature = "std")] {
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat_till;
@@ -640,6 +648,7 @@ where
 /// Zero or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
@@ -659,6 +668,7 @@ where
 /// One or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
@@ -678,6 +688,7 @@ where
 /// Fixed number of repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
@@ -697,6 +708,7 @@ where
 /// Arbitrary repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
@@ -1032,6 +1044,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_foldl1;
@@ -1099,6 +1112,7 @@ where
 /// # Example
 ///
 /// ```
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_foldr1;
@@ -1150,6 +1164,7 @@ where
 /// # Example
 ///
 /// ```rust
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::fill;

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -14,7 +14,6 @@ use crate::error::ParserError;
 use crate::lib::std::borrow::ToOwned;
 use crate::stream::Stream;
 use crate::token::take;
-use crate::unpeek;
 use crate::PResult;
 use crate::Parser;
 use crate::Partial;
@@ -534,33 +533,27 @@ fn alt_test() {
         }
     }
 
-    fn work(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        Ok(input.peek_finish())
+    fn work<'i>(input: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+        Ok(input.finish())
     }
 
     #[allow(unused_variables)]
-    fn dont_work(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
+    fn dont_work<'i>(input: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
         Err(ErrMode::Backtrack(ErrorStr("abcd".to_owned())))
     }
 
-    fn work2(input: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        Ok((input, &b""[..]))
+    fn work2<'i>(_input: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+        Ok(&b""[..])
     }
 
-    fn alt1(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        alt((unpeek(dont_work), unpeek(dont_work))).parse_peek(i)
+    fn alt1<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+        alt((dont_work, dont_work)).parse_next(i)
     }
-    fn alt2(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        alt((unpeek(dont_work), unpeek(work))).parse_peek(i)
+    fn alt2<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+        alt((dont_work, work)).parse_next(i)
     }
-    fn alt3(i: &[u8]) -> IResult<&[u8], &[u8], ErrorStr> {
-        alt((
-            unpeek(dont_work),
-            unpeek(dont_work),
-            unpeek(work2),
-            unpeek(dont_work),
-        ))
-        .parse_peek(i)
+    fn alt3<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+        alt((dont_work, dont_work, work2, dont_work)).parse_next(i)
     }
     //named!(alt1, alt!(dont_work | dont_work));
     //named!(alt2, alt!(dont_work | work));
@@ -568,15 +561,15 @@ fn alt_test() {
 
     let a = &b"abcd"[..];
     assert_eq!(
-        alt1(a),
+        alt1.parse_peek(a),
         Err(ErrMode::Backtrack(error_node_position!(
             &a,
             ErrorKind::Alt,
             ErrorStr("abcd".to_owned())
         )))
     );
-    assert_eq!(alt2(a), Ok((&b""[..], a)));
-    assert_eq!(alt3(a), Ok((a, &b""[..])));
+    assert_eq!(alt2.parse_peek(a), Ok((&b""[..], a)));
+    assert_eq!(alt3.parse_peek(a), Ok((a, &b""[..])));
 
     fn alt4(i: &[u8]) -> IResult<&[u8], &[u8]> {
         alt(("abcd", "efgh")).parse_peek(i)
@@ -1024,27 +1017,27 @@ fn repeat_till_range_test() {
 #[test]
 #[cfg(feature = "std")]
 fn infinite_many() {
-    fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
+    fn tst<'i>(input: &mut &'i [u8]) -> PResult<&'i [u8]> {
         println!("input: {input:?}");
         Err(ErrMode::Backtrack(error_position!(
-            &input,
+            input,
             ErrorKind::Literal
         )))
     }
 
     // should not go into an infinite loop
-    fn multi0(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        repeat(0.., unpeek(tst)).parse_peek(i)
+    fn multi0<'i>(i: &mut &'i [u8]) -> PResult<Vec<&'i [u8]>> {
+        repeat(0.., tst).parse_next(i)
     }
     let a = &b"abcdef"[..];
-    assert_eq!(multi0(a), Ok((a, Vec::new())));
+    assert_eq!(multi0.parse_peek(a), Ok((a, Vec::new())));
 
-    fn multi1(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        repeat(1.., unpeek(tst)).parse_peek(i)
+    fn multi1<'i>(i: &mut &'i [u8]) -> PResult<Vec<&'i [u8]>> {
+        repeat(1.., tst).parse_next(i)
     }
     let a = &b"abcdef"[..];
     assert_eq!(
-        multi1(a),
+        multi1.parse_peek(a),
         Err(ErrMode::Backtrack(error_position!(&a, ErrorKind::Literal)))
     );
 }

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -6,6 +6,7 @@ use crate::binary::u8;
 use crate::binary::Endianness;
 use crate::error::ErrMode;
 use crate::error::ErrorKind;
+use crate::error::IResult;
 use crate::error::InputError;
 use crate::error::Needed;
 use crate::error::ParserError;
@@ -14,7 +15,6 @@ use crate::lib::std::borrow::ToOwned;
 use crate::stream::Stream;
 use crate::token::take;
 use crate::unpeek;
-use crate::IResult;
 use crate::PResult;
 use crate::Parser;
 use crate::Partial;
@@ -24,7 +24,7 @@ use crate::lib::std::vec::Vec;
 
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {
-    let res: $crate::IResult<_, _, InputError<_>> = $left;
+    let res: $crate::error::IResult<_, _, InputError<_>> = $left;
     assert_eq!(res, $right);
   };
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,6 @@ pub mod prelude {
     pub use crate::stream::ContainsToken as _;
     pub use crate::stream::Stream as _;
     pub use crate::stream::StreamIsPartial as _;
-    pub use crate::IResult;
     pub use crate::PResult;
     pub use crate::Parser;
     #[cfg(feature = "unstable-recover")]
@@ -157,7 +156,6 @@ pub mod prelude {
     pub use crate::RecoverableParser as _;
 }
 
-pub use error::IResult;
 pub use error::PResult;
 pub use parser::*;
 pub use stream::BStr;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1271,8 +1271,9 @@ where
     }
 }
 
-/// Convert a [`Parser::parse_peek`] style parse function to be a [`Parser`]
+/// Deprecated
 #[inline(always)]
+#[deprecated(since = "0.6.23")]
 pub fn unpeek<'a, I, O, E>(
     mut peek: impl FnMut(I) -> IResult<I, O, E> + 'a,
 ) -> impl FnMut(&mut I) -> PResult<O, E>

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -254,6 +254,7 @@ pub trait Parser<I, O, E> {
     /// ```rust
     /// # use winnow::prelude::*;
     /// # use winnow::error::InputError;
+    /// # use winnow::error::IResult;
     /// use winnow::ascii::alpha1;
     /// # fn main() {
     ///

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -38,6 +38,7 @@ use crate::Parser;
 /// ```rust
 /// # use winnow::{token::any, error::ErrMode, error::{InputError, ErrorKind}};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// fn parser(input: &str) -> IResult<&str, char> {
 ///     any.parse_peek(input)
 /// }
@@ -49,6 +50,7 @@ use crate::Parser;
 /// ```rust
 /// # use winnow::{token::any, error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// assert_eq!(any::<_, InputError<_>>.parse_peek(Partial::new("abc")), Ok((Partial::new("bc"),'a')));
 /// assert_eq!(any::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -115,6 +117,7 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// #
 /// fn parser(s: &str) -> IResult<&str, &str> {
@@ -128,6 +131,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::Partial;
 ///
@@ -144,6 +148,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// use winnow::token::literal;
 /// use winnow::ascii::Caseless;
 ///
@@ -233,6 +238,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::token::one_of;
 /// assert_eq!(one_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek("b"), Ok(("", 'b')));
@@ -249,6 +255,7 @@ where
 ///
 /// ```
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::token::one_of;
@@ -306,6 +313,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::token::none_of;
 /// assert_eq!(none_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek("z"), Ok(("", 'z')));
 /// assert_eq!(none_of::<_, _, InputError<_>>(['a', 'b']).parse_peek("a"), Err(ErrMode::Backtrack(InputError::new("a", ErrorKind::Verify))));
@@ -315,6 +323,7 @@ where
 /// ```
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// # use winnow::token::none_of;
 /// assert_eq!(none_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek(Partial::new("z")), Ok((Partial::new(""), 'z')));
@@ -366,6 +375,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
@@ -382,6 +392,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
@@ -400,6 +411,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
@@ -425,6 +437,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
@@ -452,6 +465,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
@@ -469,6 +483,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
@@ -650,6 +665,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// use winnow::token::take_till;
 ///
 /// fn till_colon(s: &str) -> IResult<&str, &str> {
@@ -665,6 +681,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_till;
 ///
@@ -750,6 +767,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// use winnow::token::take;
 ///
 /// fn take6(s: &str) -> IResult<&str, &str> {
@@ -768,6 +786,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// use winnow::error::InputError;
 /// use winnow::token::take;
 ///
@@ -777,7 +796,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::error::{ErrMode, ErrorKind, InputError, Needed, IResult};
 /// # use winnow::Partial;
 /// use winnow::token::take;
 ///
@@ -858,6 +877,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// use winnow::token::take_until;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -873,6 +893,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_until;
 ///
@@ -889,6 +910,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// use winnow::token::take_until;
 ///
 /// fn until_eof(s: &str) -> IResult<&str, &str> {
@@ -905,6 +927,7 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_until;
 ///
@@ -1051,6 +1074,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::error::ErrorKind;
 /// # use winnow::error::InputError;
 /// use winnow::token::rest;
@@ -1089,6 +1113,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
+/// # use winnow::error::IResult;
 /// # use winnow::error::ErrorKind;
 /// # use winnow::error::InputError;
 /// use winnow::token::rest_len;

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -7,18 +7,18 @@ use crate::ascii::Caseless;
 use crate::combinator::delimited;
 use crate::error::ErrMode;
 use crate::error::ErrorKind;
+use crate::error::IResult;
 use crate::error::InputError;
 use crate::error::Needed;
 use crate::stream::AsChar;
 use crate::token::literal;
 use crate::unpeek;
-use crate::IResult;
 use crate::Parser;
 use crate::Partial;
 
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {
-    let res: $crate::IResult<_, _, InputError<_>> = $left;
+    let res: $crate::error::IResult<_, _, InputError<_>> = $left;
     assert_eq!(res, $right);
   };
 );

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -12,7 +12,6 @@ use crate::error::InputError;
 use crate::error::Needed;
 use crate::stream::AsChar;
 use crate::token::literal;
-use crate::unpeek;
 use crate::Parser;
 use crate::Partial;
 
@@ -732,18 +731,18 @@ fn partial_take_while_m_n_utf8_full_match_range() {
 #[test]
 #[cfg(feature = "std")]
 fn partial_take_take_while0() {
-    fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while(0.., AsChar::is_alphanum).parse_peek(i)
+    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        take_while(0.., AsChar::is_alphanum).parse_next(i)
     }
-    fn y(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        unpeek(x).take().parse_peek(i)
+    fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        x.take().parse_next(i)
     }
     assert_eq!(
-        x(Partial::new(&b"ab."[..])),
+        x.parse_peek(Partial::new(&b"ab."[..])),
         Ok((Partial::new(&b"."[..]), &b"ab"[..]))
     );
     assert_eq!(
-        y(Partial::new(&b"ab."[..])),
+        y.parse_peek(Partial::new(&b"ab."[..])),
         Ok((Partial::new(&b"."[..]), &b"ab"[..]))
     );
 }

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -4,11 +4,9 @@ use winnow::ascii::digit1 as digit;
 #[cfg(feature = "alloc")]
 use winnow::combinator::repeat;
 use winnow::combinator::terminated;
-use winnow::error::IResult;
 use winnow::error::{ErrorKind, ParserError};
 use winnow::prelude::*;
 use winnow::stream::Stream;
-use winnow::unpeek;
 use winnow::Partial;
 
 #[derive(Debug)]
@@ -35,23 +33,23 @@ impl<'a> ParserError<Partial<&'a str>> for CustomError {
     }
 }
 
-fn test1(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
+fn test1<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, CustomError> {
     //fix_error!(input, CustomError, tag!("abcd"))
-    "abcd".parse_peek(input)
+    "abcd".parse_next(input)
 }
 
-fn test2(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
+fn test2<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, CustomError> {
     //terminated!(input, test1, fix_error!(CustomError, digit))
-    terminated(unpeek(test1), digit).parse_peek(input)
+    terminated(test1, digit).parse_next(input)
 }
 
-fn test3(input: Partial<&str>) -> IResult<Partial<&str>, &str, CustomError> {
-    unpeek(test1)
+fn test3<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, CustomError> {
+    test1
         .verify(|s: &str| s.starts_with("abcd"))
-        .parse_peek(input)
+        .parse_next(input)
 }
 
 #[cfg(feature = "alloc")]
-fn test4(input: Partial<&str>) -> IResult<Partial<&str>, Vec<&str>, CustomError> {
-    repeat(4, unpeek(test1)).parse_peek(input)
+fn test4<'i>(input: &mut Partial<&'i str>) -> PResult<Vec<&'i str>, CustomError> {
+    repeat(4, test1).parse_next(input)
 }

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -4,11 +4,11 @@ use winnow::ascii::digit1 as digit;
 #[cfg(feature = "alloc")]
 use winnow::combinator::repeat;
 use winnow::combinator::terminated;
+use winnow::error::IResult;
 use winnow::error::{ErrorKind, ParserError};
 use winnow::prelude::*;
 use winnow::stream::Stream;
 use winnow::unpeek;
-use winnow::IResult;
 use winnow::Partial;
 
 #[derive(Debug)]

--- a/tests/testsuite/float.rs
+++ b/tests/testsuite/float.rs
@@ -2,45 +2,64 @@ use winnow::ascii::digit1 as digit;
 use winnow::combinator::alt;
 use winnow::combinator::delimited;
 use winnow::combinator::opt;
-use winnow::error::IResult;
 use winnow::prelude::*;
-use winnow::unpeek;
 
 use std::str;
 use std::str::FromStr;
 
-fn unsigned_float(i: &[u8]) -> IResult<&[u8], f32> {
+fn unsigned_float(i: &mut &[u8]) -> PResult<f32> {
     let float_bytes = alt((
         delimited(digit, ".", opt(digit)),
         delimited(opt(digit), ".", digit),
     ))
     .take();
     let float_str = float_bytes.try_map(str::from_utf8);
-    float_str.try_map(FromStr::from_str).parse_peek(i)
+    float_str.try_map(FromStr::from_str).parse_next(i)
 }
 
-fn float(i: &[u8]) -> IResult<&[u8], f32> {
-    (opt(alt(("+", "-"))), unpeek(unsigned_float))
+fn float(i: &mut &[u8]) -> PResult<f32> {
+    (opt(alt(("+", "-"))), unsigned_float)
         .map(|(sign, value)| {
             sign.and_then(|s| if s[0] == b'-' { Some(-1f32) } else { None })
                 .unwrap_or(1f32)
                 * value
         })
-        .parse_peek(i)
+        .parse_next(i)
 }
 
 #[test]
 fn unsigned_float_test() {
-    assert_eq!(unsigned_float(&b"123.456;"[..]), Ok((&b";"[..], 123.456)));
-    assert_eq!(unsigned_float(&b"0.123;"[..]), Ok((&b";"[..], 0.123)));
-    assert_eq!(unsigned_float(&b"123.0;"[..]), Ok((&b";"[..], 123.0)));
-    assert_eq!(unsigned_float(&b"123.;"[..]), Ok((&b";"[..], 123.0)));
-    assert_eq!(unsigned_float(&b".123;"[..]), Ok((&b";"[..], 0.123)));
+    assert_eq!(
+        unsigned_float.parse_peek(&b"123.456;"[..]),
+        Ok((&b";"[..], 123.456))
+    );
+    assert_eq!(
+        unsigned_float.parse_peek(&b"0.123;"[..]),
+        Ok((&b";"[..], 0.123))
+    );
+    assert_eq!(
+        unsigned_float.parse_peek(&b"123.0;"[..]),
+        Ok((&b";"[..], 123.0))
+    );
+    assert_eq!(
+        unsigned_float.parse_peek(&b"123.;"[..]),
+        Ok((&b";"[..], 123.0))
+    );
+    assert_eq!(
+        unsigned_float.parse_peek(&b".123;"[..]),
+        Ok((&b";"[..], 0.123))
+    );
 }
 
 #[test]
 fn float_test() {
-    assert_eq!(float(&b"123.456;"[..]), Ok((&b";"[..], 123.456)));
-    assert_eq!(float(&b"+123.456;"[..]), Ok((&b";"[..], 123.456)));
-    assert_eq!(float(&b"-123.456;"[..]), Ok((&b";"[..], -123.456)));
+    assert_eq!(float.parse_peek(&b"123.456;"[..]), Ok((&b";"[..], 123.456)));
+    assert_eq!(
+        float.parse_peek(&b"+123.456;"[..]),
+        Ok((&b";"[..], 123.456))
+    );
+    assert_eq!(
+        float.parse_peek(&b"-123.456;"[..]),
+        Ok((&b";"[..], -123.456))
+    );
 }

--- a/tests/testsuite/float.rs
+++ b/tests/testsuite/float.rs
@@ -2,9 +2,9 @@ use winnow::ascii::digit1 as digit;
 use winnow::combinator::alt;
 use winnow::combinator::delimited;
 use winnow::combinator::opt;
+use winnow::error::IResult;
 use winnow::prelude::*;
 use winnow::unpeek;
-use winnow::IResult;
 
 use std::str;
 use std::str::FromStr;

--- a/tests/testsuite/fnmut.rs
+++ b/tests/testsuite/fnmut.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "alloc")]
 
 use winnow::combinator::repeat;
-use winnow::unpeek;
 use winnow::Parser;
 
 #[test]
@@ -10,13 +9,10 @@ fn parse() {
     let mut counter = 0;
 
     let res = {
-        let mut parser = repeat::<_, _, Vec<_>, (), _>(
-            0..,
-            unpeek(|i| {
-                counter += 1;
-                "abc".parse_peek(i)
-            }),
-        );
+        let mut parser = repeat::<_, _, Vec<_>, (), _>(0.., |i: &mut _| {
+            counter += 1;
+            "abc".parse_next(i)
+        });
 
         parser.parse_peek("abcabcabcabc").unwrap()
     };
@@ -30,14 +26,11 @@ fn accumulate() {
     let mut v = Vec::new();
 
     let (_, count) = {
-        let mut parser = repeat::<_, _, usize, (), _>(
-            0..,
-            unpeek(|i| {
-                let (i, o) = "abc".parse_peek(i)?;
-                v.push(o);
-                Ok((i, ()))
-            }),
-        );
+        let mut parser = repeat::<_, _, usize, (), _>(0.., |i: &mut _| {
+            let o = "abc".parse_next(i)?;
+            v.push(o);
+            Ok(())
+        });
         parser.parse_peek("abcabcabcabc").unwrap()
     };
 

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -4,7 +4,9 @@
 
 use winnow::prelude::*;
 use winnow::Partial;
-use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed, unpeek, IResult};
+use winnow::{
+    error::ErrMode, error::ErrorKind, error::IResult, error::InputError, error::Needed, unpeek,
+};
 
 #[allow(dead_code)]
 struct Range {
@@ -29,7 +31,8 @@ mod parse_int {
         ascii::{digit1 as digit, space1 as space},
         combinator::opt,
         combinator::repeat,
-        unpeek, IResult,
+        error::IResult,
+        unpeek,
     };
 
     fn parse_ints(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<i32>> {
@@ -135,7 +138,7 @@ mod issue_647 {
     use super::*;
     use winnow::combinator::separated;
     use winnow::token::literal;
-    use winnow::{binary::be_f64, error::ErrMode, IResult};
+    use winnow::{binary::be_f64, error::ErrMode, error::IResult};
     pub(crate) type Stream<'a> = Partial<&'a [u8]>;
 
     #[derive(PartialEq, Debug, Clone)]

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -4,9 +4,7 @@
 
 use winnow::prelude::*;
 use winnow::Partial;
-use winnow::{
-    error::ErrMode, error::ErrorKind, error::IResult, error::InputError, error::Needed, unpeek,
-};
+use winnow::{error::ErrMode, error::ErrorKind, error::IResult, error::InputError, error::Needed};
 
 #[allow(dead_code)]
 struct Range {
@@ -31,17 +29,15 @@ mod parse_int {
         ascii::{digit1 as digit, space1 as space},
         combinator::opt,
         combinator::repeat,
-        error::IResult,
-        unpeek,
     };
 
-    fn parse_ints(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<i32>> {
-        repeat(0.., unpeek(spaces_or_int)).parse_peek(input)
+    fn parse_ints(input: &mut Partial<&[u8]>) -> PResult<Vec<i32>> {
+        repeat(0.., spaces_or_int).parse_next(input)
     }
 
-    fn spaces_or_int(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-        let (i, _) = opt(space.complete_err()).parse_peek(input)?;
-        let (i, res) = digit
+    fn spaces_or_int(input: &mut Partial<&[u8]>) -> PResult<i32> {
+        let _ = opt(space.complete_err()).parse_next(input)?;
+        let res = digit
             .complete_err()
             .map(|x| {
                 println!("x: {x:?}");
@@ -53,18 +49,18 @@ mod parse_int {
                     Err(e) => panic!("UH OH! NOT A DIGIT! {e:?}"),
                 }
             })
-            .parse_peek(i)?;
+            .parse_next(input)?;
 
-        Ok((i, res))
+        Ok(res)
     }
 
     #[test]
     fn issue_142() {
-        let subject = parse_ints(Partial::new(&b"12 34 5689a"[..]));
+        let subject = parse_ints.parse_peek(Partial::new(&b"12 34 5689a"[..]));
         let expected = Ok((Partial::new(&b"a"[..]), vec![12, 34, 5689]));
         assert_eq!(subject, expected);
 
-        let subject = parse_ints(Partial::new(&b"12 34 5689 "[..]));
+        let subject = parse_ints.parse_peek(Partial::new(&b"12 34 5689 "[..]));
         let expected = Ok((Partial::new(&b" "[..]), vec![12, 34, 5689]));
         assert_eq!(subject, expected);
     }
@@ -166,17 +162,17 @@ mod issue_647 {
 #[test]
 #[cfg_attr(debug_assertions, should_panic)]
 fn issue_848_overflow_incomplete_bits_to_bytes() {
-    fn take(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
+    fn take<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         use winnow::token::take;
-        take(0x2000000000000000_usize).parse_peek(i)
+        take(0x2000000000000000_usize).parse_next(i)
     }
-    fn parser(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
+    fn parser<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         use winnow::binary::bits::{bits, bytes};
 
-        bits(bytes(unpeek(take))).parse_peek(i)
+        bits(bytes(take)).parse_next(i)
     }
     assert_eq!(
-        parser(Partial::new(&b""[..])),
+        parser.parse_peek(Partial::new(&b""[..])),
         Err(ErrMode::Cut(InputError::new(
             Partial::new(&b""[..]),
             ErrorKind::Assert

--- a/tests/testsuite/multiline.rs
+++ b/tests/testsuite/multiline.rs
@@ -4,7 +4,8 @@ use winnow::{
     ascii::{alphanumeric1 as alphanumeric, line_ending as eol},
     combinator::repeat,
     combinator::terminated,
-    unpeek, IResult, Parser,
+    error::IResult,
+    unpeek, Parser,
 };
 
 pub(crate) fn end_of_line(input: &str) -> IResult<&str, &str> {

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -7,7 +7,7 @@ use winnow::binary::be_u64;
 use winnow::binary::length_take;
 #[cfg(feature = "alloc")]
 use winnow::combinator::repeat;
-use winnow::error::{ErrMode, Needed};
+use winnow::error::{ErrMode, IResult, Needed};
 use winnow::prelude::*;
 use winnow::token::take;
 use winnow::Partial;

--- a/tests/testsuite/reborrow_fold.rs
+++ b/tests/testsuite/reborrow_fold.rs
@@ -5,10 +5,10 @@ use std::str;
 
 use winnow::combinator::delimited;
 use winnow::combinator::repeat;
+use winnow::error::IResult;
 use winnow::error::InputError;
 use winnow::prelude::*;
 use winnow::token::take_till;
-use winnow::IResult;
 
 fn atom<'a>(_tomb: &mut ()) -> impl Parser<&'a [u8], String, InputError<&'a [u8]>> {
     take_till(1.., [' ', '\t', '\r', '\n'])

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -7,9 +7,8 @@ mod test {
     use winnow::{combinator::alt, combinator::repeat, token::literal};
     use winnow::{
         error::ErrMode,
-        error::{ErrorKind, InputError},
+        error::{ErrorKind, IResult, InputError},
         token::{take, take_till, take_until, take_while},
-        IResult,
     };
 
     #[test]
@@ -64,9 +63,7 @@ mod test {
         match res {
             Err(ErrMode::Backtrack(_)) => (),
             other => {
-                panic!(
-                    "Parser `literal` didn't fail when it should have. Got `{other:?}`.`"
-                );
+                panic!("Parser `literal` didn't fail when it should have. Got `{other:?}`.`");
             }
         };
     }
@@ -387,9 +384,7 @@ mod test {
         }
         match test(INPUT) {
             Err(ErrMode::Backtrack(_)) => (),
-            other => panic!(
-                "Parser `is_a` didn't fail when it should have. Got `{other:?}`."
-            ),
+            other => panic!("Parser `is_a` didn't fail when it should have. Got `{other:?}`."),
         };
     }
 
@@ -459,9 +454,7 @@ mod test {
         }
         match test(INPUT) {
             Err(ErrMode::Backtrack(_)) => (),
-            other => panic!(
-                "Parser `is_not` didn't fail when it should have. Got `{other:?}`."
-            ),
+            other => panic!("Parser `is_not` didn't fail when it should have. Got `{other:?}`."),
         };
     }
 


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
