### PR TITLE
fix(ascii): Improve 'float' error quality by removing 'alt'

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -8,7 +8,6 @@ mod tests;
 use crate::lib::std::ops::{Add, Shl};
 
 use crate::combinator::alt;
-use crate::combinator::cut_err;
 use crate::combinator::dispatch;
 use crate::combinator::empty;
 use crate::combinator::fail;
@@ -1549,7 +1548,7 @@ where
     I: AsBStr,
 {
     dispatch! {opt(peek(any).map(AsChar::as_char));
-        Some('E') | Some('e') => (one_of(['e', 'E']), opt(one_of(['+', '-'])), cut_err(digit1)).void(),
+        Some('E') | Some('e') => (one_of(['e', 'E']), opt(one_of(['+', '-'])), digit1).void(),
         _ => empty,
     }
     .parse_next(input)

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1512,8 +1512,12 @@ where
     alt((
         take_float,
         Caseless("nan"),
-        (opt(one_of(['+', '-'])), Caseless("infinity")).take(),
-        (opt(one_of(['+', '-'])), Caseless("inf")).take(),
+        (
+            opt(one_of(['+', '-'])),
+            Caseless("inf"),
+            opt(Caseless("inity")),
+        )
+            .take(),
     ))
     .parse_next(input)
 }

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1511,17 +1511,9 @@ where
 {
     alt((
         take_float,
-        crate::token::literal(Caseless("nan")),
-        (
-            opt(one_of(['+', '-'])),
-            crate::token::literal(Caseless("infinity")),
-        )
-            .take(),
-        (
-            opt(one_of(['+', '-'])),
-            crate::token::literal(Caseless("inf")),
-        )
-            .take(),
+        Caseless("nan"),
+        (opt(one_of(['+', '-'])), Caseless("infinity")).take(),
+        (opt(one_of(['+', '-'])), Caseless("inf")).take(),
     ))
     .parse_next(input)
 }

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1511,19 +1511,20 @@ where
 {
     alt((
         take_float,
-        Caseless("nan"),
+        Caseless("nan").void(),
         (
             opt(one_of(['+', '-'])),
             Caseless("inf"),
             opt(Caseless("inity")),
         )
-            .take(),
+            .void(),
     ))
+    .take()
     .parse_next(input)
 }
 
 #[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
-fn take_float<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+fn take_float<I, E: ParserError<I>>(input: &mut I) -> PResult<(), E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1540,7 +1541,7 @@ where
         )),
         opt((one_of(['e', 'E']), opt(one_of(['+', '-'])), cut_err(digit1))),
     )
-        .take()
+        .void()
         .parse_next(input)
 }
 

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -604,7 +604,7 @@ mod complete {
         let remaining_exponent = "-1.234E-";
         assert_parse!(
             float::<_, f64, _>.parse_peek(remaining_exponent),
-            Err(ErrMode::Cut(InputError::new("", ErrorKind::Slice)))
+            Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice)))
         );
 
         let nan_test_cases = ["nan", "NaN", "NAN"];


### PR DESCRIPTION
Really an excuse to remove `cut_err`