### PR TITLE
fix: Deprecate `unpeek`

### DIFF
--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -8,7 +8,7 @@ use crate::combinator::trace;
 use crate::error::{ErrMode, ErrorConvert, ErrorKind, Needed, ParserError};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
 use crate::stream::{Stream, StreamIsPartial, ToUsize};
-use crate::{unpeek, IResult, PResult, Parser};
+use crate::{IResult, PResult, Parser};
 
 /// Number of bits in a byte
 const BYTE: usize = u8::BITS as usize;
@@ -56,6 +56,8 @@ where
     Input: Stream + Clone,
     ParseNext: Parser<(Input, usize), Output, BitError>,
 {
+    #![allow(deprecated)]
+    use crate::unpeek;
     trace(
         "bits",
         unpeek(move |input: Input| {
@@ -123,6 +125,8 @@ where
     Input: Stream<Token = u8> + Clone,
     ParseNext: Parser<Input, Output, ByteError>,
 {
+    #![allow(deprecated)]
+    use crate::unpeek;
     trace(
         "bytes",
         unpeek(move |(input, offset): (Input, usize)| {
@@ -203,6 +207,8 @@ where
     Count: ToUsize,
     Error: ParserError<(Input, usize)>,
 {
+    #![allow(deprecated)]
+    use crate::unpeek;
     let count = count.to_usize();
     trace(
         "take",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1261,8 +1261,9 @@ impl<I, O, E> Parser<I, O, E> for Box<dyn Parser<I, O, E> + '_> {
     }
 }
 
-/// Convert a [`Parser::parse_peek`] style parse function to be a [`Parser`]
+/// Deprecated
 #[inline(always)]
+#[deprecated(since = "0.6.23")]
 pub fn unpeek<'a, I, O, E>(
     mut peek: impl FnMut(I) -> IResult<I, O, E> + 'a,
 ) -> impl FnMut(&mut I) -> PResult<O, E>


### PR DESCRIPTION
This is a partial cherry-pick of #676