### PR TITLE
fix(stream): Re-add re-export of Located in root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,8 @@ pub use error::PResult;
 pub use parser::*;
 pub use stream::BStr;
 pub use stream::Bytes;
+#[allow(deprecated)]
+pub use stream::Located;
 pub use stream::LocatingSlice;
 pub use stream::Partial;
 pub use stream::Stateful;


### PR DESCRIPTION
Over-aggressive regex and missed this in the audit