### PR TITLE
docs: Clean up examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-latest
+    env:
+      MIRIFLAGS: "-Zmiri-disable-isolation"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -224,10 +224,10 @@
 //! > Let's look at it more closely as its used above (resolving all generic parameters):
 //! > ```rust
 //! > # use winnow::prelude::*;
-//! > # use winnow::error::InputError;
+//! > # use winnow::error::ContextError;
 //! > pub fn one_of<'i>(
 //! >     list: &'static [char]
-//! > ) -> impl Parser<&'i str, char, InputError<&'i str>> {
+//! > ) -> impl Parser<&'i str, char, ContextError> {
 //! >     // ...
 //! > #    winnow::token::one_of(list)
 //! > }

--- a/src/_tutorial/chapter_6.rs
+++ b/src/_tutorial/chapter_6.rs
@@ -111,7 +111,6 @@ use super::chapter_1;
 use super::chapter_7;
 use crate::combinator::eof;
 use crate::error::ErrMode;
-use crate::error::InputError;
 use crate::error::ParseError;
 use crate::PResult;
 use crate::Parser;

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -74,7 +74,7 @@ impl Caseless<&str> {
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}};
 /// # use winnow::ascii::crlf;
@@ -87,7 +87,7 @@ impl Caseless<&str> {
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -124,7 +124,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::till_line_ending;
@@ -140,7 +140,7 @@ where
 /// assert_eq!(parser.parse_peek("a\rbc"), Err(ErrMode::Backtrack(InputError::new("\rbc", ErrorKind::Literal ))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::Partial;
@@ -220,7 +220,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::line_ending;
@@ -233,7 +233,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -270,7 +270,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::newline;
@@ -283,7 +283,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -321,7 +321,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::tab;
@@ -334,7 +334,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -373,7 +373,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::alpha0;
@@ -386,7 +386,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -426,7 +426,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::alpha1;
@@ -439,7 +439,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -479,7 +479,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::digit0;
@@ -493,7 +493,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -533,7 +533,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::digit1;
@@ -546,7 +546,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -560,7 +560,7 @@ where
 ///
 /// You can use `digit1` in combination with [`Parser::try_map`] to parse an integer:
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed, Parser};
 /// # use winnow::ascii::digit1;
@@ -603,7 +603,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::hex_digit0;
@@ -616,7 +616,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -657,7 +657,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::hex_digit1;
@@ -670,7 +670,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -710,7 +710,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::oct_digit0;
@@ -723,7 +723,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -764,7 +764,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::oct_digit1;
@@ -777,7 +777,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -817,7 +817,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::alphanumeric0;
@@ -830,7 +830,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -870,7 +870,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::alphanumeric1;
@@ -883,7 +883,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -923,7 +923,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -963,7 +963,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::space1;
@@ -976,7 +976,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -1016,7 +1016,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::multispace0;
@@ -1029,7 +1029,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -1069,7 +1069,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::multispace1;
@@ -1082,7 +1082,7 @@ where
 /// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::Partial;
@@ -1759,7 +1759,7 @@ where
 /// # }
 /// ```
 ///
-/// ```
+/// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -41,8 +41,8 @@ use crate::Parser;
 /// assert_eq!(parser.parse_peek("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser.parse_peek("hello, World!"), Ok((", World!", "hello")));
 /// assert_eq!(parser.parse_peek("HeLlo, World!"), Ok((", World!", "HeLlo")));
-/// assert_eq!(parser.parse_peek("Some"), Err(ErrMode::Backtrack(InputError::new("Some", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser.parse_peek("Some").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 #[derive(Copy, Clone, Debug)]
 pub struct Caseless<T>(pub T);
@@ -83,8 +83,8 @@ impl Caseless<&str> {
 /// }
 ///
 /// assert_eq!(parser.parse_peek("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser.parse_peek("ab\r\nc"), Err(ErrMode::Backtrack(InputError::new("ab\r\nc", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser.parse_peek("ab\r\nc").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -93,7 +93,7 @@ impl Caseless<&str> {
 /// # use winnow::Partial;
 /// # use winnow::ascii::crlf;
 /// assert_eq!(crlf::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
-/// assert_eq!(crlf::<_, InputError<_>>.parse_peek(Partial::new("ab\r\nc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("ab\r\nc"), ErrorKind::Literal))));
+/// assert!(crlf::<_, InputError<_>>.parse_peek(Partial::new("ab\r\nc")).is_err());
 /// assert_eq!(crlf::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
@@ -136,8 +136,8 @@ where
 /// assert_eq!(parser.parse_peek("ab\nc"), Ok(("\nc", "ab")));
 /// assert_eq!(parser.parse_peek("abc"), Ok(("", "abc")));
 /// assert_eq!(parser.parse_peek(""), Ok(("", "")));
-/// assert_eq!(parser.parse_peek("a\rb\nc"), Err(ErrMode::Backtrack(InputError::new("\rb\nc", ErrorKind::Literal ))));
-/// assert_eq!(parser.parse_peek("a\rbc"), Err(ErrMode::Backtrack(InputError::new("\rbc", ErrorKind::Literal ))));
+/// assert!(parser.parse_peek("a\rb\nc").is_err());
+/// assert!(parser.parse_peek("a\rbc").is_err());
 /// ```
 ///
 /// ```rust
@@ -148,8 +148,8 @@ where
 /// assert_eq!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("ab\r\nc")), Ok((Partial::new("\r\nc"), "ab")));
 /// assert_eq!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("a\rb\nc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("\rb\nc"), ErrorKind::Literal ))));
-/// assert_eq!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("a\rbc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("\rbc"), ErrorKind::Literal ))));
+/// assert!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("a\rb\nc")).is_err());
+/// assert!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("a\rbc")).is_err());
 /// ```
 #[inline(always)]
 pub fn till_line_ending<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -229,8 +229,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser.parse_peek("ab\r\nc"), Err(ErrMode::Backtrack(InputError::new("ab\r\nc", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser.parse_peek("ab\r\nc").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -239,7 +239,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::line_ending;
 /// assert_eq!(line_ending::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
-/// assert_eq!(line_ending::<_, InputError<_>>.parse_peek(Partial::new("ab\r\nc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("ab\r\nc"), ErrorKind::Literal))));
+/// assert!(line_ending::<_, InputError<_>>.parse_peek(Partial::new("ab\r\nc")).is_err());
 /// assert_eq!(line_ending::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -279,8 +279,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("\nc"), Ok(("c", '\n')));
-/// assert_eq!(parser.parse_peek("\r\nc"), Err(ErrMode::Backtrack(InputError::new("\r\nc", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser.parse_peek("\r\nc").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -289,7 +289,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::newline;
 /// assert_eq!(newline::<_, InputError<_>>.parse_peek(Partial::new("\nc")), Ok((Partial::new("c"), '\n')));
-/// assert_eq!(newline::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("\r\nc"), ErrorKind::Literal))));
+/// assert!(newline::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")).is_err());
 /// assert_eq!(newline::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -330,8 +330,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("\tc"), Ok(("c", '\t')));
-/// assert_eq!(parser.parse_peek("\r\nc"), Err(ErrMode::Backtrack(InputError::new("\r\nc", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser.parse_peek("\r\nc").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -340,7 +340,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::tab;
 /// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("\tc")), Ok((Partial::new("c"), '\t')));
-/// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("\r\nc"), ErrorKind::Literal))));
+/// assert!(tab::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")).is_err());
 /// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -435,8 +435,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(parser.parse_peek("1c"), Err(ErrMode::Backtrack(InputError::new("1c", ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("1c").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -445,7 +445,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::alpha1;
 /// assert_eq!(alpha1::<_, InputError<_>>.parse_peek(Partial::new("aB1c")), Ok((Partial::new("1c"), "aB")));
-/// assert_eq!(alpha1::<_, InputError<_>>.parse_peek(Partial::new("1c")), Err(ErrMode::Backtrack(InputError::new(Partial::new("1c"), ErrorKind::Slice))));
+/// assert!(alpha1::<_, InputError<_>>.parse_peek(Partial::new("1c")).is_err());
 /// assert_eq!(alpha1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -542,8 +542,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("21c"), Ok(("c", "21")));
-/// assert_eq!(parser.parse_peek("c1"), Err(ErrMode::Backtrack(InputError::new("c1", ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("c1").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -552,7 +552,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::digit1;
 /// assert_eq!(digit1::<_, InputError<_>>.parse_peek(Partial::new("21c")), Ok((Partial::new("c"), "21")));
-/// assert_eq!(digit1::<_, InputError<_>>.parse_peek(Partial::new("c1")), Err(ErrMode::Backtrack(InputError::new(Partial::new("c1"), ErrorKind::Slice))));
+/// assert!(digit1::<_, InputError<_>>.parse_peek(Partial::new("c1")).is_err());
 /// assert_eq!(digit1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
@@ -666,8 +666,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(parser.parse_peek("H2"), Err(ErrMode::Backtrack(InputError::new("H2", ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("H2").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -676,7 +676,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::hex_digit1;
 /// assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
-/// assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(Partial::new("H2")), Err(ErrMode::Backtrack(InputError::new(Partial::new("H2"), ErrorKind::Slice))));
+/// assert!(hex_digit1::<_, InputError<_>>.parse_peek(Partial::new("H2")).is_err());
 /// assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -773,8 +773,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(parser.parse_peek("H2"), Err(ErrMode::Backtrack(InputError::new("H2", ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("H2").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -783,7 +783,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::oct_digit1;
 /// assert_eq!(oct_digit1::<_, InputError<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
-/// assert_eq!(oct_digit1::<_, InputError<_>>.parse_peek(Partial::new("H2")), Err(ErrMode::Backtrack(InputError::new(Partial::new("H2"), ErrorKind::Slice))));
+/// assert!(oct_digit1::<_, InputError<_>>.parse_peek(Partial::new("H2")).is_err());
 /// assert_eq!(oct_digit1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -879,8 +879,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(parser.parse_peek("&H2"), Err(ErrMode::Backtrack(InputError::new("&H2", ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("&H2").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -889,7 +889,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::alphanumeric1;
 /// assert_eq!(alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
-/// assert_eq!(alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new("&H2")), Err(ErrMode::Backtrack(InputError::new(Partial::new("&H2"), ErrorKind::Slice))));
+/// assert!(alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new("&H2")).is_err());
 /// assert_eq!(alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -972,8 +972,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(parser.parse_peek("H2"), Err(ErrMode::Backtrack(InputError::new("H2", ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("H2").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -982,7 +982,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::space1;
 /// assert_eq!(space1::<_, InputError<_>>.parse_peek(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
-/// assert_eq!(space1::<_, InputError<_>>.parse_peek(Partial::new("H2")), Err(ErrMode::Backtrack(InputError::new(Partial::new("H2"), ErrorKind::Slice))));
+/// assert!(space1::<_, InputError<_>>.parse_peek(Partial::new("H2")).is_err());
 /// assert_eq!(space1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -1078,8 +1078,8 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(parser.parse_peek("H2"), Err(ErrMode::Backtrack(InputError::new("H2", ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("H2").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -1088,7 +1088,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::ascii::multispace1;
 /// assert_eq!(multispace1::<_, InputError<_>>.parse_peek(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
-/// assert_eq!(multispace1::<_, InputError<_>>.parse_peek(Partial::new("H2")), Err(ErrMode::Backtrack(InputError::new(Partial::new("H2"), ErrorKind::Slice))));
+/// assert!(multispace1::<_, InputError<_>>.parse_peek(Partial::new("H2")).is_err());
 /// assert_eq!(multispace1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -1308,7 +1308,7 @@ impl Int for isize {
 ///
 /// assert_eq!(parser.parse_peek(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
 /// assert_eq!(parser.parse_peek(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser.parse_peek(&b"ggg"[..]), Err(ErrMode::Backtrack(InputError::new(&b"ggg"[..], ErrorKind::Slice))));
+/// assert!(parser.parse_peek(&b"ggg"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1323,7 +1323,7 @@ impl Int for isize {
 ///
 /// assert_eq!(parser.parse_peek(Partial::new(&b"01AE;"[..])), Ok((Partial::new(&b";"[..]), 0x01AE)));
 /// assert_eq!(parser.parse_peek(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(parser.parse_peek(Partial::new(&b"ggg"[..])), Err(ErrMode::Backtrack(InputError::new(Partial::new(&b"ggg"[..]), ErrorKind::Slice))));
+/// assert!(parser.parse_peek(Partial::new(&b"ggg"[..])).is_err());
 /// ```
 #[inline]
 pub fn hex_uint<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
@@ -1458,7 +1458,7 @@ impl HexUint for u128 {
 /// assert_eq!(parser.parse_peek("11e-1"), Ok(("", 1.1)));
 /// assert_eq!(parser.parse_peek("123E-02"), Ok(("", 1.23)));
 /// assert_eq!(parser.parse_peek("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser.parse_peek("abc"), Err(ErrMode::Backtrack(InputError::new("abc", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("abc").is_err());
 /// ```
 ///
 /// ```rust
@@ -1476,7 +1476,7 @@ impl HexUint for u128 {
 /// assert_eq!(parser.parse_peek(Partial::new("11e-1")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(parser.parse_peek(Partial::new("123E-02")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(parser.parse_peek(Partial::new("123K-01")), Ok((Partial::new("K-01"), 123.0)));
-/// assert_eq!(parser.parse_peek(Partial::new("abc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("abc"), ErrorKind::Slice))));
+/// assert!(parser.parse_peek(Partial::new("abc")).is_err());
 /// ```
 #[inline(always)]
 #[doc(alias = "f32")]

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -31,10 +31,10 @@ use crate::Parser;
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}};
+/// # use winnow::{error::ErrMode, error::{ErrorKind}};
 /// # use winnow::ascii::Caseless;
 ///
-/// fn parser<'s>(s: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(s: &mut &'s str) -> PResult<&'s str> {
 ///   Caseless("hello").parse_next(s)
 /// }
 ///
@@ -76,9 +76,8 @@ impl Caseless<&str> {
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}};
 /// # use winnow::ascii::crlf;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     crlf.parse_next(input)
 /// }
 ///
@@ -89,12 +88,12 @@ impl Caseless<&str> {
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::crlf;
-/// assert_eq!(crlf::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
-/// assert!(crlf::<_, InputError<_>>.parse_peek(Partial::new("ab\r\nc")).is_err());
-/// assert_eq!(crlf::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(crlf::<_, ContextError>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
+/// assert!(crlf::<_, ContextError>.parse_peek(Partial::new("ab\r\nc")).is_err());
+/// assert_eq!(crlf::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn crlf<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -126,9 +125,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::till_line_ending;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     till_line_ending.parse_next(input)
 /// }
 ///
@@ -142,14 +140,14 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::till_line_ending;
-/// assert_eq!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("ab\r\nc")), Ok((Partial::new("\r\nc"), "ab")));
-/// assert_eq!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("a\rb\nc")).is_err());
-/// assert!(till_line_ending::<_, InputError<_>>.parse_peek(Partial::new("a\rbc")).is_err());
+/// assert_eq!(till_line_ending::<_, ContextError>.parse_peek(Partial::new("ab\r\nc")), Ok((Partial::new("\r\nc"), "ab")));
+/// assert_eq!(till_line_ending::<_, ContextError>.parse_peek(Partial::new("abc")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(till_line_ending::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert!(till_line_ending::<_, ContextError>.parse_peek(Partial::new("a\rb\nc")).is_err());
+/// assert!(till_line_ending::<_, ContextError>.parse_peek(Partial::new("a\rbc")).is_err());
 /// ```
 #[inline(always)]
 pub fn till_line_ending<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -222,9 +220,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::line_ending;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     line_ending.parse_next(input)
 /// }
 ///
@@ -235,12 +232,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::line_ending;
-/// assert_eq!(line_ending::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
-/// assert!(line_ending::<_, InputError<_>>.parse_peek(Partial::new("ab\r\nc")).is_err());
-/// assert_eq!(line_ending::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(line_ending::<_, ContextError>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
+/// assert!(line_ending::<_, ContextError>.parse_peek(Partial::new("ab\r\nc")).is_err());
+/// assert_eq!(line_ending::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn line_ending<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -272,9 +269,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::newline;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<char, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<char> {
 ///     newline.parse_next(input)
 /// }
 ///
@@ -285,12 +281,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::newline;
-/// assert_eq!(newline::<_, InputError<_>>.parse_peek(Partial::new("\nc")), Ok((Partial::new("c"), '\n')));
-/// assert!(newline::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")).is_err());
-/// assert_eq!(newline::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(newline::<_, ContextError>.parse_peek(Partial::new("\nc")), Ok((Partial::new("c"), '\n')));
+/// assert!(newline::<_, ContextError>.parse_peek(Partial::new("\r\nc")).is_err());
+/// assert_eq!(newline::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn newline<I, Error: ParserError<I>>(input: &mut I) -> PResult<char, Error>
@@ -323,9 +319,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::tab;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<char, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<char> {
 ///     tab.parse_next(input)
 /// }
 ///
@@ -336,12 +331,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::tab;
-/// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("\tc")), Ok((Partial::new("c"), '\t')));
-/// assert!(tab::<_, InputError<_>>.parse_peek(Partial::new("\r\nc")).is_err());
-/// assert_eq!(tab::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(tab::<_, ContextError>.parse_peek(Partial::new("\tc")), Ok((Partial::new("c"), '\t')));
+/// assert!(tab::<_, ContextError>.parse_peek(Partial::new("\r\nc")).is_err());
+/// assert_eq!(tab::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn tab<Input, Error>(input: &mut Input) -> PResult<char, Error>
@@ -375,9 +370,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::alpha0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     alpha0.parse_next(input)
 /// }
 ///
@@ -388,12 +382,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alpha0;
-/// assert_eq!(alpha0::<_, InputError<_>>.parse_peek(Partial::new("ab1c")), Ok((Partial::new("1c"), "ab")));
-/// assert_eq!(alpha0::<_, InputError<_>>.parse_peek(Partial::new("1c")), Ok((Partial::new("1c"), "")));
-/// assert_eq!(alpha0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha0::<_, ContextError>.parse_peek(Partial::new("ab1c")), Ok((Partial::new("1c"), "ab")));
+/// assert_eq!(alpha0::<_, ContextError>.parse_peek(Partial::new("1c")), Ok((Partial::new("1c"), "")));
+/// assert_eq!(alpha0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alpha0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -428,9 +422,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::alpha1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     alpha1.parse_next(input)
 /// }
 ///
@@ -441,12 +434,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alpha1;
-/// assert_eq!(alpha1::<_, InputError<_>>.parse_peek(Partial::new("aB1c")), Ok((Partial::new("1c"), "aB")));
-/// assert!(alpha1::<_, InputError<_>>.parse_peek(Partial::new("1c")).is_err());
-/// assert_eq!(alpha1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha1::<_, ContextError>.parse_peek(Partial::new("aB1c")), Ok((Partial::new("1c"), "aB")));
+/// assert!(alpha1::<_, ContextError>.parse_peek(Partial::new("1c")).is_err());
+/// assert_eq!(alpha1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alpha1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -481,9 +474,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::digit0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     digit0.parse_next(input)
 /// }
 ///
@@ -495,12 +487,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::digit0;
-/// assert_eq!(digit0::<_, InputError<_>>.parse_peek(Partial::new("21c")), Ok((Partial::new("c"), "21")));
-/// assert_eq!(digit0::<_, InputError<_>>.parse_peek(Partial::new("a21c")), Ok((Partial::new("a21c"), "")));
-/// assert_eq!(digit0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(digit0::<_, ContextError>.parse_peek(Partial::new("21c")), Ok((Partial::new("c"), "21")));
+/// assert_eq!(digit0::<_, ContextError>.parse_peek(Partial::new("a21c")), Ok((Partial::new("a21c"), "")));
+/// assert_eq!(digit0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn digit0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -535,9 +527,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::digit1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     digit1.parse_next(input)
 /// }
 ///
@@ -548,12 +539,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::digit1;
-/// assert_eq!(digit1::<_, InputError<_>>.parse_peek(Partial::new("21c")), Ok((Partial::new("c"), "21")));
-/// assert!(digit1::<_, InputError<_>>.parse_peek(Partial::new("c1")).is_err());
-/// assert_eq!(digit1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(digit1::<_, ContextError>.parse_peek(Partial::new("21c")), Ok((Partial::new("c"), "21")));
+/// assert!(digit1::<_, ContextError>.parse_peek(Partial::new("c1")).is_err());
+/// assert_eq!(digit1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// ## Parsing an integer
@@ -562,9 +553,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed, Parser};
 /// # use winnow::ascii::digit1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<u32, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<u32> {
 ///   digit1.try_map(str::parse).parse_next(input)
 /// }
 ///
@@ -605,9 +595,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::hex_digit0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     hex_digit0.parse_next(input)
 /// }
 ///
@@ -618,12 +607,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::hex_digit0;
-/// assert_eq!(hex_digit0::<_, InputError<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
-/// assert_eq!(hex_digit0::<_, InputError<_>>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
-/// assert_eq!(hex_digit0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit0::<_, ContextError>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
+/// assert_eq!(hex_digit0::<_, ContextError>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(hex_digit0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn hex_digit0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -659,9 +648,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::hex_digit1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     hex_digit1.parse_next(input)
 /// }
 ///
@@ -672,12 +660,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::hex_digit1;
-/// assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
-/// assert!(hex_digit1::<_, InputError<_>>.parse_peek(Partial::new("H2")).is_err());
-/// assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex_digit1::<_, ContextError>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
+/// assert!(hex_digit1::<_, ContextError>.parse_peek(Partial::new("H2")).is_err());
+/// assert_eq!(hex_digit1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn hex_digit1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -712,9 +700,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::oct_digit0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     oct_digit0.parse_next(input)
 /// }
 ///
@@ -725,12 +712,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::oct_digit0;
-/// assert_eq!(oct_digit0::<_, InputError<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
-/// assert_eq!(oct_digit0::<_, InputError<_>>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
-/// assert_eq!(oct_digit0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit0::<_, ContextError>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
+/// assert_eq!(oct_digit0::<_, ContextError>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(oct_digit0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn oct_digit0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -766,9 +753,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::oct_digit1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     oct_digit1.parse_next(input)
 /// }
 ///
@@ -779,12 +765,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::oct_digit1;
-/// assert_eq!(oct_digit1::<_, InputError<_>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
-/// assert!(oct_digit1::<_, InputError<_>>.parse_peek(Partial::new("H2")).is_err());
-/// assert_eq!(oct_digit1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(oct_digit1::<_, ContextError>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
+/// assert!(oct_digit1::<_, ContextError>.parse_peek(Partial::new("H2")).is_err());
+/// assert_eq!(oct_digit1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn oct_digit1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -819,9 +805,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::alphanumeric0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     alphanumeric0.parse_next(input)
 /// }
 ///
@@ -832,12 +817,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alphanumeric0;
-/// assert_eq!(alphanumeric0::<_, InputError<_>>.parse_peek(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
-/// assert_eq!(alphanumeric0::<_, InputError<_>>.parse_peek(Partial::new("&Z21c")), Ok((Partial::new("&Z21c"), "")));
-/// assert_eq!(alphanumeric0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric0::<_, ContextError>.parse_peek(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
+/// assert_eq!(alphanumeric0::<_, ContextError>.parse_peek(Partial::new("&Z21c")), Ok((Partial::new("&Z21c"), "")));
+/// assert_eq!(alphanumeric0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alphanumeric0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -872,9 +857,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::alphanumeric1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     alphanumeric1.parse_next(input)
 /// }
 ///
@@ -885,12 +869,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alphanumeric1;
-/// assert_eq!(alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
-/// assert!(alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new("&H2")).is_err());
-/// assert_eq!(alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alphanumeric1::<_, ContextError>.parse_peek(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
+/// assert!(alphanumeric1::<_, ContextError>.parse_peek(Partial::new("&H2")).is_err());
+/// assert_eq!(alphanumeric1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn alphanumeric1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -925,12 +909,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::space0;
-/// assert_eq!(space0::<_, InputError<_>>.parse_peek(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
-/// assert_eq!(space0::<_, InputError<_>>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
-/// assert_eq!(space0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(space0::<_, ContextError>.parse_peek(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
+/// assert_eq!(space0::<_, ContextError>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(space0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn space0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -965,9 +949,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::space1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     space1.parse_next(input)
 /// }
 ///
@@ -978,12 +961,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::space1;
-/// assert_eq!(space1::<_, InputError<_>>.parse_peek(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
-/// assert!(space1::<_, InputError<_>>.parse_peek(Partial::new("H2")).is_err());
-/// assert_eq!(space1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(space1::<_, ContextError>.parse_peek(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
+/// assert!(space1::<_, ContextError>.parse_peek(Partial::new("H2")).is_err());
+/// assert_eq!(space1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn space1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -1018,9 +1001,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::multispace0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     multispace0.parse_next(input)
 /// }
 ///
@@ -1031,12 +1013,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::multispace0;
-/// assert_eq!(multispace0::<_, InputError<_>>.parse_peek(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
-/// assert_eq!(multispace0::<_, InputError<_>>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
-/// assert_eq!(multispace0::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace0::<_, ContextError>.parse_peek(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
+/// assert_eq!(multispace0::<_, ContextError>.parse_peek(Partial::new("Z21c")), Ok((Partial::new("Z21c"), "")));
+/// assert_eq!(multispace0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn multispace0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -1071,9 +1053,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::ascii::multispace1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
 ///     multispace1.parse_next(input)
 /// }
 ///
@@ -1084,12 +1065,12 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::multispace1;
-/// assert_eq!(multispace1::<_, InputError<_>>.parse_peek(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
-/// assert!(multispace1::<_, InputError<_>>.parse_peek(Partial::new("H2")).is_err());
-/// assert_eq!(multispace1::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(multispace1::<_, ContextError>.parse_peek(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
+/// assert!(multispace1::<_, ContextError>.parse_peek(Partial::new("H2")).is_err());
+/// assert_eq!(multispace1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn multispace1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -1299,10 +1280,9 @@ impl Int for isize {
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// use winnow::ascii::hex_uint;
 ///
-/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<u32, InputError<&'s [u8]>> {
+/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<u32> {
 ///   hex_uint(s)
 /// }
 ///
@@ -1313,11 +1293,11 @@ impl Int for isize {
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::Partial;
 /// use winnow::ascii::hex_uint;
 ///
-/// fn parser<'s>(s: &mut Partial<&'s [u8]>) -> PResult<u32, InputError<Partial<&'s [u8]>>> {
+/// fn parser<'s>(s: &mut Partial<&'s [u8]>) -> PResult<u32> {
 ///   hex_uint(s)
 /// }
 ///
@@ -1447,11 +1427,10 @@ impl HexUint for u128 {
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::error::Needed::Size;
 /// use winnow::ascii::float;
 ///
-/// fn parser<'s>(s: &mut &'s str) -> PResult<f64, InputError<&'s str>> {
+/// fn parser<'s>(s: &mut &'s str) -> PResult<f64> {
 ///   float(s)
 /// }
 ///
@@ -1463,12 +1442,12 @@ impl HexUint for u128 {
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::ascii::float;
 ///
-/// fn parser<'s>(s: &mut Partial<&'s str>) -> PResult<f64, InputError<Partial<&'s str>>> {
+/// fn parser<'s>(s: &mut Partial<&'s str>) -> PResult<f64> {
 ///   float(s)
 /// }
 ///
@@ -1582,7 +1561,6 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::digit1;
 /// # use winnow::prelude::*;
 /// use winnow::ascii::take_escaped;
@@ -1598,7 +1576,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::ascii::digit1;
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -1735,14 +1713,13 @@ where
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use std::str::from_utf8;
 /// use winnow::token::literal;
 /// use winnow::ascii::escaped_transform;
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;
 ///
-/// fn parser<'s>(input: &mut &'s str) -> PResult<String, InputError<&'s str>> {
+/// fn parser<'s>(input: &mut &'s str) -> PResult<String> {
 ///   escaped_transform(
 ///     alpha1,
 ///     '\\',
@@ -1762,7 +1739,7 @@ where
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use std::str::from_utf8;
 /// # use winnow::Partial;
 /// use winnow::token::literal;
@@ -1770,7 +1747,7 @@ where
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;
 ///
-/// fn parser<'s>(input: &mut Partial<&'s str>) -> PResult<String, InputError<Partial<&'s str>>> {
+/// fn parser<'s>(input: &mut Partial<&'s str>) -> PResult<String> {
 ///   escaped_transform(
 ///     alpha1,
 ///     '\\',

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1582,35 +1582,35 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed, error::IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::digit1;
 /// # use winnow::prelude::*;
 /// use winnow::ascii::take_escaped;
 /// use winnow::token::one_of;
 ///
-/// fn esc(s: &str) -> IResult<&str, &str> {
-///   take_escaped(digit1, '\\', one_of(['"', 'n', '\\'])).parse_peek(s)
+/// fn esc<'i>(input: &mut &'i str) -> PResult<&'i str> {
+///   take_escaped(digit1, '\\', one_of(['"', 'n', '\\'])).parse_next(input)
 /// }
 ///
-/// assert_eq!(esc("123;"), Ok((";", "123")));
-/// assert_eq!(esc(r#"12\"34;"#), Ok((";", r#"12\"34"#)));
+/// assert_eq!(esc.parse_peek("123;"), Ok((";", "123")));
+/// assert_eq!(esc.parse_peek(r#"12\"34;"#), Ok((";", r#"12\"34"#)));
 /// ```
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed, error::IResult};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::ascii::digit1;
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::ascii::take_escaped;
 /// use winnow::token::one_of;
 ///
-/// fn esc(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   take_escaped(digit1, '\\', one_of(['"', 'n', '\\'])).parse_peek(s)
+/// fn esc<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str> {
+///   take_escaped(digit1, '\\', one_of(['"', 'n', '\\'])).parse_next(input)
 /// }
 ///
-/// assert_eq!(esc(Partial::new("123;")), Ok((Partial::new(";"), "123")));
-/// assert_eq!(esc(Partial::new("12\\\"34;")), Ok((Partial::new(";"), "12\\\"34")));
+/// assert_eq!(esc.parse_peek(Partial::new("123;")), Ok((Partial::new(";"), "123")));
+/// assert_eq!(esc.parse_peek(Partial::new("12\\\"34;")), Ok((Partial::new(";"), "12\\\"34")));
 /// ```
 #[inline(always)]
 pub fn take_escaped<Input, Error, Normal, Escapable, NormalOutput, EscapableOutput>(

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -1,10 +1,10 @@
 use super::*;
+use snapbox::str;
 
 mod complete {
     use super::*;
     use crate::combinator::alt;
     use crate::error::ErrMode;
-    use crate::error::ErrorKind;
     use crate::error::InputError;
     use crate::stream::ParseSlice;
     use crate::token::none_of;
@@ -15,151 +15,690 @@ mod complete {
 
     #[test]
     fn character() {
-        let empty: &[u8] = b"";
         let a: &[u8] = b"abcd";
         let b: &[u8] = b"1234";
         let c: &[u8] = b"a123";
         let d: &[u8] = "azé12".as_bytes();
         let e: &[u8] = b" ";
         let f: &[u8] = b" ;";
-        //assert_eq!(alpha1::<_, InputError>(a), Err(ErrMode::Incomplete(Needed::Size(1))));
-        assert_parse!(alpha1.parse_peek(a), Ok((empty, a)));
-        assert_eq!(
+        //assert_parse!(alpha1::<_, InputError>(a), str![]);
+        assert_parse!(
+            alpha1.parse_peek(a),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             alpha1.parse_peek(b),
-            Err(ErrMode::Backtrack(InputError::new(b, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                49,
+                50,
+                51,
+                52,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alpha1::<_, InputError<_>>.parse_peek(c),
-            Ok((&c[1..], &b"a"[..]))
+        assert_parse!(
+            alpha1.parse_peek(c),
+            str![[r#"
+Ok(
+    (
+        [
+            49,
+            50,
+            51,
+        ],
+        [
+            97,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alpha1::<_, InputError<_>>.parse_peek(d),
-            Ok(("é12".as_bytes(), &b"az"[..]))
+        assert_parse!(
+            alpha1.parse_peek(d),
+            str![[r#"
+Ok(
+    (
+        [
+            195,
+            169,
+            49,
+            50,
+        ],
+        [
+            97,
+            122,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             digit1.parse_peek(a),
-            Err(ErrMode::Backtrack(InputError::new(a, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                97,
+                98,
+                99,
+                100,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(digit1::<_, InputError<_>>.parse_peek(b), Ok((empty, b)));
-        assert_eq!(
+        assert_parse!(
+            digit1.parse_peek(b),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            49,
+            50,
+            51,
+            52,
+        ],
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             digit1.parse_peek(c),
-            Err(ErrMode::Backtrack(InputError::new(c, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                97,
+                49,
+                50,
+                51,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             digit1.parse_peek(d),
-            Err(ErrMode::Backtrack(InputError::new(d, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                97,
+                122,
+                195,
+                169,
+                49,
+                50,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(a), Ok((empty, a)));
-        assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(b), Ok((empty, b)));
-        assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(c), Ok((empty, c)));
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(d),
-            Ok(("zé12".as_bytes(), &b"a"[..]))
+        assert_parse!(
+            hex_digit1.parse_peek(a),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
+            hex_digit1.parse_peek(b),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            49,
+            50,
+            51,
+            52,
+        ],
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            hex_digit1.parse_peek(c),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            97,
+            49,
+            50,
+            51,
+        ],
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            hex_digit1.parse_peek(d),
+            str![[r#"
+Ok(
+    (
+        [
+            122,
+            195,
+            169,
+            49,
+            50,
+        ],
+        [
+            97,
+        ],
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             hex_digit1.parse_peek(e),
-            Err(ErrMode::Backtrack(InputError::new(e, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                32,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(a),
-            Err(ErrMode::Backtrack(InputError::new(a, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                97,
+                98,
+                99,
+                100,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(oct_digit1::<_, InputError<_>>.parse_peek(b), Ok((empty, b)));
-        assert_eq!(
+        assert_parse!(
+            oct_digit1.parse_peek(b),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            49,
+            50,
+            51,
+            52,
+        ],
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             oct_digit1.parse_peek(c),
-            Err(ErrMode::Backtrack(InputError::new(c, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                97,
+                49,
+                50,
+                51,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(d),
-            Err(ErrMode::Backtrack(InputError::new(d, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                97,
+                122,
+                195,
+                169,
+                49,
+                50,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(a),
-            Ok((empty, a))
+        assert_parse!(
+            alphanumeric1.parse_peek(a),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
-        //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(c),
-            Ok((empty, c))
+        //assert_parse!(fix_error!(b,(), alphanumeric), str![]);
+        assert_parse!(
+            alphanumeric1.parse_peek(c),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            97,
+            49,
+            50,
+            51,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(d),
-            Ok(("é12".as_bytes(), &b"az"[..]))
+        assert_parse!(
+            alphanumeric1.parse_peek(d),
+            str![[r#"
+Ok(
+    (
+        [
+            195,
+            169,
+            49,
+            50,
+        ],
+        [
+            97,
+            122,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(space1::<_, InputError<_>>.parse_peek(e), Ok((empty, e)));
-        assert_eq!(
-            space1::<_, InputError<_>>.parse_peek(f),
-            Ok((&b";"[..], &b" "[..]))
+        assert_parse!(
+            space1.parse_peek(e),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            32,
+        ],
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            space1.parse_peek(f),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        [
+            32,
+        ],
+    ),
+)
+
+"#]]
         );
     }
 
     #[cfg(feature = "alloc")]
     #[test]
     fn character_s() {
-        let empty = "";
         let a = "abcd";
         let b = "1234";
         let c = "a123";
         let d = "azé12";
         let e = " ";
-        assert_eq!(alpha1::<_, InputError<_>>.parse_peek(a), Ok((empty, a)));
-        assert_eq!(
+        assert_parse!(
+            alpha1.parse_peek(a),
+            str![[r#"
+Ok(
+    (
+        "",
+        "abcd",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             alpha1.parse_peek(b),
-            Err(ErrMode::Backtrack(InputError::new(b, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "1234",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(alpha1::<_, InputError<_>>.parse_peek(c), Ok((&c[1..], "a")));
-        assert_eq!(alpha1::<_, InputError<_>>.parse_peek(d), Ok(("é12", "az")));
-        assert_eq!(
+        assert_parse!(
+            alpha1.parse_peek(c),
+            str![[r#"
+Ok(
+    (
+        "123",
+        "a",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            alpha1.parse_peek(d),
+            str![[r#"
+Ok(
+    (
+        "é12",
+        "az",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             digit1.parse_peek(a),
-            Err(ErrMode::Backtrack(InputError::new(a, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "abcd",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(digit1::<_, InputError<_>>.parse_peek(b), Ok((empty, b)));
-        assert_eq!(
+        assert_parse!(
+            digit1.parse_peek(b),
+            str![[r#"
+Ok(
+    (
+        "",
+        "1234",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             digit1.parse_peek(c),
-            Err(ErrMode::Backtrack(InputError::new(c, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "a123",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             digit1.parse_peek(d),
-            Err(ErrMode::Backtrack(InputError::new(d, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "azé12",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(a), Ok((empty, a)));
-        assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(b), Ok((empty, b)));
-        assert_eq!(hex_digit1::<_, InputError<_>>.parse_peek(c), Ok((empty, c)));
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(d),
-            Ok(("zé12", "a"))
+        assert_parse!(
+            hex_digit1.parse_peek(a),
+            str![[r#"
+Ok(
+    (
+        "",
+        "abcd",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
+            hex_digit1.parse_peek(b),
+            str![[r#"
+Ok(
+    (
+        "",
+        "1234",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            hex_digit1.parse_peek(c),
+            str![[r#"
+Ok(
+    (
+        "",
+        "a123",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            hex_digit1.parse_peek(d),
+            str![[r#"
+Ok(
+    (
+        "zé12",
+        "a",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             hex_digit1.parse_peek(e),
-            Err(ErrMode::Backtrack(InputError::new(e, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: " ",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(a),
-            Err(ErrMode::Backtrack(InputError::new(a, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "abcd",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(oct_digit1::<_, InputError<_>>.parse_peek(b), Ok((empty, b)));
-        assert_eq!(
+        assert_parse!(
+            oct_digit1.parse_peek(b),
+            str![[r#"
+Ok(
+    (
+        "",
+        "1234",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             oct_digit1.parse_peek(c),
-            Err(ErrMode::Backtrack(InputError::new(c, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "a123",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(d),
-            Err(ErrMode::Backtrack(InputError::new(d, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "azé12",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(a),
-            Ok((empty, a))
+        assert_parse!(
+            alphanumeric1.parse_peek(a),
+            str![[r#"
+Ok(
+    (
+        "",
+        "abcd",
+    ),
+)
+
+"#]]
         );
-        //assert_eq!(fix_error!(b,(), alphanumeric), Ok((empty, b)));
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(c),
-            Ok((empty, c))
+        //assert_parse!(fix_error!(b,(), alphanumeric), str![]);
+        assert_parse!(
+            alphanumeric1.parse_peek(c),
+            str![[r#"
+Ok(
+    (
+        "",
+        "a123",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(d),
-            Ok(("é12", "az"))
+        assert_parse!(
+            alphanumeric1.parse_peek(d),
+            str![[r#"
+Ok(
+    (
+        "é12",
+        "az",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(space1::<_, InputError<_>>.parse_peek(e), Ok((empty, e)));
+        assert_parse!(
+            space1.parse_peek(e),
+            str![[r#"
+Ok(
+    (
+        "",
+        " ",
+    ),
+)
+
+"#]]
+        );
     }
 
     use crate::stream::Offset;
@@ -219,63 +758,227 @@ mod complete {
     #[test]
     fn is_till_line_ending_bytes() {
         let a: &[u8] = b"ab12cd\nefgh";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(a),
-            Ok((&b"\nefgh"[..], &b"ab12cd"[..]))
+        assert_parse!(
+            till_line_ending.parse_peek(a),
+            str![[r#"
+Ok(
+    (
+        [
+            10,
+            101,
+            102,
+            103,
+            104,
+        ],
+        [
+            97,
+            98,
+            49,
+            50,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
 
         let b: &[u8] = b"ab12cd\nefgh\nijkl";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(b),
-            Ok((&b"\nefgh\nijkl"[..], &b"ab12cd"[..]))
+        assert_parse!(
+            till_line_ending.parse_peek(b),
+            str![[r#"
+Ok(
+    (
+        [
+            10,
+            101,
+            102,
+            103,
+            104,
+            10,
+            105,
+            106,
+            107,
+            108,
+        ],
+        [
+            97,
+            98,
+            49,
+            50,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
 
         let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(c),
-            Ok((&b"\r\nefgh\nijkl"[..], &b"ab12cd"[..]))
+        assert_parse!(
+            till_line_ending.parse_peek(c),
+            str![[r#"
+Ok(
+    (
+        [
+            13,
+            10,
+            101,
+            102,
+            103,
+            104,
+            10,
+            105,
+            106,
+            107,
+            108,
+        ],
+        [
+            97,
+            98,
+            49,
+            50,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
 
         let d: &[u8] = b"ab12cd";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(d),
-            Ok((&[][..], d))
+        assert_parse!(
+            till_line_ending.parse_peek(d),
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            97,
+            98,
+            49,
+            50,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
     }
 
     #[test]
     fn is_till_line_ending_str() {
         let f = "βèƒôřè\rÂßÇáƒƭèř";
-        assert_eq!(
+        assert_parse!(
             till_line_ending.parse_peek(f),
-            Err(ErrMode::Backtrack(InputError::new(
-                &f[12..],
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "/rÂßÇáƒƭèř",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
 
         let g2: &str = "ab12cd";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(g2),
-            Ok(("", g2))
+        assert_parse!(
+            till_line_ending.parse_peek(g2),
+            str![[r#"
+Ok(
+    (
+        "",
+        "ab12cd",
+    ),
+)
+
+"#]]
         );
     }
 
     #[test]
     fn hex_digit_test() {
         let i = &b"0123456789abcdefABCDEF;"[..];
-        assert_parse!(hex_digit1.parse_peek(i), Ok((&b";"[..], &i[..i.len() - 1])));
+        assert_parse!(
+            hex_digit1.parse_peek(i),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        [
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+            56,
+            57,
+            97,
+            98,
+            99,
+            100,
+            101,
+            102,
+            65,
+            66,
+            67,
+            68,
+            69,
+            70,
+        ],
+    ),
+)
+
+"#]]
+        );
 
         let i = &b"g"[..];
         assert_parse!(
             hex_digit1.parse_peek(i),
-            Err(ErrMode::Backtrack(error_position!(&i, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                103,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
 
         let i = &b"G"[..];
         assert_parse!(
             hex_digit1.parse_peek(i),
-            Err(ErrMode::Backtrack(error_position!(&i, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                71,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
 
         assert!(AsChar::is_hex_digit(b'0'));
@@ -295,12 +998,46 @@ mod complete {
     #[test]
     fn oct_digit_test() {
         let i = &b"01234567;"[..];
-        assert_parse!(oct_digit1.parse_peek(i), Ok((&b";"[..], &i[..i.len() - 1])));
+        assert_parse!(
+            oct_digit1.parse_peek(i),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        [
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+        ],
+    ),
+)
+
+"#]]
+        );
 
         let i = &b"8"[..];
         assert_parse!(
             oct_digit1.parse_peek(i),
-            Err(ErrMode::Backtrack(error_position!(&i, ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                56,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
 
         assert!(AsChar::is_oct_digit(b'0'));
@@ -317,73 +1054,204 @@ mod complete {
 
     #[test]
     fn full_line_windows() {
-        fn take_full_line<'i>(i: &mut &'i [u8]) -> PResult<(&'i [u8], &'i [u8])> {
+        #[allow(clippy::type_complexity)]
+        fn take_full_line<'i>(
+            i: &mut &'i [u8],
+        ) -> PResult<(&'i [u8], &'i [u8]), InputError<&'i [u8]>> {
             (till_line_ending, line_ending).parse_next(i)
         }
         let input = b"abc\r\n";
         let output = take_full_line.parse_peek(input);
-        assert_eq!(output, Ok((&b""[..], (&b"abc"[..], &b"\r\n"[..]))));
+        assert_parse!(
+            output,
+            str![[r#"
+Ok(
+    (
+        [],
+        (
+            [
+                97,
+                98,
+                99,
+            ],
+            [
+                13,
+                10,
+            ],
+        ),
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn full_line_unix() {
-        fn take_full_line<'i>(i: &mut &'i [u8]) -> PResult<(&'i [u8], &'i [u8])> {
+        #[allow(clippy::type_complexity)]
+        fn take_full_line<'i>(
+            i: &mut &'i [u8],
+        ) -> PResult<(&'i [u8], &'i [u8]), InputError<&'i [u8]>> {
             (till_line_ending, line_ending).parse_next(i)
         }
         let input = b"abc\n";
         let output = take_full_line.parse_peek(input);
-        assert_eq!(output, Ok((&b""[..], (&b"abc"[..], &b"\n"[..]))));
+        assert_parse!(
+            output,
+            str![[r#"
+Ok(
+    (
+        [],
+        (
+            [
+                97,
+                98,
+                99,
+            ],
+            [
+                10,
+            ],
+        ),
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn check_windows_lineending() {
         let input = b"\r\n";
         let output = line_ending.parse_peek(&input[..]);
-        assert_parse!(output, Ok((&b""[..], &b"\r\n"[..])));
+        assert_parse!(
+            output,
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            13,
+            10,
+        ],
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn check_unix_lineending() {
         let input = b"\n";
         let output = line_ending.parse_peek(&input[..]);
-        assert_parse!(output, Ok((&b""[..], &b"\n"[..])));
+        assert_parse!(
+            output,
+            str![[r#"
+Ok(
+    (
+        [],
+        [
+            10,
+        ],
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn cr_lf() {
         assert_parse!(
             crlf.parse_peek(&b"\r\na"[..]),
-            Ok((&b"a"[..], &b"\r\n"[..]))
+            str![[r#"
+Ok(
+    (
+        [
+            97,
+        ],
+        [
+            13,
+            10,
+        ],
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             crlf.parse_peek(&b"\r"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"\r"[..],
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                13,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             crlf.parse_peek(&b"\ra"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"\ra"[..],
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                13,
+                97,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
 
-        assert_parse!(crlf.parse_peek("\r\na"), Ok(("a", "\r\n")));
+        assert_parse!(
+            crlf.parse_peek("\r\na"),
+            str![[r#"
+Ok(
+    (
+        "a",
+        "/r/n",
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             crlf.parse_peek("\r"),
-            Err(ErrMode::Backtrack(error_position!(
-                &"\r",
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "/r",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             crlf.parse_peek("\ra"),
-            Err(ErrMode::Backtrack(error_position!(
-                &"\ra",
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "/ra",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
     }
 
@@ -391,42 +1259,122 @@ mod complete {
     fn end_of_line() {
         assert_parse!(
             line_ending.parse_peek(&b"\na"[..]),
-            Ok((&b"a"[..], &b"\n"[..]))
+            str![[r#"
+Ok(
+    (
+        [
+            97,
+        ],
+        [
+            10,
+        ],
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek(&b"\r\na"[..]),
-            Ok((&b"a"[..], &b"\r\n"[..]))
+            str![[r#"
+Ok(
+    (
+        [
+            97,
+        ],
+        [
+            13,
+            10,
+        ],
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek(&b"\r"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"\r"[..],
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                13,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek(&b"\ra"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"\ra"[..],
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                13,
+                97,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
 
-        assert_parse!(line_ending.parse_peek("\na"), Ok(("a", "\n")));
-        assert_parse!(line_ending.parse_peek("\r\na"), Ok(("a", "\r\n")));
+        assert_parse!(
+            line_ending.parse_peek("\na"),
+            str![[r#"
+Ok(
+    (
+        "a",
+        "/n",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            line_ending.parse_peek("\r\na"),
+            str![[r#"
+Ok(
+    (
+        "a",
+        "/r/n",
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             line_ending.parse_peek("\r"),
-            Err(ErrMode::Backtrack(error_position!(
-                &"\r",
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "/r",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek("\ra"),
-            Err(ErrMode::Backtrack(error_position!(
-                &"\ra",
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "/ra",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
     }
 
@@ -438,20 +1386,99 @@ mod complete {
 
         assert_parse!(
             dec_u32.parse_peek(&b";"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b";"[..],
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                59,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_parse!(dec_u32.parse_peek(&b"0;"[..]), Ok((&b";"[..], 0)));
-        assert_parse!(dec_u32.parse_peek(&b"1;"[..]), Ok((&b";"[..], 1)));
-        assert_parse!(dec_u32.parse_peek(&b"32;"[..]), Ok((&b";"[..], 32)));
+        assert_parse!(
+            dec_u32.parse_peek(&b"0;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        0,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            dec_u32.parse_peek(&b"1;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        1,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            dec_u32.parse_peek(&b"32;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        32,
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             dec_u32.parse_peek(&b"1000000000000000000000;"[..]), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"1000000000000000000000;"[..],
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                49,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                59,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
     }
 
@@ -463,29 +1490,145 @@ mod complete {
 
         assert_parse!(
             dec_i32.parse_peek(&b";"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b";"[..],
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                59,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_parse!(dec_i32.parse_peek(&b"0;"[..]), Ok((&b";"[..], 0)));
-        assert_parse!(dec_i32.parse_peek(&b"1;"[..]), Ok((&b";"[..], 1)));
-        assert_parse!(dec_i32.parse_peek(&b"32;"[..]), Ok((&b";"[..], 32)));
+        assert_parse!(
+            dec_i32.parse_peek(&b"0;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        0,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            dec_i32.parse_peek(&b"1;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        1,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            dec_i32.parse_peek(&b"32;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        32,
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             dec_i32.parse_peek(&b"-0;"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"-0;"[..],
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                45,
+                48,
+                59,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_parse!(dec_i32.parse_peek(&b"-1;"[..]), Ok((&b";"[..], -1)));
-        assert_parse!(dec_i32.parse_peek(&b"-32;"[..]), Ok((&b";"[..], -32)));
+        assert_parse!(
+            dec_i32.parse_peek(&b"-1;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        -1,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            dec_i32.parse_peek(&b"-32;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        -32,
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             dec_i32.parse_peek(&b"1000000000000000000000;"[..]), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"1000000000000000000000;"[..],
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                49,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                48,
+                59,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
     }
 
@@ -497,55 +1640,236 @@ mod complete {
 
         assert_parse!(
             hex_u32.parse_peek(&b";"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b";"[..],
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                59,
+            ],
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_parse!(hex_u32.parse_peek(&b"ff;"[..]), Ok((&b";"[..], 255)));
-        assert_parse!(hex_u32.parse_peek(&b"1be2;"[..]), Ok((&b";"[..], 7138)));
+        assert_parse!(
+            hex_u32.parse_peek(&b"ff;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        255,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            hex_u32.parse_peek(&b"1be2;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        7138,
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             hex_u32.parse_peek(&b"c5a31be2;"[..]),
-            Ok((&b";"[..], 3_315_801_058))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        3315801058,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(&b"C5A31be2;"[..]),
-            Ok((&b";"[..], 3_315_801_058))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        3315801058,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(&b"00c5a31be2;"[..]), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"00c5a31be2;"[..],
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                48,
+                48,
+                99,
+                53,
+                97,
+                51,
+                49,
+                98,
+                101,
+                50,
+                59,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(&b"c5a31be201;"[..]), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"c5a31be201;"[..],
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                99,
+                53,
+                97,
+                51,
+                49,
+                98,
+                101,
+                50,
+                48,
+                49,
+                59,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(&b"ffffffff;"[..]),
-            Ok((&b";"[..], 4_294_967_295))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        4294967295,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(&b"ffffffffffffffff;"[..]), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"ffffffffffffffff;"[..],
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                59,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(&b"ffffffffffffffff"[..]), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &&b"ffffffffffffffff"[..],
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+                102,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_parse!(hex_u32.parse_peek(&b"0x1be2;"[..]), Ok((&b"x1be2;"[..], 0)));
-        assert_parse!(hex_u32.parse_peek(&b"12af"[..]), Ok((&b""[..], 0x12af)));
+        assert_parse!(
+            hex_u32.parse_peek(&b"0x1be2;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            120,
+            49,
+            98,
+            101,
+            50,
+            59,
+        ],
+        0,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            hex_u32.parse_peek(&b"12af"[..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        4783,
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
@@ -589,23 +1913,39 @@ mod complete {
 
             println!("now parsing: {test} -> {expected32}");
 
-            assert_parse!(
-                float.parse_peek(test.as_bytes()),
+            assert_eq!(
+                float::<_, _, InputError<_>>.parse_peek(test.as_bytes()),
                 Ok((&b""[..], expected32))
             );
-            assert_parse!(float.parse_peek(test), Ok(("", expected32)));
+            assert_eq!(
+                float::<_, _, InputError<_>>.parse_peek(test),
+                Ok(("", expected32))
+            );
 
-            assert_parse!(
-                float.parse_peek(test.as_bytes()),
+            assert_eq!(
+                float::<_, _, InputError<_>>.parse_peek(test.as_bytes()),
                 Ok((&b""[..], expected64))
             );
-            assert_parse!(float.parse_peek(test), Ok(("", expected64)));
+            assert_eq!(
+                float::<_, _, InputError<_>>.parse_peek(test),
+                Ok(("", expected64))
+            );
         }
 
         let remaining_exponent = "-1.234E-";
         assert_parse!(
             float::<_, f64, _>.parse_peek(remaining_exponent),
-            Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
 
         let nan_test_cases = ["nan", "NaN", "NAN"];
@@ -664,17 +2004,14 @@ mod complete {
     #[cfg_attr(debug_assertions, should_panic)]
     fn complete_take_escaped_hang_1() {
         // issue #1336 "take_escaped hangs if normal parser accepts empty"
-        fn escaped_string<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        fn escaped_string<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
             use crate::ascii::alpha0;
             use crate::token::one_of;
             take_escaped(alpha0, '\\', one_of(['n'])).parse_next(input)
         }
 
         let input = "7";
-        assert_eq!(
-            escaped_string.parse_peek(input),
-            Err(ErrMode::Cut(error_position!(&input, ErrorKind::Assert)))
-        );
+        assert_parse!(escaped_string.parse_peek(input), str![]);
     }
 
     // issue #1336 "take_escaped hangs if normal parser accepts empty"
@@ -682,27 +2019,21 @@ mod complete {
     #[cfg_attr(debug_assertions, should_panic)]
     fn complete_take_escaped_hang_2() {
         // issue #1336 "take_escaped hangs if normal parser accepts empty"
-        fn escaped_string<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        fn escaped_string<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
             use crate::ascii::alpha0;
             use crate::token::one_of;
             take_escaped(alpha0, '\\', one_of(['n'])).parse_next(input)
         }
 
         let input = "a7";
-        assert_eq!(
-            escaped_string.parse_peek(input),
-            Err(ErrMode::Cut(error_position!(
-                &&input[1..],
-                ErrorKind::Assert
-            )))
-        );
+        assert_parse!(escaped_string.parse_peek(input), str![]);
     }
 
     #[test]
     #[cfg_attr(debug_assertions, should_panic)]
     fn complete_take_escaped_hang_1118() {
         // issue ##1118 take_escaped does not work with empty string
-        fn unquote<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        fn unquote<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
             use crate::combinator::delimited;
             use crate::combinator::opt;
             use crate::token::one_of;
@@ -720,13 +2051,7 @@ mod complete {
         }
 
         let input = r#""""#;
-        assert_eq!(
-            unquote.parse_peek(input),
-            Err(ErrMode::Cut(error_position!(
-                &&input[1..],
-                ErrorKind::Assert
-            )))
-        );
+        assert_parse!(unquote.parse_peek(input), str![]);
     }
 
     #[cfg(feature = "alloc")]
@@ -736,45 +2061,162 @@ mod complete {
         use crate::ascii::{alpha1 as alpha, digit1 as digit};
         use crate::token::one_of;
 
-        fn esc<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        fn esc<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
             take_escaped(alpha, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
-        assert_eq!(esc.parse_peek(&b"abcd;"[..]), Ok((&b";"[..], &b"abcd"[..])));
-        assert_eq!(
+        assert_parse!(
+            esc.parse_peek(&b"abcd;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        [
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             esc.parse_peek(&b"ab\\\"cd;"[..]),
-            Ok((&b";"[..], &b"ab\\\"cd"[..]))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        [
+            97,
+            98,
+            92,
+            34,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"\\\"abcd;"[..]),
-            Ok((&b";"[..], &b"\\\"abcd"[..]))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        [
+            92,
+            34,
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(esc.parse_peek(&b"\\n;"[..]), Ok((&b";"[..], &b"\\n"[..])));
-        assert_eq!(
+        assert_parse!(
+            esc.parse_peek(&b"\\n;"[..]),
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        [
+            92,
+            110,
+        ],
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             esc.parse_peek(&b"ab\\\"12"[..]),
-            Ok((&b"12"[..], &b"ab\\\""[..]))
+            str![[r#"
+Ok(
+    (
+        [
+            49,
+            50,
+        ],
+        [
+            97,
+            98,
+            92,
+            34,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"AB\\"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b""[..],
-                ErrorKind::Token
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [],
+            kind: Token,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"AB\\A"[..]),
-            Err(ErrMode::Backtrack(error_node_position!(
-                &&b"AB\\A"[..],
-                ErrorKind::Token,
-                error_position!(&&b"A"[..], ErrorKind::Verify)
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                65,
+            ],
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
 
-        fn esc2<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        fn esc2<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
             take_escaped(digit, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             esc2.parse_peek(&b"12\\nnn34"[..]),
-            Ok((&b"nn34"[..], &b"12\\n"[..]))
+            str![[r#"
+Ok(
+    (
+        [
+            110,
+            110,
+            51,
+            52,
+        ],
+        [
+            49,
+            50,
+            92,
+            110,
+        ],
+    ),
+)
+
+"#]]
         );
     }
 
@@ -784,46 +2226,150 @@ mod complete {
         use crate::ascii::{alpha1 as alpha, digit1 as digit};
         use crate::token::one_of;
 
-        fn esc<'i>(i: &mut &'i str) -> PResult<&'i str> {
+        fn esc<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
             take_escaped(alpha, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
-        assert_eq!(esc.parse_peek("abcd;"), Ok((";", "abcd")));
-        assert_eq!(esc.parse_peek("ab\\\"cd;"), Ok((";", "ab\\\"cd")));
-        assert_eq!(esc.parse_peek("\\\"abcd;"), Ok((";", "\\\"abcd")));
-        assert_eq!(esc.parse_peek("\\n;"), Ok((";", "\\n")));
-        assert_eq!(esc.parse_peek("ab\\\"12"), Ok(("12", "ab\\\"")));
-        assert_eq!(
-            esc.parse_peek("AB\\"),
-            Err(ErrMode::Backtrack(error_position!(&"", ErrorKind::Token)))
+        assert_parse!(
+            esc.parse_peek("abcd;"),
+            str![[r#"
+Ok(
+    (
+        ";",
+        "abcd",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
+            esc.parse_peek("ab\\\"cd;"),
+            str![[r#"
+Ok(
+    (
+        ";",
+        "ab///"cd",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            esc.parse_peek("\\\"abcd;"),
+            str![[r#"
+Ok(
+    (
+        ";",
+        "///"abcd",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            esc.parse_peek("\\n;"),
+            str![[r#"
+Ok(
+    (
+        ";",
+        "//n",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            esc.parse_peek("ab\\\"12"),
+            str![[r#"
+Ok(
+    (
+        "12",
+        "ab///"",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            esc.parse_peek("AB\\"),
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "",
+            kind: Token,
+        },
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             esc.parse_peek("AB\\A"),
-            Err(ErrMode::Backtrack(error_node_position!(
-                &"AB\\A",
-                ErrorKind::Token,
-                error_position!(&"A", ErrorKind::Verify)
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "A",
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
 
-        fn esc2<'i>(i: &mut &'i str) -> PResult<&'i str> {
+        fn esc2<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
             take_escaped(digit, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
-        assert_eq!(esc2.parse_peek("12\\nnn34"), Ok(("nn34", "12\\n")));
+        assert_parse!(
+            esc2.parse_peek("12\\nnn34"),
+            str![[r#"
+Ok(
+    (
+        "nn34",
+        "12//n",
+    ),
+)
 
-        fn esc3<'i>(i: &mut &'i str) -> PResult<&'i str> {
+"#]]
+        );
+
+        fn esc3<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
             take_escaped(alpha, '\u{241b}', one_of(['\"', 'n'])).parse_next(i)
         }
-        assert_eq!(esc3.parse_peek("ab␛ncd;"), Ok((";", "ab␛ncd")));
+        assert_parse!(
+            esc3.parse_peek("ab␛ncd;"),
+            str![[r#"
+Ok(
+    (
+        ";",
+        "ab␛ncd",
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn test_escaped_error() {
-        fn esc<'i>(i: &mut &'i str) -> PResult<&'i str> {
+        fn esc<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
             use crate::ascii::digit1;
             take_escaped(digit1, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
 
-        assert_eq!(esc.parse_peek("abcd"), Ok(("abcd", "")));
+        assert_parse!(
+            esc.parse_peek("abcd"),
+            str![[r#"
+Ok(
+    (
+        "abcd",
+        "",
+    ),
+)
+
+"#]]
+        );
     }
 
     #[cfg(feature = "alloc")]
@@ -836,7 +2382,7 @@ mod complete {
             String::from_utf8_lossy(&i).into_owned()
         }
 
-        fn esc(i: &mut &[u8]) -> PResult<String> {
+        fn esc<'i>(i: &mut &'i [u8]) -> PResult<String, InputError<&'i [u8]>> {
             escaped_transform(
                 alpha,
                 '\\',
@@ -850,43 +2396,109 @@ mod complete {
             .parse_next(i)
         }
 
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"abcd;"[..]),
-            Ok((&b";"[..], String::from("abcd")))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        "abcd",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"ab\\\"cd;"[..]),
-            Ok((&b";"[..], String::from("ab\"cd")))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        "ab/"cd",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"\\\"abcd;"[..]),
-            Ok((&b";"[..], String::from("\"abcd")))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        "/"abcd",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"\\n;"[..]),
-            Ok((&b";"[..], String::from("\n")))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        "/n",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"ab\\\"12"[..]),
-            Ok((&b"12"[..], String::from("ab\"")))
+            str![[r#"
+Ok(
+    (
+        [
+            49,
+            50,
+        ],
+        "ab/"",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"AB\\"[..]),
-            Err(ErrMode::Backtrack(error_position!(
-                &&b""[..],
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek(&b"AB\\A"[..]),
-            Err(ErrMode::Backtrack(error_node_position!(
-                &&b"AB\\A"[..],
-                ErrorKind::Eof,
-                error_position!(&&b"A"[..], ErrorKind::Literal)
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                65,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
 
-        fn esc2(i: &mut &[u8]) -> PResult<String> {
+        fn esc2<'i>(i: &mut &'i [u8]) -> PResult<String, InputError<&'i [u8]>> {
             escaped_transform(
                 alpha,
                 '&',
@@ -898,13 +2510,33 @@ mod complete {
             .map(to_s)
             .parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             esc2.parse_peek(&b"ab&egrave;DEF;"[..]),
-            Ok((&b";"[..], String::from("abèDEF")))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        "abèDEF",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc2.parse_peek(&b"ab&egrave;D&agrave;EF;"[..]),
-            Ok((&b";"[..], String::from("abèDàEF")))
+            str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        "abèDàEF",
+    ),
+)
+
+"#]]
         );
     }
 
@@ -913,7 +2545,7 @@ mod complete {
     fn complete_escape_transform_str() {
         use crate::ascii::alpha1 as alpha;
 
-        fn esc(i: &mut &str) -> PResult<String> {
+        fn esc<'i>(i: &mut &'i str) -> PResult<String, InputError<&'i str>> {
             escaped_transform(
                 alpha,
                 '\\',
@@ -922,31 +2554,96 @@ mod complete {
             .parse_next(i)
         }
 
-        assert_eq!(esc.parse_peek("abcd;"), Ok((";", String::from("abcd"))));
-        assert_eq!(
+        assert_parse!(
+            esc.parse_peek("abcd;"),
+            str![[r#"
+Ok(
+    (
+        ";",
+        "abcd",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             esc.parse_peek("ab\\\"cd;"),
-            Ok((";", String::from("ab\"cd")))
+            str![[r#"
+Ok(
+    (
+        ";",
+        "ab/"cd",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek("\\\"abcd;"),
-            Ok((";", String::from("\"abcd")))
+            str![[r#"
+Ok(
+    (
+        ";",
+        "/"abcd",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(esc.parse_peek("\\n;"), Ok((";", String::from("\n"))));
-        assert_eq!(esc.parse_peek("ab\\\"12"), Ok(("12", String::from("ab\""))));
-        assert_eq!(
+        assert_parse!(
+            esc.parse_peek("\\n;"),
+            str![[r#"
+Ok(
+    (
+        ";",
+        "/n",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            esc.parse_peek("ab\\\"12"),
+            str![[r#"
+Ok(
+    (
+        "12",
+        "ab/"",
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             esc.parse_peek("AB\\"),
-            Err(ErrMode::Backtrack(error_position!(&"", ErrorKind::Literal)))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc.parse_peek("AB\\A"),
-            Err(ErrMode::Backtrack(error_node_position!(
-                &"AB\\A",
-                ErrorKind::Eof,
-                error_position!(&"A", ErrorKind::Literal)
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "A",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
 
-        fn esc2(i: &mut &str) -> PResult<String> {
+        fn esc2<'i>(i: &mut &'i str) -> PResult<String, InputError<&'i str>> {
             escaped_transform(
                 alpha,
                 '&',
@@ -954,41 +2651,74 @@ mod complete {
             )
             .parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             esc2.parse_peek("ab&egrave;DEF;"),
-            Ok((";", String::from("abèDEF")))
+            str![[r#"
+Ok(
+    (
+        ";",
+        "abèDEF",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             esc2.parse_peek("ab&egrave;D&agrave;EF;"),
-            Ok((";", String::from("abèDàEF")))
+            str![[r#"
+Ok(
+    (
+        ";",
+        "abèDàEF",
+    ),
+)
+
+"#]]
         );
 
-        fn esc3(i: &mut &str) -> PResult<String> {
+        fn esc3<'i>(i: &mut &'i str) -> PResult<String, InputError<&'i str>> {
             escaped_transform(alpha, '␛', alt(("0".value("\0"), "n".value("\n")))).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             esc3.parse_peek("a␛0bc␛n"),
-            Ok(("", String::from("a\0bc\n")))
+            str![[r#"
+Ok(
+    (
+        "",
+        "a/0bc/n",
+    ),
+)
+
+"#]]
         );
     }
 
     #[test]
     #[cfg(feature = "alloc")]
     fn test_escaped_transform_error() {
-        fn esc_trans(i: &mut &str) -> PResult<String> {
+        fn esc_trans<'i>(i: &mut &'i str) -> PResult<String, InputError<&'i str>> {
             use crate::ascii::digit1;
             escaped_transform(digit1, '\\', "n").parse_next(i)
         }
 
-        assert_eq!(esc_trans.parse_peek("abcd"), Ok(("abcd", String::new())));
+        assert_parse!(
+            esc_trans.parse_peek("abcd"),
+            str![[r#"
+Ok(
+    (
+        "abcd",
+        "",
+    ),
+)
+
+"#]]
+        );
     }
 }
 
 mod partial {
     use super::*;
-    use crate::error::ErrorKind;
     use crate::error::InputError;
-    use crate::error::{ErrMode, Needed};
     use crate::Partial;
 
     #[test]
@@ -999,119 +2729,410 @@ mod partial {
         let d: &[u8] = "azé12".as_bytes();
         let e: &[u8] = b" ";
         let f: &[u8] = b" ;";
-        //assert_eq!(alpha1::<_, Error<_>>(a), Err(ErrMode::Incomplete(Needed::new(1))));
+        //assert_parse!(alpha1::<_, Error<_>>(a), Err(ErrMode::Incomplete(Needed::new(1))));
         assert_parse!(
             alpha1.parse_peek(Partial::new(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             alpha1.parse_peek(Partial::new(b)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(b),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    49,
+                    50,
+                    51,
+                    52,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alpha1::<_, InputError<_>>.parse_peek(Partial::new(c)),
-            Ok((Partial::new(&c[1..]), &b"a"[..]))
+        assert_parse!(
+            alpha1.parse_peek(Partial::new(c)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                49,
+                50,
+                51,
+            ],
+            partial: true,
+        },
+        [
+            97,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alpha1::<_, InputError<_>>.parse_peek(Partial::new(d)),
-            Ok((Partial::new("é12".as_bytes()), &b"az"[..]))
+        assert_parse!(
+            alpha1.parse_peek(Partial::new(d)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                195,
+                169,
+                49,
+                50,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            122,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             digit1.parse_peek(Partial::new(a)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(a),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    98,
+                    99,
+                    100,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            digit1::<_, InputError<_>>.parse_peek(Partial::new(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            digit1.parse_peek(Partial::new(b)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             digit1.parse_peek(Partial::new(c)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(c),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    49,
+                    50,
+                    51,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             digit1.parse_peek(Partial::new(d)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(d),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    122,
+                    195,
+                    169,
+                    49,
+                    50,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(Partial::new(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            hex_digit1.parse_peek(Partial::new(a)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(Partial::new(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            hex_digit1.parse_peek(Partial::new(b)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(Partial::new(c)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            hex_digit1.parse_peek(Partial::new(c)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(Partial::new(d)),
-            Ok((Partial::new("zé12".as_bytes()), &b"a"[..]))
+        assert_parse!(
+            hex_digit1.parse_peek(Partial::new(d)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                122,
+                195,
+                169,
+                49,
+                50,
+            ],
+            partial: true,
+        },
+        [
+            97,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             hex_digit1.parse_peek(Partial::new(e)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(e),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    32,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(Partial::new(a)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(a),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    98,
+                    99,
+                    100,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            oct_digit1::<_, InputError<_>>.parse_peek(Partial::new(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            oct_digit1.parse_peek(Partial::new(b)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(Partial::new(c)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(c),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    49,
+                    50,
+                    51,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(Partial::new(d)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(d),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    122,
+                    195,
+                    169,
+                    49,
+                    50,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            alphanumeric1.parse_peek(Partial::new(a)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new(c)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        //assert_parse!(fix_error!(b,(), alphanumeric1), str![]);
+        assert_parse!(
+            alphanumeric1.parse_peek(Partial::new(c)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new(d)),
-            Ok((Partial::new("é12".as_bytes()), &b"az"[..]))
+        assert_parse!(
+            alphanumeric1.parse_peek(Partial::new(d)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                195,
+                169,
+                49,
+                50,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            122,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            space1::<_, InputError<_>>.parse_peek(Partial::new(e)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            space1.parse_peek(Partial::new(e)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            space1::<_, InputError<_>>.parse_peek(Partial::new(f)),
-            Ok((Partial::new(&b";"[..]), &b" "[..]))
+        assert_parse!(
+            space1.parse_peek(Partial::new(f)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            32,
+        ],
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1123,114 +3144,319 @@ mod partial {
         let c = "a123";
         let d = "azé12";
         let e = " ";
-        assert_eq!(
-            alpha1::<_, InputError<_>>.parse_peek(Partial::new(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            alpha1.parse_peek(Partial::new(a)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             alpha1.parse_peek(Partial::new(b)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(b),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "1234",
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alpha1::<_, InputError<_>>.parse_peek(Partial::new(c)),
-            Ok((Partial::new(&c[1..]), "a"))
+        assert_parse!(
+            alpha1.parse_peek(Partial::new(c)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: "123",
+            partial: true,
+        },
+        "a",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alpha1::<_, InputError<_>>.parse_peek(Partial::new(d)),
-            Ok((Partial::new("é12"), "az"))
+        assert_parse!(
+            alpha1.parse_peek(Partial::new(d)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: "é12",
+            partial: true,
+        },
+        "az",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             digit1.parse_peek(Partial::new(a)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(a),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "abcd",
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            digit1::<_, InputError<_>>.parse_peek(Partial::new(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            digit1.parse_peek(Partial::new(b)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             digit1.parse_peek(Partial::new(c)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(c),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "a123",
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             digit1.parse_peek(Partial::new(d)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(d),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "azé12",
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(Partial::new(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            hex_digit1.parse_peek(Partial::new(a)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(Partial::new(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            hex_digit1.parse_peek(Partial::new(b)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(Partial::new(c)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            hex_digit1.parse_peek(Partial::new(c)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            hex_digit1::<_, InputError<_>>.parse_peek(Partial::new(d)),
-            Ok((Partial::new("zé12"), "a"))
+        assert_parse!(
+            hex_digit1.parse_peek(Partial::new(d)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: "zé12",
+            partial: true,
+        },
+        "a",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             hex_digit1.parse_peek(Partial::new(e)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(e),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: " ",
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(Partial::new(a)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(a),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "abcd",
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            oct_digit1::<_, InputError<_>>.parse_peek(Partial::new(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            oct_digit1.parse_peek(Partial::new(b)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(Partial::new(c)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(c),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "a123",
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             oct_digit1.parse_peek(Partial::new(d)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(d),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "azé12",
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            alphanumeric1.parse_peek(Partial::new(a)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        //assert_eq!(fix_error!(b,(), alphanumeric1), Ok((empty, b)));
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new(c)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        //assert_parse!(fix_error!(b,(), alphanumeric1), str![]);
+        assert_parse!(
+            alphanumeric1.parse_peek(Partial::new(c)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            alphanumeric1::<_, InputError<_>>.parse_peek(Partial::new(d)),
-            Ok((Partial::new("é12"), "az"))
+        assert_parse!(
+            alphanumeric1.parse_peek(Partial::new(d)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: "é12",
+            partial: true,
+        },
+        "az",
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
-            space1::<_, InputError<_>>.parse_peek(Partial::new(e)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+        assert_parse!(
+            space1.parse_peek(Partial::new(e)),
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1298,45 +3524,152 @@ mod partial {
     #[test]
     fn is_till_line_ending_bytes() {
         let a: &[u8] = b"ab12cd\nefgh";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(a)),
-            Ok((Partial::new(&b"\nefgh"[..]), &b"ab12cd"[..]))
+        assert_parse!(
+            till_line_ending.parse_peek(Partial::new(a)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                10,
+                101,
+                102,
+                103,
+                104,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            49,
+            50,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
 
         let b: &[u8] = b"ab12cd\nefgh\nijkl";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(b)),
-            Ok((Partial::new(&b"\nefgh\nijkl"[..]), &b"ab12cd"[..]))
+        assert_parse!(
+            till_line_ending.parse_peek(Partial::new(b)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                10,
+                101,
+                102,
+                103,
+                104,
+                10,
+                105,
+                106,
+                107,
+                108,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            49,
+            50,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
 
         let c: &[u8] = b"ab12cd\r\nefgh\nijkl";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(c)),
-            Ok((Partial::new(&b"\r\nefgh\nijkl"[..]), &b"ab12cd"[..]))
+        assert_parse!(
+            till_line_ending.parse_peek(Partial::new(c)),
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                13,
+                10,
+                101,
+                102,
+                103,
+                104,
+                10,
+                105,
+                106,
+                107,
+                108,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            49,
+            50,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
         );
 
         let d: &[u8] = b"ab12cd";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(d)),
-            Err(ErrMode::Incomplete(Needed::Unknown))
+        assert_parse!(
+            till_line_ending.parse_peek(Partial::new(d)),
+            str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
         );
     }
 
     #[test]
     fn is_till_line_ending_str() {
         let f = "βèƒôřè\rÂßÇáƒƭèř";
-        assert_eq!(
+        assert_parse!(
             till_line_ending.parse_peek(Partial::new(f)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(&f[12..]),
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "/rÂßÇáƒƭèř",
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
 
         let g2: &str = "ab12cd";
-        assert_eq!(
-            till_line_ending::<_, InputError<_>>.parse_peek(Partial::new(g2)),
-            Err(ErrMode::Incomplete(Needed::Unknown))
+        assert_parse!(
+            till_line_ending.parse_peek(Partial::new(g2)),
+            str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1345,25 +3678,85 @@ mod partial {
         let i = &b"0123456789abcdefABCDEF;"[..];
         assert_parse!(
             hex_digit1.parse_peek(Partial::new(i)),
-            Ok((Partial::new(&b";"[..]), &i[..i.len() - 1]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+            56,
+            57,
+            97,
+            98,
+            99,
+            100,
+            101,
+            102,
+            65,
+            66,
+            67,
+            68,
+            69,
+            70,
+        ],
+    ),
+)
+
+"#]]
         );
 
         let i = &b"g"[..];
         assert_parse!(
             hex_digit1.parse_peek(Partial::new(i)),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(i),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    103,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
 
         let i = &b"G"[..];
         assert_parse!(
             hex_digit1.parse_peek(Partial::new(i)),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(i),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    71,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
 
         assert!(AsChar::is_hex_digit(b'0'));
@@ -1385,16 +3778,50 @@ mod partial {
         let i = &b"01234567;"[..];
         assert_parse!(
             oct_digit1.parse_peek(Partial::new(i)),
-            Ok((Partial::new(&b";"[..]), &i[..i.len() - 1]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+        ],
+    ),
+)
+
+"#]]
         );
 
         let i = &b"8"[..];
         assert_parse!(
             oct_digit1.parse_peek(Partial::new(i)),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(i),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    56,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
 
         assert!(AsChar::is_oct_digit(b'0'));
@@ -1412,28 +3839,73 @@ mod partial {
     #[test]
     fn full_line_windows() {
         #[allow(clippy::type_complexity)]
-        fn take_full_line<'i>(i: &mut Partial<&'i [u8]>) -> PResult<(&'i [u8], &'i [u8])> {
+        fn take_full_line<'i>(
+            i: &mut Partial<&'i [u8]>,
+        ) -> PResult<(&'i [u8], &'i [u8]), InputError<Partial<&'i [u8]>>> {
             (till_line_ending, line_ending).parse_next(i)
         }
         let input = b"abc\r\n";
         let output = take_full_line.parse_peek(Partial::new(input));
-        assert_eq!(
+        assert_parse!(
             output,
-            Ok((Partial::new(&b""[..]), (&b"abc"[..], &b"\r\n"[..])))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        (
+            [
+                97,
+                98,
+                99,
+            ],
+            [
+                13,
+                10,
+            ],
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
     #[test]
     fn full_line_unix() {
         #[allow(clippy::type_complexity)]
-        fn take_full_line<'i>(i: &mut Partial<&'i [u8]>) -> PResult<(&'i [u8], &'i [u8])> {
+        fn take_full_line<'i>(
+            i: &mut Partial<&'i [u8]>,
+        ) -> PResult<(&'i [u8], &'i [u8]), InputError<Partial<&'i [u8]>>> {
             (till_line_ending, line_ending).parse_next(i)
         }
         let input = b"abc\n";
         let output = take_full_line.parse_peek(Partial::new(input));
-        assert_eq!(
+        assert_parse!(
             output,
-            Ok((Partial::new(&b""[..]), (&b"abc"[..], &b"\n"[..])))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        (
+            [
+                97,
+                98,
+                99,
+            ],
+            [
+                10,
+            ],
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1441,48 +3913,149 @@ mod partial {
     fn check_windows_lineending() {
         let input = b"\r\n";
         let output = line_ending.parse_peek(Partial::new(&input[..]));
-        assert_parse!(output, Ok((Partial::new(&b""[..]), &b"\r\n"[..])));
+        assert_parse!(
+            output,
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        [
+            13,
+            10,
+        ],
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn check_unix_lineending() {
         let input = b"\n";
         let output = line_ending.parse_peek(Partial::new(&input[..]));
-        assert_parse!(output, Ok((Partial::new(&b""[..]), &b"\n"[..])));
+        assert_parse!(
+            output,
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        [
+            10,
+        ],
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn cr_lf() {
         assert_parse!(
             crlf.parse_peek(Partial::new(&b"\r\na"[..])),
-            Ok((Partial::new(&b"a"[..]), &b"\r\n"[..]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                97,
+            ],
+            partial: true,
+        },
+        [
+            13,
+            10,
+        ],
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             crlf.parse_peek(Partial::new(&b"\r"[..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             crlf.parse_peek(Partial::new(&b"\ra"[..])),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b"\ra"[..]),
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    13,
+                    97,
+                ],
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
 
         assert_parse!(
             crlf.parse_peek(Partial::new("\r\na")),
-            Ok((Partial::new("a"), "\r\n"))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: "a",
+            partial: true,
+        },
+        "/r/n",
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             crlf.parse_peek(Partial::new("\r")),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             crlf.parse_peek(Partial::new("\ra")),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new("\ra"),
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "/ra",
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1490,42 +4063,136 @@ mod partial {
     fn end_of_line() {
         assert_parse!(
             line_ending.parse_peek(Partial::new(&b"\na"[..])),
-            Ok((Partial::new(&b"a"[..]), &b"\n"[..]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                97,
+            ],
+            partial: true,
+        },
+        [
+            10,
+        ],
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek(Partial::new(&b"\r\na"[..])),
-            Ok((Partial::new(&b"a"[..]), &b"\r\n"[..]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                97,
+            ],
+            partial: true,
+        },
+        [
+            13,
+            10,
+        ],
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek(Partial::new(&b"\r"[..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek(Partial::new(&b"\ra"[..])),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b"\ra"[..]),
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    13,
+                    97,
+                ],
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
 
         assert_parse!(
             line_ending.parse_peek(Partial::new("\na")),
-            Ok((Partial::new("a"), "\n"))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: "a",
+            partial: true,
+        },
+        "/n",
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek(Partial::new("\r\na")),
-            Ok((Partial::new("a"), "\r\n"))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: "a",
+            partial: true,
+        },
+        "/r/n",
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek(Partial::new("\r")),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             line_ending.parse_peek(Partial::new("\ra")),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new("\ra"),
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "/ra",
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1539,66 +4206,269 @@ mod partial {
 
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b";"[..])),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b";"[..]),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    59,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"ff;"[..])),
-            Ok((Partial::new(&b";"[..]), 255))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        255,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"1be2;"[..])),
-            Ok((Partial::new(&b";"[..]), 7138))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        7138,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"c5a31be2;"[..])),
-            Ok((Partial::new(&b";"[..]), 3_315_801_058))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        3315801058,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"C5A31be2;"[..])),
-            Ok((Partial::new(&b";"[..]), 3_315_801_058))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        3315801058,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"00c5a31be2;"[..])), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b"00c5a31be2;"[..]),
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    48,
+                    48,
+                    99,
+                    53,
+                    97,
+                    51,
+                    49,
+                    98,
+                    101,
+                    50,
+                    59,
+                ],
+                partial: true,
+            },
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"c5a31be201;"[..])), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b"c5a31be201;"[..]),
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    99,
+                    53,
+                    97,
+                    51,
+                    49,
+                    98,
+                    101,
+                    50,
+                    48,
+                    49,
+                    59,
+                ],
+                partial: true,
+            },
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"ffffffff;"[..])),
-            Ok((Partial::new(&b";"[..]), 4_294_967_295))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        4294967295,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"ffffffffffffffff;"[..])), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b"ffffffffffffffff;"[..]),
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    59,
+                ],
+                partial: true,
+            },
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"ffffffffffffffff"[..])), // overflow
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b"ffffffffffffffff"[..]),
-                ErrorKind::Verify
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                    102,
+                ],
+                partial: true,
+            },
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"0x1be2;"[..])),
-            Ok((Partial::new(&b"x1be2;"[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                120,
+                49,
+                98,
+                101,
+                50,
+                59,
+            ],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             hex_u32.parse_peek(Partial::new(&b"12af"[..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 }

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -3,15 +3,18 @@ use snapbox::str;
 
 mod complete {
     use super::*;
+
+    use proptest::prelude::*;
+
     use crate::combinator::alt;
     use crate::error::ErrMode;
     use crate::error::InputError;
+    use crate::prelude::*;
     use crate::stream::ParseSlice;
     use crate::token::none_of;
     use crate::token::one_of;
     #[cfg(feature = "alloc")]
     use crate::{lib::std::string::String, lib::std::vec::Vec};
-    use proptest::prelude::*;
 
     #[test]
     fn character() {
@@ -1055,9 +1058,7 @@ Err(
     #[test]
     fn full_line_windows() {
         #[allow(clippy::type_complexity)]
-        fn take_full_line<'i>(
-            i: &mut &'i [u8],
-        ) -> PResult<(&'i [u8], &'i [u8]), InputError<&'i [u8]>> {
+        fn take_full_line<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], (&'i [u8], &'i [u8])> {
             (till_line_ending, line_ending).parse_next(i)
         }
         let input = b"abc\r\n";
@@ -1089,9 +1090,7 @@ Ok(
     #[test]
     fn full_line_unix() {
         #[allow(clippy::type_complexity)]
-        fn take_full_line<'i>(
-            i: &mut &'i [u8],
-        ) -> PResult<(&'i [u8], &'i [u8]), InputError<&'i [u8]>> {
+        fn take_full_line<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], (&'i [u8], &'i [u8])> {
             (till_line_ending, line_ending).parse_next(i)
         }
         let input = b"abc\n";
@@ -1380,7 +1379,7 @@ Err(
 
     #[test]
     fn dec_uint_tests() {
-        fn dec_u32<'i>(input: &mut &'i [u8]) -> PResult<u32, InputError<&'i [u8]>> {
+        fn dec_u32<'i>(input: &mut &'i [u8]) -> TestResult<&'i [u8], u32> {
             dec_uint.parse_next(input)
         }
 
@@ -1484,7 +1483,7 @@ Err(
 
     #[test]
     fn dec_int_tests() {
-        fn dec_i32<'i>(input: &mut &'i [u8]) -> PResult<i32, InputError<&'i [u8]>> {
+        fn dec_i32<'i>(input: &mut &'i [u8]) -> TestResult<&'i [u8], i32> {
             dec_int.parse_next(input)
         }
 
@@ -1634,7 +1633,7 @@ Err(
 
     #[test]
     fn hex_uint_tests() {
-        fn hex_u32<'i>(input: &mut &'i [u8]) -> PResult<u32, InputError<&'i [u8]>> {
+        fn hex_u32<'i>(input: &mut &'i [u8]) -> TestResult<&'i [u8], u32> {
             hex_uint.parse_next(input)
         }
 
@@ -2004,7 +2003,7 @@ Err(
     #[cfg_attr(debug_assertions, should_panic)]
     fn complete_take_escaped_hang_1() {
         // issue #1336 "take_escaped hangs if normal parser accepts empty"
-        fn escaped_string<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+        fn escaped_string<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
             use crate::ascii::alpha0;
             use crate::token::one_of;
             take_escaped(alpha0, '\\', one_of(['n'])).parse_next(input)
@@ -2019,7 +2018,7 @@ Err(
     #[cfg_attr(debug_assertions, should_panic)]
     fn complete_take_escaped_hang_2() {
         // issue #1336 "take_escaped hangs if normal parser accepts empty"
-        fn escaped_string<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+        fn escaped_string<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
             use crate::ascii::alpha0;
             use crate::token::one_of;
             take_escaped(alpha0, '\\', one_of(['n'])).parse_next(input)
@@ -2033,7 +2032,7 @@ Err(
     #[cfg_attr(debug_assertions, should_panic)]
     fn complete_take_escaped_hang_1118() {
         // issue ##1118 take_escaped does not work with empty string
-        fn unquote<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+        fn unquote<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
             use crate::combinator::delimited;
             use crate::combinator::opt;
             use crate::token::one_of;
@@ -2061,7 +2060,7 @@ Err(
         use crate::ascii::{alpha1 as alpha, digit1 as digit};
         use crate::token::one_of;
 
-        fn esc<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
+        fn esc<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], &'i [u8]> {
             take_escaped(alpha, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
         assert_parse!(
@@ -2193,7 +2192,7 @@ Err(
 "#]]
         );
 
-        fn esc2<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
+        fn esc2<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], &'i [u8]> {
             take_escaped(digit, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
         assert_parse!(
@@ -2226,7 +2225,7 @@ Ok(
         use crate::ascii::{alpha1 as alpha, digit1 as digit};
         use crate::token::one_of;
 
-        fn esc<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+        fn esc<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
             take_escaped(alpha, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
         assert_parse!(
@@ -2318,7 +2317,7 @@ Err(
 "#]]
         );
 
-        fn esc2<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+        fn esc2<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
             take_escaped(digit, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
         assert_parse!(
@@ -2334,7 +2333,7 @@ Ok(
 "#]]
         );
 
-        fn esc3<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+        fn esc3<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
             take_escaped(alpha, '\u{241b}', one_of(['\"', 'n'])).parse_next(i)
         }
         assert_parse!(
@@ -2353,7 +2352,7 @@ Ok(
 
     #[test]
     fn test_escaped_error() {
-        fn esc<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+        fn esc<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
             use crate::ascii::digit1;
             take_escaped(digit1, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
         }
@@ -2382,7 +2381,7 @@ Ok(
             String::from_utf8_lossy(&i).into_owned()
         }
 
-        fn esc<'i>(i: &mut &'i [u8]) -> PResult<String, InputError<&'i [u8]>> {
+        fn esc<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], String> {
             escaped_transform(
                 alpha,
                 '\\',
@@ -2498,7 +2497,7 @@ Err(
 "#]]
         );
 
-        fn esc2<'i>(i: &mut &'i [u8]) -> PResult<String, InputError<&'i [u8]>> {
+        fn esc2<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], String> {
             escaped_transform(
                 alpha,
                 '&',
@@ -2545,7 +2544,7 @@ Ok(
     fn complete_escape_transform_str() {
         use crate::ascii::alpha1 as alpha;
 
-        fn esc<'i>(i: &mut &'i str) -> PResult<String, InputError<&'i str>> {
+        fn esc<'i>(i: &mut &'i str) -> TestResult<&'i str, String> {
             escaped_transform(
                 alpha,
                 '\\',
@@ -2643,7 +2642,7 @@ Err(
 "#]]
         );
 
-        fn esc2<'i>(i: &mut &'i str) -> PResult<String, InputError<&'i str>> {
+        fn esc2<'i>(i: &mut &'i str) -> TestResult<&'i str, String> {
             escaped_transform(
                 alpha,
                 '&',
@@ -2676,7 +2675,7 @@ Ok(
 "#]]
         );
 
-        fn esc3<'i>(i: &mut &'i str) -> PResult<String, InputError<&'i str>> {
+        fn esc3<'i>(i: &mut &'i str) -> TestResult<&'i str, String> {
             escaped_transform(alpha, '␛', alt(("0".value("\0"), "n".value("\n")))).parse_next(i)
         }
         assert_parse!(
@@ -2696,7 +2695,7 @@ Ok(
     #[test]
     #[cfg(feature = "alloc")]
     fn test_escaped_transform_error() {
-        fn esc_trans<'i>(i: &mut &'i str) -> PResult<String, InputError<&'i str>> {
+        fn esc_trans<'i>(i: &mut &'i str) -> TestResult<&'i str, String> {
             use crate::ascii::digit1;
             escaped_transform(digit1, '\\', "n").parse_next(i)
         }
@@ -2718,7 +2717,9 @@ Ok(
 
 mod partial {
     use super::*;
+
     use crate::error::InputError;
+    use crate::prelude::*;
     use crate::Partial;
 
     #[test]
@@ -3841,7 +3842,7 @@ Err(
         #[allow(clippy::type_complexity)]
         fn take_full_line<'i>(
             i: &mut Partial<&'i [u8]>,
-        ) -> PResult<(&'i [u8], &'i [u8]), InputError<Partial<&'i [u8]>>> {
+        ) -> TestResult<Partial<&'i [u8]>, (&'i [u8], &'i [u8])> {
             (till_line_ending, line_ending).parse_next(i)
         }
         let input = b"abc\r\n";
@@ -3878,7 +3879,7 @@ Ok(
         #[allow(clippy::type_complexity)]
         fn take_full_line<'i>(
             i: &mut Partial<&'i [u8]>,
-        ) -> PResult<(&'i [u8], &'i [u8]), InputError<Partial<&'i [u8]>>> {
+        ) -> TestResult<Partial<&'i [u8]>, (&'i [u8], &'i [u8])> {
             (till_line_ending, line_ending).parse_next(i)
         }
         let input = b"abc\n";
@@ -4198,9 +4199,7 @@ Err(
 
     #[test]
     fn hex_uint_tests() {
-        fn hex_u32<'i>(
-            input: &mut Partial<&'i [u8]>,
-        ) -> PResult<u32, InputError<Partial<&'i [u8]>>> {
+        fn hex_u32<'i>(input: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u32> {
             hex_uint.parse_next(input)
         }
 

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -13,13 +13,6 @@ mod complete {
     use crate::{lib::std::string::String, lib::std::vec::Vec};
     use proptest::prelude::*;
 
-    macro_rules! assert_parse(
-    ($left: expr, $right: expr) => {
-      let res: $crate::error::IResult<_, _, InputError<_>> = $left;
-      assert_eq!(res, $right);
-    };
-  );
-
     #[test]
     fn character() {
         let empty: &[u8] = b"";
@@ -997,13 +990,6 @@ mod partial {
     use crate::error::InputError;
     use crate::error::{ErrMode, Needed};
     use crate::Partial;
-
-    macro_rules! assert_parse(
-    ($left: expr, $right: expr) => {
-      let res: $crate::error::IResult<_, _, InputError<_>> = $left;
-      assert_eq!(res, $right);
-    };
-  );
 
     #[test]
     fn character() {

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -188,7 +188,7 @@ where
 /// assert_eq!(parser((stream(&[0b00010010]), 4), 4), Ok(((stream(&[]), 0), 0b00000010)));
 ///
 /// // Tries to consume 12 bits but only 8 are available
-/// assert_eq!(parser((stream(&[0b00010010]), 0), 12), Err(winnow::error::ErrMode::Backtrack(InputError::new((stream(&[0b00010010]), 0), ErrorKind::Eof))));
+/// assert!(parser((stream(&[0b00010010]), 0), 12).is_err());
 /// ```
 #[inline(always)]
 pub fn take<Input, Output, Count, Error>(count: Count) -> impl Parser<(Input, usize), Output, Error>
@@ -313,22 +313,10 @@ where
 /// );
 ///
 /// // The lowest 2 bits of 0b11111111 and 0b00000001 are different.
-/// assert_eq!(
-///     parser(0b000000_01, 2, (stream(&[0b111111_11]), 0)),
-///     Err(winnow::error::ErrMode::Backtrack(InputError::new(
-///         (stream(&[0b11111111]), 0),
-///         ErrorKind::Literal
-///     )))
-/// );
+/// assert!(parser(0b000000_01, 2, (stream(&[0b111111_11]), 0)).is_err());
 ///
 /// // The lowest 8 bits of 0b11111111 and 0b11111110 are different.
-/// assert_eq!(
-///     parser(0b11111110, 8, (stream(&[0b11111111]), 0)),
-///     Err(winnow::error::ErrMode::Backtrack(InputError::new(
-///         (stream(&[0b11111111]), 0),
-///         ErrorKind::Literal
-///     )))
-/// );
+/// assert!(parser(0b11111110, 8, (stream(&[0b11111111]), 0)).is_err());
 /// ```
 #[inline(always)]
 #[doc(alias = "literal")]

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -18,7 +18,7 @@ const BYTE: usize = u8::BITS as usize;
 /// See [`bytes`] to convert it back.
 ///
 /// # Example
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
 /// # use winnow::binary::bits::{bits, take};

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -22,21 +22,20 @@ const BYTE: usize = u8::BITS as usize;
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
 /// # use winnow::binary::bits::{bits, take};
-/// # use winnow::error::InputError;
-/// # use winnow::error::IResult;
+/// # use winnow::error::ContextError;
 /// type Stream<'i> = &'i Bytes;
 ///
 /// fn stream(b: &[u8]) -> Stream<'_> {
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parse(input: Stream<'_>) -> IResult<Stream<'_>, (u8, u8)> {
-///     bits::<_, _, InputError<(_, usize)>, _, _>((take(4usize), take(8usize))).parse_peek(input)
+/// fn parse(input: &mut Stream<'_>) -> PResult<(u8, u8)> {
+///     bits::<_, _, ContextError, _, _>((take(4usize), take(8usize))).parse_next(input)
 /// }
 ///
 /// let input = stream(&[0x12, 0x34, 0xff, 0xff]);
 ///
-/// let output = parse(input).expect("We take 1.5 bytes and the input is longer than 2 bytes");
+/// let output = parse.parse_peek(input).expect("We take 1.5 bytes and the input is longer than 2 bytes");
 ///
 /// // The first byte is consumed, the second byte is partially consumed and dropped.
 /// let remaining = output.0;
@@ -91,8 +90,7 @@ where
 /// use winnow::Bytes;
 /// use winnow::binary::bits::{bits, bytes, take};
 /// use winnow::token::rest;
-/// use winnow::error::InputError;
-/// use winnow::error::IResult;
+/// use winnow::error::ContextError;
 ///
 /// type Stream<'i> = &'i Bytes;
 ///
@@ -100,17 +98,17 @@ where
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parse(input: Stream<'_>) -> IResult<Stream<'_>, (u8, u8, &[u8])> {
-///   bits::<_, _, InputError<(_, usize)>, _, _>((
+/// fn parse<'i>(input: &mut Stream<'i>) -> PResult<(u8, u8, &'i [u8])> {
+///   bits::<_, _, ContextError, _, _>((
 ///     take(4usize),
 ///     take(8usize),
-///     bytes::<_, _, InputError<_>, _, _>(rest)
-///   )).parse_peek(input)
+///     bytes::<_, _, ContextError, _, _>(rest)
+///   )).parse_next(input)
 /// }
 ///
 /// let input = stream(&[0x12, 0x34, 0xff, 0xff]);
 ///
-/// assert_eq!(parse(input), Ok(( stream(&[]), (0x01, 0x23, &[0xff, 0xff][..]) )));
+/// assert_eq!(parse.parse_peek(input), Ok(( stream(&[]), (0x01, 0x23, &[0xff, 0xff][..]) )));
 /// ```
 pub fn bytes<Input, Output, ByteError, BitError, ParseNext>(
     mut parser: ParseNext,
@@ -164,8 +162,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
-/// # use winnow::error::{InputError, ErrorKind};
-/// # use winnow::error::IResult;
+/// # use winnow::error::{ContextError, ErrorKind};
 /// use winnow::binary::bits::take;
 ///
 /// type Stream<'i> = &'i Bytes;
@@ -174,21 +171,17 @@ where
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parser(input: (Stream<'_>, usize), count: usize)-> IResult<(Stream<'_>, usize), u8> {
-///   take(count).parse_peek(input)
-/// }
-///
 /// // Consumes 0 bits, returns 0
-/// assert_eq!(parser((stream(&[0b00010010]), 0), 0), Ok(((stream(&[0b00010010]), 0), 0)));
+/// assert_eq!(take::<_, usize, _, ContextError>(0usize).parse_peek((stream(&[0b00010010]), 0)), Ok(((stream(&[0b00010010]), 0), 0)));
 ///
 /// // Consumes 4 bits, returns their values and increase offset to 4
-/// assert_eq!(parser((stream(&[0b00010010]), 0), 4), Ok(((stream(&[0b00010010]), 4), 0b00000001)));
+/// assert_eq!(take::<_, usize, _, ContextError>(4usize).parse_peek((stream(&[0b00010010]), 0)), Ok(((stream(&[0b00010010]), 4), 0b00000001)));
 ///
 /// // Consumes 4 bits, offset is 4, returns their values and increase offset to 0 of next byte
-/// assert_eq!(parser((stream(&[0b00010010]), 4), 4), Ok(((stream(&[]), 0), 0b00000010)));
+/// assert_eq!(take::<_, usize, _, ContextError>(4usize).parse_peek((stream(&[0b00010010]), 4)), Ok(((stream(&[]), 0), 0b00000010)));
 ///
 /// // Tries to consume 12 bits but only 8 are available
-/// assert!(parser((stream(&[0b00010010]), 0), 12).is_err());
+/// assert!(take::<_, usize, _, ContextError>(12usize).parse_peek((stream(&[0b00010010]), 0)).is_err());
 /// ```
 #[inline(always)]
 pub fn take<Input, Output, Count, Error>(count: Count) -> impl Parser<(Input, usize), Output, Error>
@@ -283,8 +276,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
-/// # use winnow::error::{InputError, ErrorKind};
-/// # use winnow::error::IResult;
+/// # use winnow::error::{ContextError, ErrorKind};
 /// use winnow::binary::bits::pattern;
 ///
 /// type Stream<'i> = &'i Bytes;
@@ -296,27 +288,27 @@ where
 /// /// Compare the lowest `count` bits of `input` against the lowest `count` bits of `pattern`.
 /// /// Return Ok and the matching section of `input` if there's a match.
 /// /// Return Err if there's no match.
-/// fn parser(bits: u8, count: u8, input: (Stream<'_>, usize)) -> IResult<(Stream<'_>, usize), u8> {
-///     pattern(bits, count).parse_peek(input)
+/// fn parser(bits: u8, count: u8, input: &mut (Stream<'_>, usize)) -> PResult<u8> {
+///     pattern(bits, count).parse_next(input)
 /// }
 ///
 /// // The lowest 4 bits of 0b00001111 match the lowest 4 bits of 0b11111111.
 /// assert_eq!(
-///     parser(0b0000_1111, 4, (stream(&[0b1111_1111]), 0)),
+///     pattern::<_, usize, _, ContextError>(0b0000_1111, 4usize).parse_peek((stream(&[0b1111_1111]), 0)),
 ///     Ok(((stream(&[0b1111_1111]), 4), 0b0000_1111))
 /// );
 ///
 /// // The lowest bit of 0b00001111 matches the lowest bit of 0b11111111 (both are 1).
 /// assert_eq!(
-///     parser(0b00000001, 1, (stream(&[0b11111111]), 0)),
+///     pattern::<_, usize, _, ContextError>(0b00000001, 1usize).parse_peek((stream(&[0b11111111]), 0)),
 ///     Ok(((stream(&[0b11111111]), 1), 0b00000001))
 /// );
 ///
 /// // The lowest 2 bits of 0b11111111 and 0b00000001 are different.
-/// assert!(parser(0b000000_01, 2, (stream(&[0b111111_11]), 0)).is_err());
+/// assert!(pattern::<_, usize, _, ContextError>(0b000000_01, 2usize).parse_peek((stream(&[0b111111_11]), 0)).is_err());
 ///
 /// // The lowest 8 bits of 0b11111111 and 0b11111110 are different.
-/// assert!(parser(0b11111110, 8, (stream(&[0b11111111]), 0)).is_err());
+/// assert!(pattern::<_, usize, _, ContextError>(0b11111110, 8usize).parse_peek((stream(&[0b11111111]), 0)).is_err());
 /// ```
 #[inline(always)]
 #[doc(alias = "literal")]
@@ -373,7 +365,6 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
 /// # use winnow::error::{InputError, ErrorKind};
-/// # use winnow::error::IResult;
 /// use winnow::binary::bits::bool;
 ///
 /// type Stream<'i> = &'i Bytes;
@@ -382,12 +373,12 @@ where
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parse(input: (Stream<'_>, usize)) -> IResult<(Stream<'_>, usize), bool> {
-///     bool.parse_peek(input)
+/// fn parse(input: &mut (Stream<'_>, usize)) -> PResult<bool> {
+///     bool.parse_next(input)
 /// }
 ///
-/// assert_eq!(parse((stream(&[0b10000000]), 0)), Ok(((stream(&[0b10000000]), 1), true)));
-/// assert_eq!(parse((stream(&[0b10000000]), 1)), Ok(((stream(&[0b10000000]), 2), false)));
+/// assert_eq!(parse.parse_peek((stream(&[0b10000000]), 0)), Ok(((stream(&[0b10000000]), 1), true)));
+/// assert_eq!(parse.parse_peek((stream(&[0b10000000]), 1)), Ok(((stream(&[0b10000000]), 2), false)));
 /// ```
 #[doc(alias = "any")]
 pub fn bool<Input, Error: ParserError<(Input, usize)>>(

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -1348,15 +1348,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u16;
 ///
-/// let be_u16 = |s| {
-///     u16(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u16(input: &[u8]) -> IResult<&[u8], u16> {
+///     u16(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_u16 = |s| {
-///     u16(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u16(input: &[u8]) -> IResult<&[u8], u16> {
+///     u16(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
@@ -1371,15 +1371,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u16;
 ///
-/// let be_u16 = |s| {
-///     u16::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
+///     u16::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_u16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// let le_u16 = |s| {
-///     u16::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>,  u16> {
+///     u16::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
@@ -1421,15 +1421,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u24;
 ///
-/// let be_u24 = |s| {
-///     u24(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u24(input: &[u8]) -> IResult<&[u8], u32> {
+///     u24(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_u24 = |s| {
-///     u24(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u24(input: &[u8]) -> IResult<&[u8], u32> {
+///     u24(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
@@ -1444,15 +1444,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u24;
 ///
-/// let be_u24 = |s| {
-///     u24::<_,InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+///     u24::<_,InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_u24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
-/// let le_u24 = |s| {
-///     u24::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+///     u24::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
@@ -1494,15 +1494,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u32;
 ///
-/// let be_u32 = |s| {
-///     u32(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u32(input: &[u8]) -> IResult<&[u8], u32> {
+///     u32(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_u32 = |s| {
-///     u32(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u32(input: &[u8]) -> IResult<&[u8], u32> {
+///     u32(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
@@ -1517,15 +1517,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u32;
 ///
-/// let be_u32 = |s| {
-///     u32::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+///     u32::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_u32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
-/// let le_u32 = |s| {
-///     u32::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
+///     u32::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
@@ -1567,15 +1567,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u64;
 ///
-/// let be_u64 = |s| {
-///     u64(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u64(input: &[u8]) -> IResult<&[u8], u64> {
+///     u64(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_u64 = |s| {
-///     u64(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u64(input: &[u8]) -> IResult<&[u8], u64> {
+///     u64(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
@@ -1590,15 +1590,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u64;
 ///
-/// let be_u64 = |s| {
-///     u64::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
+///     u64::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_u64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
-/// let le_u64 = |s| {
-///     u64::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
+///     u64::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
@@ -1640,15 +1640,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u128;
 ///
-/// let be_u128 = |s| {
-///     u128(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u128(input: &[u8]) -> IResult<&[u8], u128> {
+///     u128(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_u128 = |s| {
-///     u128(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u128(input: &[u8]) -> IResult<&[u8], u128> {
+///     u128(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
@@ -1663,15 +1663,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u128;
 ///
-/// let be_u128 = |s| {
-///     u128::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_u128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
+///     u128::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_u128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
-/// let le_u128 = |s| {
-///     u128::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_u128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
+///     u128::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
@@ -1774,15 +1774,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i16;
 ///
-/// let be_i16 = |s| {
-///     i16(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i16(input: &[u8]) -> IResult<&[u8], i16> {
+///     i16(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_i16 = |s| {
-///     i16(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i16(input: &[u8]) -> IResult<&[u8], i16> {
+///     i16(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
@@ -1797,15 +1797,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i16;
 ///
-/// let be_i16 = |s| {
-///     i16::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
+///     i16::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_i16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// let le_i16 = |s| {
-///     i16::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
+///     i16::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
@@ -1847,15 +1847,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i24;
 ///
-/// let be_i24 = |s| {
-///     i24(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i24(input: &[u8]) -> IResult<&[u8], i32> {
+///     i24(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_i24 = |s| {
-///     i24(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i24(input: &[u8]) -> IResult<&[u8], i32> {
+///     i24(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
@@ -1870,15 +1870,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i24;
 ///
-/// let be_i24 = |s| {
-///     i24::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
+///     i24::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_i24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
-/// let le_i24 = |s| {
-///     i24::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
+///     i24::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
@@ -1920,15 +1920,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i32;
 ///
-/// let be_i32 = |s| {
-///     i32(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i32(input: &[u8]) -> IResult<&[u8], i32> {
+///     i32(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_i32 = |s| {
-///     i32(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i32(input: &[u8]) -> IResult<&[u8], i32> {
+///     i32(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
@@ -1943,15 +1943,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i32;
 ///
-/// let be_i32 = |s| {
-///     i32::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
+///     i32::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_i32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
-/// let le_i32 = |s| {
-///     i32::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
+///     i32::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
@@ -1993,15 +1993,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i64;
 ///
-/// let be_i64 = |s| {
-///     i64(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i64(input: &[u8]) -> IResult<&[u8], i64> {
+///     i64(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_i64 = |s| {
-///     i64(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i64(input: &[u8]) -> IResult<&[u8], i64> {
+///     i64(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
@@ -2016,15 +2016,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i64;
 ///
-/// let be_i64 = |s| {
-///     i64::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
+///     i64::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_i64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
-/// let le_i64 = |s| {
-///     i64::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
+///     i64::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
@@ -2066,15 +2066,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i128;
 ///
-/// let be_i128 = |s| {
-///     i128(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i128(input: &[u8]) -> IResult<&[u8], i128> {
+///     i128(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
 ///
-/// let le_i128 = |s| {
-///     i128(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i128(input: &[u8]) -> IResult<&[u8], i128> {
+///     i128(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
@@ -2089,15 +2089,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i128;
 ///
-/// let be_i128 = |s| {
-///     i128::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_i128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
+///     i128::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_i128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
-/// let le_i128 = |s| {
-///     i128::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_i128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
+///     i128::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
@@ -2336,15 +2336,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::f32;
 ///
-/// let be_f32 = |s| {
-///     f32(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_f32(input: &[u8]) -> IResult<&[u8], f32> {
+///     f32(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
 ///
-/// let le_f32 = |s| {
-///     f32(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_f32(input: &[u8]) -> IResult<&[u8], f32> {
+///     f32(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
@@ -2359,15 +2359,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::f32;
 ///
-/// let be_f32 = |s| {
-///     f32::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_f32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
+///     f32::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_f32(Partial::new(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(be_f32(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// let le_f32 = |s| {
-///     f32::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_f32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
+///     f32::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_f32(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
@@ -2409,15 +2409,15 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::f64;
 ///
-/// let be_f64 = |s| {
-///     f64(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_f64(input: &[u8]) -> IResult<&[u8], f64> {
+///     f64(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
 ///
-/// let le_f64 = |s| {
-///     f64(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_f64(input: &[u8]) -> IResult<&[u8], f64> {
+///     f64(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
@@ -2432,15 +2432,15 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::f64;
 ///
-/// let be_f64 = |s| {
-///     f64::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(s)
+/// fn be_f64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
+///     f64::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_f64(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(be_f64(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 ///
-/// let le_f64 = |s| {
-///     f64::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(s)
+/// fn le_f64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
+///     f64::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_f64(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Partial::new(&b""[..]), 12.5)));

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -721,7 +721,7 @@ where
 /// use winnow::binary::le_u16;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-///       le_u16::<_, InputError<_>>.parse_peek(s)
+///       le_u16.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
@@ -767,7 +767,7 @@ where
 /// use winnow::binary::le_u24;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///       le_u24::<_, InputError<_>>.parse_peek(s)
+///       le_u24.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
@@ -813,7 +813,7 @@ where
 /// use winnow::binary::le_u32;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///       le_u32::<_, InputError<_>>.parse_peek(s)
+///       le_u32.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
@@ -859,7 +859,7 @@ where
 /// use winnow::binary::le_u64;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-///       le_u64::<_, InputError<_>>.parse_peek(s)
+///       le_u64.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
@@ -905,7 +905,7 @@ where
 /// use winnow::binary::le_u128;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
-///       le_u128::<_, InputError<_>>.parse_peek(s)
+///       le_u128.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
@@ -1034,7 +1034,7 @@ where
 /// use winnow::binary::le_i16;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-///       le_i16::<_, InputError<_>>.parse_peek(s)
+///       le_i16.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
@@ -1083,7 +1083,7 @@ where
 /// use winnow::binary::le_i24;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///       le_i24::<_, InputError<_>>.parse_peek(s)
+///       le_i24.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
@@ -1140,7 +1140,7 @@ where
 /// use winnow::binary::le_i32;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///       le_i32::<_, InputError<_>>.parse_peek(s)
+///       le_i32.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
@@ -1189,7 +1189,7 @@ where
 /// use winnow::binary::le_i64;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-///       le_i64::<_, InputError<_>>.parse_peek(s)
+///       le_i64.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
@@ -1238,7 +1238,7 @@ where
 /// use winnow::binary::le_i128;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
-///       le_i128::<_, InputError<_>>.parse_peek(s)
+///       le_i128.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
@@ -1294,7 +1294,7 @@ where
 /// use winnow::binary::u8;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-///       u8::<_, InputError<_>>.parse_peek(s)
+///       u8.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"\x03abcefg"[..]), 0x00)));
@@ -1372,14 +1372,14 @@ where
 /// use winnow::binary::u16;
 ///
 /// fn be_u16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-///     u16::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     u16(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_u16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn le_u16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>,  u16> {
-///     u16::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     u16(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
@@ -1445,14 +1445,14 @@ where
 /// use winnow::binary::u24;
 ///
 /// fn be_u24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     u24::<_,InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     u24(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_u24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// fn le_u24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     u24::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     u24(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
@@ -1518,14 +1518,14 @@ where
 /// use winnow::binary::u32;
 ///
 /// fn be_u32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     u32::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     u32(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_u32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// fn le_u32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     u32::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     u32(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
@@ -1591,14 +1591,14 @@ where
 /// use winnow::binary::u64;
 ///
 /// fn be_u64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-///     u64::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     u64(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_u64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// fn le_u64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-///     u64::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     u64(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
@@ -1664,14 +1664,14 @@ where
 /// use winnow::binary::u128;
 ///
 /// fn be_u128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
-///     u128::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     u128(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_u128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// fn le_u128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
-///     u128::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     u128(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
@@ -1798,14 +1798,14 @@ where
 /// use winnow::binary::i16;
 ///
 /// fn be_i16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-///     i16::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     i16(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_i16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn le_i16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-///     i16::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     i16(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
@@ -1871,14 +1871,14 @@ where
 /// use winnow::binary::i24;
 ///
 /// fn be_i24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///     i24::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     i24(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_i24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
 /// fn le_i24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///     i24::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     i24(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
@@ -1944,14 +1944,14 @@ where
 /// use winnow::binary::i32;
 ///
 /// fn be_i32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///     i32::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     i32(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_i32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
 /// fn le_i32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///     i32::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     i32(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
@@ -2017,14 +2017,14 @@ where
 /// use winnow::binary::i64;
 ///
 /// fn be_i64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-///     i64::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     i64(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_i64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
 /// fn le_i64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-///     i64::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     i64(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
@@ -2090,14 +2090,14 @@ where
 /// use winnow::binary::i128;
 ///
 /// fn be_i128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
-///     i128::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     i128(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_i128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
 /// fn le_i128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
-///     i128::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     i128(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
@@ -2202,7 +2202,7 @@ where
 /// use winnow::binary::be_f64;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
-///       be_f64::<_, InputError<_>>.parse_peek(s)
+///       be_f64.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
@@ -2251,7 +2251,7 @@ where
 /// use winnow::binary::le_f32;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
-///       le_f32::<_, InputError<_>>.parse_peek(s)
+///       le_f32.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
@@ -2300,7 +2300,7 @@ where
 /// use winnow::binary::le_f64;
 ///
 /// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
-///       le_f64::<_, InputError<_>>.parse_peek(s)
+///       le_f64.parse_peek(s)
 /// }
 ///
 /// assert_eq!(parser(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 3145728.0)));
@@ -2360,14 +2360,14 @@ where
 /// use winnow::binary::f32;
 ///
 /// fn be_f32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
-///     f32::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     f32(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_f32(Partial::new(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(be_f32(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn le_f32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
-///     f32::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     f32(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_f32(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
@@ -2433,14 +2433,14 @@ where
 /// use winnow::binary::f64;
 ///
 /// fn be_f64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
-///     f64::<_, InputError<_>>(winnow::binary::Endianness::Big).parse_peek(input)
+///     f64(winnow::binary::Endianness::Big).parse_peek(input)
 /// };
 ///
 /// assert_eq!(be_f64(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(be_f64(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 ///
 /// fn le_f64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
-///     f64::<_, InputError<_>>(winnow::binary::Endianness::Little).parse_peek(input)
+///     f64(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_f64(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Partial::new(&b""[..]), 12.5)));

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -40,33 +40,31 @@ pub enum Endianness {
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u8;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u8> {
-///     be_u8.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u8> {
+///     be_u8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert!(parser(&b""[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u8;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-///     be_u8.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u8> {
+///     be_u8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn be_u8<Input, Error>(input: &mut Input) -> PResult<u8, Error>
@@ -86,33 +84,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u16;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u16> {
-///     be_u16.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u16> {
+///     be_u16.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u16;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-///     be_u16.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u16> {
+///     be_u16.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn be_u16<Input, Error>(input: &mut Input) -> PResult<u16, Error>
@@ -132,33 +128,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u24;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u32> {
-///     be_u24.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u32> {
+///     be_u24.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u24;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     be_u24.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u32> {
+///     be_u24.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x000102)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x000102)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn be_u24<Input, Error>(input: &mut Input) -> PResult<u32, Error>
@@ -178,33 +172,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u32;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u32> {
-///     be_u32.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u32> {
+///     be_u32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u32;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     be_u32.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u32> {
+///     be_u32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn be_u32<Input, Error>(input: &mut Input) -> PResult<u32, Error>
@@ -224,33 +216,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u64;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u64> {
-///     be_u64.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u64> {
+///     be_u64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u64;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-///     be_u64.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u64> {
+///     be_u64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001020304050607)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001020304050607)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn be_u64<Input, Error>(input: &mut Input) -> PResult<u64, Error>
@@ -270,33 +260,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u128;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u128> {
-///     be_u128.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u128> {
+///     be_u128.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u128;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
-///     be_u128.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u128> {
+///     be_u128.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203040506070809101112131415)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn be_u128<Input, Error>(input: &mut Input) -> PResult<u128, Error>
@@ -354,33 +342,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i8;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i8> {
-///     be_i8.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i8> {
+///     be_i8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert!(parser(&b""[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i8;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i8> {
-///       be_i8.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i8> {
+///       be_i8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn be_i8<Input, Error>(input: &mut Input) -> PResult<i8, Error>
@@ -400,33 +386,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i16;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i16> {
-///     be_i16.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i16> {
+///     be_i16.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i16;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-///       be_i16.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i16> {
+///       be_i16.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001)));
-/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn be_i16<Input, Error>(input: &mut Input) -> PResult<i16, Error>
@@ -449,33 +433,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i24;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i32> {
-///     be_i24.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i32> {
+///     be_i24.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i24;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///       be_i24.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i32> {
+///       be_i24.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x000102)));
-/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x000102)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn be_i24<Input, Error>(input: &mut Input) -> PResult<i32, Error>
@@ -506,33 +488,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i32;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i32> {
-///       be_i32.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i32> {
+///       be_i32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i32;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///       be_i32.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i32> {
+///       be_i32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203)));
-/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
 pub fn be_i32<Input, Error>(input: &mut Input) -> PResult<i32, Error>
@@ -555,33 +535,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i64;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i64> {
-///       be_i64.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i64> {
+///       be_i64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i64;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-///       be_i64.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i64> {
+///       be_i64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001020304050607)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0001020304050607)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn be_i64<Input, Error>(input: &mut Input) -> PResult<i64, Error>
@@ -604,33 +582,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i128;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i128> {
-///       be_i128.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i128> {
+///       be_i128.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i128;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
-///       be_i128.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i128> {
+///       be_i128.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x00010203040506070809101112131415)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn be_i128<Input, Error>(input: &mut Input) -> PResult<i128, Error>
@@ -653,33 +629,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u8;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u8> {
-///       le_u8.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u8> {
+///       le_u8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert!(parser(&b""[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u8;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-///       le_u8.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u8> {
+///       le_u8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_u8<Input, Error>(input: &mut Input) -> PResult<u8, Error>
@@ -699,33 +673,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u16;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u16> {
-///       le_u16.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u16> {
+///       le_u16.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u16;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-///       le_u16.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u16> {
+///       le_u16.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_u16<Input, Error>(input: &mut Input) -> PResult<u16, Error>
@@ -745,33 +717,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u24;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u32> {
-///       le_u24.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u32> {
+///       le_u24.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u24;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///       le_u24.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u32> {
+///       le_u24.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn le_u24<Input, Error>(input: &mut Input) -> PResult<u32, Error>
@@ -791,33 +761,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u32;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u32> {
-///       le_u32.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u32> {
+///       le_u32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u32;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///       le_u32.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u32> {
+///       le_u32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn le_u32<Input, Error>(input: &mut Input) -> PResult<u32, Error>
@@ -837,33 +805,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u64;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u64> {
-///       le_u64.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u64> {
+///       le_u64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u64;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-///       le_u64.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u64> {
+///       le_u64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn le_u64<Input, Error>(input: &mut Input) -> PResult<u64, Error>
@@ -883,33 +849,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u128;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u128> {
-///       le_u128.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u128> {
+///       le_u128.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u128;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
-///       le_u128.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u128> {
+///       le_u128.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn le_u128<Input, Error>(input: &mut Input) -> PResult<u128, Error>
@@ -966,33 +930,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i8;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i8> {
-///       le_i8.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i8> {
+///       le_i8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert!(parser(&b""[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i8;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i8> {
-///       le_i8.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i8> {
+///       le_i8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
-/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"\x01abcd"[..]), 0x00)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_i8<Input, Error>(input: &mut Input) -> PResult<i8, Error>
@@ -1012,33 +974,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i16;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i16> {
-///       le_i16.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i16> {
+///       le_i16.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i16;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-///       le_i16.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i16> {
+///       le_i16.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn le_i16<Input, Error>(input: &mut Input) -> PResult<i16, Error>
@@ -1061,33 +1021,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i24;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i32> {
-///       le_i24.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i32> {
+///       le_i24.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i24;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///       le_i24.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i32> {
+///       le_i24.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x020100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn le_i24<Input, Error>(input: &mut Input) -> PResult<i32, Error>
@@ -1118,33 +1076,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i32;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i32> {
-///       le_i32.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i32> {
+///       le_i32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i32;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///       le_i32.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i32> {
+///       le_i32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x03020100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn le_i32<Input, Error>(input: &mut Input) -> PResult<i32, Error>
@@ -1167,33 +1123,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i64;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i64> {
-///       le_i64.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i64> {
+///       le_i64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i64;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-///       le_i64.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i64> {
+///       le_i64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x0706050403020100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn le_i64<Input, Error>(input: &mut Input) -> PResult<i64, Error>
@@ -1216,33 +1170,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i128;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i128> {
-///       le_i128.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i128> {
+///       le_i128.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert!(parser(&b"\x01"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
+/// assert!(parser.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i128;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
-///       le_i128.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i128> {
+///       le_i128.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..])), Ok((Partial::new(&b"abcd"[..]), 0x15141312111009080706050403020100)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn le_i128<Input, Error>(input: &mut Input) -> PResult<i128, Error>
@@ -1271,34 +1223,32 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u8;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], u8> {
-///       u8.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<u8> {
+///       u8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert!(parser(&b""[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::u8;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-///       u8.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u8> {
+///       u8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"\x03abcefg"[..]), 0x00)));
-/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"\x03abcefg"[..]), 0x00)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn u8<Input, Error>(input: &mut Input) -> PResult<u8, Error>
@@ -1342,48 +1292,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u16;
 ///
-/// fn be_u16(input: &[u8]) -> IResult<&[u8], u16> {
-///     u16(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u16(input: &mut &[u8]) -> PResult<u16> {
+///     u16(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert!(be_u16(&b"\x01"[..]).is_err());
+/// assert_eq!(be_u16.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+/// assert!(be_u16.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u16(input: &[u8]) -> IResult<&[u8], u16> {
-///     u16(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u16(input: &mut &[u8]) -> PResult<u16> {
+///     u16(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert!(le_u16(&b"\x01"[..]).is_err());
+/// assert_eq!(le_u16.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+/// assert!(le_u16.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::u16;
 ///
-/// fn be_u16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-///     u16(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u16(input: &mut Partial<&[u8]>) -> PResult<u16> {
+///     u16(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
-/// assert_eq!(be_u16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(be_u16.parse_peek(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
+/// assert_eq!(be_u16.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// fn le_u16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>,  u16> {
-///     u16(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u16(input: &mut Partial<&[u8]>) -> PResult< u16> {
+///     u16(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
-/// assert_eq!(le_u16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(le_u16.parse_peek(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
+/// assert_eq!(le_u16.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn u16<Input, Error>(endian: Endianness) -> impl Parser<Input, u16, Error>
@@ -1415,48 +1363,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u24;
 ///
-/// fn be_u24(input: &[u8]) -> IResult<&[u8], u32> {
-///     u24(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u24(input: &mut &[u8]) -> PResult<u32> {
+///     u24(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert!(be_u24(&b"\x01"[..]).is_err());
+/// assert_eq!(be_u24.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
+/// assert!(be_u24.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u24(input: &[u8]) -> IResult<&[u8], u32> {
-///     u24(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u24(input: &mut &[u8]) -> PResult<u32> {
+///     u24(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert!(le_u24(&b"\x01"[..]).is_err());
+/// assert_eq!(le_u24.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
+/// assert!(le_u24.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::u24;
 ///
-/// fn be_u24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     u24(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u24(input: &mut Partial<&[u8]>) -> PResult<u32> {
+///     u24(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
-/// assert_eq!(be_u24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(be_u24.parse_peek(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
+/// assert_eq!(be_u24.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
-/// fn le_u24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     u24(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u24(input: &mut Partial<&[u8]>) -> PResult<u32> {
+///     u24(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
-/// assert_eq!(le_u24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(le_u24.parse_peek(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
+/// assert_eq!(le_u24.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn u24<Input, Error>(endian: Endianness) -> impl Parser<Input, u32, Error>
@@ -1488,48 +1434,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u32;
 ///
-/// fn be_u32(input: &[u8]) -> IResult<&[u8], u32> {
-///     u32(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u32(input: &mut &[u8]) -> PResult<u32> {
+///     u32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert!(be_u32(&b"\x01"[..]).is_err());
+/// assert_eq!(be_u32.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
+/// assert!(be_u32.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u32(input: &[u8]) -> IResult<&[u8], u32> {
-///     u32(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u32(input: &mut &[u8]) -> PResult<u32> {
+///     u32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert!(le_u32(&b"\x01"[..]).is_err());
+/// assert_eq!(le_u32.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
+/// assert!(le_u32.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::u32;
 ///
-/// fn be_u32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     u32(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u32(input: &mut Partial<&[u8]>) -> PResult<u32> {
+///     u32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
-/// assert_eq!(be_u32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(be_u32.parse_peek(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
+/// assert_eq!(be_u32.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
-/// fn le_u32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-///     u32(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u32(input: &mut Partial<&[u8]>) -> PResult<u32> {
+///     u32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
-/// assert_eq!(le_u32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(le_u32.parse_peek(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
+/// assert_eq!(le_u32.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn u32<Input, Error>(endian: Endianness) -> impl Parser<Input, u32, Error>
@@ -1561,48 +1505,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u64;
 ///
-/// fn be_u64(input: &[u8]) -> IResult<&[u8], u64> {
-///     u64(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u64(input: &mut &[u8]) -> PResult<u64> {
+///     u64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert!(be_u64(&b"\x01"[..]).is_err());
+/// assert_eq!(be_u64.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
+/// assert!(be_u64.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u64(input: &[u8]) -> IResult<&[u8], u64> {
-///     u64(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u64(input: &mut &[u8]) -> PResult<u64> {
+///     u64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert!(le_u64(&b"\x01"[..]).is_err());
+/// assert_eq!(le_u64.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
+/// assert!(le_u64.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::u64;
 ///
-/// fn be_u64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-///     u64(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u64(input: &mut Partial<&[u8]>) -> PResult<u64> {
+///     u64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
-/// assert_eq!(be_u64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(be_u64.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
+/// assert_eq!(be_u64.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
-/// fn le_u64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-///     u64(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u64(input: &mut Partial<&[u8]>) -> PResult<u64> {
+///     u64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
-/// assert_eq!(le_u64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(le_u64.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
+/// assert_eq!(le_u64.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn u64<Input, Error>(endian: Endianness) -> impl Parser<Input, u64, Error>
@@ -1634,48 +1576,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u128;
 ///
-/// fn be_u128(input: &[u8]) -> IResult<&[u8], u128> {
-///     u128(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u128(input: &mut &[u8]) -> PResult<u128> {
+///     u128(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert!(be_u128(&b"\x01"[..]).is_err());
+/// assert_eq!(be_u128.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
+/// assert!(be_u128.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u128(input: &[u8]) -> IResult<&[u8], u128> {
-///     u128(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u128(input: &mut &[u8]) -> PResult<u128> {
+///     u128(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert!(le_u128(&b"\x01"[..]).is_err());
+/// assert_eq!(le_u128.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
+/// assert!(le_u128.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::u128;
 ///
-/// fn be_u128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
-///     u128(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_u128(input: &mut Partial<&[u8]>) -> PResult<u128> {
+///     u128(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(be_u128.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
+/// assert_eq!(be_u128.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
-/// fn le_u128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u128> {
-///     u128(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_u128(input: &mut Partial<&[u8]>) -> PResult<u128> {
+///     u128(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_u128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(le_u128.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
+/// assert_eq!(le_u128.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn u128<Input, Error>(endian: Endianness) -> impl Parser<Input, u128, Error>
@@ -1710,34 +1650,32 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i8;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], i8> {
-///       i8.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<i8> {
+///       i8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert!(parser(&b""[..]).is_err());
+/// assert_eq!(parser.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::i8;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i8> {
-///       i8.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i8> {
+///       i8.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"\x03abcefg"[..]), 0x00)));
-/// assert_eq!(parser(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser.parse_peek(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"\x03abcefg"[..]), 0x00)));
+/// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn i8<Input, Error>(input: &mut Input) -> PResult<i8, Error>
@@ -1768,48 +1706,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i16;
 ///
-/// fn be_i16(input: &[u8]) -> IResult<&[u8], i16> {
-///     i16(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i16(input: &mut &[u8]) -> PResult<i16> {
+///     i16(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert!(be_i16(&b"\x01"[..]).is_err());
+/// assert_eq!(be_i16.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+/// assert!(be_i16.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i16(input: &[u8]) -> IResult<&[u8], i16> {
-///     i16(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i16(input: &mut &[u8]) -> PResult<i16> {
+///     i16(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert!(le_i16(&b"\x01"[..]).is_err());
+/// assert_eq!(le_i16.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+/// assert!(le_i16.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::i16;
 ///
-/// fn be_i16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-///     i16(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i16(input: &mut Partial<&[u8]>) -> PResult<i16> {
+///     i16(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
-/// assert_eq!(be_i16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(be_i16.parse_peek(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
+/// assert_eq!(be_i16.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// fn le_i16(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-///     i16(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i16(input: &mut Partial<&[u8]>) -> PResult<i16> {
+///     i16(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i16(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
-/// assert_eq!(le_i16(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(le_i16.parse_peek(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0300)));
+/// assert_eq!(le_i16.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn i16<Input, Error>(endian: Endianness) -> impl Parser<Input, i16, Error>
@@ -1841,48 +1777,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i24;
 ///
-/// fn be_i24(input: &[u8]) -> IResult<&[u8], i32> {
-///     i24(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i24(input: &mut &[u8]) -> PResult<i32> {
+///     i24(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert!(be_i24(&b"\x01"[..]).is_err());
+/// assert_eq!(be_i24.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
+/// assert!(be_i24.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i24(input: &[u8]) -> IResult<&[u8], i32> {
-///     i24(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i24(input: &mut &[u8]) -> PResult<i32> {
+///     i24(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert!(le_i24(&b"\x01"[..]).is_err());
+/// assert_eq!(le_i24.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
+/// assert!(le_i24.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::i24;
 ///
-/// fn be_i24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///     i24(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i24(input: &mut Partial<&[u8]>) -> PResult<i32> {
+///     i24(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
-/// assert_eq!(be_i24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(be_i24.parse_peek(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
+/// assert_eq!(be_i24.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
-/// fn le_i24(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///     i24(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i24(input: &mut Partial<&[u8]>) -> PResult<i32> {
+///     i24(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i24(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
-/// assert_eq!(le_i24(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(le_i24.parse_peek(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x050300)));
+/// assert_eq!(le_i24.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
 pub fn i24<Input, Error>(endian: Endianness) -> impl Parser<Input, i32, Error>
@@ -1914,48 +1848,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i32;
 ///
-/// fn be_i32(input: &[u8]) -> IResult<&[u8], i32> {
-///     i32(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i32(input: &mut &[u8]) -> PResult<i32> {
+///     i32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert!(be_i32(&b"\x01"[..]).is_err());
+/// assert_eq!(be_i32.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
+/// assert!(be_i32.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i32(input: &[u8]) -> IResult<&[u8], i32> {
-///     i32(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i32(input: &mut &[u8]) -> PResult<i32> {
+///     i32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert!(le_i32(&b"\x01"[..]).is_err());
+/// assert_eq!(le_i32.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
+/// assert!(le_i32.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::i32;
 ///
-/// fn be_i32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///     i32(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i32(input: &mut Partial<&[u8]>) -> PResult<i32> {
+///     i32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
-/// assert_eq!(be_i32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(be_i32.parse_peek(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
+/// assert_eq!(be_i32.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
-/// fn le_i32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-///     i32(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i32(input: &mut Partial<&[u8]>) -> PResult<i32> {
+///     i32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i32(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
-/// assert_eq!(le_i32(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(le_i32.parse_peek(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07050300)));
+/// assert_eq!(le_i32.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn i32<Input, Error>(endian: Endianness) -> impl Parser<Input, i32, Error>
@@ -1987,48 +1919,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i64;
 ///
-/// fn be_i64(input: &[u8]) -> IResult<&[u8], i64> {
-///     i64(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i64(input: &mut &[u8]) -> PResult<i64> {
+///     i64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert!(be_i64(&b"\x01"[..]).is_err());
+/// assert_eq!(be_i64.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
+/// assert!(be_i64.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i64(input: &[u8]) -> IResult<&[u8], i64> {
-///     i64(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i64(input: &mut &[u8]) -> PResult<i64> {
+///     i64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert!(le_i64(&b"\x01"[..]).is_err());
+/// assert_eq!(le_i64.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
+/// assert!(le_i64.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::i64;
 ///
-/// fn be_i64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-///     i64(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i64(input: &mut Partial<&[u8]>) -> PResult<i64> {
+///     i64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
-/// assert_eq!(be_i64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(be_i64.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
+/// assert_eq!(be_i64.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
-/// fn le_i64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-///     i64(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i64(input: &mut Partial<&[u8]>) -> PResult<i64> {
+///     i64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i64(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
-/// assert_eq!(le_i64(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(le_i64.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0706050403020100)));
+/// assert_eq!(le_i64.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn i64<Input, Error>(endian: Endianness) -> impl Parser<Input, i64, Error>
@@ -2060,48 +1990,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i128;
 ///
-/// fn be_i128(input: &[u8]) -> IResult<&[u8], i128> {
-///     i128(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i128(input: &mut &[u8]) -> PResult<i128> {
+///     i128(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert!(be_i128(&b"\x01"[..]).is_err());
+/// assert_eq!(be_i128.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
+/// assert!(be_i128.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i128(input: &[u8]) -> IResult<&[u8], i128> {
-///     i128(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i128(input: &mut &[u8]) -> PResult<i128> {
+///     i128(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert!(le_i128(&b"\x01"[..]).is_err());
+/// assert_eq!(le_i128.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
+/// assert!(le_i128.parse_peek(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::i128;
 ///
-/// fn be_i128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
-///     i128(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_i128(input: &mut Partial<&[u8]>) -> PResult<i128> {
+///     i128(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(be_i128.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
+/// assert_eq!(be_i128.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
-/// fn le_i128(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i128> {
-///     i128(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_i128(input: &mut Partial<&[u8]>) -> PResult<i128> {
+///     i128(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_i128(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
+/// assert_eq!(le_i128.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x07060504030201000706050403020100)));
+/// assert_eq!(le_i128.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
 pub fn i128<Input, Error>(endian: Endianness) -> impl Parser<Input, i128, Error>
@@ -2130,34 +2058,32 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_f32;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], f32> {
-///       be_f32.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<f32> {
+///       be_f32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert!(parser(&b"abc"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+/// assert!(parser.parse_peek(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_f32;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
-///       be_f32.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<f32> {
+///       be_f32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&[0x40, 0x29, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 2.640625)));
-/// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser.parse_peek(Partial::new(&[0x40, 0x29, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 2.640625)));
+/// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn be_f32<Input, Error>(input: &mut Input) -> PResult<f32, Error>
@@ -2180,33 +2106,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_f64;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], f64> {
-///       be_f64.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<f64> {
+///       be_f64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert!(parser(&b"abc"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+/// assert!(parser.parse_peek(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_f64;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
-///       be_f64.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<f64> {
+///       be_f64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
-/// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser.parse_peek(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn be_f64<Input, Error>(input: &mut Input) -> PResult<f64, Error>
@@ -2229,33 +2153,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_f32;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], f32> {
-///       le_f32.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<f32> {
+///       le_f32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert!(parser(&b"abc"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+/// assert!(parser.parse_peek(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_f32;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
-///       le_f32.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<f32> {
+///       le_f32.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
-/// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
+/// assert_eq!(parser.parse_peek(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
 pub fn le_f32<Input, Error>(input: &mut Input) -> PResult<f32, Error>
@@ -2278,33 +2200,31 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_f64;
 ///
-/// fn parser(s: &[u8]) -> IResult<&[u8], f64> {
-///       le_f64.parse_peek(s)
+/// fn parser(s: &mut &[u8]) -> PResult<f64> {
+///       le_f64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert!(parser(&b"abc"[..]).is_err());
+/// assert_eq!(parser.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
+/// assert!(parser.parse_peek(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_f64;
 ///
-/// fn parser(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
-///       le_f64.parse_peek(s)
+/// fn parser(s: &mut Partial<&[u8]>) -> PResult<f64> {
+///       le_f64.parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 3145728.0)));
-/// assert_eq!(parser(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
+/// assert_eq!(parser.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 3145728.0)));
+/// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
 pub fn le_f64<Input, Error>(input: &mut Input) -> PResult<f64, Error>
@@ -2330,48 +2250,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::f32;
 ///
-/// fn be_f32(input: &[u8]) -> IResult<&[u8], f32> {
-///     f32(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_f32(input: &mut &[u8]) -> PResult<f32> {
+///     f32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert!(be_f32(&b"abc"[..]).is_err());
+/// assert_eq!(be_f32.parse_peek(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+/// assert!(be_f32.parse_peek(&b"abc"[..]).is_err());
 ///
-/// fn le_f32(input: &[u8]) -> IResult<&[u8], f32> {
-///     f32(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_f32(input: &mut &[u8]) -> PResult<f32> {
+///     f32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert!(le_f32(&b"abc"[..]).is_err());
+/// assert_eq!(le_f32.parse_peek(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+/// assert!(le_f32.parse_peek(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::f32;
 ///
-/// fn be_f32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
-///     f32(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_f32(input: &mut Partial<&[u8]>) -> PResult<f32> {
+///     f32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_f32(Partial::new(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
-/// assert_eq!(be_f32(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(be_f32.parse_peek(Partial::new(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(be_f32.parse_peek(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// fn le_f32(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f32> {
-///     f32(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_f32(input: &mut Partial<&[u8]>) -> PResult<f32> {
+///     f32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_f32(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
-/// assert_eq!(le_f32(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(le_f32.parse_peek(Partial::new(&[0x00, 0x00, 0x48, 0x41][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(le_f32.parse_peek(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn f32<Input, Error>(endian: Endianness) -> impl Parser<Input, f32, Error>
@@ -2403,48 +2321,46 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::f64;
 ///
-/// fn be_f64(input: &[u8]) -> IResult<&[u8], f64> {
-///     f64(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_f64(input: &mut &[u8]) -> PResult<f64> {
+///     f64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert!(be_f64(&b"abc"[..]).is_err());
+/// assert_eq!(be_f64.parse_peek(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+/// assert!(be_f64.parse_peek(&b"abc"[..]).is_err());
 ///
-/// fn le_f64(input: &[u8]) -> IResult<&[u8], f64> {
-///     f64(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_f64(input: &mut &[u8]) -> PResult<f64> {
+///     f64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert!(le_f64(&b"abc"[..]).is_err());
+/// assert_eq!(le_f64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
+/// assert!(le_f64.parse_peek(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::binary::f64;
 ///
-/// fn be_f64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
-///     f64(winnow::binary::Endianness::Big).parse_peek(input)
+/// fn be_f64(input: &mut Partial<&[u8]>) -> PResult<f64> {
+///     f64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
-/// assert_eq!(be_f64(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
-/// assert_eq!(be_f64(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
+/// assert_eq!(be_f64.parse_peek(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(be_f64.parse_peek(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 ///
-/// fn le_f64(input: Partial<&[u8]>) -> IResult<Partial<&[u8]>, f64> {
-///     f64(winnow::binary::Endianness::Little).parse_peek(input)
+/// fn le_f64(input: &mut Partial<&[u8]>) -> PResult<f64> {
+///     f64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
-/// assert_eq!(le_f64(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Partial::new(&b""[..]), 12.5)));
-/// assert_eq!(le_f64(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
+/// assert_eq!(le_f64.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..])), Ok((Partial::new(&b""[..]), 12.5)));
+/// assert_eq!(le_f64.parse_peek(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 /// ```
 #[inline(always)]
 pub fn f64<Input, Error>(endian: Endianness) -> impl Parser<Input, f64, Error>
@@ -2477,7 +2393,6 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, stream::Partial};
 /// # use winnow::prelude::*;
 /// use winnow::Bytes;
@@ -2490,12 +2405,12 @@ where
 ///     Partial::new(Bytes::new(b))
 /// }
 ///
-/// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-///   length_take(be_u16).parse_peek(s)
+/// fn parser<'i>(s: &mut Stream<'i>) -> PResult<&'i [u8]> {
+///   length_take(be_u16).parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
-/// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser.parse_peek(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
+/// assert_eq!(parser.parse_peek(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 pub fn length_take<Input, Count, Error, CountParser>(
     mut count: CountParser,
@@ -2522,7 +2437,6 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed, stream::{Partial, StreamIsPartial}};
 /// # use winnow::prelude::*;
 /// use winnow::Bytes;
@@ -2541,13 +2455,13 @@ where
 ///     p
 /// }
 ///
-/// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, &[u8]> {
-///   length_and_then(be_u16, "abc").parse_peek(s)
+/// fn parser<'i>(s: &mut Stream<'i>) -> PResult<&'i [u8]> {
+///   length_and_then(be_u16, "abc").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
-/// assert!(parser(stream(b"\x00\x03123123")).is_err());
-/// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(parser.parse_peek(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
+/// assert!(parser.parse_peek(stream(b"\x00\x03123123")).is_err());
+/// assert_eq!(parser.parse_peek(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 pub fn length_and_then<Input, Output, Count, Error, CountParser, ParseNext>(
     mut count: CountParser,
@@ -2576,7 +2490,6 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # #[cfg(feature = "std")] {
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
@@ -2591,15 +2504,15 @@ where
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parser(s: Stream<'_>) -> IResult<Stream<'_>, Vec<&[u8]>> {
+/// fn parser<'i>(s: &mut Stream<'i>) -> PResult<Vec<&'i [u8]>> {
 ///   length_repeat(u8.map(|i| {
 ///      println!("got number: {}", i);
 ///      i
-///   }), "abc").parse_peek(s)
+///   }), "abc").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(stream(b"\x02abcabcabc")), Ok((stream(b"abc"), vec![&b"abc"[..], &b"abc"[..]])));
-/// assert!(parser(stream(b"\x03123123123")).is_err());
+/// assert_eq!(parser.parse_peek(stream(b"\x02abcabcabc")), Ok((stream(b"abc"), vec![&b"abc"[..], &b"abc"[..]])));
+/// assert!(parser.parse_peek(stream(b"\x03123123123")).is_err());
 /// # }
 /// ```
 pub fn length_repeat<Input, Output, Accumulator, Count, Error, CountParser, ParseNext>(

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -51,7 +51,7 @@ pub enum Endianness {
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&[][..], ErrorKind::Token))));
+/// assert!(parser(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -97,7 +97,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -143,7 +143,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -189,7 +189,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -235,7 +235,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -281,7 +281,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -365,7 +365,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&[][..], ErrorKind::Token))));
+/// assert!(parser(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -411,7 +411,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -460,7 +460,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -517,7 +517,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -566,7 +566,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -615,7 +615,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -664,7 +664,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&[][..], ErrorKind::Token))));
+/// assert!(parser(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -710,7 +710,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -756,7 +756,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -802,7 +802,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -848,7 +848,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -894,7 +894,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -977,7 +977,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&[][..], ErrorKind::Token))));
+/// assert!(parser(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1023,7 +1023,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1072,7 +1072,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1129,7 +1129,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1178,7 +1178,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1227,7 +1227,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(parser(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1282,7 +1282,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&[][..], ErrorKind::Token))));
+/// assert!(parser(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1353,14 +1353,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_u16(&b"\x01"[..]).is_err());
 ///
 /// fn le_u16(input: &[u8]) -> IResult<&[u8], u16> {
 ///     u16(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_u16(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1426,14 +1426,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_u24(&b"\x01"[..]).is_err());
 ///
 /// fn le_u24(input: &[u8]) -> IResult<&[u8], u32> {
 ///     u24(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_u24(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1499,14 +1499,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_u32(&b"\x01"[..]).is_err());
 ///
 /// fn le_u32(input: &[u8]) -> IResult<&[u8], u32> {
 ///     u32(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_u32(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1572,14 +1572,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_u64(&b"\x01"[..]).is_err());
 ///
 /// fn le_u64(input: &[u8]) -> IResult<&[u8], u64> {
 ///     u64(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_u64(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1645,14 +1645,14 @@ where
 /// };
 ///
 /// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_u128(&b"\x01"[..]).is_err());
 ///
 /// fn le_u128(input: &[u8]) -> IResult<&[u8], u128> {
 ///     u128(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_u128(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1721,7 +1721,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&[][..], ErrorKind::Token))));
+/// assert!(parser(&b""[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1779,14 +1779,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_i16(&b"\x01"[..]).is_err());
 ///
 /// fn le_i16(input: &[u8]) -> IResult<&[u8], i16> {
 ///     i16(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_i16(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1852,14 +1852,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_i24(&b"\x01"[..]).is_err());
 ///
 /// fn le_i24(input: &[u8]) -> IResult<&[u8], i32> {
 ///     i24(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_i24(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1925,14 +1925,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_i32(&b"\x01"[..]).is_err());
 ///
 /// fn le_i32(input: &[u8]) -> IResult<&[u8], i32> {
 ///     i32(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_i32(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -1998,14 +1998,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_i64(&b"\x01"[..]).is_err());
 ///
 /// fn le_i64(input: &[u8]) -> IResult<&[u8], i64> {
 ///     i64(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_i64(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -2071,14 +2071,14 @@ where
 /// };
 ///
 /// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(be_i128(&b"\x01"[..]).is_err());
 ///
 /// fn le_i128(input: &[u8]) -> IResult<&[u8], i128> {
 ///     i128(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(ErrMode::Backtrack(InputError::new(&[0x01][..], ErrorKind::Slice))));
+/// assert!(le_i128(&b"\x01"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -2142,7 +2142,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
+/// assert!(parser(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -2191,7 +2191,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
+/// assert!(parser(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -2240,7 +2240,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
+/// assert!(parser(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -2289,7 +2289,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
+/// assert!(parser(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -2341,14 +2341,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
+/// assert!(be_f32(&b"abc"[..]).is_err());
 ///
 /// fn le_f32(input: &[u8]) -> IResult<&[u8], f32> {
 ///     f32(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
+/// assert!(le_f32(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -2414,14 +2414,14 @@ where
 /// };
 ///
 /// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
+/// assert!(be_f64(&b"abc"[..]).is_err());
 ///
 /// fn le_f64(input: &[u8]) -> IResult<&[u8], f64> {
 ///     f64(winnow::binary::Endianness::Little).parse_peek(input)
 /// };
 ///
 /// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
+/// assert!(le_f64(&b"abc"[..]).is_err());
 /// ```
 ///
 /// ```rust
@@ -2546,7 +2546,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(stream(b"\x00\x03abcefg")), Ok((stream(&b"efg"[..]), &b"abc"[..])));
-/// assert_eq!(parser(stream(b"\x00\x03123123")), Err(ErrMode::Backtrack(InputError::new(complete_stream(&b"123"[..]), ErrorKind::Literal))));
+/// assert!(parser(stream(b"\x00\x03123123")).is_err());
 /// assert_eq!(parser(stream(b"\x00\x03a")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 pub fn length_and_then<Input, Output, Count, Error, CountParser, ParseNext>(
@@ -2599,7 +2599,7 @@ where
 /// }
 ///
 /// assert_eq!(parser(stream(b"\x02abcabcabc")), Ok((stream(b"abc"), vec![&b"abc"[..], &b"abc"[..]])));
-/// assert_eq!(parser(stream(b"\x03123123123")), Err(ErrMode::Backtrack(InputError::new(stream(b"123123123"), ErrorKind::Literal))));
+/// assert!(parser(stream(b"\x03123123123")).is_err());
 /// # }
 /// ```
 pub fn length_repeat<Input, Output, Accumulator, Count, Error, CountParser, ParseNext>(

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -2,7 +2,6 @@ use super::*;
 
 mod complete {
     use super::*;
-    use crate::error::IResult;
     use crate::error::InputError;
 
     macro_rules! assert_parse(
@@ -352,81 +351,87 @@ mod complete {
     fn configurable_endianness() {
         use crate::binary::Endianness;
 
-        fn be_tst16(i: &[u8]) -> IResult<&[u8], u16> {
-            u16(Endianness::Big).parse_peek(i)
+        fn be_tst16(i: &mut &[u8]) -> PResult<u16> {
+            u16(Endianness::Big).parse_next(i)
         }
-        fn le_tst16(i: &[u8]) -> IResult<&[u8], u16> {
-            u16(Endianness::Little).parse_peek(i)
-        }
-        assert_eq!(be_tst16(&[0x80, 0x00]), Ok((&b""[..], 32_768_u16)));
-        assert_eq!(le_tst16(&[0x80, 0x00]), Ok((&b""[..], 128_u16)));
-
-        fn be_tst32(i: &[u8]) -> IResult<&[u8], u32> {
-            u32(Endianness::Big).parse_peek(i)
-        }
-        fn le_tst32(i: &[u8]) -> IResult<&[u8], u32> {
-            u32(Endianness::Little).parse_peek(i)
+        fn le_tst16(i: &mut &[u8]) -> PResult<u16> {
+            u16(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tst32(&[0x12, 0x00, 0x60, 0x00]),
+            be_tst16.parse_peek(&[0x80, 0x00]),
+            Ok((&b""[..], 32_768_u16))
+        );
+        assert_eq!(le_tst16.parse_peek(&[0x80, 0x00]), Ok((&b""[..], 128_u16)));
+
+        fn be_tst32(i: &mut &[u8]) -> PResult<u32> {
+            u32(Endianness::Big).parse_next(i)
+        }
+        fn le_tst32(i: &mut &[u8]) -> PResult<u32> {
+            u32(Endianness::Little).parse_next(i)
+        }
+        assert_eq!(
+            be_tst32.parse_peek(&[0x12, 0x00, 0x60, 0x00]),
             Ok((&b""[..], 302_014_464_u32))
         );
         assert_eq!(
-            le_tst32(&[0x12, 0x00, 0x60, 0x00]),
+            le_tst32.parse_peek(&[0x12, 0x00, 0x60, 0x00]),
             Ok((&b""[..], 6_291_474_u32))
         );
 
-        fn be_tst64(i: &[u8]) -> IResult<&[u8], u64> {
-            u64(Endianness::Big).parse_peek(i)
+        fn be_tst64(i: &mut &[u8]) -> PResult<u64> {
+            u64(Endianness::Big).parse_next(i)
         }
-        fn le_tst64(i: &[u8]) -> IResult<&[u8], u64> {
-            u64(Endianness::Little).parse_peek(i)
+        fn le_tst64(i: &mut &[u8]) -> PResult<u64> {
+            u64(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tst64(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
+            be_tst64.parse_peek(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
             Ok((&b""[..], 1_297_142_246_100_992_000_u64))
         );
         assert_eq!(
-            le_tst64(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
+            le_tst64.parse_peek(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
             Ok((&b""[..], 36_028_874_334_666_770_u64))
         );
 
-        fn be_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
-            i16(Endianness::Big).parse_peek(i)
+        fn be_tsti16(i: &mut &[u8]) -> PResult<i16> {
+            i16(Endianness::Big).parse_next(i)
         }
-        fn le_tsti16(i: &[u8]) -> IResult<&[u8], i16> {
-            i16(Endianness::Little).parse_peek(i)
+        fn le_tsti16(i: &mut &[u8]) -> PResult<i16> {
+            i16(Endianness::Little).parse_next(i)
         }
-        assert_eq!(be_tsti16(&[0x00, 0x80]), Ok((&b""[..], 128_i16)));
-        assert_eq!(le_tsti16(&[0x00, 0x80]), Ok((&b""[..], -32_768_i16)));
+        assert_eq!(be_tsti16.parse_peek(&[0x00, 0x80]), Ok((&b""[..], 128_i16)));
+        assert_eq!(
+            le_tsti16.parse_peek(&[0x00, 0x80]),
+            Ok((&b""[..], -32_768_i16))
+        );
 
-        fn be_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
-            i32(Endianness::Big).parse_peek(i)
+        fn be_tsti32(i: &mut &[u8]) -> PResult<i32> {
+            i32(Endianness::Big).parse_next(i)
         }
-        fn le_tsti32(i: &[u8]) -> IResult<&[u8], i32> {
-            i32(Endianness::Little).parse_peek(i)
+        fn le_tsti32(i: &mut &[u8]) -> PResult<i32> {
+            i32(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tsti32(&[0x00, 0x12, 0x60, 0x00]),
+            be_tsti32.parse_peek(&[0x00, 0x12, 0x60, 0x00]),
             Ok((&b""[..], 1_204_224_i32))
         );
         assert_eq!(
-            le_tsti32(&[0x00, 0x12, 0x60, 0x00]),
+            le_tsti32.parse_peek(&[0x00, 0x12, 0x60, 0x00]),
             Ok((&b""[..], 6_296_064_i32))
         );
 
-        fn be_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
-            i64(Endianness::Big).parse_peek(i)
+        fn be_tsti64(i: &mut &[u8]) -> PResult<i64> {
+            i64(Endianness::Big).parse_next(i)
         }
-        fn le_tsti64(i: &[u8]) -> IResult<&[u8], i64> {
-            i64(Endianness::Little).parse_peek(i)
+        fn le_tsti64(i: &mut &[u8]) -> PResult<i64> {
+            i64(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tsti64(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
+            be_tsti64.parse_peek(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
             Ok((&b""[..], 71_881_672_479_506_432_i64))
         );
         assert_eq!(
-            le_tsti64(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
+            le_tsti64.parse_peek(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
             Ok((&b""[..], 36_028_874_334_732_032_i64))
         );
     }
@@ -435,7 +440,6 @@ mod complete {
 mod partial {
     use super::*;
     use crate::error::ErrMode;
-    use crate::error::IResult;
     use crate::error::InputError;
     use crate::error::Needed;
     #[cfg(feature = "alloc")]
@@ -1053,99 +1057,99 @@ mod partial {
     fn configurable_endianness() {
         use crate::binary::Endianness;
 
-        fn be_tst16(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-            u16(Endianness::Big).parse_peek(i)
+        fn be_tst16(i: &mut Partial<&[u8]>) -> PResult<u16> {
+            u16(Endianness::Big).parse_next(i)
         }
-        fn le_tst16(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-            u16(Endianness::Little).parse_peek(i)
+        fn le_tst16(i: &mut Partial<&[u8]>) -> PResult<u16> {
+            u16(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tst16(Partial::new(&[0x80, 0x00])),
+            be_tst16.parse_peek(Partial::new(&[0x80, 0x00])),
             Ok((Partial::new(&b""[..]), 32_768_u16))
         );
         assert_eq!(
-            le_tst16(Partial::new(&[0x80, 0x00])),
+            le_tst16.parse_peek(Partial::new(&[0x80, 0x00])),
             Ok((Partial::new(&b""[..]), 128_u16))
         );
 
-        fn be_tst32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-            u32(Endianness::Big).parse_peek(i)
+        fn be_tst32(i: &mut Partial<&[u8]>) -> PResult<u32> {
+            u32(Endianness::Big).parse_next(i)
         }
-        fn le_tst32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u32> {
-            u32(Endianness::Little).parse_peek(i)
+        fn le_tst32(i: &mut Partial<&[u8]>) -> PResult<u32> {
+            u32(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tst32(Partial::new(&[0x12, 0x00, 0x60, 0x00])),
+            be_tst32.parse_peek(Partial::new(&[0x12, 0x00, 0x60, 0x00])),
             Ok((Partial::new(&b""[..]), 302_014_464_u32))
         );
         assert_eq!(
-            le_tst32(Partial::new(&[0x12, 0x00, 0x60, 0x00])),
+            le_tst32.parse_peek(Partial::new(&[0x12, 0x00, 0x60, 0x00])),
             Ok((Partial::new(&b""[..]), 6_291_474_u32))
         );
 
-        fn be_tst64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-            u64(Endianness::Big).parse_peek(i)
+        fn be_tst64(i: &mut Partial<&[u8]>) -> PResult<u64> {
+            u64(Endianness::Big).parse_next(i)
         }
-        fn le_tst64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u64> {
-            u64(Endianness::Little).parse_peek(i)
+        fn le_tst64(i: &mut Partial<&[u8]>) -> PResult<u64> {
+            u64(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tst64(Partial::new(&[
+            be_tst64.parse_peek(Partial::new(&[
                 0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
             ])),
             Ok((Partial::new(&b""[..]), 1_297_142_246_100_992_000_u64))
         );
         assert_eq!(
-            le_tst64(Partial::new(&[
+            le_tst64.parse_peek(Partial::new(&[
                 0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
             ])),
             Ok((Partial::new(&b""[..]), 36_028_874_334_666_770_u64))
         );
 
-        fn be_tsti16(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-            i16(Endianness::Big).parse_peek(i)
+        fn be_tsti16(i: &mut Partial<&[u8]>) -> PResult<i16> {
+            i16(Endianness::Big).parse_next(i)
         }
-        fn le_tsti16(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i16> {
-            i16(Endianness::Little).parse_peek(i)
+        fn le_tsti16(i: &mut Partial<&[u8]>) -> PResult<i16> {
+            i16(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tsti16(Partial::new(&[0x00, 0x80])),
+            be_tsti16.parse_peek(Partial::new(&[0x00, 0x80])),
             Ok((Partial::new(&b""[..]), 128_i16))
         );
         assert_eq!(
-            le_tsti16(Partial::new(&[0x00, 0x80])),
+            le_tsti16.parse_peek(Partial::new(&[0x00, 0x80])),
             Ok((Partial::new(&b""[..]), -32_768_i16))
         );
 
-        fn be_tsti32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-            i32(Endianness::Big).parse_peek(i)
+        fn be_tsti32(i: &mut Partial<&[u8]>) -> PResult<i32> {
+            i32(Endianness::Big).parse_next(i)
         }
-        fn le_tsti32(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i32> {
-            i32(Endianness::Little).parse_peek(i)
+        fn le_tsti32(i: &mut Partial<&[u8]>) -> PResult<i32> {
+            i32(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tsti32(Partial::new(&[0x00, 0x12, 0x60, 0x00])),
+            be_tsti32.parse_peek(Partial::new(&[0x00, 0x12, 0x60, 0x00])),
             Ok((Partial::new(&b""[..]), 1_204_224_i32))
         );
         assert_eq!(
-            le_tsti32(Partial::new(&[0x00, 0x12, 0x60, 0x00])),
+            le_tsti32.parse_peek(Partial::new(&[0x00, 0x12, 0x60, 0x00])),
             Ok((Partial::new(&b""[..]), 6_296_064_i32))
         );
 
-        fn be_tsti64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-            i64(Endianness::Big).parse_peek(i)
+        fn be_tsti64(i: &mut Partial<&[u8]>) -> PResult<i64> {
+            i64(Endianness::Big).parse_next(i)
         }
-        fn le_tsti64(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, i64> {
-            i64(Endianness::Little).parse_peek(i)
+        fn le_tsti64(i: &mut Partial<&[u8]>) -> PResult<i64> {
+            i64(Endianness::Little).parse_next(i)
         }
         assert_eq!(
-            be_tsti64(Partial::new(&[
+            be_tsti64.parse_peek(Partial::new(&[
                 0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
             ])),
             Ok((Partial::new(&b""[..]), 71_881_672_479_506_432_i64))
         );
         assert_eq!(
-            le_tsti64(Partial::new(&[
+            le_tsti64.parse_peek(Partial::new(&[
                 0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
             ])),
             Ok((Partial::new(&b""[..]), 36_028_874_334_732_032_i64))
@@ -1198,44 +1202,44 @@ mod partial {
     fn partial_length_bytes() {
         use crate::binary::le_u8;
 
-        fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-            length_take(le_u8).parse_peek(i)
+        fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+            length_take(le_u8).parse_next(i)
         }
         assert_eq!(
-            x(Partial::new(b"\x02..>>")),
+            x.parse_peek(Partial::new(b"\x02..>>")),
             Ok((Partial::new(&b">>"[..]), &b".."[..]))
         );
         assert_eq!(
-            x(Partial::new(b"\x02..")),
+            x.parse_peek(Partial::new(b"\x02..")),
             Ok((Partial::new(&[][..]), &b".."[..]))
         );
         assert_eq!(
-            x(Partial::new(b"\x02.")),
+            x.parse_peek(Partial::new(b"\x02.")),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            x(Partial::new(b"\x02")),
+            x.parse_peek(Partial::new(b"\x02")),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
 
-        fn y(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-            let (i, _) = "magic".parse_peek(i)?;
-            length_take(le_u8).parse_peek(i)
+        fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+            let _ = "magic".parse_next(i)?;
+            length_take(le_u8).parse_next(i)
         }
         assert_eq!(
-            y(Partial::new(b"magic\x02..>>")),
+            y.parse_peek(Partial::new(b"magic\x02..>>")),
             Ok((Partial::new(&b">>"[..]), &b".."[..]))
         );
         assert_eq!(
-            y(Partial::new(b"magic\x02..")),
+            y.parse_peek(Partial::new(b"magic\x02..")),
             Ok((Partial::new(&[][..]), &b".."[..]))
         );
         assert_eq!(
-            y(Partial::new(b"magic\x02.")),
+            y.parse_peek(Partial::new(b"magic\x02.")),
             Err(ErrMode::Incomplete(Needed::new(1)))
         );
         assert_eq!(
-            y(Partial::new(b"magic\x02")),
+            y.parse_peek(Partial::new(b"magic\x02")),
             Err(ErrMode::Incomplete(Needed::new(2)))
         );
     }
@@ -1278,11 +1282,11 @@ mod partial {
     fn length_and_then_test() {
         use crate::stream::StreamIsPartial;
 
-        fn length_and_then_1(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u16> {
-            length_and_then(be_u8, be_u16).parse_peek(i)
+        fn length_and_then_1(i: &mut Partial<&[u8]>) -> PResult<u16> {
+            length_and_then(be_u8, be_u16).parse_next(i)
         }
-        fn length_and_then_2(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (u8, u8)> {
-            length_and_then(be_u8, (be_u8, be_u8)).parse_peek(i)
+        fn length_and_then_2(i: &mut Partial<&[u8]>) -> PResult<(u8, u8)> {
+            length_and_then(be_u8, (be_u8, be_u8)).parse_next(i)
         }
 
         let mut empty_complete = Partial::new(&b""[..]);
@@ -1290,14 +1294,14 @@ mod partial {
 
         let i1 = [0, 5, 6];
         assert_eq!(
-            length_and_then_1(Partial::new(&i1)),
+            length_and_then_1.parse_peek(Partial::new(&i1)),
             Err(ErrMode::Backtrack(error_position!(
                 &empty_complete,
                 ErrorKind::Slice
             )))
         );
         assert_eq!(
-            length_and_then_2(Partial::new(&i1)),
+            length_and_then_2.parse_peek(Partial::new(&i1)),
             Err(ErrMode::Backtrack(error_position!(
                 &empty_complete,
                 ErrorKind::Token
@@ -1309,14 +1313,14 @@ mod partial {
             let mut middle_complete = Partial::new(&i2[1..2]);
             let _ = middle_complete.complete();
             assert_eq!(
-                length_and_then_1(Partial::new(&i2)),
+                length_and_then_1.parse_peek(Partial::new(&i2)),
                 Err(ErrMode::Backtrack(error_position!(
                     &middle_complete,
                     ErrorKind::Slice
                 )))
             );
             assert_eq!(
-                length_and_then_2(Partial::new(&i2)),
+                length_and_then_2.parse_peek(Partial::new(&i2)),
                 Err(ErrMode::Backtrack(error_position!(
                     &empty_complete,
                     ErrorKind::Token
@@ -1326,21 +1330,21 @@ mod partial {
 
         let i3 = [2, 5, 6, 3, 4, 5, 7];
         assert_eq!(
-            length_and_then_1(Partial::new(&i3)),
+            length_and_then_1.parse_peek(Partial::new(&i3)),
             Ok((Partial::new(&i3[3..]), 1286))
         );
         assert_eq!(
-            length_and_then_2(Partial::new(&i3)),
+            length_and_then_2.parse_peek(Partial::new(&i3)),
             Ok((Partial::new(&i3[3..]), (5, 6)))
         );
 
         let i4 = [3, 5, 6, 3, 4, 5];
         assert_eq!(
-            length_and_then_1(Partial::new(&i4)),
+            length_and_then_1.parse_peek(Partial::new(&i4)),
             Ok((Partial::new(&i4[4..]), 1286))
         );
         assert_eq!(
-            length_and_then_2(Partial::new(&i4)),
+            length_and_then_2.parse_peek(Partial::new(&i4)),
             Ok((Partial::new(&i4[4..]), (5, 6)))
         );
     }

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use snapbox::str;
 
 mod complete {
     use super::*;
@@ -6,31 +7,157 @@ mod complete {
 
     #[test]
     fn i8_tests() {
-        assert_parse!(i8.parse_peek(&[0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(i8.parse_peek(&[0x7f][..]), Ok((&b""[..], 127)));
-        assert_parse!(i8.parse_peek(&[0xff][..]), Ok((&b""[..], -1)));
-        assert_parse!(i8.parse_peek(&[0x80][..]), Ok((&b""[..], -128)));
+        assert_parse!(
+            i8.parse_peek(&[0x00][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            i8.parse_peek(&[0x7f][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        127,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            i8.parse_peek(&[0xff][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            i8.parse_peek(&[0x80][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        -128,
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn be_i8_tests() {
-        assert_parse!(be_i8.parse_peek(&[0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(be_i8.parse_peek(&[0x7f][..]), Ok((&b""[..], 127)));
-        assert_parse!(be_i8.parse_peek(&[0xff][..]), Ok((&b""[..], -1)));
-        assert_parse!(be_i8.parse_peek(&[0x80][..]), Ok((&b""[..], -128)));
+        assert_parse!(
+            be_i8.parse_peek(&[0x00][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            be_i8.parse_peek(&[0x7f][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        127,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            be_i8.parse_peek(&[0xff][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            be_i8.parse_peek(&[0x80][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        -128,
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn be_i16_tests() {
-        assert_parse!(be_i16.parse_peek(&[0x00, 0x00][..]), Ok((&b""[..], 0)));
+        assert_parse!(
+            be_i16.parse_peek(&[0x00, 0x00][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             be_i16.parse_peek(&[0x7f, 0xff][..]),
-            Ok((&b""[..], 32_767_i16))
+            str![[r#"
+Ok(
+    (
+        [],
+        32767,
+    ),
+)
+
+"#]]
         );
-        assert_parse!(be_i16.parse_peek(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
+        assert_parse!(
+            be_i16.parse_peek(&[0xff, 0xff][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             be_i16.parse_peek(&[0x80, 0x00][..]),
-            Ok((&b""[..], -32_768_i16))
+            str![[r#"
+Ok(
+    (
+        [],
+        -32768,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -38,15 +165,39 @@ mod complete {
     fn be_u24_tests() {
         assert_parse!(
             be_u24.parse_peek(&[0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0))
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_u24.parse_peek(&[0x00, 0xFF, 0xFF][..]),
-            Ok((&b""[..], 65_535_u32))
+            str![[r#"
+Ok(
+    (
+        [],
+        65535,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_u24.parse_peek(&[0x12, 0x34, 0x56][..]),
-            Ok((&b""[..], 1_193_046_u32))
+            str![[r#"
+Ok(
+    (
+        [],
+        1193046,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -54,15 +205,39 @@ mod complete {
     fn be_i24_tests() {
         assert_parse!(
             be_i24.parse_peek(&[0xFF, 0xFF, 0xFF][..]),
-            Ok((&b""[..], -1_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i24.parse_peek(&[0xFF, 0x00, 0x00][..]),
-            Ok((&b""[..], -65_536_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        -65536,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i24.parse_peek(&[0xED, 0xCB, 0xAA][..]),
-            Ok((&b""[..], -1_193_046_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1193046,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -70,19 +245,51 @@ mod complete {
     fn be_i32_tests() {
         assert_parse!(
             be_i32.parse_peek(&[0x00, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0))
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(&[0x7f, 0xff, 0xff, 0xff][..]),
-            Ok((&b""[..], 2_147_483_647_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        2147483647,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(&[0xff, 0xff, 0xff, 0xff][..]),
-            Ok((&b""[..], -1))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(&[0x80, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], -2_147_483_648_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        -2147483648,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -90,19 +297,51 @@ mod complete {
     fn be_i64_tests() {
         assert_parse!(
             be_i64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0))
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
-            Ok((&b""[..], 9_223_372_036_854_775_807_i64))
+            str![[r#"
+Ok(
+    (
+        [],
+        9223372036854775807,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
-            Ok((&b""[..], -1))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], -9_223_372_036_854_775_808_i64))
+            str![[r#"
+Ok(
+    (
+        [],
+        -9223372036854775808,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -115,7 +354,15 @@ mod complete {
                     0x00, 0x00, 0x00
                 ][..]
             ),
-            Ok((&b""[..], 0))
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(
@@ -124,10 +371,15 @@ mod complete {
                     0xff, 0xff, 0xff
                 ][..]
             ),
-            Ok((
-                &b""[..],
-                170_141_183_460_469_231_731_687_303_715_884_105_727_i128
-            ))
+            str![[r#"
+Ok(
+    (
+        [],
+        170141183460469231731687303715884105727,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(
@@ -136,7 +388,15 @@ mod complete {
                     0xff, 0xff, 0xff
                 ][..]
             ),
-            Ok((&b""[..], -1))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(
@@ -145,32 +405,119 @@ mod complete {
                     0x00, 0x00, 0x00
                 ][..]
             ),
-            Ok((
-                &b""[..],
-                -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
-            ))
+            str![[r#"
+Ok(
+    (
+        [],
+        -170141183460469231731687303715884105728,
+    ),
+)
+
+"#]]
         );
     }
 
     #[test]
     fn le_i8_tests() {
-        assert_parse!(le_i8.parse_peek(&[0x00][..]), Ok((&b""[..], 0)));
-        assert_parse!(le_i8.parse_peek(&[0x7f][..]), Ok((&b""[..], 127)));
-        assert_parse!(le_i8.parse_peek(&[0xff][..]), Ok((&b""[..], -1)));
-        assert_parse!(le_i8.parse_peek(&[0x80][..]), Ok((&b""[..], -128)));
+        assert_parse!(
+            le_i8.parse_peek(&[0x00][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            le_i8.parse_peek(&[0x7f][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        127,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            le_i8.parse_peek(&[0xff][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
+            le_i8.parse_peek(&[0x80][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        -128,
+    ),
+)
+
+"#]]
+        );
     }
 
     #[test]
     fn le_i16_tests() {
-        assert_parse!(le_i16.parse_peek(&[0x00, 0x00][..]), Ok((&b""[..], 0)));
+        assert_parse!(
+            le_i16.parse_peek(&[0x00, 0x00][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             le_i16.parse_peek(&[0xff, 0x7f][..]),
-            Ok((&b""[..], 32_767_i16))
+            str![[r#"
+Ok(
+    (
+        [],
+        32767,
+    ),
+)
+
+"#]]
         );
-        assert_parse!(le_i16.parse_peek(&[0xff, 0xff][..]), Ok((&b""[..], -1)));
+        assert_parse!(
+            le_i16.parse_peek(&[0xff, 0xff][..]),
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
+        );
         assert_parse!(
             le_i16.parse_peek(&[0x00, 0x80][..]),
-            Ok((&b""[..], -32_768_i16))
+            str![[r#"
+Ok(
+    (
+        [],
+        -32768,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -178,15 +525,39 @@ mod complete {
     fn le_u24_tests() {
         assert_parse!(
             le_u24.parse_peek(&[0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0))
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_u24.parse_peek(&[0xFF, 0xFF, 0x00][..]),
-            Ok((&b""[..], 65_535_u32))
+            str![[r#"
+Ok(
+    (
+        [],
+        65535,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_u24.parse_peek(&[0x56, 0x34, 0x12][..]),
-            Ok((&b""[..], 1_193_046_u32))
+            str![[r#"
+Ok(
+    (
+        [],
+        1193046,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -194,15 +565,39 @@ mod complete {
     fn le_i24_tests() {
         assert_parse!(
             le_i24.parse_peek(&[0xFF, 0xFF, 0xFF][..]),
-            Ok((&b""[..], -1_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i24.parse_peek(&[0x00, 0x00, 0xFF][..]),
-            Ok((&b""[..], -65_536_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        -65536,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i24.parse_peek(&[0xAA, 0xCB, 0xED][..]),
-            Ok((&b""[..], -1_193_046_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1193046,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -210,19 +605,51 @@ mod complete {
     fn le_i32_tests() {
         assert_parse!(
             le_i32.parse_peek(&[0x00, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0))
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i32.parse_peek(&[0xff, 0xff, 0xff, 0x7f][..]),
-            Ok((&b""[..], 2_147_483_647_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        2147483647,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i32.parse_peek(&[0xff, 0xff, 0xff, 0xff][..]),
-            Ok((&b""[..], -1))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i32.parse_peek(&[0x00, 0x00, 0x00, 0x80][..]),
-            Ok((&b""[..], -2_147_483_648_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        -2147483648,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -230,19 +657,51 @@ mod complete {
     fn le_i64_tests() {
         assert_parse!(
             le_i64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0))
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i64.parse_peek(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f][..]),
-            Ok((&b""[..], 9_223_372_036_854_775_807_i64))
+            str![[r#"
+Ok(
+    (
+        [],
+        9223372036854775807,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i64.parse_peek(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]),
-            Ok((&b""[..], -1))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80][..]),
-            Ok((&b""[..], -9_223_372_036_854_775_808_i64))
+            str![[r#"
+Ok(
+    (
+        [],
+        -9223372036854775808,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -255,7 +714,15 @@ mod complete {
                     0x00, 0x00, 0x00
                 ][..]
             ),
-            Ok((&b""[..], 0))
+            str![[r#"
+Ok(
+    (
+        [],
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i128.parse_peek(
@@ -264,10 +731,15 @@ mod complete {
                     0xff, 0xff, 0x7f
                 ][..]
             ),
-            Ok((
-                &b""[..],
-                170_141_183_460_469_231_731_687_303_715_884_105_727_i128
-            ))
+            str![[r#"
+Ok(
+    (
+        [],
+        170141183460469231731687303715884105727,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i128.parse_peek(
@@ -276,7 +748,15 @@ mod complete {
                     0xff, 0xff, 0xff
                 ][..]
             ),
-            Ok((&b""[..], -1))
+            str![[r#"
+Ok(
+    (
+        [],
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i128.parse_peek(
@@ -285,10 +765,15 @@ mod complete {
                     0x00, 0x00, 0x80
                 ][..]
             ),
-            Ok((
-                &b""[..],
-                -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
-            ))
+            str![[r#"
+Ok(
+    (
+        [],
+        -170141183460469231731687303715884105728,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -296,11 +781,27 @@ mod complete {
     fn be_f32_tests() {
         assert_parse!(
             be_f32.parse_peek(&[0x00, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0_f32))
+            str![[r#"
+Ok(
+    (
+        [],
+        0.0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_f32.parse_peek(&[0x4d, 0x31, 0x1f, 0xd8][..]),
-            Ok((&b""[..], 185_728_380_f32))
+            str![[r#"
+Ok(
+    (
+        [],
+        185728380.0,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -308,11 +809,27 @@ mod complete {
     fn be_f64_tests() {
         assert_parse!(
             be_f64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0_f64))
+            str![[r#"
+Ok(
+    (
+        [],
+        0.0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_f64.parse_peek(&[0x41, 0xa6, 0x23, 0xfb, 0x10, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 185_728_392_f64))
+            str![[r#"
+Ok(
+    (
+        [],
+        185728392.0,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -320,11 +837,27 @@ mod complete {
     fn le_f32_tests() {
         assert_parse!(
             le_f32.parse_peek(&[0x00, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0_f32))
+            str![[r#"
+Ok(
+    (
+        [],
+        0.0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_f32.parse_peek(&[0xd8, 0x1f, 0x31, 0x4d][..]),
-            Ok((&b""[..], 185_728_380_f32))
+            str![[r#"
+Ok(
+    (
+        [],
+        185728380.0,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -332,11 +865,27 @@ mod complete {
     fn le_f64_tests() {
         assert_parse!(
             le_f64.parse_peek(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
-            Ok((&b""[..], 0_f64))
+            str![[r#"
+Ok(
+    (
+        [],
+        0.0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_f64.parse_peek(&[0x00, 0x00, 0x00, 0x10, 0xfb, 0x23, 0xa6, 0x41][..]),
-            Ok((&b""[..], 185_728_392_f64))
+            str![[r#"
+Ok(
+    (
+        [],
+        185728392.0,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -344,104 +893,203 @@ mod complete {
     fn configurable_endianness() {
         use crate::binary::Endianness;
 
-        fn be_tst16(i: &mut &[u8]) -> PResult<u16> {
+        fn be_tst16<'i>(i: &mut &'i [u8]) -> PResult<u16, InputError<&'i [u8]>> {
             u16(Endianness::Big).parse_next(i)
         }
-        fn le_tst16(i: &mut &[u8]) -> PResult<u16> {
+        fn le_tst16<'i>(i: &mut &'i [u8]) -> PResult<u16, InputError<&'i [u8]>> {
             u16(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tst16.parse_peek(&[0x80, 0x00]),
-            Ok((&b""[..], 32_768_u16))
-        );
-        assert_eq!(le_tst16.parse_peek(&[0x80, 0x00]), Ok((&b""[..], 128_u16)));
+            str![[r#"
+Ok(
+    (
+        [],
+        32768,
+    ),
+)
 
-        fn be_tst32(i: &mut &[u8]) -> PResult<u32> {
+"#]]
+        );
+        assert_parse!(
+            le_tst16.parse_peek(&[0x80, 0x00]),
+            str![[r#"
+Ok(
+    (
+        [],
+        128,
+    ),
+)
+
+"#]]
+        );
+
+        fn be_tst32<'i>(i: &mut &'i [u8]) -> PResult<u32, InputError<&'i [u8]>> {
             u32(Endianness::Big).parse_next(i)
         }
-        fn le_tst32(i: &mut &[u8]) -> PResult<u32> {
+        fn le_tst32<'i>(i: &mut &'i [u8]) -> PResult<u32, InputError<&'i [u8]>> {
             u32(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tst32.parse_peek(&[0x12, 0x00, 0x60, 0x00]),
-            Ok((&b""[..], 302_014_464_u32))
+            str![[r#"
+Ok(
+    (
+        [],
+        302014464,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tst32.parse_peek(&[0x12, 0x00, 0x60, 0x00]),
-            Ok((&b""[..], 6_291_474_u32))
+            str![[r#"
+Ok(
+    (
+        [],
+        6291474,
+    ),
+)
+
+"#]]
         );
 
-        fn be_tst64(i: &mut &[u8]) -> PResult<u64> {
+        fn be_tst64<'i>(i: &mut &'i [u8]) -> PResult<u64, InputError<&'i [u8]>> {
             u64(Endianness::Big).parse_next(i)
         }
-        fn le_tst64(i: &mut &[u8]) -> PResult<u64> {
+        fn le_tst64<'i>(i: &mut &'i [u8]) -> PResult<u64, InputError<&'i [u8]>> {
             u64(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tst64.parse_peek(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
-            Ok((&b""[..], 1_297_142_246_100_992_000_u64))
+            str![[r#"
+Ok(
+    (
+        [],
+        1297142246100992000,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tst64.parse_peek(&[0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
-            Ok((&b""[..], 36_028_874_334_666_770_u64))
+            str![[r#"
+Ok(
+    (
+        [],
+        36028874334666770,
+    ),
+)
+
+"#]]
         );
 
-        fn be_tsti16(i: &mut &[u8]) -> PResult<i16> {
+        fn be_tsti16<'i>(i: &mut &'i [u8]) -> PResult<i16, InputError<&'i [u8]>> {
             i16(Endianness::Big).parse_next(i)
         }
-        fn le_tsti16(i: &mut &[u8]) -> PResult<i16> {
+        fn le_tsti16<'i>(i: &mut &'i [u8]) -> PResult<i16, InputError<&'i [u8]>> {
             i16(Endianness::Little).parse_next(i)
         }
-        assert_eq!(be_tsti16.parse_peek(&[0x00, 0x80]), Ok((&b""[..], 128_i16)));
-        assert_eq!(
+        assert_parse!(
+            be_tsti16.parse_peek(&[0x00, 0x80]),
+            str![[r#"
+Ok(
+    (
+        [],
+        128,
+    ),
+)
+
+"#]]
+        );
+        assert_parse!(
             le_tsti16.parse_peek(&[0x00, 0x80]),
-            Ok((&b""[..], -32_768_i16))
+            str![[r#"
+Ok(
+    (
+        [],
+        -32768,
+    ),
+)
+
+"#]]
         );
 
-        fn be_tsti32(i: &mut &[u8]) -> PResult<i32> {
+        fn be_tsti32<'i>(i: &mut &'i [u8]) -> PResult<i32, InputError<&'i [u8]>> {
             i32(Endianness::Big).parse_next(i)
         }
-        fn le_tsti32(i: &mut &[u8]) -> PResult<i32> {
+        fn le_tsti32<'i>(i: &mut &'i [u8]) -> PResult<i32, InputError<&'i [u8]>> {
             i32(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tsti32.parse_peek(&[0x00, 0x12, 0x60, 0x00]),
-            Ok((&b""[..], 1_204_224_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        1204224,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tsti32.parse_peek(&[0x00, 0x12, 0x60, 0x00]),
-            Ok((&b""[..], 6_296_064_i32))
+            str![[r#"
+Ok(
+    (
+        [],
+        6296064,
+    ),
+)
+
+"#]]
         );
 
-        fn be_tsti64(i: &mut &[u8]) -> PResult<i64> {
+        fn be_tsti64<'i>(i: &mut &'i [u8]) -> PResult<i64, InputError<&'i [u8]>> {
             i64(Endianness::Big).parse_next(i)
         }
-        fn le_tsti64(i: &mut &[u8]) -> PResult<i64> {
+        fn le_tsti64<'i>(i: &mut &'i [u8]) -> PResult<i64, InputError<&'i [u8]>> {
             i64(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tsti64.parse_peek(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
-            Ok((&b""[..], 71_881_672_479_506_432_i64))
+            str![[r#"
+Ok(
+    (
+        [],
+        71881672479506432,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tsti64.parse_peek(&[0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00]),
-            Ok((&b""[..], 36_028_874_334_732_032_i64))
+            str![[r#"
+Ok(
+    (
+        [],
+        36028874334732032,
+    ),
+)
+
+"#]]
         );
     }
 }
 
 mod partial {
     use super::*;
-    use crate::error::ErrMode;
     use crate::error::InputError;
-    use crate::error::Needed;
     #[cfg(feature = "alloc")]
     use crate::lib::std::vec::Vec;
     use crate::Partial;
     use crate::{
         ascii::digit1 as digit,
         binary::{be_u16, be_u8},
-        error::ErrorKind,
         lib::std::str::{self, FromStr},
     };
 
@@ -449,23 +1097,76 @@ mod partial {
     fn i8_tests() {
         assert_parse!(
             be_i8.parse_peek(Partial::new(&[0x00][..])),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i8.parse_peek(Partial::new(&[0x7f][..])),
-            Ok((Partial::new(&b""[..]), 127))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        127,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i8.parse_peek(Partial::new(&[0xff][..])),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i8.parse_peek(Partial::new(&[0x80][..])),
-            Ok((Partial::new(&b""[..]), -128))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -128,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i8.parse_peek(Partial::new(&[][..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -473,27 +1174,89 @@ mod partial {
     fn i16_tests() {
         assert_parse!(
             be_i16.parse_peek(Partial::new(&[0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i16.parse_peek(Partial::new(&[0x7f, 0xff][..])),
-            Ok((Partial::new(&b""[..]), 32_767_i16))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        32767,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i16.parse_peek(Partial::new(&[0xff, 0xff][..])),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i16.parse_peek(Partial::new(&[0x80, 0x00][..])),
-            Ok((Partial::new(&b""[..]), -32_768_i16))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -32768,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i16.parse_peek(Partial::new(&[][..])),
-            Err(ErrMode::Incomplete(Needed::new(2)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i16.parse_peek(Partial::new(&[0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -501,27 +1264,87 @@ mod partial {
     fn u24_tests() {
         assert_parse!(
             be_u24.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_u24.parse_peek(Partial::new(&[0x00, 0xFF, 0xFF][..])),
-            Ok((Partial::new(&b""[..]), 65_535_u32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        65535,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_u24.parse_peek(Partial::new(&[0x12, 0x34, 0x56][..])),
-            Ok((Partial::new(&b""[..]), 1_193_046_u32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        1193046,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_u24.parse_peek(Partial::new(&[][..])),
-            Err(ErrMode::Incomplete(Needed::new(3)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            3,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_u24.parse_peek(Partial::new(&[0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(2)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_u24.parse_peek(Partial::new(&[0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -529,27 +1352,87 @@ mod partial {
     fn i24_tests() {
         assert_parse!(
             be_i24.parse_peek(Partial::new(&[0xFF, 0xFF, 0xFF][..])),
-            Ok((Partial::new(&b""[..]), -1_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i24.parse_peek(Partial::new(&[0xFF, 0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), -65_536_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -65536,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i24.parse_peek(Partial::new(&[0xED, 0xCB, 0xAA][..])),
-            Ok((Partial::new(&b""[..]), -1_193_046_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1193046,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i24.parse_peek(Partial::new(&[][..])),
-            Err(ErrMode::Incomplete(Needed::new(3)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            3,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i24.parse_peek(Partial::new(&[0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(2)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i24.parse_peek(Partial::new(&[0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -557,35 +1440,115 @@ mod partial {
     fn i32_tests() {
         assert_parse!(
             be_i32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(Partial::new(&[0x7f, 0xff, 0xff, 0xff][..])),
-            Ok((Partial::new(&b""[..]), 2_147_483_647_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        2147483647,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(Partial::new(&[0xff, 0xff, 0xff, 0xff][..])),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(Partial::new(&[0x80, 0x00, 0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), -2_147_483_648_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -2147483648,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(Partial::new(&[][..])),
-            Err(ErrMode::Incomplete(Needed::new(4)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            4,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(Partial::new(&[0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(3)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            3,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(Partial::new(&[0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(2)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i32.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -595,59 +1558,175 @@ mod partial {
             be_i64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(
                 &[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
             )),
-            Ok((Partial::new(&b""[..]), 9_223_372_036_854_775_807_i64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        9223372036854775807,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(
                 &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
             )),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(
                 &[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial::new(&b""[..]), -9_223_372_036_854_775_808_i64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -9223372036854775808,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(&[][..])),
-            Err(ErrMode::Incomplete(Needed::new(8)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            8,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(&[0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(7)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            7,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(&[0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(6)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            6,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(5)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            5,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(4)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            4,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(3)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            3,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(2)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -660,7 +1739,18 @@ mod partial {
                     0x00, 0x00, 0x00
                 ][..]
             )),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
@@ -669,10 +1759,18 @@ mod partial {
                     0xff, 0xff, 0xff
                 ][..]
             )),
-            Ok((
-                Partial::new(&b""[..]),
-                170_141_183_460_469_231_731_687_303_715_884_105_727_i128
-            ))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        170141183460469231731687303715884105727,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
@@ -681,7 +1779,18 @@ mod partial {
                     0xff, 0xff, 0xff
                 ][..]
             )),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
@@ -690,80 +1799,214 @@ mod partial {
                     0x00, 0x00, 0x00
                 ][..]
             )),
-            Ok((
-                Partial::new(&b""[..]),
-                -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
-            ))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -170141183460469231731687303715884105728,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(&[][..])),
-            Err(ErrMode::Incomplete(Needed::new(16)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            16,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(&[0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(15)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            15,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(&[0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(14)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            14,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(13)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            13,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(12)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            12,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(11)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            11,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])),
-            Err(ErrMode::Incomplete(Needed::new(10)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            10,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(9)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            9,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(8)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            8,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(7)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            7,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(6)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            6,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(5)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            5,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(4)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            4,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(3)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            3,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
@@ -772,7 +2015,16 @@ mod partial {
                     0x00
                 ][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(2)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_i128.parse_peek(Partial::new(
@@ -781,7 +2033,16 @@ mod partial {
                     0x00, 0x00
                 ][..]
             )),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -789,15 +2050,46 @@ mod partial {
     fn le_u16_tests() {
         assert_parse!(
             le_u16.parse_peek(Partial::new(&[0x00, 0x03][..])),
-            Ok((Partial::new(&b""[..]), 0x0300))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        768,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_u16.parse_peek(Partial::new(&[b'a', b'b'][..])),
-            Ok((Partial::new(&b""[..]), 0x6261))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        25185,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_u16.parse_peek(Partial::new(&[0x01][..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -805,19 +2097,63 @@ mod partial {
     fn le_i8_tests() {
         assert_parse!(
             le_i8.parse_peek(Partial::new(&[0x00][..])),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i8.parse_peek(Partial::new(&[0x7f][..])),
-            Ok((Partial::new(&b""[..]), 127))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        127,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i8.parse_peek(Partial::new(&[0xff][..])),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i8.parse_peek(Partial::new(&[0x80][..])),
-            Ok((Partial::new(&b""[..]), -128))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -128,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -825,19 +2161,63 @@ mod partial {
     fn le_i16_tests() {
         assert_parse!(
             le_i16.parse_peek(Partial::new(&[0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i16.parse_peek(Partial::new(&[0xff, 0x7f][..])),
-            Ok((Partial::new(&b""[..]), 32_767_i16))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        32767,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i16.parse_peek(Partial::new(&[0xff, 0xff][..])),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i16.parse_peek(Partial::new(&[0x00, 0x80][..])),
-            Ok((Partial::new(&b""[..]), -32_768_i16))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -32768,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -845,15 +2225,48 @@ mod partial {
     fn le_u24_tests() {
         assert_parse!(
             le_u24.parse_peek(Partial::new(&[0x00, 0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_u24.parse_peek(Partial::new(&[0xFF, 0xFF, 0x00][..])),
-            Ok((Partial::new(&b""[..]), 65_535_u32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        65535,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_u24.parse_peek(Partial::new(&[0x56, 0x34, 0x12][..])),
-            Ok((Partial::new(&b""[..]), 1_193_046_u32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        1193046,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -861,15 +2274,48 @@ mod partial {
     fn le_i24_tests() {
         assert_parse!(
             le_i24.parse_peek(Partial::new(&[0xFF, 0xFF, 0xFF][..])),
-            Ok((Partial::new(&b""[..]), -1_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i24.parse_peek(Partial::new(&[0x00, 0x00, 0xFF][..])),
-            Ok((Partial::new(&b""[..]), -65_536_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -65536,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i24.parse_peek(Partial::new(&[0xAA, 0xCB, 0xED][..])),
-            Ok((Partial::new(&b""[..]), -1_193_046_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1193046,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -877,15 +2323,46 @@ mod partial {
     fn le_u32_test() {
         assert_parse!(
             le_u32.parse_peek(Partial::new(&[0x00, 0x03, 0x05, 0x07][..])),
-            Ok((Partial::new(&b""[..]), 0x07050300))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        117768960,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_u32.parse_peek(Partial::new(&[b'a', b'b', b'c', b'd'][..])),
-            Ok((Partial::new(&b""[..]), 0x64636261))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        1684234849,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_u32.parse_peek(Partial::new(&[0x01][..])),
-            Err(ErrMode::Incomplete(Needed::new(3)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            3,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
@@ -893,19 +2370,63 @@ mod partial {
     fn le_i32_tests() {
         assert_parse!(
             le_i32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i32.parse_peek(Partial::new(&[0xff, 0xff, 0xff, 0x7f][..])),
-            Ok((Partial::new(&b""[..]), 2_147_483_647_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        2147483647,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i32.parse_peek(Partial::new(&[0xff, 0xff, 0xff, 0xff][..])),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x80][..])),
-            Ok((Partial::new(&b""[..]), -2_147_483_648_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -2147483648,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -915,25 +2436,69 @@ mod partial {
             le_i64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i64.parse_peek(Partial::new(
                 &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f][..]
             )),
-            Ok((Partial::new(&b""[..]), 9_223_372_036_854_775_807_i64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        9223372036854775807,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i64.parse_peek(Partial::new(
                 &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff][..]
             )),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80][..]
             )),
-            Ok((Partial::new(&b""[..]), -9_223_372_036_854_775_808_i64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -9223372036854775808,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -946,7 +2511,18 @@ mod partial {
                     0x00, 0x00, 0x00
                 ][..]
             )),
-            Ok((Partial::new(&b""[..]), 0))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i128.parse_peek(Partial::new(
@@ -955,10 +2531,18 @@ mod partial {
                     0xff, 0xff, 0x7f
                 ][..]
             )),
-            Ok((
-                Partial::new(&b""[..]),
-                170_141_183_460_469_231_731_687_303_715_884_105_727_i128
-            ))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        170141183460469231731687303715884105727,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i128.parse_peek(Partial::new(
@@ -967,7 +2551,18 @@ mod partial {
                     0xff, 0xff, 0xff
                 ][..]
             )),
-            Ok((Partial::new(&b""[..]), -1))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -1,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_i128.parse_peek(Partial::new(
@@ -976,10 +2571,18 @@ mod partial {
                     0x00, 0x00, 0x80
                 ][..]
             )),
-            Ok((
-                Partial::new(&b""[..]),
-                -170_141_183_460_469_231_731_687_303_715_884_105_728_i128
-            ))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -170141183460469231731687303715884105728,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -987,11 +2590,33 @@ mod partial {
     fn be_f32_tests() {
         assert_parse!(
             be_f32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), 0_f32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0.0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_f32.parse_peek(Partial::new(&[0x4d, 0x31, 0x1f, 0xd8][..])),
-            Ok((Partial::new(&b""[..]), 185_728_380_f32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        185728380.0,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1001,13 +2626,35 @@ mod partial {
             be_f64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial::new(&b""[..]), 0_f64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0.0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             be_f64.parse_peek(Partial::new(
                 &[0x41, 0xa6, 0x23, 0xfb, 0x10, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial::new(&b""[..]), 185_728_392_f64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        185728392.0,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1015,11 +2662,33 @@ mod partial {
     fn le_f32_tests() {
         assert_parse!(
             le_f32.parse_peek(Partial::new(&[0x00, 0x00, 0x00, 0x00][..])),
-            Ok((Partial::new(&b""[..]), 0_f32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0.0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_f32.parse_peek(Partial::new(&[0xd8, 0x1f, 0x31, 0x4d][..])),
-            Ok((Partial::new(&b""[..]), 185_728_380_f32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        185728380.0,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1029,13 +2698,35 @@ mod partial {
             le_f64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]
             )),
-            Ok((Partial::new(&b""[..]), 0_f64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        0.0,
+    ),
+)
+
+"#]]
         );
         assert_parse!(
             le_f64.parse_peek(Partial::new(
                 &[0x00, 0x00, 0x00, 0x10, 0xfb, 0x23, 0xa6, 0x41][..]
             )),
-            Ok((Partial::new(&b""[..]), 185_728_392_f64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        185728392.0,
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1043,144 +2734,353 @@ mod partial {
     fn configurable_endianness() {
         use crate::binary::Endianness;
 
-        fn be_tst16(i: &mut Partial<&[u8]>) -> PResult<u16> {
+        fn be_tst16<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u16, InputError<Partial<&'i [u8]>>> {
             u16(Endianness::Big).parse_next(i)
         }
-        fn le_tst16(i: &mut Partial<&[u8]>) -> PResult<u16> {
+        fn le_tst16<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u16, InputError<Partial<&'i [u8]>>> {
             u16(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tst16.parse_peek(Partial::new(&[0x80, 0x00])),
-            Ok((Partial::new(&b""[..]), 32_768_u16))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        32768,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tst16.parse_peek(Partial::new(&[0x80, 0x00])),
-            Ok((Partial::new(&b""[..]), 128_u16))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        128,
+    ),
+)
+
+"#]]
         );
 
-        fn be_tst32(i: &mut Partial<&[u8]>) -> PResult<u32> {
+        fn be_tst32<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u32, InputError<Partial<&'i [u8]>>> {
             u32(Endianness::Big).parse_next(i)
         }
-        fn le_tst32(i: &mut Partial<&[u8]>) -> PResult<u32> {
+        fn le_tst32<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u32, InputError<Partial<&'i [u8]>>> {
             u32(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tst32.parse_peek(Partial::new(&[0x12, 0x00, 0x60, 0x00])),
-            Ok((Partial::new(&b""[..]), 302_014_464_u32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        302014464,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tst32.parse_peek(Partial::new(&[0x12, 0x00, 0x60, 0x00])),
-            Ok((Partial::new(&b""[..]), 6_291_474_u32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        6291474,
+    ),
+)
+
+"#]]
         );
 
-        fn be_tst64(i: &mut Partial<&[u8]>) -> PResult<u64> {
+        fn be_tst64<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u64, InputError<Partial<&'i [u8]>>> {
             u64(Endianness::Big).parse_next(i)
         }
-        fn le_tst64(i: &mut Partial<&[u8]>) -> PResult<u64> {
+        fn le_tst64<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u64, InputError<Partial<&'i [u8]>>> {
             u64(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tst64.parse_peek(Partial::new(&[
                 0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
             ])),
-            Ok((Partial::new(&b""[..]), 1_297_142_246_100_992_000_u64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        1297142246100992000,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tst64.parse_peek(Partial::new(&[
                 0x12, 0x00, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
             ])),
-            Ok((Partial::new(&b""[..]), 36_028_874_334_666_770_u64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        36028874334666770,
+    ),
+)
+
+"#]]
         );
 
-        fn be_tsti16(i: &mut Partial<&[u8]>) -> PResult<i16> {
+        fn be_tsti16<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i16, InputError<Partial<&'i [u8]>>> {
             i16(Endianness::Big).parse_next(i)
         }
-        fn le_tsti16(i: &mut Partial<&[u8]>) -> PResult<i16> {
+        fn le_tsti16<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i16, InputError<Partial<&'i [u8]>>> {
             i16(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tsti16.parse_peek(Partial::new(&[0x00, 0x80])),
-            Ok((Partial::new(&b""[..]), 128_i16))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        128,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tsti16.parse_peek(Partial::new(&[0x00, 0x80])),
-            Ok((Partial::new(&b""[..]), -32_768_i16))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        -32768,
+    ),
+)
+
+"#]]
         );
 
-        fn be_tsti32(i: &mut Partial<&[u8]>) -> PResult<i32> {
+        fn be_tsti32<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i32, InputError<Partial<&'i [u8]>>> {
             i32(Endianness::Big).parse_next(i)
         }
-        fn le_tsti32(i: &mut Partial<&[u8]>) -> PResult<i32> {
+        fn le_tsti32<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i32, InputError<Partial<&'i [u8]>>> {
             i32(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tsti32.parse_peek(Partial::new(&[0x00, 0x12, 0x60, 0x00])),
-            Ok((Partial::new(&b""[..]), 1_204_224_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        1204224,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tsti32.parse_peek(Partial::new(&[0x00, 0x12, 0x60, 0x00])),
-            Ok((Partial::new(&b""[..]), 6_296_064_i32))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        6296064,
+    ),
+)
+
+"#]]
         );
 
-        fn be_tsti64(i: &mut Partial<&[u8]>) -> PResult<i64> {
+        fn be_tsti64<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i64, InputError<Partial<&'i [u8]>>> {
             i64(Endianness::Big).parse_next(i)
         }
-        fn le_tsti64(i: &mut Partial<&[u8]>) -> PResult<i64> {
+        fn le_tsti64<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i64, InputError<Partial<&'i [u8]>>> {
             i64(Endianness::Little).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             be_tsti64.parse_peek(Partial::new(&[
                 0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
             ])),
-            Ok((Partial::new(&b""[..]), 71_881_672_479_506_432_i64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        71881672479506432,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             le_tsti64.parse_peek(Partial::new(&[
                 0x00, 0xFF, 0x60, 0x00, 0x12, 0x00, 0x80, 0x00
             ])),
-            Ok((Partial::new(&b""[..]), 36_028_874_334_732_032_i64))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        36028874334732032,
+    ),
+)
+
+"#]]
         );
     }
 
     #[test]
     #[cfg(feature = "alloc")]
     fn length_repeat_test() {
-        fn number(i: &mut Partial<&[u8]>) -> PResult<u32> {
+        fn number<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u32, InputError<Partial<&'i [u8]>>> {
             digit
                 .try_map(str::from_utf8)
                 .try_map(FromStr::from_str)
                 .parse_next(i)
         }
 
-        fn cnt<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        fn cnt<'i>(
+            i: &mut Partial<&'i [u8]>,
+        ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
             length_repeat(number, "abc").parse_next(i)
         }
 
-        assert_eq!(
+        assert_parse!(
             cnt.parse_peek(Partial::new(&b"2abcabcabcdef"[..])),
-            Ok((Partial::new(&b"abcdef"[..]), vec![&b"abc"[..], &b"abc"[..]]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                97,
+                98,
+                99,
+                100,
+                101,
+                102,
+            ],
+            partial: true,
+        },
+        [
+            [
+                97,
+                98,
+                99,
+            ],
+            [
+                97,
+                98,
+                99,
+            ],
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             cnt.parse_peek(Partial::new(&b"2ab"[..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             cnt.parse_peek(Partial::new(&b"3abcab"[..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             cnt.parse_peek(Partial::new(&b"xxx"[..])),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b"xxx"[..]),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    120,
+                    120,
+                    120,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             cnt.parse_peek(Partial::new(&b"2abcxxx"[..])),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b"xxx"[..]),
-                ErrorKind::Literal
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    120,
+                    120,
+                    120,
+                ],
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1188,79 +3088,244 @@ mod partial {
     fn partial_length_bytes() {
         use crate::binary::le_u8;
 
-        fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
             length_take(le_u8).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             x.parse_peek(Partial::new(b"\x02..>>")),
-            Ok((Partial::new(&b">>"[..]), &b".."[..]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                62,
+                62,
+            ],
+            partial: true,
+        },
+        [
+            46,
+            46,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             x.parse_peek(Partial::new(b"\x02..")),
-            Ok((Partial::new(&[][..]), &b".."[..]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        [
+            46,
+            46,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             x.parse_peek(Partial::new(b"\x02.")),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             x.parse_peek(Partial::new(b"\x02")),
-            Err(ErrMode::Incomplete(Needed::new(2)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
         );
 
-        fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
             let _ = "magic".parse_next(i)?;
             length_take(le_u8).parse_next(i)
         }
-        assert_eq!(
+        assert_parse!(
             y.parse_peek(Partial::new(b"magic\x02..>>")),
-            Ok((Partial::new(&b">>"[..]), &b".."[..]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                62,
+                62,
+            ],
+            partial: true,
+        },
+        [
+            46,
+            46,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             y.parse_peek(Partial::new(b"magic\x02..")),
-            Ok((Partial::new(&[][..]), &b".."[..]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [],
+            partial: true,
+        },
+        [
+            46,
+            46,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             y.parse_peek(Partial::new(b"magic\x02.")),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             y.parse_peek(Partial::new(b"magic\x02")),
-            Err(ErrMode::Incomplete(Needed::new(2)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 
     #[test]
     fn length_take_test() {
-        fn number(i: &mut Partial<&[u8]>) -> PResult<u32> {
+        fn number<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u32, InputError<Partial<&'i [u8]>>> {
             digit
                 .try_map(str::from_utf8)
                 .try_map(FromStr::from_str)
                 .parse_next(i)
         }
 
-        fn take<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        fn take<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
             length_take(number).parse_next(i)
         }
 
-        assert_eq!(
+        assert_parse!(
             take.parse_peek(Partial::new(&b"6abcabcabcdef"[..])),
-            Ok((Partial::new(&b"abcdef"[..]), &b"abcabc"[..]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                97,
+                98,
+                99,
+                100,
+                101,
+                102,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            99,
+            97,
+            98,
+            99,
+        ],
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             take.parse_peek(Partial::new(&b"3ab"[..])),
-            Err(ErrMode::Incomplete(Needed::new(1)))
+            str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             take.parse_peek(Partial::new(&b"xxx"[..])),
-            Err(ErrMode::Backtrack(error_position!(
-                &Partial::new(&b"xxx"[..]),
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    120,
+                    120,
+                    120,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             take.parse_peek(Partial::new(&b"2abcxxx"[..])),
-            Ok((Partial::new(&b"cxxx"[..]), &b"ab"[..]))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                99,
+                120,
+                120,
+                120,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+        ],
+    ),
+)
+
+"#]]
         );
     }
 
@@ -1268,10 +3333,14 @@ mod partial {
     fn length_and_then_test() {
         use crate::stream::StreamIsPartial;
 
-        fn length_and_then_1(i: &mut Partial<&[u8]>) -> PResult<u16> {
+        fn length_and_then_1<'i>(
+            i: &mut Partial<&'i [u8]>,
+        ) -> PResult<u16, InputError<Partial<&'i [u8]>>> {
             length_and_then(be_u8, be_u16).parse_next(i)
         }
-        fn length_and_then_2(i: &mut Partial<&[u8]>) -> PResult<(u8, u8)> {
+        fn length_and_then_2<'i>(
+            i: &mut Partial<&'i [u8]>,
+        ) -> PResult<(u8, u8), InputError<Partial<&'i [u8]>>> {
             length_and_then(be_u8, (be_u8, be_u8)).parse_next(i)
         }
 
@@ -1279,59 +3348,167 @@ mod partial {
         let _ = empty_complete.complete();
 
         let i1 = [0, 5, 6];
-        assert_eq!(
+        assert_parse!(
             length_and_then_1.parse_peek(Partial::new(&i1)),
-            Err(ErrMode::Backtrack(error_position!(
-                &empty_complete,
-                ErrorKind::Slice
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [],
+                partial: false,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             length_and_then_2.parse_peek(Partial::new(&i1)),
-            Err(ErrMode::Backtrack(error_position!(
-                &empty_complete,
-                ErrorKind::Token
-            )))
+            str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [],
+                partial: false,
+            },
+            kind: Token,
+        },
+    ),
+)
+
+"#]]
         );
 
         let i2 = [1, 5, 6, 3];
         {
             let mut middle_complete = Partial::new(&i2[1..2]);
             let _ = middle_complete.complete();
-            assert_eq!(
+            assert_parse!(
                 length_and_then_1.parse_peek(Partial::new(&i2)),
-                Err(ErrMode::Backtrack(error_position!(
-                    &middle_complete,
-                    ErrorKind::Slice
-                )))
+                str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    5,
+                ],
+                partial: false,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
             );
-            assert_eq!(
+            assert_parse!(
                 length_and_then_2.parse_peek(Partial::new(&i2)),
-                Err(ErrMode::Backtrack(error_position!(
-                    &empty_complete,
-                    ErrorKind::Token
-                )))
+                str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [],
+                partial: false,
+            },
+            kind: Token,
+        },
+    ),
+)
+
+"#]]
             );
         }
 
         let i3 = [2, 5, 6, 3, 4, 5, 7];
-        assert_eq!(
+        assert_parse!(
             length_and_then_1.parse_peek(Partial::new(&i3)),
-            Ok((Partial::new(&i3[3..]), 1286))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                3,
+                4,
+                5,
+                7,
+            ],
+            partial: true,
+        },
+        1286,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             length_and_then_2.parse_peek(Partial::new(&i3)),
-            Ok((Partial::new(&i3[3..]), (5, 6)))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                3,
+                4,
+                5,
+                7,
+            ],
+            partial: true,
+        },
+        (
+            5,
+            6,
+        ),
+    ),
+)
+
+"#]]
         );
 
         let i4 = [3, 5, 6, 3, 4, 5];
-        assert_eq!(
+        assert_parse!(
             length_and_then_1.parse_peek(Partial::new(&i4)),
-            Ok((Partial::new(&i4[4..]), 1286))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                4,
+                5,
+            ],
+            partial: true,
+        },
+        1286,
+    ),
+)
+
+"#]]
         );
-        assert_eq!(
+        assert_parse!(
             length_and_then_2.parse_peek(Partial::new(&i4)),
-            Ok((Partial::new(&i4[4..]), (5, 6)))
+            str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                4,
+                5,
+            ],
+            partial: true,
+        },
+        (
+            5,
+            6,
+        ),
+    ),
+)
+
+"#]]
         );
     }
 }

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -1,9 +1,11 @@
 use super::*;
+
 use snapbox::str;
+
+use crate::prelude::*;
 
 mod complete {
     use super::*;
-    use crate::error::InputError;
 
     #[test]
     fn i8_tests() {
@@ -893,10 +895,10 @@ Ok(
     fn configurable_endianness() {
         use crate::binary::Endianness;
 
-        fn be_tst16<'i>(i: &mut &'i [u8]) -> PResult<u16, InputError<&'i [u8]>> {
+        fn be_tst16<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], u16> {
             u16(Endianness::Big).parse_next(i)
         }
-        fn le_tst16<'i>(i: &mut &'i [u8]) -> PResult<u16, InputError<&'i [u8]>> {
+        fn le_tst16<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], u16> {
             u16(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -924,10 +926,10 @@ Ok(
 "#]]
         );
 
-        fn be_tst32<'i>(i: &mut &'i [u8]) -> PResult<u32, InputError<&'i [u8]>> {
+        fn be_tst32<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], u32> {
             u32(Endianness::Big).parse_next(i)
         }
-        fn le_tst32<'i>(i: &mut &'i [u8]) -> PResult<u32, InputError<&'i [u8]>> {
+        fn le_tst32<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], u32> {
             u32(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -955,10 +957,10 @@ Ok(
 "#]]
         );
 
-        fn be_tst64<'i>(i: &mut &'i [u8]) -> PResult<u64, InputError<&'i [u8]>> {
+        fn be_tst64<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], u64> {
             u64(Endianness::Big).parse_next(i)
         }
-        fn le_tst64<'i>(i: &mut &'i [u8]) -> PResult<u64, InputError<&'i [u8]>> {
+        fn le_tst64<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], u64> {
             u64(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -986,10 +988,10 @@ Ok(
 "#]]
         );
 
-        fn be_tsti16<'i>(i: &mut &'i [u8]) -> PResult<i16, InputError<&'i [u8]>> {
+        fn be_tsti16<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], i16> {
             i16(Endianness::Big).parse_next(i)
         }
-        fn le_tsti16<'i>(i: &mut &'i [u8]) -> PResult<i16, InputError<&'i [u8]>> {
+        fn le_tsti16<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], i16> {
             i16(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -1017,10 +1019,10 @@ Ok(
 "#]]
         );
 
-        fn be_tsti32<'i>(i: &mut &'i [u8]) -> PResult<i32, InputError<&'i [u8]>> {
+        fn be_tsti32<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], i32> {
             i32(Endianness::Big).parse_next(i)
         }
-        fn le_tsti32<'i>(i: &mut &'i [u8]) -> PResult<i32, InputError<&'i [u8]>> {
+        fn le_tsti32<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], i32> {
             i32(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -1048,10 +1050,10 @@ Ok(
 "#]]
         );
 
-        fn be_tsti64<'i>(i: &mut &'i [u8]) -> PResult<i64, InputError<&'i [u8]>> {
+        fn be_tsti64<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], i64> {
             i64(Endianness::Big).parse_next(i)
         }
-        fn le_tsti64<'i>(i: &mut &'i [u8]) -> PResult<i64, InputError<&'i [u8]>> {
+        fn le_tsti64<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], i64> {
             i64(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -1083,7 +1085,7 @@ Ok(
 
 mod partial {
     use super::*;
-    use crate::error::InputError;
+
     #[cfg(feature = "alloc")]
     use crate::lib::std::vec::Vec;
     use crate::Partial;
@@ -2734,10 +2736,10 @@ Ok(
     fn configurable_endianness() {
         use crate::binary::Endianness;
 
-        fn be_tst16<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u16, InputError<Partial<&'i [u8]>>> {
+        fn be_tst16<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u16> {
             u16(Endianness::Big).parse_next(i)
         }
-        fn le_tst16<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u16, InputError<Partial<&'i [u8]>>> {
+        fn le_tst16<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u16> {
             u16(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -2771,10 +2773,10 @@ Ok(
 "#]]
         );
 
-        fn be_tst32<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u32, InputError<Partial<&'i [u8]>>> {
+        fn be_tst32<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u32> {
             u32(Endianness::Big).parse_next(i)
         }
-        fn le_tst32<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u32, InputError<Partial<&'i [u8]>>> {
+        fn le_tst32<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u32> {
             u32(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -2808,10 +2810,10 @@ Ok(
 "#]]
         );
 
-        fn be_tst64<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u64, InputError<Partial<&'i [u8]>>> {
+        fn be_tst64<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u64> {
             u64(Endianness::Big).parse_next(i)
         }
-        fn le_tst64<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u64, InputError<Partial<&'i [u8]>>> {
+        fn le_tst64<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u64> {
             u64(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -2849,10 +2851,10 @@ Ok(
 "#]]
         );
 
-        fn be_tsti16<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i16, InputError<Partial<&'i [u8]>>> {
+        fn be_tsti16<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, i16> {
             i16(Endianness::Big).parse_next(i)
         }
-        fn le_tsti16<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i16, InputError<Partial<&'i [u8]>>> {
+        fn le_tsti16<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, i16> {
             i16(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -2886,10 +2888,10 @@ Ok(
 "#]]
         );
 
-        fn be_tsti32<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i32, InputError<Partial<&'i [u8]>>> {
+        fn be_tsti32<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, i32> {
             i32(Endianness::Big).parse_next(i)
         }
-        fn le_tsti32<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i32, InputError<Partial<&'i [u8]>>> {
+        fn le_tsti32<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, i32> {
             i32(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -2923,10 +2925,10 @@ Ok(
 "#]]
         );
 
-        fn be_tsti64<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i64, InputError<Partial<&'i [u8]>>> {
+        fn be_tsti64<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, i64> {
             i64(Endianness::Big).parse_next(i)
         }
-        fn le_tsti64<'i>(i: &mut Partial<&'i [u8]>) -> PResult<i64, InputError<Partial<&'i [u8]>>> {
+        fn le_tsti64<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, i64> {
             i64(Endianness::Little).parse_next(i)
         }
         assert_parse!(
@@ -2968,16 +2970,14 @@ Ok(
     #[test]
     #[cfg(feature = "alloc")]
     fn length_repeat_test() {
-        fn number<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u32, InputError<Partial<&'i [u8]>>> {
+        fn number<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u32> {
             digit
                 .try_map(str::from_utf8)
                 .try_map(FromStr::from_str)
                 .parse_next(i)
         }
 
-        fn cnt<'i>(
-            i: &mut Partial<&'i [u8]>,
-        ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
+        fn cnt<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, Vec<&'i [u8]>> {
             length_repeat(number, "abc").parse_next(i)
         }
 
@@ -3088,7 +3088,7 @@ Err(
     fn partial_length_bytes() {
         use crate::binary::le_u8;
 
-        fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+        fn x<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
             length_take(le_u8).parse_next(i)
         }
         assert_parse!(
@@ -3157,7 +3157,7 @@ Err(
 "#]]
         );
 
-        fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+        fn y<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
             let _ = "magic".parse_next(i)?;
             length_take(le_u8).parse_next(i)
         }
@@ -3230,14 +3230,14 @@ Err(
 
     #[test]
     fn length_take_test() {
-        fn number<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u32, InputError<Partial<&'i [u8]>>> {
+        fn number<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u32> {
             digit
                 .try_map(str::from_utf8)
                 .try_map(FromStr::from_str)
                 .parse_next(i)
         }
 
-        fn take<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+        fn take<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
             length_take(number).parse_next(i)
         }
 
@@ -3333,14 +3333,12 @@ Ok(
     fn length_and_then_test() {
         use crate::stream::StreamIsPartial;
 
-        fn length_and_then_1<'i>(
-            i: &mut Partial<&'i [u8]>,
-        ) -> PResult<u16, InputError<Partial<&'i [u8]>>> {
+        fn length_and_then_1<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u16> {
             length_and_then(be_u8, be_u16).parse_next(i)
         }
         fn length_and_then_2<'i>(
             i: &mut Partial<&'i [u8]>,
-        ) -> PResult<(u8, u8), InputError<Partial<&'i [u8]>>> {
+        ) -> TestResult<Partial<&'i [u8]>, (u8, u8)> {
             length_and_then(be_u8, (be_u8, be_u8)).parse_next(i)
         }
 

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -4,13 +4,6 @@ mod complete {
     use super::*;
     use crate::error::InputError;
 
-    macro_rules! assert_parse(
-    ($left: expr, $right: expr) => {
-      let res: $crate::error::IResult<_, _, InputError<_>> = $left;
-      assert_eq!(res, $right);
-    };
-  );
-
     #[test]
     fn i8_tests() {
         assert_parse!(i8.parse_peek(&[0x00][..]), Ok((&b""[..], 0)));
@@ -451,13 +444,6 @@ mod partial {
         error::ErrorKind,
         lib::std::str::{self, FromStr},
     };
-
-    macro_rules! assert_parse(
-    ($left: expr, $right: expr) => {
-      let res: $crate::error::IResult<_, _, InputError<_>> = $left;
-      assert_eq!(res, $right);
-    };
-  );
 
     #[test]
     fn i8_tests() {

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -28,24 +28,23 @@ pub trait Alt<I, O, E> {
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::ascii::{alpha1, digit1};
 /// use winnow::combinator::alt;
 /// # fn main() {
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///   alt((alpha1, digit1)).parse_peek(input)
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
+///   alt((alpha1, digit1)).parse_next(input)
 /// };
 ///
 /// // the first parser, alpha1, takes the input
-/// assert_eq!(parser("abc"), Ok(("", "abc")));
+/// assert_eq!(parser.parse_peek("abc"), Ok(("", "abc")));
 ///
 /// // the first parser returns an error, so alt tries the second one
-/// assert_eq!(parser("123456"), Ok(("", "123456")));
+/// assert_eq!(parser.parse_peek("123456"), Ok(("", "123456")));
 ///
 /// // both parsers failed, and with the default error type, alt will return the last error
-/// assert!(parser(" ").is_err());
+/// assert!(parser.parse_peek(" ").is_err());
 /// # }
 /// ```
 #[doc(alias = "choice")]
@@ -80,46 +79,44 @@ pub trait Permutation<I, O, E> {
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode,error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::ascii::{alpha1, digit1};
 /// use winnow::combinator::permutation;
 /// # fn main() {
-/// fn parser(input: &str) -> IResult<&str, (&str, &str)> {
-///   permutation((alpha1, digit1)).parse_peek(input)
+/// fn parser<'i>(input: &mut &'i str) -> PResult<(&'i str, &'i str)> {
+///   permutation((alpha1, digit1)).parse_next(input)
 /// }
 ///
 /// // permutation takes alphabetic characters then digit
-/// assert_eq!(parser("abc123"), Ok(("", ("abc", "123"))));
+/// assert_eq!(parser.parse_peek("abc123"), Ok(("", ("abc", "123"))));
 ///
 /// // but also in inverse order
-/// assert_eq!(parser("123abc"), Ok(("", ("abc", "123"))));
+/// assert_eq!(parser.parse_peek("123abc"), Ok(("", ("abc", "123"))));
 ///
 /// // it will fail if one of the parsers failed
-/// assert!(parser("abc;").is_err());
+/// assert!(parser.parse_peek("abc;").is_err());
 /// # }
 /// ```
 ///
 /// The parsers are applied greedily: if there are multiple unapplied parsers
 /// that could parse the next slice of input, the first one is used.
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::permutation;
 /// use winnow::token::any;
 ///
-/// fn parser(input: &str) -> IResult<&str, (char, char)> {
-///   permutation((any, 'a')).parse_peek(input)
+/// fn parser(input: &mut &str) -> PResult<(char, char)> {
+///   permutation((any, 'a')).parse_next(input)
 /// }
 ///
 /// // any parses 'b', then char('a') parses 'a'
-/// assert_eq!(parser("ba"), Ok(("", ('b', 'a'))));
+/// assert_eq!(parser.parse_peek("ba"), Ok(("", ('b', 'a'))));
 ///
 /// // any parses 'a', then char('a') fails on 'b',
 /// // even though char('a') followed by any would succeed
-/// assert!(parser("ab").is_err());
+/// assert!(parser.parse_peek("ab").is_err());
 /// ```
 ///
 #[inline(always)]

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -45,7 +45,7 @@ pub trait Alt<I, O, E> {
 /// assert_eq!(parser("123456"), Ok(("", "123456")));
 ///
 /// // both parsers failed, and with the default error type, alt will return the last error
-/// assert_eq!(parser(" "), Err(ErrMode::Backtrack(InputError::new(" ", ErrorKind::Slice))));
+/// assert!(parser(" ").is_err());
 /// # }
 /// ```
 #[doc(alias = "choice")]
@@ -97,7 +97,7 @@ pub trait Permutation<I, O, E> {
 /// assert_eq!(parser("123abc"), Ok(("", ("abc", "123"))));
 ///
 /// // it will fail if one of the parsers failed
-/// assert_eq!(parser("abc;"), Err(ErrMode::Backtrack(InputError::new(";", ErrorKind::Slice))));
+/// assert!(parser("abc;").is_err());
 /// # }
 /// ```
 ///
@@ -119,7 +119,7 @@ pub trait Permutation<I, O, E> {
 ///
 /// // any parses 'a', then char('a') fails on 'b',
 /// // even though char('a') followed by any would succeed
-/// assert_eq!(parser("ab"), Err(ErrMode::Backtrack(InputError::new("b", ErrorKind::Literal))));
+/// assert!(parser("ab").is_err());
 /// ```
 ///
 #[inline(always)]

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -29,7 +29,7 @@ pub trait Alt<I, O, E> {
 ///
 /// ```rust
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::InputError,error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::ascii::{alpha1, digit1};
 /// use winnow::combinator::alt;
@@ -81,7 +81,7 @@ pub trait Permutation<I, O, E> {
 ///
 /// ```rust
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode,error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode,error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::ascii::{alpha1, digit1};
 /// use winnow::combinator::permutation;
@@ -105,7 +105,7 @@ pub trait Permutation<I, O, E> {
 /// that could parse the next slice of input, the first one is used.
 /// ```rust
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}};
+/// # use winnow::{error::ErrMode, error::ErrorKind};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::permutation;
 /// use winnow::token::any;

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -33,7 +33,6 @@ where
 ///
 /// ```rust
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::opt;
 /// use winnow::ascii::alpha1;
@@ -72,7 +71,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::IResult};
+/// # use winnow::error::IResult;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::cond;
 /// use winnow::ascii::alpha1;
@@ -113,13 +112,12 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::IResult};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::peek;
 /// use winnow::ascii::alpha1;
 /// # fn main() {
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
 ///     peek(alpha1).parse_next(input)
 /// }
 ///
@@ -166,11 +164,10 @@ where
 /// ```rust
 /// # use winnow::error::IResult;
 /// # use std::str;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::combinator::eof;
 /// # use winnow::prelude::*;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
 ///     eof.parse_next(input)
 /// }
 /// assert!(parser.parse_peek("abc").is_err());
@@ -204,13 +201,12 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::IResult};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::not;
 /// use winnow::ascii::alpha1;
 /// # fn main() {
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<(), InputError<&'i str>> {
+/// fn parser<'i>(input: &mut &'i str) -> PResult<()> {
 ///     not(alpha1).parse_next(input)
 /// }
 ///
@@ -248,7 +244,6 @@ where
 /// Without `cut_err`:
 /// ```rust
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::token::one_of;
 /// # use winnow::token::rest;
 /// # use winnow::ascii::digit1;
@@ -479,7 +474,6 @@ enum State<E> {
 ///
 /// ```rust
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::alt;
 /// use winnow::combinator::empty;

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -119,7 +119,9 @@ where
 /// use winnow::ascii::alpha1;
 /// # fn main() {
 ///
-/// let mut parser = peek(alpha1);
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+///     peek(alpha1).parse_next(input)
+/// }
 ///
 /// assert_eq!(parser.parse_peek("abcd;"), Ok(("abcd;", "abcd")));
 /// assert_eq!(parser.parse_peek("123;"), Err(ErrMode::Backtrack(InputError::new("123;", ErrorKind::Slice))));
@@ -168,7 +170,9 @@ where
 /// # use winnow::combinator::eof;
 /// # use winnow::prelude::*;
 ///
-/// let mut parser = eof;
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+///     eof.parse_next(input)
+/// }
 /// assert_eq!(parser.parse_peek("abc"), Err(ErrMode::Backtrack(InputError::new("abc", ErrorKind::Eof))));
 /// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
@@ -206,7 +210,9 @@ where
 /// use winnow::ascii::alpha1;
 /// # fn main() {
 ///
-/// let mut parser = not(alpha1);
+/// fn parser<'i>(input: &mut &'i str) -> PResult<(), InputError<&'i str>> {
+///     not(alpha1).parse_next(input)
+/// }
 ///
 /// assert_eq!(parser.parse_peek("123"), Ok(("123", ())));
 /// assert_eq!(parser.parse_peek("abcd"), Err(ErrMode::Backtrack(InputError::new("abcd", ErrorKind::Not))));
@@ -512,8 +518,11 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::fail;
 ///
-/// let s = "string";
-/// assert_eq!(fail::<_, &str, _>.parse_peek(s), Err(ErrMode::Backtrack(InputError::new(s, ErrorKind::Fail))));
+/// fn parser<'i>(input: &mut &'i str) -> PResult<(), InputError<&'i str>> {
+///     fail.parse_next(input)
+/// }
+///
+/// assert_eq!(parser.parse_peek("string"), Err(ErrMode::Backtrack(InputError::new("string", ErrorKind::Fail))));
 /// ```
 #[doc(alias = "unexpected")]
 #[inline]

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -73,18 +73,21 @@ where
 /// ```rust
 /// # use winnow::error::IResult;
 /// # use winnow::prelude::*;
+/// # use winnow::combinator::opt;
 /// use winnow::combinator::cond;
 /// use winnow::ascii::alpha1;
 /// # fn main() {
 ///
-/// fn parser(b: bool, i: &str) -> IResult<&str, Option<&str>> {
-///   cond(b, alpha1).parse_peek(i)
+/// fn parser(i: &str) -> IResult<&str, Option<&str>> {
+///   let (i, prefix) = opt("-").parse_peek(i)?;
+///   let condition = prefix.is_some();
+///   cond(condition, alpha1).parse_peek(i)
 /// }
 ///
-/// assert_eq!(parser(true, "abcd;"), Ok((";", Some("abcd"))));
-/// assert_eq!(parser(false, "abcd;"), Ok(("abcd;", None)));
-/// assert!(parser(true, "123;").is_err());
-/// assert_eq!(parser(false, "123;"), Ok(("123;", None)));
+/// assert_eq!(parser("-abcd;"), Ok((";", Some("abcd"))));
+/// assert_eq!(parser("abcd;"), Ok(("abcd;", None)));
+/// assert!(parser("-123;").is_err());
+/// assert_eq!(parser("123;"), Ok(("123;", None)));
 /// # }
 /// ```
 pub fn cond<Input, Output, Error, ParseNext>(

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -84,7 +84,7 @@ where
 ///
 /// assert_eq!(parser(true, "abcd;"), Ok((";", Some("abcd"))));
 /// assert_eq!(parser(false, "abcd;"), Ok(("abcd;", None)));
-/// assert_eq!(parser(true, "123;"), Err(ErrMode::Backtrack(InputError::new("123;", ErrorKind::Slice))));
+/// assert!(parser(true, "123;").is_err());
 /// assert_eq!(parser(false, "123;"), Ok(("123;", None)));
 /// # }
 /// ```
@@ -124,7 +124,7 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("abcd;"), Ok(("abcd;", "abcd")));
-/// assert_eq!(parser.parse_peek("123;"), Err(ErrMode::Backtrack(InputError::new("123;", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("123;").is_err());
 /// # }
 /// ```
 #[doc(alias = "look_ahead")]
@@ -173,7 +173,7 @@ where
 /// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
 ///     eof.parse_next(input)
 /// }
-/// assert_eq!(parser.parse_peek("abc"), Err(ErrMode::Backtrack(InputError::new("abc", ErrorKind::Eof))));
+/// assert!(parser.parse_peek("abc").is_err());
 /// assert_eq!(parser.parse_peek(""), Ok(("", "")));
 /// ```
 #[doc(alias = "end")]
@@ -215,7 +215,7 @@ where
 /// }
 ///
 /// assert_eq!(parser.parse_peek("123"), Ok(("123", ())));
-/// assert_eq!(parser.parse_peek("abcd"), Err(ErrMode::Backtrack(InputError::new("abcd", ErrorKind::Not))));
+/// assert!(parser.parse_peek("abcd").is_err());
 /// # }
 /// ```
 pub fn not<Input, Output, Error, ParseNext>(mut parser: ParseNext) -> impl Parser<Input, (), Error>

--- a/src/combinator/debug/mod.rs
+++ b/src/combinator/debug/mod.rs
@@ -16,13 +16,13 @@ use crate::Parser;
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::token::take_while;
 /// # use winnow::stream::AsChar;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::trace;
 ///
-/// fn short_alpha<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8], InputError<&'s [u8]>> {
+/// fn short_alpha<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8]> {
 ///   trace("short_alpha",
 ///     take_while(3..=6, AsChar::is_alpha)
 ///   ).parse_next(s)

--- a/src/combinator/debug/mod.rs
+++ b/src/combinator/debug/mod.rs
@@ -31,8 +31,8 @@ use crate::Parser;
 /// assert_eq!(short_alpha.parse_peek(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha.parse_peek(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
 /// assert_eq!(short_alpha.parse_peek(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha.parse_peek(b"ed"), Err(ErrMode::Backtrack(InputError::new(&b"ed"[..], ErrorKind::Slice))));
-/// assert_eq!(short_alpha.parse_peek(b"12345"), Err(ErrMode::Backtrack(InputError::new(&b"12345"[..], ErrorKind::Slice))));
+/// assert!(short_alpha.parse_peek(b"ed").is_err());
+/// assert!(short_alpha.parse_peek(b"12345").is_err());
 /// ```
 #[cfg_attr(not(feature = "debug"), allow(unused_variables))]
 #[cfg_attr(not(feature = "debug"), allow(unused_mut))]

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -53,7 +53,7 @@ use crate::Parser;
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
@@ -72,7 +72,7 @@ use crate::Parser;
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
@@ -208,7 +208,7 @@ where
     /// One or more repetitions:
     /// ```rust
     /// # use winnow::error::IResult;
-    /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+    /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
@@ -315,7 +315,7 @@ where
     /// Guaranteeing that the input had unique elements:
     /// ```rust
     /// # use winnow::error::IResult;
-    /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+    /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     /// use std::collections::HashSet;
@@ -392,7 +392,7 @@ where
     /// Writing the output to a vector of bytes:
     /// ```rust
     /// # use winnow::error::IResult;
-    /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+    /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     /// use std::io::Write;
@@ -635,7 +635,7 @@ where
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat_till;
 ///
@@ -821,7 +821,7 @@ where
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
@@ -841,7 +841,7 @@ where
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
@@ -861,7 +861,7 @@ where
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
@@ -1197,7 +1197,7 @@ where
 ///
 /// ```rust
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_foldl1;
 /// use winnow::ascii::dec_int;
@@ -1265,7 +1265,7 @@ where
 ///
 /// ```rust
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_foldr1;
 /// use winnow::ascii::dec_uint;
@@ -1317,7 +1317,7 @@ where
 ///
 /// ```rust
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::fill;
 ///

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -1263,7 +1263,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -63,8 +63,8 @@ use crate::Parser;
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
 /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(InputError::new("123123", ErrorKind::Literal))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser("123123").is_err());
+/// assert!(parser("").is_err());
 /// # }
 /// ```
 ///
@@ -81,9 +81,9 @@ use crate::Parser;
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Err(ErrMode::Backtrack(InputError::new("123", ErrorKind::Literal))));
-/// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(InputError::new("123123", ErrorKind::Literal))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser("abc123").is_err());
+/// assert!(parser("123123").is_err());
+/// assert!(parser("").is_err());
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// # }
 /// ```
@@ -227,8 +227,8 @@ where
     ///
     /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
     /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-    /// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(InputError::new("123123", ErrorKind::Repeat))));
-    /// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Repeat))));
+    /// assert!(parser("123123").is_err());
+    /// assert!(parser("").is_err());
     /// ```
     ///
     /// Arbitrary number of repetitions:
@@ -337,7 +337,7 @@ where
     /// }
     ///
     /// assert_eq!(parser("abc"), Ok(("", HashSet::from(["abc"]))));
-    /// assert_eq!(parser("abcabc"), Err(ErrMode::Backtrack(InputError::new("abc", ErrorKind::Verify))));
+    /// assert!(parser("abcabc").is_err());
     /// assert_eq!(parser("abc123"), Ok(("123", HashSet::from(["abc"]))));
     /// assert_eq!(parser("123123"), Ok(("123123", HashSet::from([]))));
     /// assert_eq!(parser(""), Ok(("", HashSet::from([]))));
@@ -644,9 +644,9 @@ where
 /// };
 ///
 /// assert_eq!(parser("abcabcend"), Ok(("", (vec!["abc", "abc"], "end"))));
-/// assert_eq!(parser("abc123end"), Err(ErrMode::Backtrack(InputError::new("123end", ErrorKind::Literal))));
-/// assert_eq!(parser("123123end"), Err(ErrMode::Backtrack(InputError::new("123123end", ErrorKind::Literal))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser("abc123end").is_err());
+/// assert!(parser("123123end").is_err());
+/// assert!(parser("").is_err());
 /// assert_eq!(parser("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
 /// # }
 /// ```
@@ -832,8 +832,8 @@ where
 /// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
 /// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
 /// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
-/// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(InputError::new("def|abc", ErrorKind::Literal))));
+/// assert!(parser("").is_err());
+/// assert!(parser("def|abc").is_err());
 /// # }
 /// ```
 ///
@@ -850,10 +850,10 @@ where
 /// }
 ///
 /// assert_eq!(parser("abc|abc|abc"), Ok(("|abc", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123abc"), Err(ErrMode::Backtrack(InputError::new("123abc", ErrorKind::Literal))));
-/// assert_eq!(parser("abc|def"), Err(ErrMode::Backtrack(InputError::new("def", ErrorKind::Literal))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
-/// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(InputError::new("def|abc", ErrorKind::Literal))));
+/// assert!(parser("abc123abc").is_err());
+/// assert!(parser("abc|def").is_err());
+/// assert!(parser("").is_err());
+/// assert!(parser("def|abc").is_err());
 /// # }
 /// ```
 ///
@@ -1207,8 +1207,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("9-3-5"), Ok(("", 1)));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
-/// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(InputError::new("def|abc", ErrorKind::Verify))));
+/// assert!(parser("").is_err());
+/// assert!(parser("def|abc").is_err());
 /// ```
 pub fn separated_foldl1<Input, Output, Sep, Error, ParseNext, SepParser, Op>(
     mut parser: ParseNext,
@@ -1276,8 +1276,8 @@ where
 ///
 /// assert_eq!(parser("2^3^2"), Ok(("", 512)));
 /// assert_eq!(parser("2"), Ok(("", 2)));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
-/// assert_eq!(parser("def|abc"), Err(ErrMode::Backtrack(InputError::new("def|abc", ErrorKind::Verify))));
+/// assert!(parser("").is_err());
+/// assert!(parser("def|abc").is_err());
 /// ```
 #[cfg(feature = "alloc")]
 pub fn separated_foldr1<Input, Output, Sep, Error, ParseNext, SepParser, Op>(
@@ -1328,9 +1328,9 @@ where
 /// }
 ///
 /// assert_eq!(parser("abcabc"), Ok(("", ["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Err(ErrMode::Backtrack(InputError::new("123", ErrorKind::Literal))));
-/// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(InputError::new("123123", ErrorKind::Literal))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser("abc123").is_err());
+/// assert!(parser("123123").is_err());
+/// assert!(parser("").is_err());
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", ["abc", "abc"])));
 /// ```
 pub fn fill<'i, Input, Output, Error, ParseNext>(

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -33,78 +33,74 @@ use crate::Parser;
 /// Zero or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   repeat(0.., "abc").parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+///   repeat(0.., "abc").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
+/// assert_eq!(parser.parse_peek("abcabc"), Ok(("", vec!["abc", "abc"])));
+/// assert_eq!(parser.parse_peek("abc123"), Ok(("123", vec!["abc"])));
+/// assert_eq!(parser.parse_peek("123123"), Ok(("123123", vec![])));
+/// assert_eq!(parser.parse_peek(""), Ok(("", vec![])));
 /// # }
 /// ```
 ///
 /// One or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   repeat(1.., "abc").parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+///   repeat(1.., "abc").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert!(parser("123123").is_err());
-/// assert!(parser("").is_err());
+/// assert_eq!(parser.parse_peek("abcabc"), Ok(("", vec!["abc", "abc"])));
+/// assert_eq!(parser.parse_peek("abc123"), Ok(("123", vec!["abc"])));
+/// assert!(parser.parse_peek("123123").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// # }
 /// ```
 ///
 /// Fixed number of repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   repeat(2, "abc").parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+///   repeat(2, "abc").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert!(parser("abc123").is_err());
-/// assert!(parser("123123").is_err());
-/// assert!(parser("").is_err());
-/// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// assert_eq!(parser.parse_peek("abcabc"), Ok(("", vec!["abc", "abc"])));
+/// assert!(parser.parse_peek("abc123").is_err());
+/// assert!(parser.parse_peek("123123").is_err());
+/// assert!(parser.parse_peek("").is_err());
+/// assert_eq!(parser.parse_peek("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// # }
 /// ```
 ///
 /// Arbitrary repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   repeat(0..=2, "abc").parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+///   repeat(0..=2, "abc").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
-/// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// assert_eq!(parser.parse_peek("abcabc"), Ok(("", vec!["abc", "abc"])));
+/// assert_eq!(parser.parse_peek("abc123"), Ok(("123", vec!["abc"])));
+/// assert_eq!(parser.parse_peek("123123"), Ok(("123123", vec![])));
+/// assert_eq!(parser.parse_peek(""), Ok(("", vec![])));
+/// assert_eq!(parser.parse_peek("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// # }
 /// ```
 #[doc(alias = "many0")]
@@ -181,12 +177,11 @@ where
     ///
     /// Zero or more repetitions:
     /// ```rust
-    /// # use winnow::error::IResult;
     /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
-    /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+    /// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
     ///   repeat(
     ///     0..,
     ///     "abc"
@@ -196,23 +191,22 @@ where
     ///       acc.push(item);
     ///       acc
     ///     }
-    ///   ).parse_peek(s)
+    ///   ).parse_next(s)
     /// }
     ///
-    /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-    /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-    /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-    /// assert_eq!(parser(""), Ok(("", vec![])));
+    /// assert_eq!(parser.parse_peek("abcabc"), Ok(("", vec!["abc", "abc"])));
+    /// assert_eq!(parser.parse_peek("abc123"), Ok(("123", vec!["abc"])));
+    /// assert_eq!(parser.parse_peek("123123"), Ok(("123123", vec![])));
+    /// assert_eq!(parser.parse_peek(""), Ok(("", vec![])));
     /// ```
     ///
     /// One or more repetitions:
     /// ```rust
-    /// # use winnow::error::IResult;
     /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
-    /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+    /// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
     ///   repeat(
     ///     1..,
     ///     "abc",
@@ -222,23 +216,22 @@ where
     ///       acc.push(item);
     ///       acc
     ///     }
-    ///   ).parse_peek(s)
+    ///   ).parse_next(s)
     /// }
     ///
-    /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-    /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-    /// assert!(parser("123123").is_err());
-    /// assert!(parser("").is_err());
+    /// assert_eq!(parser.parse_peek("abcabc"), Ok(("", vec!["abc", "abc"])));
+    /// assert_eq!(parser.parse_peek("abc123"), Ok(("123", vec!["abc"])));
+    /// assert!(parser.parse_peek("123123").is_err());
+    /// assert!(parser.parse_peek("").is_err());
     /// ```
     ///
     /// Arbitrary number of repetitions:
     /// ```rust
-    /// # use winnow::error::IResult;
     /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
-    /// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+    /// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
     ///   repeat(
     ///     0..=2,
     ///     "abc",
@@ -248,14 +241,14 @@ where
     ///       acc.push(item);
     ///       acc
     ///     }
-    ///   ).parse_peek(s)
+    ///   ).parse_next(s)
     /// }
     ///
-    /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-    /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-    /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-    /// assert_eq!(parser(""), Ok(("", vec![])));
-    /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+    /// assert_eq!(parser.parse_peek("abcabc"), Ok(("", vec!["abc", "abc"])));
+    /// assert_eq!(parser.parse_peek("abc123"), Ok(("123", vec!["abc"])));
+    /// assert_eq!(parser.parse_peek("123123"), Ok(("123123", vec![])));
+    /// assert_eq!(parser.parse_peek(""), Ok(("", vec![])));
+    /// assert_eq!(parser.parse_peek("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
     /// ```
     #[doc(alias = "fold_many0")]
     #[doc(alias = "fold_many1")]
@@ -314,13 +307,12 @@ where
     ///
     /// Guaranteeing that the input had unique elements:
     /// ```rust
-    /// # use winnow::error::IResult;
     /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     /// use std::collections::HashSet;
     ///
-    /// fn parser(s: &str) -> IResult<&str, HashSet<&str>> {
+    /// fn parser<'i>(s: &mut &'i str) -> PResult<HashSet<&'i str>> {
     ///   repeat(
     ///     0..,
     ///     "abc"
@@ -333,14 +325,14 @@ where
     ///          None
     ///       }
     ///     }
-    ///   ).parse_peek(s)
+    ///   ).parse_next(s)
     /// }
     ///
-    /// assert_eq!(parser("abc"), Ok(("", HashSet::from(["abc"]))));
-    /// assert!(parser("abcabc").is_err());
-    /// assert_eq!(parser("abc123"), Ok(("123", HashSet::from(["abc"]))));
-    /// assert_eq!(parser("123123"), Ok(("123123", HashSet::from([]))));
-    /// assert_eq!(parser(""), Ok(("", HashSet::from([]))));
+    /// assert_eq!(parser.parse_peek("abc"), Ok(("", HashSet::from(["abc"]))));
+    /// assert!(parser.parse_peek("abcabc").is_err());
+    /// assert_eq!(parser.parse_peek("abc123"), Ok(("123", HashSet::from(["abc"]))));
+    /// assert_eq!(parser.parse_peek("123123"), Ok(("123123", HashSet::from([]))));
+    /// assert_eq!(parser.parse_peek(""), Ok(("", HashSet::from([]))));
     /// ```
     #[inline(always)]
     pub fn verify_fold<Init, Op, Result>(
@@ -391,14 +383,13 @@ where
     ///
     /// Writing the output to a vector of bytes:
     /// ```rust
-    /// # use winnow::error::IResult;
     /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     /// use std::io::Write;
     /// use std::io::Error;
     ///
-    /// fn parser(s: &str) -> IResult<&str, Vec<u8>> {
+    /// fn parser(s: &mut &str) -> PResult<Vec<u8>> {
     ///   repeat(
     ///     0..,
     ///     "abc"
@@ -408,13 +399,13 @@ where
     ///       acc.write(item.as_bytes())?;
     ///       Ok(acc)
     ///     }
-    ///   ).parse_peek(s)
+    ///   ).parse_next(s)
     /// }
     ///
-    /// assert_eq!(parser("abc"), Ok(("", b"abc".to_vec())));
-    /// assert_eq!(parser("abc123"), Ok(("123", b"abc".to_vec())));
-    /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-    /// assert_eq!(parser(""), Ok(("", vec![])));
+    /// assert_eq!(parser.parse_peek("abc"), Ok(("", b"abc".to_vec())));
+    /// assert_eq!(parser.parse_peek("abc123"), Ok(("123", b"abc".to_vec())));
+    /// assert_eq!(parser.parse_peek("123123"), Ok(("123123", vec![])));
+    /// assert_eq!(parser.parse_peek(""), Ok(("", vec![])));
     #[inline(always)]
     pub fn try_fold<Init, Op, OpError, Result>(
         mut self,
@@ -634,20 +625,19 @@ where
 ///
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat_till;
 ///
-/// fn parser(s: &str) -> IResult<&str, (Vec<&str>, &str)> {
-///   repeat_till(0.., "abc", "end").parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<(Vec<&'i str>, &'i str)> {
+///   repeat_till(0.., "abc", "end").parse_next(s)
 /// };
 ///
-/// assert_eq!(parser("abcabcend"), Ok(("", (vec!["abc", "abc"], "end"))));
-/// assert!(parser("abc123end").is_err());
-/// assert!(parser("123123end").is_err());
-/// assert!(parser("").is_err());
-/// assert_eq!(parser("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
+/// assert_eq!(parser.parse_peek("abcabcend"), Ok(("", (vec!["abc", "abc"], "end"))));
+/// assert!(parser.parse_peek("abc123end").is_err());
+/// assert!(parser.parse_peek("123123end").is_err());
+/// assert!(parser.parse_peek("").is_err());
+/// assert_eq!(parser.parse_peek("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
 /// # }
 /// ```
 #[doc(alias = "many_till0")]
@@ -800,80 +790,76 @@ where
 /// Zero or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated(0.., "abc", "|").parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+///   separated(0.., "abc", "|").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
-/// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
-/// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
-/// assert_eq!(parser("def|abc"), Ok(("def|abc", vec![])));
+/// assert_eq!(parser.parse_peek("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
+/// assert_eq!(parser.parse_peek("abc123abc"), Ok(("123abc", vec!["abc"])));
+/// assert_eq!(parser.parse_peek("abc|def"), Ok(("|def", vec!["abc"])));
+/// assert_eq!(parser.parse_peek(""), Ok(("", vec![])));
+/// assert_eq!(parser.parse_peek("def|abc"), Ok(("def|abc", vec![])));
 /// # }
 /// ```
 ///
 /// One or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated(1.., "abc", "|").parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+///   separated(1.., "abc", "|").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
-/// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
-/// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
-/// assert!(parser("").is_err());
-/// assert!(parser("def|abc").is_err());
+/// assert_eq!(parser.parse_peek("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
+/// assert_eq!(parser.parse_peek("abc123abc"), Ok(("123abc", vec!["abc"])));
+/// assert_eq!(parser.parse_peek("abc|def"), Ok(("|def", vec!["abc"])));
+/// assert!(parser.parse_peek("").is_err());
+/// assert!(parser.parse_peek("def|abc").is_err());
 /// # }
 /// ```
 ///
 /// Fixed number of repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated(2, "abc", "|").parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+///   separated(2, "abc", "|").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("abc|abc|abc"), Ok(("|abc", vec!["abc", "abc"])));
-/// assert!(parser("abc123abc").is_err());
-/// assert!(parser("abc|def").is_err());
-/// assert!(parser("").is_err());
-/// assert!(parser("def|abc").is_err());
+/// assert_eq!(parser.parse_peek("abc|abc|abc"), Ok(("|abc", vec!["abc", "abc"])));
+/// assert!(parser.parse_peek("abc123abc").is_err());
+/// assert!(parser.parse_peek("abc|def").is_err());
+/// assert!(parser.parse_peek("").is_err());
+/// assert!(parser.parse_peek("def|abc").is_err());
 /// # }
 /// ```
 ///
 /// Arbitrary repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated(0..=2, "abc", "|").parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+///   separated(0..=2, "abc", "|").parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("abc|abc|abc"), Ok(("|abc", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
-/// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
-/// assert_eq!(parser("def|abc"), Ok(("def|abc", vec![])));
+/// assert_eq!(parser.parse_peek("abc|abc|abc"), Ok(("|abc", vec!["abc", "abc"])));
+/// assert_eq!(parser.parse_peek("abc123abc"), Ok(("123abc", vec!["abc"])));
+/// assert_eq!(parser.parse_peek("abc|def"), Ok(("|def", vec!["abc"])));
+/// assert_eq!(parser.parse_peek(""), Ok(("", vec![])));
+/// assert_eq!(parser.parse_peek("def|abc"), Ok(("def|abc", vec![])));
 /// # }
 /// ```
 #[doc(alias = "sep_by")]
@@ -1196,19 +1182,18 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_foldl1;
 /// use winnow::ascii::dec_int;
 ///
-/// fn parser(s: &str) -> IResult<&str, i32> {
-///   separated_foldl1(dec_int, "-", |l, _, r| l - r).parse_peek(s)
+/// fn parser(s: &mut &str) -> PResult<i32> {
+///   separated_foldl1(dec_int, "-", |l, _, r| l - r).parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("9-3-5"), Ok(("", 1)));
-/// assert!(parser("").is_err());
-/// assert!(parser("def|abc").is_err());
+/// assert_eq!(parser.parse_peek("9-3-5"), Ok(("", 1)));
+/// assert!(parser.parse_peek("").is_err());
+/// assert!(parser.parse_peek("def|abc").is_err());
 /// ```
 pub fn separated_foldl1<Input, Output, Sep, Error, ParseNext, SepParser, Op>(
     mut parser: ParseNext,
@@ -1264,20 +1249,19 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_foldr1;
 /// use winnow::ascii::dec_uint;
 ///
-/// fn parser(s: &str) -> IResult<&str, u32> {
-///   separated_foldr1(dec_uint, "^", |l: u32, _, r: u32| l.pow(r)).parse_peek(s)
+/// fn parser(s: &mut &str) -> PResult<u32> {
+///   separated_foldr1(dec_uint, "^", |l: u32, _, r: u32| l.pow(r)).parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("2^3^2"), Ok(("", 512)));
-/// assert_eq!(parser("2"), Ok(("", 2)));
-/// assert!(parser("").is_err());
-/// assert!(parser("def|abc").is_err());
+/// assert_eq!(parser.parse_peek("2^3^2"), Ok(("", 512)));
+/// assert_eq!(parser.parse_peek("2"), Ok(("", 2)));
+/// assert!(parser.parse_peek("").is_err());
+/// assert!(parser.parse_peek("def|abc").is_err());
 /// ```
 #[cfg(feature = "alloc")]
 pub fn separated_foldr1<Input, Output, Sep, Error, ParseNext, SepParser, Op>(
@@ -1316,22 +1300,21 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::fill;
 ///
-/// fn parser(s: &str) -> IResult<&str, [&str; 2]> {
+/// fn parser<'i>(s: &mut &'i str) -> PResult<[&'i str; 2]> {
 ///   let mut buf = ["", ""];
-///   let (rest, ()) = fill("abc", &mut buf).parse_peek(s)?;
-///   Ok((rest, buf))
+///   fill("abc", &mut buf).parse_next(s)?;
+///   Ok(buf)
 /// }
 ///
-/// assert_eq!(parser("abcabc"), Ok(("", ["abc", "abc"])));
-/// assert!(parser("abc123").is_err());
-/// assert!(parser("123123").is_err());
-/// assert!(parser("").is_err());
-/// assert_eq!(parser("abcabcabc"), Ok(("abc", ["abc", "abc"])));
+/// assert_eq!(parser.parse_peek("abcabc"), Ok(("", ["abc", "abc"])));
+/// assert!(parser.parse_peek("abc123").is_err());
+/// assert!(parser.parse_peek("123123").is_err());
+/// assert!(parser.parse_peek("").is_err());
+/// assert_eq!(parser.parse_peek("abcabcabc"), Ok(("abc", ["abc", "abc"])));
 /// ```
 pub fn fill<'i, Input, Output, Error, ParseNext>(
     mut parser: ParseNext,

--- a/src/combinator/sequence.rs
+++ b/src/combinator/sequence.rs
@@ -24,8 +24,8 @@ pub use crate::seq;
 ///
 /// assert_eq!(parser.parse_peek("abcefg"), Ok(("", "efg")));
 /// assert_eq!(parser.parse_peek("abcefghij"), Ok(("hij", "efg")));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek("123"), Err(ErrMode::Backtrack(InputError::new("123", ErrorKind::Literal))));
+/// assert!(parser.parse_peek("").is_err());
+/// assert!(parser.parse_peek("123").is_err());
 /// ```
 #[doc(alias = "ignore_then")]
 pub fn preceded<Input, Ignored, Output, Error, IgnoredParser, ParseNext>(
@@ -62,8 +62,8 @@ where
 ///
 /// assert_eq!(parser.parse_peek("abcefg"), Ok(("", "abc")));
 /// assert_eq!(parser.parse_peek("abcefghij"), Ok(("hij", "abc")));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek("123"), Err(ErrMode::Backtrack(InputError::new("123", ErrorKind::Literal))));
+/// assert!(parser.parse_peek("").is_err());
+/// assert!(parser.parse_peek("123").is_err());
 /// ```
 #[doc(alias = "then_ignore")]
 pub fn terminated<Input, Output, Ignored, Error, ParseNext, IgnoredParser>(
@@ -100,8 +100,8 @@ where
 ///
 /// assert_eq!(parser.parse_peek("abc|efg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser.parse_peek("abc|efghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek("123"), Err(ErrMode::Backtrack(InputError::new("123", ErrorKind::Literal))));
+/// assert!(parser.parse_peek("").is_err());
+/// assert!(parser.parse_peek("123").is_err());
 /// ```
 pub fn separated_pair<Input, O1, Sep, O2, Error, P1, SepParser, P2>(
     mut first: P1,
@@ -140,8 +140,8 @@ where
 ///
 /// assert_eq!(parser.parse_peek("(abc)"), Ok(("", "abc")));
 /// assert_eq!(parser.parse_peek("(abc)def"), Ok(("def", "abc")));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek("123"), Err(ErrMode::Backtrack(InputError::new("123", ErrorKind::Literal))));
+/// assert!(parser.parse_peek("").is_err());
+/// assert!(parser.parse_peek("123").is_err());
 /// ```
 #[doc(alias = "between")]
 #[doc(alias = "padded")]

--- a/src/combinator/sequence.rs
+++ b/src/combinator/sequence.rs
@@ -13,12 +13,12 @@ pub use crate::seq;
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::preceded;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
 ///     preceded("abc", "efg").parse_next(input)
 /// }
 ///
@@ -51,12 +51,12 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::terminated;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
 ///     terminated("abc", "efg").parse_next(input)
 /// }
 ///
@@ -89,12 +89,12 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::error::Needed::Size;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_pair;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<(&'i str, &'i str), InputError<&'i str>> {
+/// fn parser<'i>(input: &mut &'i str) -> PResult<(&'i str, &'i str)> {
 ///     separated_pair("abc", "|", "efg").parse_next(input)
 /// }
 ///
@@ -129,12 +129,12 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
 /// # use winnow::error::Needed::Size;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::delimited;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
 ///     delimited("(", "abc", ")").parse_next(input)
 /// }
 ///

--- a/src/combinator/sequence.rs
+++ b/src/combinator/sequence.rs
@@ -18,7 +18,9 @@ pub use crate::seq;
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::preceded;
 ///
-/// let mut parser = preceded("abc", "efg");
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+///     preceded("abc", "efg").parse_next(input)
+/// }
 ///
 /// assert_eq!(parser.parse_peek("abcefg"), Ok(("", "efg")));
 /// assert_eq!(parser.parse_peek("abcefghij"), Ok(("hij", "efg")));
@@ -54,7 +56,9 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::terminated;
 ///
-/// let mut parser = terminated("abc", "efg");
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+///     terminated("abc", "efg").parse_next(input)
+/// }
 ///
 /// assert_eq!(parser.parse_peek("abcefg"), Ok(("", "abc")));
 /// assert_eq!(parser.parse_peek("abcefghij"), Ok(("hij", "abc")));
@@ -90,7 +94,9 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_pair;
 ///
-/// let mut parser = separated_pair("abc", "|", "efg");
+/// fn parser<'i>(input: &mut &'i str) -> PResult<(&'i str, &'i str), InputError<&'i str>> {
+///     separated_pair("abc", "|", "efg").parse_next(input)
+/// }
 ///
 /// assert_eq!(parser.parse_peek("abc|efg"), Ok(("", ("abc", "efg"))));
 /// assert_eq!(parser.parse_peek("abc|efghij"), Ok(("hij", ("abc", "efg"))));
@@ -128,7 +134,9 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::delimited;
 ///
-/// let mut parser = delimited("(", "abc", ")");
+/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+///     delimited("(", "abc", ")").parse_next(input)
+/// }
 ///
 /// assert_eq!(parser.parse_peek("(abc)"), Ok(("", "abc")));
 /// assert_eq!(parser.parse_peek("(abc)def"), Ok(("def", "abc")));

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -20,13 +20,6 @@ use crate::Partial;
 #[cfg(feature = "alloc")]
 use crate::lib::std::vec::Vec;
 
-macro_rules! assert_parse(
-  ($left: expr, $right: expr) => {
-    let res: $crate::error::IResult<_, _, InputError<_>> = $left;
-    assert_eq!(res, $right);
-  };
-);
-
 #[test]
 fn eof_on_slices() {
     let not_over: &[u8] = &b"Hello, world!"[..];

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -6,7 +6,6 @@ use crate::binary::u8;
 use crate::binary::Endianness;
 use crate::error::ErrMode;
 use crate::error::ErrorKind;
-use crate::error::IResult;
 use crate::error::InputError;
 use crate::error::Needed;
 use crate::error::ParserError;
@@ -83,9 +82,9 @@ impl<I: Stream> ParserError<I> for CustomError {
 
 struct CustomError;
 #[allow(dead_code)]
-fn custom_error(input: &[u8]) -> IResult<&[u8], &[u8], CustomError> {
+fn custom_error<'i>(input: &mut &'i [u8]) -> PResult<&'i [u8], CustomError> {
     //fix_error!(input, CustomError<_>, alphanumeric)
-    crate::ascii::alphanumeric1.parse_peek(input)
+    crate::ascii::alphanumeric1.parse_next(input)
 }
 
 #[test]
@@ -98,9 +97,9 @@ fn test_parser_flat_map() {
 }
 
 #[allow(dead_code)]
-fn test_closure_compiles_195(input: &[u8]) -> IResult<&[u8], ()> {
+fn test_closure_compiles_195(input: &mut &[u8]) -> PResult<()> {
     u8.flat_map(|num| repeat(num as usize, u16(Endianness::Big)))
-        .parse_peek(input)
+        .parse_next(input)
 }
 
 #[test]
@@ -137,50 +136,50 @@ fn test_parser_into() {
     use crate::token::take;
 
     let mut parser = take::<_, _, InputError<_>>(3u8).output_into();
-    let result: IResult<&[u8], Vec<u8>> = parser.parse_peek(&b"abcdefg"[..]);
+    let result: crate::error::IResult<&[u8], Vec<u8>> = parser.parse_peek(&b"abcdefg"[..]);
 
     assert_eq!(result, Ok((&b"defg"[..], vec![97, 98, 99])));
 }
 
 #[test]
 fn opt_test() {
-    fn opt_abcd(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Option<&[u8]>> {
-        opt("abcd").parse_peek(i)
+    fn opt_abcd<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Option<&'i [u8]>> {
+        opt("abcd").parse_next(i)
     }
 
     let a = &b"abcdef"[..];
     let b = &b"bcdefg"[..];
     let c = &b"ab"[..];
     assert_eq!(
-        opt_abcd(Partial::new(a)),
+        opt_abcd.parse_peek(Partial::new(a)),
         Ok((Partial::new(&b"ef"[..]), Some(&b"abcd"[..])))
     );
     assert_eq!(
-        opt_abcd(Partial::new(b)),
+        opt_abcd.parse_peek(Partial::new(b)),
         Ok((Partial::new(&b"bcdefg"[..]), None))
     );
     assert_eq!(
-        opt_abcd(Partial::new(c)),
+        opt_abcd.parse_peek(Partial::new(c)),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
 }
 
 #[test]
 fn peek_test() {
-    fn peek_literal(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        peek("abcd").parse_peek(i)
+    fn peek_literal<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        peek("abcd").parse_next(i)
     }
 
     assert_eq!(
-        peek_literal(Partial::new(&b"abcdef"[..])),
+        peek_literal.parse_peek(Partial::new(&b"abcdef"[..])),
         Ok((Partial::new(&b"abcdef"[..]), &b"abcd"[..]))
     );
     assert_eq!(
-        peek_literal(Partial::new(&b"ab"[..])),
+        peek_literal.parse_peek(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        peek_literal(Partial::new(&b"xxx"[..])),
+        peek_literal.parse_peek(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Literal
@@ -190,23 +189,23 @@ fn peek_test() {
 
 #[test]
 fn not_test() {
-    fn not_aaa(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, ()> {
-        not("aaa").parse_peek(i)
+    fn not_aaa(i: &mut Partial<&[u8]>) -> PResult<()> {
+        not("aaa").parse_next(i)
     }
 
     assert_eq!(
-        not_aaa(Partial::new(&b"aaa"[..])),
+        not_aaa.parse_peek(Partial::new(&b"aaa"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"aaa"[..]),
             ErrorKind::Not
         )))
     );
     assert_eq!(
-        not_aaa(Partial::new(&b"aa"[..])),
+        not_aaa.parse_peek(Partial::new(&b"aa"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        not_aaa(Partial::new(&b"abcd"[..])),
+        not_aaa.parse_peek(Partial::new(&b"abcd"[..])),
         Ok((Partial::new(&b"abcd"[..]), ()))
     );
 }
@@ -215,24 +214,24 @@ fn not_test() {
 fn test_parser_verify() {
     use crate::token::take;
 
-    fn test(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
+    fn test<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
         take(5u8)
             .verify(|slice: &[u8]| slice[0] == b'a')
-            .parse_peek(i)
+            .parse_next(i)
     }
     assert_eq!(
-        test(Partial::new(&b"bcd"[..])),
+        test.parse_peek(Partial::new(&b"bcd"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        test(Partial::new(&b"bcdefg"[..])),
+        test.parse_peek(Partial::new(&b"bcdefg"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"bcdefg"[..]),
             ErrorKind::Verify
         )))
     );
     assert_eq!(
-        test(Partial::new(&b"abcdefg"[..])),
+        test.parse_peek(Partial::new(&b"abcdefg"[..])),
         Ok((Partial::new(&b"fg"[..]), &b"abcde"[..]))
     );
 }
@@ -256,10 +255,10 @@ fn test_parser_verify_ref() {
         )))
     );
 
-    fn parser2(i: &[u8]) -> IResult<&[u8], u32> {
+    fn parser2(i: &mut &[u8]) -> PResult<u32> {
         crate::binary::be_u32
             .verify(|val: &u32| *val < 3)
-            .parse_peek(i)
+            .parse_next(i)
     }
 }
 
@@ -301,13 +300,13 @@ fn fail_test() {
 
 #[test]
 fn complete() {
-    fn err_test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        let (i, _) = "ijkl".parse_peek(i)?;
-        "mnop".parse_peek(i)
+    fn err_test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        let _ = "ijkl".parse_next(i)?;
+        "mnop".parse_next(i)
     }
     let a = &b"ijklmn"[..];
 
-    let res_a = err_test(a);
+    let res_a = err_test.parse_peek(a);
     assert_eq!(
         res_a,
         Err(ErrMode::Backtrack(error_position!(
@@ -320,38 +319,38 @@ fn complete() {
 #[test]
 fn separated_pair_test() {
     #[allow(clippy::type_complexity)]
-    fn sep_pair_abc_def(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8])> {
-        separated_pair("abc", ",", "def").parse_peek(i)
+    fn sep_pair_abc_def<'i>(i: &mut Partial<&'i [u8]>) -> PResult<(&'i [u8], &'i [u8])> {
+        separated_pair("abc", ",", "def").parse_next(i)
     }
 
     assert_eq!(
-        sep_pair_abc_def(Partial::new(&b"abc,defghijkl"[..])),
+        sep_pair_abc_def.parse_peek(Partial::new(&b"abc,defghijkl"[..])),
         Ok((Partial::new(&b"ghijkl"[..]), (&b"abc"[..], &b"def"[..])))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial::new(&b"ab"[..])),
+        sep_pair_abc_def.parse_peek(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial::new(&b"abc,d"[..])),
+        sep_pair_abc_def.parse_peek(Partial::new(&b"abc,d"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial::new(&b"xxx"[..])),
+        sep_pair_abc_def.parse_peek(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial::new(&b"xxx,def"[..])),
+        sep_pair_abc_def.parse_peek(Partial::new(&b"xxx,def"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx,def"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        sep_pair_abc_def(Partial::new(&b"abc,xxx"[..])),
+        sep_pair_abc_def.parse_peek(Partial::new(&b"abc,xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Literal
@@ -361,38 +360,38 @@ fn separated_pair_test() {
 
 #[test]
 fn preceded_test() {
-    fn preceded_abcd_efgh(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        preceded("abcd", "efgh").parse_peek(i)
+    fn preceded_abcd_efgh<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        preceded("abcd", "efgh").parse_next(i)
     }
 
     assert_eq!(
-        preceded_abcd_efgh(Partial::new(&b"abcdefghijkl"[..])),
+        preceded_abcd_efgh.parse_peek(Partial::new(&b"abcdefghijkl"[..])),
         Ok((Partial::new(&b"ijkl"[..]), &b"efgh"[..]))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial::new(&b"ab"[..])),
+        preceded_abcd_efgh.parse_peek(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial::new(&b"abcde"[..])),
+        preceded_abcd_efgh.parse_peek(Partial::new(&b"abcde"[..])),
         Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial::new(&b"xxx"[..])),
+        preceded_abcd_efgh.parse_peek(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial::new(&b"xxxxdef"[..])),
+        preceded_abcd_efgh.parse_peek(Partial::new(&b"xxxxdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxxxdef"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        preceded_abcd_efgh(Partial::new(&b"abcdxxx"[..])),
+        preceded_abcd_efgh.parse_peek(Partial::new(&b"abcdxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Literal
@@ -402,38 +401,38 @@ fn preceded_test() {
 
 #[test]
 fn terminated_test() {
-    fn terminated_abcd_efgh(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        terminated("abcd", "efgh").parse_peek(i)
+    fn terminated_abcd_efgh<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        terminated("abcd", "efgh").parse_next(i)
     }
 
     assert_eq!(
-        terminated_abcd_efgh(Partial::new(&b"abcdefghijkl"[..])),
+        terminated_abcd_efgh.parse_peek(Partial::new(&b"abcdefghijkl"[..])),
         Ok((Partial::new(&b"ijkl"[..]), &b"abcd"[..]))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial::new(&b"ab"[..])),
+        terminated_abcd_efgh.parse_peek(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial::new(&b"abcde"[..])),
+        terminated_abcd_efgh.parse_peek(Partial::new(&b"abcde"[..])),
         Err(ErrMode::Incomplete(Needed::new(3)))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial::new(&b"xxx"[..])),
+        terminated_abcd_efgh.parse_peek(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial::new(&b"xxxxdef"[..])),
+        terminated_abcd_efgh.parse_peek(Partial::new(&b"xxxxdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxxxdef"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        terminated_abcd_efgh(Partial::new(&b"abcdxxxx"[..])),
+        terminated_abcd_efgh.parse_peek(Partial::new(&b"abcdxxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxxx"[..]),
             ErrorKind::Literal
@@ -443,49 +442,49 @@ fn terminated_test() {
 
 #[test]
 fn delimited_test() {
-    fn delimited_abc_def_ghi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        delimited("abc", "def", "ghi").parse_peek(i)
+    fn delimited_abc_def_ghi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        delimited("abc", "def", "ghi").parse_next(i)
     }
 
     assert_eq!(
-        delimited_abc_def_ghi(Partial::new(&b"abcdefghijkl"[..])),
+        delimited_abc_def_ghi.parse_peek(Partial::new(&b"abcdefghijkl"[..])),
         Ok((Partial::new(&b"jkl"[..]), &b"def"[..]))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial::new(&b"ab"[..])),
+        delimited_abc_def_ghi.parse_peek(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial::new(&b"abcde"[..])),
+        delimited_abc_def_ghi.parse_peek(Partial::new(&b"abcde"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial::new(&b"abcdefgh"[..])),
+        delimited_abc_def_ghi.parse_peek(Partial::new(&b"abcdefgh"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial::new(&b"xxx"[..])),
+        delimited_abc_def_ghi.parse_peek(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial::new(&b"xxxdefghi"[..])),
+        delimited_abc_def_ghi.parse_peek(Partial::new(&b"xxxdefghi"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxxdefghi"[..]),
             ErrorKind::Literal
         ),))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial::new(&b"abcxxxghi"[..])),
+        delimited_abc_def_ghi.parse_peek(Partial::new(&b"abcxxxghi"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxxghi"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        delimited_abc_def_ghi(Partial::new(&b"abcdefxxx"[..])),
+        delimited_abc_def_ghi.parse_peek(Partial::new(&b"abcdefxxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Literal
@@ -571,38 +570,38 @@ fn alt_test() {
     assert_eq!(alt2.parse_peek(a), Ok((&b""[..], a)));
     assert_eq!(alt3.parse_peek(a), Ok((a, &b""[..])));
 
-    fn alt4(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        alt(("abcd", "efgh")).parse_peek(i)
+    fn alt4<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        alt(("abcd", "efgh")).parse_next(i)
     }
     let b = &b"efgh"[..];
-    assert_eq!(alt4(a), Ok((&b""[..], a)));
-    assert_eq!(alt4(b), Ok((&b""[..], b)));
+    assert_eq!(alt4.parse_peek(a), Ok((&b""[..], a)));
+    assert_eq!(alt4.parse_peek(b), Ok((&b""[..], b)));
 }
 
 #[test]
 fn alt_incomplete() {
-    fn alt1(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        alt(("a", "bc", "def")).parse_peek(i)
+    fn alt1<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        alt(("a", "bc", "def")).parse_next(i)
     }
 
     let a = &b""[..];
     assert_eq!(
-        alt1(Partial::new(a)),
+        alt1.parse_peek(Partial::new(a)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     let a = &b"b"[..];
     assert_eq!(
-        alt1(Partial::new(a)),
+        alt1.parse_peek(Partial::new(a)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     let a = &b"bcd"[..];
     assert_eq!(
-        alt1(Partial::new(a)),
+        alt1.parse_peek(Partial::new(a)),
         Ok((Partial::new(&b"d"[..]), &b"bc"[..]))
     );
     let a = &b"cde"[..];
     assert_eq!(
-        alt1(Partial::new(a)),
+        alt1.parse_peek(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(a),
             ErrorKind::Literal
@@ -610,12 +609,12 @@ fn alt_incomplete() {
     );
     let a = &b"de"[..];
     assert_eq!(
-        alt1(Partial::new(a)),
+        alt1.parse_peek(Partial::new(a)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     let a = &b"defg"[..];
     assert_eq!(
-        alt1(Partial::new(a)),
+        alt1.parse_peek(Partial::new(a)),
         Ok((Partial::new(&b"g"[..]), &b"def"[..]))
     );
 }
@@ -661,31 +660,31 @@ fn alt_dynamic_array() {
 #[test]
 fn permutation_test() {
     #[allow(clippy::type_complexity)]
-    fn perm(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8], &[u8])> {
-        permutation(("abcd", "efg", "hi")).parse_peek(i)
+    fn perm<'i>(i: &mut Partial<&'i [u8]>) -> PResult<(&'i [u8], &'i [u8], &'i [u8])> {
+        permutation(("abcd", "efg", "hi")).parse_next(i)
     }
 
     let expected = (&b"abcd"[..], &b"efg"[..], &b"hi"[..]);
 
     let a = &b"abcdefghijk"[..];
     assert_eq!(
-        perm(Partial::new(a)),
+        perm.parse_peek(Partial::new(a)),
         Ok((Partial::new(&b"jk"[..]), expected))
     );
     let b = &b"efgabcdhijk"[..];
     assert_eq!(
-        perm(Partial::new(b)),
+        perm.parse_peek(Partial::new(b)),
         Ok((Partial::new(&b"jk"[..]), expected))
     );
     let c = &b"hiefgabcdjk"[..];
     assert_eq!(
-        perm(Partial::new(c)),
+        perm.parse_peek(Partial::new(c)),
         Ok((Partial::new(&b"jk"[..]), expected))
     );
 
     let d = &b"efgxyzabcdefghi"[..];
     assert_eq!(
-        perm(Partial::new(d)),
+        perm.parse_peek(Partial::new(d)),
         Err(ErrMode::Backtrack(error_node_position!(
             &Partial::new(&b"efgxyzabcdefghi"[..]),
             ErrorKind::Alt,
@@ -695,7 +694,7 @@ fn permutation_test() {
 
     let e = &b"efgabc"[..];
     assert_eq!(
-        perm(Partial::new(e)),
+        perm.parse_peek(Partial::new(e)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
 }
@@ -703,14 +702,14 @@ fn permutation_test() {
 #[test]
 #[cfg(feature = "alloc")]
 fn separated0_test() {
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated(0.., "abcd", ",").parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        separated(0.., "abcd", ",").parse_next(i)
     }
-    fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated(0.., "", ",").parse_peek(i)
+    fn multi_empty<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        separated(0.., "", ",").parse_next(i)
     }
-    fn multi_longsep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated(0.., "abcd", "..").parse_peek(i)
+    fn multi_longsep<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        separated(0.., "abcd", "..").parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -723,34 +722,40 @@ fn separated0_test() {
     let h = &b"abcd,abc"[..];
 
     let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(Partial::new(a)), Ok((Partial::new(&b"ef"[..]), res1)));
-    let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-    assert_eq!(multi(Partial::new(b)), Ok((Partial::new(&b"ef"[..]), res2)));
     assert_eq!(
-        multi(Partial::new(c)),
+        multi.parse_peek(Partial::new(a)),
+        Ok((Partial::new(&b"ef"[..]), res1))
+    );
+    let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
+    assert_eq!(
+        multi.parse_peek(Partial::new(b)),
+        Ok((Partial::new(&b"ef"[..]), res2))
+    );
+    assert_eq!(
+        multi.parse_peek(Partial::new(c)),
         Ok((Partial::new(&b"azerty"[..]), Vec::new()))
     );
     let res3 = vec![&b""[..], &b""[..], &b""[..]];
     assert_eq!(
-        multi_empty(Partial::new(d)),
+        multi_empty.parse_peek(Partial::new(d)),
         Ok((Partial::new(&b"abc"[..]), res3))
     );
     let res4 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(
-        multi(Partial::new(e)),
+        multi.parse_peek(Partial::new(e)),
         Ok((Partial::new(&b",ef"[..]), res4))
     );
 
     assert_eq!(
-        multi(Partial::new(f)),
+        multi.parse_peek(Partial::new(f)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        multi_longsep(Partial::new(g)),
+        multi_longsep.parse_peek(Partial::new(g)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        multi(Partial::new(h)),
+        multi.parse_peek(Partial::new(h)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
 }
@@ -759,15 +764,15 @@ fn separated0_test() {
 #[cfg(feature = "alloc")]
 #[cfg_attr(debug_assertions, should_panic)]
 fn separated0_empty_sep_test() {
-    fn empty_sep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated(0.., "abc", "").parse_peek(i)
+    fn empty_sep<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        separated(0.., "abc", "").parse_next(i)
     }
 
     let i = &b"abcabc"[..];
 
     let i_err_pos = &i[3..];
     assert_eq!(
-        empty_sep(Partial::new(i)),
+        empty_sep.parse_peek(Partial::new(i)),
         Err(ErrMode::Cut(error_position!(
             &Partial::new(i_err_pos),
             ErrorKind::Assert
@@ -778,11 +783,11 @@ fn separated0_empty_sep_test() {
 #[test]
 #[cfg(feature = "alloc")]
 fn separated1_test() {
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated(1.., "abcd", ",").parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        separated(1.., "abcd", ",").parse_next(i)
     }
-    fn multi_longsep(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated(1.., "abcd", "..").parse_peek(i)
+    fn multi_longsep<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        separated(1.., "abcd", "..").parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -795,11 +800,17 @@ fn separated1_test() {
     let h = &b"abcd,abc"[..];
 
     let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(Partial::new(a)), Ok((Partial::new(&b"ef"[..]), res1)));
-    let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-    assert_eq!(multi(Partial::new(b)), Ok((Partial::new(&b"ef"[..]), res2)));
     assert_eq!(
-        multi(Partial::new(c)),
+        multi.parse_peek(Partial::new(a)),
+        Ok((Partial::new(&b"ef"[..]), res1))
+    );
+    let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
+    assert_eq!(
+        multi.parse_peek(Partial::new(b)),
+        Ok((Partial::new(&b"ef"[..]), res2))
+    );
+    assert_eq!(
+        multi.parse_peek(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(c),
             ErrorKind::Literal
@@ -807,20 +818,20 @@ fn separated1_test() {
     );
     let res3 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(
-        multi(Partial::new(d)),
+        multi.parse_peek(Partial::new(d)),
         Ok((Partial::new(&b",ef"[..]), res3))
     );
 
     assert_eq!(
-        multi(Partial::new(f)),
+        multi.parse_peek(Partial::new(f)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        multi_longsep(Partial::new(g)),
+        multi_longsep.parse_peek(Partial::new(g)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        multi(Partial::new(h)),
+        multi.parse_peek(Partial::new(h)),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
 }
@@ -828,8 +839,8 @@ fn separated1_test() {
 #[test]
 #[cfg(feature = "alloc")]
 fn separated_test() {
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        separated(2..=4, "abcd", ",").parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        separated(2..=4, "abcd", ",").parse_next(i)
     }
 
     let a = &b"abcd,ef"[..];
@@ -839,7 +850,7 @@ fn separated_test() {
     let e = &b"abcd,ab"[..];
 
     assert_eq!(
-        multi(Partial::new(a)),
+        multi.parse_peek(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"ef"[..]),
             ErrorKind::Literal
@@ -847,21 +858,21 @@ fn separated_test() {
     );
     let res1 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(
-        multi(Partial::new(b)),
+        multi.parse_peek(Partial::new(b)),
         Ok((Partial::new(&b",efgh"[..]), res1))
     );
     let res2 = vec![&b"abcd"[..], &b"abcd"[..], &b"abcd"[..], &b"abcd"[..]];
     assert_eq!(
-        multi(Partial::new(c)),
+        multi.parse_peek(Partial::new(c)),
         Ok((Partial::new(&b",efgh"[..]), res2))
     );
     let res3 = vec![&b"abcd"[..], &b"abcd"[..], &b"abcd"[..], &b"abcd"[..]];
     assert_eq!(
-        multi(Partial::new(d)),
+        multi.parse_peek(Partial::new(d)),
         Ok((Partial::new(&b",abcd,efgh"[..]), res3))
     );
     assert_eq!(
-        multi(Partial::new(e)),
+        multi.parse_peek(Partial::new(e)),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
 }
@@ -869,32 +880,32 @@ fn separated_test() {
 #[test]
 #[cfg(feature = "alloc")]
 fn repeat0_test() {
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(0.., "abcd").parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(0.., "abcd").parse_next(i)
     }
 
     assert_eq!(
-        multi(Partial::new(&b"abcdef"[..])),
+        multi.parse_peek(Partial::new(&b"abcdef"[..])),
         Ok((Partial::new(&b"ef"[..]), vec![&b"abcd"[..]]))
     );
     assert_eq!(
-        multi(Partial::new(&b"abcdabcdefgh"[..])),
+        multi.parse_peek(Partial::new(&b"abcdabcdefgh"[..])),
         Ok((Partial::new(&b"efgh"[..]), vec![&b"abcd"[..], &b"abcd"[..]]))
     );
     assert_eq!(
-        multi(Partial::new(&b"azerty"[..])),
+        multi.parse_peek(Partial::new(&b"azerty"[..])),
         Ok((Partial::new(&b"azerty"[..]), Vec::new()))
     );
     assert_eq!(
-        multi(Partial::new(&b"abcdab"[..])),
+        multi.parse_peek(Partial::new(&b"abcdab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        multi(Partial::new(&b"abcd"[..])),
+        multi.parse_peek(Partial::new(&b"abcd"[..])),
         Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_eq!(
-        multi(Partial::new(&b""[..])),
+        multi.parse_peek(Partial::new(&b""[..])),
         Err(ErrMode::Incomplete(Needed::new(4)))
     );
 }
@@ -903,12 +914,12 @@ fn repeat0_test() {
 #[cfg(feature = "alloc")]
 #[cfg_attr(debug_assertions, should_panic)]
 fn repeat0_empty_test() {
-    fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(0.., "").parse_peek(i)
+    fn multi_empty<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(0.., "").parse_next(i)
     }
 
     assert_eq!(
-        multi_empty(Partial::new(&b"abcdef"[..])),
+        multi_empty.parse_peek(Partial::new(&b"abcdef"[..])),
         Err(ErrMode::Cut(error_position!(
             &Partial::new(&b"abcdef"[..]),
             ErrorKind::Assert
@@ -919,8 +930,8 @@ fn repeat0_empty_test() {
 #[test]
 #[cfg(feature = "alloc")]
 fn repeat1_test() {
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(1.., "abcd").parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(1.., "abcd").parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -929,21 +940,24 @@ fn repeat1_test() {
     let d = &b"abcdab"[..];
 
     let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(Partial::new(a)), Ok((Partial::new(&b"ef"[..]), res1)));
+    assert_eq!(
+        multi.parse_peek(Partial::new(a)),
+        Ok((Partial::new(&b"ef"[..]), res1))
+    );
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(
-        multi(Partial::new(b)),
+        multi.parse_peek(Partial::new(b)),
         Ok((Partial::new(&b"efgh"[..]), res2))
     );
     assert_eq!(
-        multi(Partial::new(c)),
+        multi.parse_peek(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(c),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        multi(Partial::new(d)),
+        multi.parse_peek(Partial::new(d)),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
 }
@@ -952,8 +966,8 @@ fn repeat1_test() {
 #[cfg(feature = "alloc")]
 fn repeat_till_test() {
     #[allow(clippy::type_complexity)]
-    fn multi(i: &[u8]) -> IResult<&[u8], (Vec<&[u8]>, &[u8])> {
-        repeat_till(0.., "abcd", "efgh").parse_peek(i)
+    fn multi<'i>(i: &mut &'i [u8]) -> PResult<(Vec<&'i [u8]>, &'i [u8])> {
+        repeat_till(0.., "abcd", "efgh").parse_next(i)
     }
 
     let a = b"abcdabcdefghabcd";
@@ -962,10 +976,10 @@ fn repeat_till_test() {
 
     let res_a = (vec![&b"abcd"[..], &b"abcd"[..]], &b"efgh"[..]);
     let res_b: (Vec<&[u8]>, &[u8]) = (Vec::new(), &b"efgh"[..]);
-    assert_eq!(multi(&a[..]), Ok((&b"abcd"[..], res_a)));
-    assert_eq!(multi(&b[..]), Ok((&b"abcd"[..], res_b)));
+    assert_eq!(multi.parse_peek(&a[..]), Ok((&b"abcd"[..], res_a)));
+    assert_eq!(multi.parse_peek(&b[..]), Ok((&b"abcd"[..], res_b)));
     assert_eq!(
-        multi(&c[..]),
+        multi.parse_peek(&c[..]),
         Err(ErrMode::Backtrack(error_node_position!(
             &&c[..],
             ErrorKind::Repeat,
@@ -978,12 +992,12 @@ fn repeat_till_test() {
 #[cfg(feature = "alloc")]
 fn repeat_till_range_test() {
     #[allow(clippy::type_complexity)]
-    fn multi(i: &str) -> IResult<&str, (Vec<&str>, &str)> {
-        repeat_till(2..=4, "ab", "cd").parse_peek(i)
+    fn multi<'i>(i: &mut &'i str) -> PResult<(Vec<&'i str>, &'i str)> {
+        repeat_till(2..=4, "ab", "cd").parse_next(i)
     }
 
     assert_eq!(
-        multi("cd"),
+        multi.parse_peek("cd"),
         Err(ErrMode::Backtrack(error_node_position!(
             &"cd",
             ErrorKind::Repeat,
@@ -991,21 +1005,27 @@ fn repeat_till_range_test() {
         )))
     );
     assert_eq!(
-        multi("abcd"),
+        multi.parse_peek("abcd"),
         Err(ErrMode::Backtrack(error_node_position!(
             &"cd",
             ErrorKind::Repeat,
             error_position!(&"cd", ErrorKind::Literal)
         )))
     );
-    assert_eq!(multi("ababcd"), Ok(("", (vec!["ab", "ab"], "cd"))));
-    assert_eq!(multi("abababcd"), Ok(("", (vec!["ab", "ab", "ab"], "cd"))));
     assert_eq!(
-        multi("ababababcd"),
+        multi.parse_peek("ababcd"),
+        Ok(("", (vec!["ab", "ab"], "cd")))
+    );
+    assert_eq!(
+        multi.parse_peek("abababcd"),
+        Ok(("", (vec!["ab", "ab", "ab"], "cd")))
+    );
+    assert_eq!(
+        multi.parse_peek("ababababcd"),
         Ok(("", (vec!["ab", "ab", "ab", "ab"], "cd")))
     );
     assert_eq!(
-        multi("abababababcd"),
+        multi.parse_peek("abababababcd"),
         Err(ErrMode::Backtrack(error_node_position!(
             &"cd",
             ErrorKind::Repeat,
@@ -1045,8 +1065,8 @@ fn infinite_many() {
 #[test]
 #[cfg(feature = "alloc")]
 fn repeat_test() {
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(2..=4, "Abcd").parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(2..=4, "Abcd").parse_next(i)
     }
 
     let a = &b"Abcdef"[..];
@@ -1056,7 +1076,7 @@ fn repeat_test() {
     let e = &b"AbcdAb"[..];
 
     assert_eq!(
-        multi(Partial::new(a)),
+        multi.parse_peek(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"ef"[..]),
             ErrorKind::Literal
@@ -1064,21 +1084,21 @@ fn repeat_test() {
     );
     let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
     assert_eq!(
-        multi(Partial::new(b)),
+        multi.parse_peek(Partial::new(b)),
         Ok((Partial::new(&b"efgh"[..]), res1))
     );
     let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
     assert_eq!(
-        multi(Partial::new(c)),
+        multi.parse_peek(Partial::new(c)),
         Ok((Partial::new(&b"efgh"[..]), res2))
     );
     let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
     assert_eq!(
-        multi(Partial::new(d)),
+        multi.parse_peek(Partial::new(d)),
         Ok((Partial::new(&b"Abcdefgh"[..]), res3))
     );
     assert_eq!(
-        multi(Partial::new(e)),
+        multi.parse_peek(Partial::new(e)),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
 }
@@ -1087,38 +1107,38 @@ fn repeat_test() {
 #[cfg(feature = "alloc")]
 fn count_test() {
     const TIMES: usize = 2;
-    fn cnt_2(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(TIMES, "abc").parse_peek(i)
+    fn cnt_2<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(TIMES, "abc").parse_next(i)
     }
 
     assert_eq!(
-        cnt_2(Partial::new(&b"abcabcabcdef"[..])),
+        cnt_2.parse_peek(Partial::new(&b"abcabcabcdef"[..])),
         Ok((Partial::new(&b"abcdef"[..]), vec![&b"abc"[..], &b"abc"[..]]))
     );
     assert_eq!(
-        cnt_2(Partial::new(&b"ab"[..])),
+        cnt_2.parse_peek(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        cnt_2(Partial::new(&b"abcab"[..])),
+        cnt_2.parse_peek(Partial::new(&b"abcab"[..])),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        cnt_2(Partial::new(&b"xxx"[..])),
+        cnt_2.parse_peek(Partial::new(&b"xxx"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxx"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        cnt_2(Partial::new(&b"xxxabcabcdef"[..])),
+        cnt_2.parse_peek(Partial::new(&b"xxxabcabcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxxabcabcdef"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        cnt_2(Partial::new(&b"abcxxxabcdef"[..])),
+        cnt_2.parse_peek(Partial::new(&b"abcxxxabcdef"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"xxxabcdef"[..]),
             ErrorKind::Literal
@@ -1130,8 +1150,8 @@ fn count_test() {
 #[cfg(feature = "alloc")]
 fn count_zero() {
     const TIMES: usize = 0;
-    fn counter_2(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-        repeat(TIMES, "abc").parse_peek(i)
+    fn counter_2<'i>(i: &mut &'i [u8]) -> PResult<Vec<&'i [u8]>> {
+        repeat(TIMES, "abc").parse_next(i)
     }
 
     let done = &b"abcabcabcdef"[..];
@@ -1151,18 +1171,24 @@ fn count_zero() {
     let parsed_err_2 = Vec::new();
     let error_2_remain = &b"abcxxxabcdef"[..];
 
-    assert_eq!(counter_2(done), Ok((rest, parsed_done)));
+    assert_eq!(counter_2.parse_peek(done), Ok((rest, parsed_done)));
     assert_eq!(
-        counter_2(incomplete_1),
+        counter_2.parse_peek(incomplete_1),
         Ok((incomplete_1, parsed_incompl_1))
     );
     assert_eq!(
-        counter_2(incomplete_2),
+        counter_2.parse_peek(incomplete_2),
         Ok((incomplete_2, parsed_incompl_2))
     );
-    assert_eq!(counter_2(error), Ok((error_remain, parsed_err)));
-    assert_eq!(counter_2(error_1), Ok((error_1_remain, parsed_err_1)));
-    assert_eq!(counter_2(error_2), Ok((error_2_remain, parsed_err_2)));
+    assert_eq!(counter_2.parse_peek(error), Ok((error_remain, parsed_err)));
+    assert_eq!(
+        counter_2.parse_peek(error_1),
+        Ok((error_1_remain, parsed_err_1))
+    );
+    assert_eq!(
+        counter_2.parse_peek(error_2),
+        Ok((error_2_remain, parsed_err_2))
+    );
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -1190,34 +1216,34 @@ fn fold_repeat0_test() {
         acc.push(item);
         acc
     }
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
         repeat(0.., "abcd")
             .fold(Vec::new, fold_into_vec)
-            .parse_peek(i)
+            .parse_next(i)
     }
 
     assert_eq!(
-        multi(Partial::new(&b"abcdef"[..])),
+        multi.parse_peek(Partial::new(&b"abcdef"[..])),
         Ok((Partial::new(&b"ef"[..]), vec![&b"abcd"[..]]))
     );
     assert_eq!(
-        multi(Partial::new(&b"abcdabcdefgh"[..])),
+        multi.parse_peek(Partial::new(&b"abcdabcdefgh"[..])),
         Ok((Partial::new(&b"efgh"[..]), vec![&b"abcd"[..], &b"abcd"[..]]))
     );
     assert_eq!(
-        multi(Partial::new(&b"azerty"[..])),
+        multi.parse_peek(Partial::new(&b"azerty"[..])),
         Ok((Partial::new(&b"azerty"[..]), Vec::new()))
     );
     assert_eq!(
-        multi(Partial::new(&b"abcdab"[..])),
+        multi.parse_peek(Partial::new(&b"abcdab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        multi(Partial::new(&b"abcd"[..])),
+        multi.parse_peek(Partial::new(&b"abcd"[..])),
         Err(ErrMode::Incomplete(Needed::new(4)))
     );
     assert_eq!(
-        multi(Partial::new(&b""[..])),
+        multi.parse_peek(Partial::new(&b""[..])),
         Err(ErrMode::Incomplete(Needed::new(4)))
     );
 }
@@ -1230,12 +1256,12 @@ fn fold_repeat0_empty_test() {
         acc.push(item);
         acc
     }
-    fn multi_empty(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(0.., "").fold(Vec::new, fold_into_vec).parse_peek(i)
+    fn multi_empty<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(0.., "").fold(Vec::new, fold_into_vec).parse_next(i)
     }
 
     assert_eq!(
-        multi_empty(Partial::new(&b"abcdef"[..])),
+        multi_empty.parse_peek(Partial::new(&b"abcdef"[..])),
         Err(ErrMode::Cut(error_position!(
             &Partial::new(&b"abcdef"[..]),
             ErrorKind::Assert
@@ -1250,10 +1276,10 @@ fn fold_repeat1_test() {
         acc.push(item);
         acc
     }
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
         repeat(1.., "abcd")
             .fold(Vec::new, fold_into_vec)
-            .parse_peek(i)
+            .parse_next(i)
     }
 
     let a = &b"abcdef"[..];
@@ -1262,21 +1288,24 @@ fn fold_repeat1_test() {
     let d = &b"abcdab"[..];
 
     let res1 = vec![&b"abcd"[..]];
-    assert_eq!(multi(Partial::new(a)), Ok((Partial::new(&b"ef"[..]), res1)));
+    assert_eq!(
+        multi.parse_peek(Partial::new(a)),
+        Ok((Partial::new(&b"ef"[..]), res1))
+    );
     let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
     assert_eq!(
-        multi(Partial::new(b)),
+        multi.parse_peek(Partial::new(b)),
         Ok((Partial::new(&b"efgh"[..]), res2))
     );
     assert_eq!(
-        multi(Partial::new(c)),
+        multi.parse_peek(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(c),
             ErrorKind::Repeat
         )))
     );
     assert_eq!(
-        multi(Partial::new(d)),
+        multi.parse_peek(Partial::new(d)),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
 }
@@ -1288,10 +1317,10 @@ fn fold_repeat_test() {
         acc.push(item);
         acc
     }
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
         repeat(2..=4, "Abcd")
             .fold(Vec::new, fold_into_vec)
-            .parse_peek(i)
+            .parse_next(i)
     }
 
     let a = &b"Abcdef"[..];
@@ -1301,7 +1330,7 @@ fn fold_repeat_test() {
     let e = &b"AbcdAb"[..];
 
     assert_eq!(
-        multi(Partial::new(a)),
+        multi.parse_peek(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"ef"[..]),
             ErrorKind::Literal
@@ -1309,58 +1338,70 @@ fn fold_repeat_test() {
     );
     let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
     assert_eq!(
-        multi(Partial::new(b)),
+        multi.parse_peek(Partial::new(b)),
         Ok((Partial::new(&b"efgh"[..]), res1))
     );
     let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
     assert_eq!(
-        multi(Partial::new(c)),
+        multi.parse_peek(Partial::new(c)),
         Ok((Partial::new(&b"efgh"[..]), res2))
     );
     let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
     assert_eq!(
-        multi(Partial::new(d)),
+        multi.parse_peek(Partial::new(d)),
         Ok((Partial::new(&b"Abcdefgh"[..]), res3))
     );
     assert_eq!(
-        multi(Partial::new(e)),
+        multi.parse_peek(Partial::new(e)),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
 }
 
 #[test]
 fn repeat0_count_test() {
-    fn count0_nums(i: &[u8]) -> IResult<&[u8], usize> {
-        repeat(0.., (digit, ",")).parse_peek(i)
+    fn count0_nums(i: &mut &[u8]) -> PResult<usize> {
+        repeat(0.., (digit, ",")).parse_next(i)
     }
 
-    assert_eq!(count0_nums(&b"123,junk"[..]), Ok((&b"junk"[..], 1)));
-
-    assert_eq!(count0_nums(&b"123,45,junk"[..]), Ok((&b"junk"[..], 2)));
+    assert_eq!(
+        count0_nums.parse_peek(&b"123,junk"[..]),
+        Ok((&b"junk"[..], 1))
+    );
 
     assert_eq!(
-        count0_nums(&b"1,2,3,4,5,6,7,8,9,0,junk"[..]),
+        count0_nums.parse_peek(&b"123,45,junk"[..]),
+        Ok((&b"junk"[..], 2))
+    );
+
+    assert_eq!(
+        count0_nums.parse_peek(&b"1,2,3,4,5,6,7,8,9,0,junk"[..]),
         Ok((&b"junk"[..], 10))
     );
 
-    assert_eq!(count0_nums(&b"hello"[..]), Ok((&b"hello"[..], 0)));
+    assert_eq!(
+        count0_nums.parse_peek(&b"hello"[..]),
+        Ok((&b"hello"[..], 0))
+    );
 }
 
 #[test]
 fn repeat1_count_test() {
-    fn count1_nums(i: &[u8]) -> IResult<&[u8], usize> {
-        repeat(1.., (digit, ",")).parse_peek(i)
+    fn count1_nums(i: &mut &[u8]) -> PResult<usize> {
+        repeat(1.., (digit, ",")).parse_next(i)
     }
 
-    assert_eq!(count1_nums(&b"123,45,junk"[..]), Ok((&b"junk"[..], 2)));
+    assert_eq!(
+        count1_nums.parse_peek(&b"123,45,junk"[..]),
+        Ok((&b"junk"[..], 2))
+    );
 
     assert_eq!(
-        count1_nums(&b"1,2,3,4,5,6,7,8,9,0,junk"[..]),
+        count1_nums.parse_peek(&b"1,2,3,4,5,6,7,8,9,0,junk"[..]),
         Ok((&b"junk"[..], 10))
     );
 
     assert_eq!(
-        count1_nums(&b"hello"[..]),
+        count1_nums.parse_peek(&b"hello"[..]),
         Err(ErrMode::Backtrack(error_position!(
             &&b"hello"[..],
             ErrorKind::Slice

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -1313,10 +1313,8 @@ fn alt_test() {
     let a = &b"abcd"[..];
     assert_eq!(
         alt1.parse_peek(a),
-        Err(ErrMode::Backtrack(error_node_position!(
-            &a,
-            ErrorKind::Alt,
-            ErrorStr("abcd".to_owned())
+        Err(ErrMode::Backtrack(ErrorStr(
+            "custom error message: ([97, 98, 99, 100], Alt) - ErrorStr(\"abcd\")".to_owned()
         )))
     );
     assert_eq!(alt2.parse_peek(a), Ok((&b""[..], a)));
@@ -2804,10 +2802,7 @@ Err(
 fn infinite_many() {
     fn tst<'i>(input: &mut &'i [u8]) -> TestResult<&'i [u8], &'i [u8]> {
         println!("input: {input:?}");
-        Err(ErrMode::Backtrack(error_position!(
-            input,
-            ErrorKind::Literal
-        )))
+        Err(ErrMode::from_error_kind(input, ErrorKind::Literal))
     }
 
     // should not go into an infinite loop

--- a/src/error.rs
+++ b/src/error.rs
@@ -1415,20 +1415,3 @@ mod test_translate_position {
         assert_eq!(position, (1, 2));
     }
 }
-
-/// Creates a parse error from a [`ErrorKind`]
-/// and the position in the input
-#[cfg(test)]
-macro_rules! error_position(
-  ($input:expr, $code:expr) => ({
-    $crate::error::ParserError::from_error_kind($input, $code)
-  });
-);
-
-#[cfg(test)]
-macro_rules! error_node_position(
-  ($input:expr, $code:expr, $next:expr) => ({
-    let start = $input.checkpoint();
-    $crate::error::ParserError::append($next, $input, &start, $code)
-  });
-);

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,9 @@ pub type PResult<O, E = ContextError> = Result<O, ErrMode<E>>;
 /// - [`ErrMode::into_inner`]
 pub type IResult<I, O, E = InputError<I>> = PResult<(I, O), E>;
 
+#[cfg(test)]
+pub(crate) type TestResult<I, O> = PResult<O, InputError<I>>;
+
 /// Contains information on needed data if a parser returned `Incomplete`
 ///
 /// <div class="warning">

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,9 @@ pub mod prelude {
     #[cfg(feature = "unstable-recover")]
     #[cfg(feature = "std")]
     pub use crate::RecoverableParser as _;
+
+    #[cfg(test)]
+    pub(crate) use crate::TestResult;
 }
 
 pub use error::PResult;
@@ -166,3 +169,6 @@ pub use stream::LocatingSlice;
 pub use stream::Partial;
 pub use stream::Stateful;
 pub use stream::Str;
+
+#[cfg(test)]
+pub(crate) use error::TestResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(extended_key_value_attributes))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![warn(missing_docs)]
 #![warn(clippy::std_instead_of_core)]
 #![warn(clippy::print_stderr)]

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -2,4 +2,12 @@ mod dispatch;
 mod seq;
 
 #[cfg(test)]
+macro_rules! assert_parse(
+  ($left: expr, $right: expr) => {
+    let res: $crate::error::IResult<_, _, InputError<_>> = $left;
+    assert_eq!(res, $right);
+  };
+);
+
+#[cfg(test)]
 mod tests;

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -4,7 +4,7 @@ mod seq;
 #[cfg(test)]
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {
-     let res: $crate::error::IResult<_, _, InputError<_>> = $left;
+     let res: $crate::error::IResult<_, _, $crate::error::InputError<_>> = $left;
      snapbox::assert_data_eq!(snapbox::data::ToDebug::to_debug(&res), $right);
   };
 );

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -4,8 +4,8 @@ mod seq;
 #[cfg(test)]
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {
-    let res: $crate::error::IResult<_, _, InputError<_>> = $left;
-    assert_eq!(res, $right);
+     let res: $crate::error::IResult<_, _, InputError<_>> = $left;
+     snapbox::assert_data_eq!(snapbox::data::ToDebug::to_debug(&res), $right);
   };
 );
 

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -6,13 +6,12 @@ use crate::combinator::dispatch;
 use crate::combinator::empty;
 use crate::combinator::fail;
 use crate::combinator::seq;
-use crate::error::InputError;
 use crate::prelude::*;
 use crate::token::any;
 
 #[test]
 fn dispatch_basics() {
-    fn escape_seq_char<'i>(input: &mut &'i str) -> PResult<char, InputError<&'i str>> {
+    fn escape_seq_char<'i>(input: &mut &'i str) -> TestResult<&'i str, char> {
         dispatch! {any;
             'b' => empty.value('\u{8}'),
             'f' => empty.value('\u{c}'),
@@ -75,7 +74,7 @@ fn seq_struct_basics() {
         y: u32,
     }
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         seq! {
             Point {
                 x: dec_uint,
@@ -139,7 +138,7 @@ fn seq_struct_default_init() {
         z: u32,
     }
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         seq! {
             Point {
                 x: dec_uint,
@@ -206,7 +205,7 @@ fn seq_struct_trailing_comma_elided() {
         y: u32,
     }
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         seq! {
             Point {
                 x: dec_uint,
@@ -229,7 +228,7 @@ fn seq_struct_no_trailing_comma() {
         y: u32,
     }
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         seq! {
             Point {
                 x: dec_uint,
@@ -251,7 +250,7 @@ fn seq_struct_no_trailing_comma_elided() {
         y: u32,
     }
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         seq! {
             Point {
                 x: dec_uint,
@@ -272,7 +271,7 @@ fn seq_enum_struct_variant() {
         Mul(u32, u32),
     }
 
-    fn add<'i>(input: &mut &'i [u8]) -> PResult<Expr, InputError<&'i [u8]>> {
+    fn add<'i>(input: &mut &'i [u8]) -> TestResult<&'i [u8], Expr> {
         seq! {Expr::Add {
             lhs: dec_uint::<_, u32, _>,
             _: b" + ",
@@ -281,7 +280,7 @@ fn seq_enum_struct_variant() {
         .parse_next(input)
     }
 
-    fn mul<'i>(input: &mut &'i [u8]) -> PResult<Expr, InputError<&'i [u8]>> {
+    fn mul<'i>(input: &mut &'i [u8]) -> TestResult<&'i [u8], Expr> {
         seq!(Expr::Mul(
              dec_uint::<_, u32, _>,
              _: b" * ",
@@ -333,7 +332,7 @@ fn seq_struct_borrow() {
         y: u32,
     }
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         let mut dec_uint = digit0.parse_to();
         seq! {
             Point {
@@ -352,7 +351,7 @@ fn seq_tuple_struct_basics() {
     #[derive(Debug, PartialEq)]
     struct Point(u32, u32);
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         seq! {
             Point(
                 dec_uint,
@@ -414,7 +413,7 @@ fn seq_tuple_struct_trailing_comma_elided() {
     #[derive(Debug, PartialEq)]
     struct Point(u32, u32);
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         seq! {
             Point(
                 dec_uint,
@@ -434,7 +433,7 @@ fn seq_tuple_struct_no_trailing_comma() {
     #[derive(Debug, PartialEq)]
     struct Point(u32, u32);
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         seq! {
             Point(
                 dec_uint,
@@ -453,7 +452,7 @@ fn seq_tuple_struct_no_trailing_comma_elided() {
     #[derive(Debug, PartialEq)]
     struct Point(u32, u32);
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         seq! {
             Point(
                 dec_uint,
@@ -468,7 +467,7 @@ fn seq_tuple_struct_no_trailing_comma_elided() {
 
 #[test]
 fn seq_tuple_basics() {
-    fn parser<'i>(input: &mut &'i str) -> PResult<(u32, u32), InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, (u32, u32)> {
         seq! {
             (
                 dec_uint,
@@ -527,7 +526,7 @@ Err(
 fn seq_tuple_trailing_comma_elided() {
     #![allow(dead_code)]
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<(u32, u32), InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, (u32, u32)> {
         seq! {
             (
                 dec_uint,
@@ -544,7 +543,7 @@ fn seq_tuple_trailing_comma_elided() {
 fn seq_tuple_no_trailing_comma() {
     #![allow(dead_code)]
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<(u32, u32), InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, (u32, u32)> {
         seq! {
             (
                 dec_uint,
@@ -560,7 +559,7 @@ fn seq_tuple_no_trailing_comma() {
 fn seq_tuple_no_trailing_comma_elided() {
     #![allow(dead_code)]
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<(u32, u32), InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, (u32, u32)> {
         seq! {
             (
                 dec_uint,
@@ -577,7 +576,7 @@ fn seq_tuple_no_trailing_comma_elided() {
 fn seq_tuple_no_parens() {
     #![allow(dead_code)]
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<(u32, u32), InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, (u32, u32)> {
         seq! (
             dec_uint,
             _: ',',
@@ -594,7 +593,7 @@ fn seq_tuple_borrow() {
     #[derive(Debug, PartialEq)]
     struct Point(u32, u32);
 
-    fn parser<'i>(input: &mut &'i str) -> PResult<Point, InputError<&'i str>> {
+    fn parser<'i>(input: &mut &'i str) -> TestResult<&'i str, Point> {
         let mut dec_uint = digit0.parse_to();
         seq! {
             Point(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -896,7 +896,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{ErrorKind, InputError}};
 /// fn parser<'s>(i: &mut &'s [u8]) -> PResult<u8, InputError<&'s [u8]>>  {
@@ -924,7 +924,7 @@ where
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{ErrorKind, InputError}};
 /// fn parser<'s>(i: &mut &'s str) -> PResult<char, InputError<&'s str>> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -163,12 +163,12 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::alpha1;
     /// # fn main() {
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<i32, InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<i32> {
     ///     alpha1.value(1234).parse_next(input)
     /// }
     ///
@@ -197,12 +197,12 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::alpha1;
     /// # fn main() {
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<u32, InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<u32> {
     ///     alpha1.default_value().parse_next(input)
     /// }
     ///
@@ -230,12 +230,12 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::alpha1;
     /// # fn main() {
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<(), InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<()> {
     ///     alpha1.void().parse_next(input)
     /// }
     ///
@@ -262,19 +262,19 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// # use winnow::error::InputError;
+    /// # use winnow::error::ContextError;
     /// # use winnow::error::IResult;
     /// use winnow::ascii::alpha1;
     /// # fn main() {
     ///
-    /// fn parser1<'s>(i: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+    /// fn parser1<'s>(i: &mut &'s str) -> PResult<&'s str> {
     ///   alpha1(i)
     /// }
     ///
     /// let mut parser2 = parser1.output_into();
     ///
     /// // the parser converts the &str output of the child parser into a Vec<u8>
-    /// let bytes: IResult<&str, Vec<u8>> = parser2.parse_peek("abcd");
+    /// let bytes: PResult<(_, Vec<u8>), _> = parser2.parse_peek("abcd");
     /// assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
     /// # }
     /// ```
@@ -298,13 +298,13 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::{alpha1};
     /// use winnow::combinator::separated_pair;
     /// # fn main() {
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
     ///     separated_pair(alpha1, ',', alpha1).take().parse_next(input)
     /// }
     ///
@@ -358,12 +358,12 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError};
+    /// # use winnow::{error::ErrMode,error::ErrorKind};
     /// use winnow::ascii::{alpha1};
     /// use winnow::token::literal;
     /// use winnow::combinator::separated_pair;
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<(bool, &'i str), InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<(bool, &'i str)> {
     ///     separated_pair(alpha1, ',', alpha1).value(true).with_taken().parse_next(input)
     /// }
     ///
@@ -408,13 +408,13 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, stream::Stream};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, stream::Stream};
     /// # use std::ops::Range;
     /// use winnow::stream::LocatingSlice;
     /// use winnow::ascii::alpha1;
     /// use winnow::combinator::separated_pair;
     ///
-    /// fn parser<'i>(input: &mut LocatingSlice<&'i str>) -> PResult<(Range<usize>, Range<usize>), InputError<LocatingSlice<&'i str>>> {
+    /// fn parser<'i>(input: &mut LocatingSlice<&'i str>) -> PResult<(Range<usize>, Range<usize>)> {
     ///     separated_pair(alpha1.span(), ',', alpha1.span()).parse_next(input)
     /// }
     ///
@@ -449,14 +449,14 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, stream::Stream};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, stream::Stream};
     /// # use std::ops::Range;
     /// use winnow::stream::LocatingSlice;
     /// use winnow::ascii::alpha1;
     /// use winnow::token::literal;
     /// use winnow::combinator::separated_pair;
     ///
-    /// fn parser<'i>(input: &mut LocatingSlice<&'i str>) -> PResult<((usize, Range<usize>), (usize, Range<usize>)), InputError<LocatingSlice<&'i str>>> {
+    /// fn parser<'i>(input: &mut LocatingSlice<&'i str>) -> PResult<((usize, Range<usize>), (usize, Range<usize>))> {
     ///     separated_pair(alpha1.value(1).with_span(), ',', alpha1.value(2).with_span()).parse_next(input)
     /// }
     ///
@@ -483,11 +483,11 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// # use winnow::ascii::digit1;
     /// # fn main() {
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<usize, InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<usize> {
     ///     digit1.map(|s: &str| s.len()).parse_next(input)
     /// }
     ///
@@ -519,12 +519,12 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::digit1;
     /// # fn main() {
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<u8, InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<u8> {
     ///     digit1.try_map(|s: &str| s.parse::<u8>()).parse_next(input)
     /// }
     ///
@@ -562,12 +562,12 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::digit1;
     /// # fn main() {
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<u8, InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<u8> {
     ///     digit1.verify_map(|s: &str| s.parse::<u8>().ok()).parse_next(input)
     /// }
     ///
@@ -607,11 +607,11 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, PResult, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, PResult, Parser};
     /// use winnow::token::take;
     /// use winnow::binary::u8;
     ///
-    /// fn length_take<'s>(input: &mut &'s [u8]) -> PResult<&'s [u8], InputError<&'s [u8]>> {
+    /// fn length_take<'s>(input: &mut &'s [u8]) -> PResult<&'s [u8]> {
     ///     u8.flat_map(take).parse_next(input)
     /// }
     ///
@@ -621,11 +621,11 @@ pub trait Parser<I, O, E> {
     ///
     /// which is the same as
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, PResult, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, PResult, Parser};
     /// use winnow::token::take;
     /// use winnow::binary::u8;
     ///
-    /// fn length_take<'s>(input: &mut &'s [u8]) -> PResult<&'s [u8], InputError<&'s [u8]>> {
+    /// fn length_take<'s>(input: &mut &'s [u8]) -> PResult<&'s [u8]> {
     ///     let length = u8.parse_next(input)?;
     ///     let data = take(length).parse_next(input)?;
     ///     Ok(data)
@@ -657,13 +657,13 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::digit1;
     /// use winnow::token::take;
     /// # fn main() {
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
     ///     take(5u8).and_then(digit1).parse_next(input)
     /// }
     ///
@@ -696,10 +696,10 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// use winnow::ascii::digit1;
     ///
-    /// fn parser<'s>(input: &mut &'s str) -> PResult<u64, InputError<&'s str>> {
+    /// fn parser<'s>(input: &mut &'s str) -> PResult<u64> {
     ///     digit1.parse_to().parse_next(input)
     /// }
     ///
@@ -735,12 +735,12 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, error::InputError, Parser};
+    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
     /// # use winnow::ascii::alpha1;
     /// # use winnow::prelude::*;
     /// # fn main() {
     ///
-    /// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    /// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
     ///     alpha1.verify(|s: &str| s.len() == 4).parse_next(input)
     /// }
     ///
@@ -909,8 +909,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ErrorKind, InputError}};
-/// fn parser<'s>(i: &mut &'s [u8]) -> PResult<u8, InputError<&'s [u8]>>  {
+/// # use winnow::{error::ErrMode, error::{ErrorKind, ContextError}};
+/// fn parser<'s>(i: &mut &'s [u8]) -> PResult<u8>  {
 ///     b'a'.parse_next(i)
 /// }
 /// assert_eq!(parser.parse_peek(&b"abc"[..]), Ok((&b"bc"[..], b'a')));
@@ -937,8 +937,8 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ErrorKind, InputError}};
-/// fn parser<'s>(i: &mut &'s str) -> PResult<char, InputError<&'s str>> {
+/// # use winnow::{error::ErrMode, error::{ErrorKind, ContextError}};
+/// fn parser<'s>(i: &mut &'s str) -> PResult<char> {
 ///     'a'.parse_next(i)
 /// }
 /// assert_eq!(parser.parse_peek("abc"), Ok(("bc", 'a')));
@@ -964,11 +964,11 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 ///
-/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8], InputError<&'s [u8]>> {
+/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8]> {
 ///   alt((&"Hello"[..], take(5usize))).parse_next(s)
 /// }
 ///
@@ -993,12 +993,12 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 /// use winnow::ascii::Caseless;
 ///
-/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8], InputError<&'s [u8]>> {
+/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8]> {
 ///   alt((Caseless(&"hello"[..]), take(5usize))).parse_next(s)
 /// }
 ///
@@ -1025,11 +1025,11 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 ///
-/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8], InputError<&'s [u8]>> {
+/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8]> {
 ///   alt((b"Hello", take(5usize))).parse_next(s)
 /// }
 ///
@@ -1054,12 +1054,12 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 /// use winnow::ascii::Caseless;
 ///
-/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8], InputError<&'s [u8]>> {
+/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8]> {
 ///   alt((Caseless(b"hello"), take(5usize))).parse_next(s)
 /// }
 ///
@@ -1087,11 +1087,11 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 ///
-/// fn parser<'s>(s: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(s: &mut &'s str) -> PResult<&'s str> {
 ///   alt(("Hello", take(5usize))).parse_next(s)
 /// }
 ///
@@ -1116,12 +1116,12 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 /// # use winnow::ascii::Caseless;
 ///
-/// fn parser<'s>(s: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn parser<'s>(s: &mut &'s str) -> PResult<&'s str> {
 ///   alt((Caseless("hello"), take(5usize))).parse_next(s)
 /// }
 ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -173,7 +173,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(parser.parse_peek("abcd"), Ok(("", 1234)));
-    /// assert_eq!(parser.parse_peek("123abcd;"), Err(ErrMode::Backtrack(InputError::new("123abcd;", ErrorKind::Slice))));
+    /// assert!(parser.parse_peek("123abcd;").is_err());
     /// # }
     /// ```
     #[doc(alias = "to")]
@@ -207,7 +207,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(parser.parse_peek("abcd"), Ok(("", 0)));
-    /// assert_eq!(parser.parse_peek("123abcd;"), Err(ErrMode::Backtrack(InputError::new("123abcd;", ErrorKind::Slice))));
+    /// assert!(parser.parse_peek("123abcd;").is_err());
     /// # }
     /// ```
     #[inline(always)]
@@ -240,7 +240,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(parser.parse_peek("abcd"), Ok(("", ())));
-    /// assert_eq!(parser.parse_peek("123abcd;"), Err(ErrMode::Backtrack(InputError::new("123abcd;", ErrorKind::Slice))));
+    /// assert!(parser.parse_peek("123abcd;").is_err());
     /// # }
     /// ```
     #[inline(always)]
@@ -309,7 +309,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(parser.parse_peek("abcd,efgh"), Ok(("", "abcd,efgh")));
-    /// assert_eq!(parser.parse_peek("abcd;"),Err(ErrMode::Backtrack(InputError::new(";", ErrorKind::Literal))));
+    /// assert!(parser.parse_peek("abcd;").is_err());
     /// # }
     /// ```
     #[doc(alias = "concat")]
@@ -368,7 +368,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(parser.parse_peek("abcd,efgh1"), Ok(("1", (true, "abcd,efgh"))));
-    /// assert_eq!(parser.parse_peek("abcd;"),Err(ErrMode::Backtrack(InputError::new(";", ErrorKind::Literal))));
+    /// assert!(parser.parse_peek("abcd;").is_err());
     /// ```
     #[doc(alias = "consumed")]
     #[doc(alias = "with_recognized")]
@@ -419,7 +419,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(parser.parse(LocatingSlice::new("abcd,efgh")), Ok((0..4, 5..9)));
-    /// assert_eq!(parser.parse_peek(LocatingSlice::new("abcd;")),Err(ErrMode::Backtrack(InputError::new(LocatingSlice::new("abcd;").peek_slice(4).0, ErrorKind::Literal))));
+    /// assert!(parser.parse_peek(LocatingSlice::new("abcd;")).is_err());
     /// ```
     #[inline(always)]
     fn span(self) -> impls::Span<Self, I, O, E>
@@ -461,7 +461,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(parser.parse(LocatingSlice::new("abcd,efgh")), Ok(((1, 0..4), (2, 5..9))));
-    /// assert_eq!(parser.parse_peek(LocatingSlice::new("abcd;")),Err(ErrMode::Backtrack(InputError::new(LocatingSlice::new("abcd;").peek_slice(4).0, ErrorKind::Literal))));
+    /// assert!(parser.parse_peek(LocatingSlice::new("abcd;")).is_err());
     /// ```
     #[inline(always)]
     fn with_span(self) -> impls::WithSpan<Self, I, O, E>
@@ -495,7 +495,7 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse_peek("123456"), Ok(("", 6)));
     ///
     /// // this will fail if digit1 fails
-    /// assert_eq!(parser.parse_peek("abc"), Err(ErrMode::Backtrack(InputError::new("abc", ErrorKind::Slice))));
+    /// assert!(parser.parse_peek("abc").is_err());
     /// # }
     /// ```
     #[inline(always)]
@@ -532,10 +532,10 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse_peek("123"), Ok(("", 123)));
     ///
     /// // this will fail if digit1 fails
-    /// assert_eq!(parser.parse_peek("abc"), Err(ErrMode::Backtrack(InputError::new("abc", ErrorKind::Slice))));
+    /// assert!(parser.parse_peek("abc").is_err());
     ///
     /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-    /// assert_eq!(parser.parse_peek("123456"), Err(ErrMode::Backtrack(InputError::new("123456", ErrorKind::Verify))));
+    /// assert!(parser.parse_peek("123456").is_err());
     /// # }
     /// ```
     #[inline(always)]
@@ -575,10 +575,10 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse_peek("123"), Ok(("", 123)));
     ///
     /// // this will fail if digit1 fails
-    /// assert_eq!(parser.parse_peek("abc"), Err(ErrMode::Backtrack(InputError::new("abc", ErrorKind::Slice))));
+    /// assert!(parser.parse_peek("abc").is_err());
     ///
     /// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-    /// assert_eq!(parser.parse_peek("123456"), Err(ErrMode::Backtrack(InputError::new("123456", ErrorKind::Verify))));
+    /// assert!(parser.parse_peek("123456").is_err());
     /// # }
     /// ```
     #[doc(alias = "satisfy_map")]
@@ -616,7 +616,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(length_take.parse_peek(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
-    /// assert_eq!(length_take.parse_peek(&[4, 0, 1, 2][..]), Err(ErrMode::Backtrack(InputError::new(&[0, 1, 2][..], ErrorKind::Slice))));
+    /// assert!(length_take.parse_peek(&[4, 0, 1, 2][..]).is_err());
     /// ```
     ///
     /// which is the same as
@@ -632,7 +632,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(length_take.parse_peek(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
-    /// assert_eq!(length_take.parse_peek(&[4, 0, 1, 2][..]), Err(ErrMode::Backtrack(InputError::new(&[0, 1, 2][..], ErrorKind::Slice))));
+    /// assert!(length_take.parse_peek(&[4, 0, 1, 2][..]).is_err());
     /// ```
     #[inline(always)]
     fn flat_map<G, H, O2>(self, map: G) -> impls::FlatMap<Self, G, H, I, O, O2, E>
@@ -669,7 +669,7 @@ pub trait Parser<I, O, E> {
     ///
     /// assert_eq!(parser.parse_peek("12345"), Ok(("", "12345")));
     /// assert_eq!(parser.parse_peek("123ab"), Ok(("", "123")));
-    /// assert_eq!(parser.parse_peek("123"), Err(ErrMode::Backtrack(InputError::new("123", ErrorKind::Slice))));
+    /// assert!(parser.parse_peek("123").is_err());
     /// # }
     /// ```
     #[inline(always)]
@@ -707,7 +707,7 @@ pub trait Parser<I, O, E> {
     /// assert_eq!(parser.parse_peek("123456"), Ok(("", 123456)));
     ///
     /// // this will fail if digit1 fails
-    /// assert_eq!(parser.parse_peek("abc"), Err(ErrMode::Backtrack(InputError::new("abc", ErrorKind::Slice))));
+    /// assert!(parser.parse_peek("abc").is_err());
     /// ```
     #[doc(alias = "from_str")]
     #[inline(always)]
@@ -745,8 +745,8 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(parser.parse_peek("abcd"), Ok(("", "abcd")));
-    /// assert_eq!(parser.parse_peek("abcde"), Err(ErrMode::Backtrack(InputError::new("abcde", ErrorKind::Verify))));
-    /// assert_eq!(parser.parse_peek("123abcd;"),Err(ErrMode::Backtrack(InputError::new("123abcd;", ErrorKind::Slice))));
+    /// assert!(parser.parse_peek("abcde").is_err());
+    /// assert!(parser.parse_peek("123abcd;").is_err());
     /// # }
     /// ```
     #[doc(alias = "satisfy")]
@@ -914,9 +914,9 @@ where
 ///     b'a'.parse_next(i)
 /// }
 /// assert_eq!(parser.parse_peek(&b"abc"[..]), Ok((&b"bc"[..], b'a')));
-/// assert_eq!(parser.parse_peek(&b" abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b" abc"[..], ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek(&b"bc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"bc"[..], ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&b""[..], ErrorKind::Literal))));
+/// assert!(parser.parse_peek(&b" abc"[..]).is_err());
+/// assert!(parser.parse_peek(&b"bc"[..]).is_err());
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 impl<I, E> Parser<I, u8, E> for u8
 where
@@ -942,9 +942,9 @@ where
 ///     'a'.parse_next(i)
 /// }
 /// assert_eq!(parser.parse_peek("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser.parse_peek(" abc"), Err(ErrMode::Backtrack(InputError::new(" abc", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek("bc"), Err(ErrMode::Backtrack(InputError::new("bc", ErrorKind::Literal))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser.parse_peek(" abc").is_err());
+/// assert!(parser.parse_peek("bc").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 impl<I, E> Parser<I, char, E> for char
 where
@@ -974,8 +974,8 @@ where
 ///
 /// assert_eq!(parser.parse_peek(&b"Hello, World!"[..]), Ok((&b", World!"[..], &b"Hello"[..])));
 /// assert_eq!(parser.parse_peek(&b"Something"[..]), Ok((&b"hing"[..], &b"Somet"[..])));
-/// assert_eq!(parser.parse_peek(&b"Some"[..]), Err(ErrMode::Backtrack(InputError::new(&b"Some"[..], ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&b""[..], ErrorKind::Slice))));
+/// assert!(parser.parse_peek(&b"Some"[..]).is_err());
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 impl<'s, I, E: ParserError<I>> Parser<I, <I as Stream>::Slice, E> for &'s [u8]
 where
@@ -1006,8 +1006,8 @@ where
 /// assert_eq!(parser.parse_peek(&b"hello, World!"[..]), Ok((&b", World!"[..], &b"hello"[..])));
 /// assert_eq!(parser.parse_peek(&b"HeLlo, World!"[..]), Ok((&b", World!"[..], &b"HeLlo"[..])));
 /// assert_eq!(parser.parse_peek(&b"Something"[..]), Ok((&b"hing"[..], &b"Somet"[..])));
-/// assert_eq!(parser.parse_peek(&b"Some"[..]), Err(ErrMode::Backtrack(InputError::new(&b"Some"[..], ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&b""[..], ErrorKind::Slice))));
+/// assert!(parser.parse_peek(&b"Some"[..]).is_err());
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 impl<'s, I, E: ParserError<I>> Parser<I, <I as Stream>::Slice, E> for AsciiCaseless<&'s [u8]>
 where
@@ -1035,8 +1035,8 @@ where
 ///
 /// assert_eq!(parser.parse_peek(&b"Hello, World!"[..]), Ok((&b", World!"[..], &b"Hello"[..])));
 /// assert_eq!(parser.parse_peek(&b"Something"[..]), Ok((&b"hing"[..], &b"Somet"[..])));
-/// assert_eq!(parser.parse_peek(&b"Some"[..]), Err(ErrMode::Backtrack(InputError::new(&b"Some"[..], ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&b""[..], ErrorKind::Slice))));
+/// assert!(parser.parse_peek(&b"Some"[..]).is_err());
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 impl<'s, I, E: ParserError<I>, const N: usize> Parser<I, <I as Stream>::Slice, E> for &'s [u8; N]
 where
@@ -1067,8 +1067,8 @@ where
 /// assert_eq!(parser.parse_peek(&b"hello, World!"[..]), Ok((&b", World!"[..], &b"hello"[..])));
 /// assert_eq!(parser.parse_peek(&b"HeLlo, World!"[..]), Ok((&b", World!"[..], &b"HeLlo"[..])));
 /// assert_eq!(parser.parse_peek(&b"Something"[..]), Ok((&b"hing"[..], &b"Somet"[..])));
-/// assert_eq!(parser.parse_peek(&b"Some"[..]), Err(ErrMode::Backtrack(InputError::new(&b"Some"[..], ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(&b""[..]), Err(ErrMode::Backtrack(InputError::new(&b""[..], ErrorKind::Slice))));
+/// assert!(parser.parse_peek(&b"Some"[..]).is_err());
+/// assert!(parser.parse_peek(&b""[..]).is_err());
 /// ```
 impl<'s, I, E: ParserError<I>, const N: usize> Parser<I, <I as Stream>::Slice, E>
     for AsciiCaseless<&'s [u8; N]>
@@ -1097,8 +1097,8 @@ where
 ///
 /// assert_eq!(parser.parse_peek("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser.parse_peek("Something"), Ok(("hing", "Somet")));
-/// assert_eq!(parser.parse_peek("Some"), Err(ErrMode::Backtrack(InputError::new("Some", ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("Some").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 impl<'s, I, E: ParserError<I>> Parser<I, <I as Stream>::Slice, E> for &'s str
 where
@@ -1129,8 +1129,8 @@ where
 /// assert_eq!(parser.parse_peek("hello, World!"), Ok((", World!", "hello")));
 /// assert_eq!(parser.parse_peek("HeLlo, World!"), Ok((", World!", "HeLlo")));
 /// assert_eq!(parser.parse_peek("Something"), Ok(("hing", "Somet")));
-/// assert_eq!(parser.parse_peek("Some"), Err(ErrMode::Backtrack(InputError::new("Some", ErrorKind::Slice))));
-/// assert_eq!(parser.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(parser.parse_peek("Some").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 impl<'s, I, E: ParserError<I>> Parser<I, <I as Stream>::Slice, E> for AsciiCaseless<&'s str>
 where

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -263,7 +263,6 @@ pub trait Parser<I, O, E> {
     /// ```rust
     /// # use winnow::prelude::*;
     /// # use winnow::error::ContextError;
-    /// # use winnow::error::IResult;
     /// use winnow::ascii::alpha1;
     /// # fn main() {
     ///

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -390,7 +390,7 @@ impl<I: crate::lib::std::fmt::Display, S> crate::lib::std::fmt::Display for Stat
 /// assert_eq!(take_partial.parse_peek(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// // but the complete parser will return an error
-/// assert_eq!(take_complete.parse_peek(&b"abc"[..]), Err(ErrMode::Backtrack(InputError::new(&b"abc"[..], ErrorKind::Slice))));
+/// assert!(take_complete.parse_peek(&b"abc"[..]).is_err());
 ///
 /// // the alpha0 function takes 0 or more alphabetic characters
 /// fn alpha0_partial<'s>(i: &mut Partial<&'s str>) -> PResult<&'s str, InputError<Partial<&'s str>>> {
@@ -3420,8 +3420,8 @@ impl AsChar for &char {
 /// }
 ///
 /// assert_eq!(hex_digit1.parse_peek("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(hex_digit1.parse_peek("H2"), Err(ErrMode::Backtrack(InputError::new("H2", ErrorKind::Slice))));
-/// assert_eq!(hex_digit1.parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(hex_digit1.parse_peek("H2").is_err());
+/// assert!(hex_digit1.parse_peek("").is_err());
 /// ```
 pub trait ContainsToken<T> {
     /// Returns true if self contains the token

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -370,14 +370,14 @@ impl<I: crate::lib::std::fmt::Display, S> crate::lib::std::fmt::Display for Stat
 /// Here is how it works in practice:
 ///
 /// ```rust
-/// # use winnow::{PResult, error::ErrMode, error::Needed, error::{InputError, ErrorKind}, token, ascii, stream::Partial};
+/// # use winnow::{PResult, error::ErrMode, error::Needed, error::{ContextError, ErrorKind}, token, ascii, stream::Partial};
 /// # use winnow::prelude::*;
 ///
-/// fn take_partial<'s>(i: &mut Partial<&'s [u8]>) -> PResult<&'s [u8], InputError<Partial<&'s [u8]>>> {
+/// fn take_partial<'s>(i: &mut Partial<&'s [u8]>) -> PResult<&'s [u8], ContextError> {
 ///   token::take(4u8).parse_next(i)
 /// }
 ///
-/// fn take_complete<'s>(i: &mut &'s [u8]) -> PResult<&'s [u8], InputError<&'s [u8]>> {
+/// fn take_complete<'s>(i: &mut &'s [u8]) -> PResult<&'s [u8], ContextError> {
 ///   token::take(4u8).parse_next(i)
 /// }
 ///
@@ -393,11 +393,11 @@ impl<I: crate::lib::std::fmt::Display, S> crate::lib::std::fmt::Display for Stat
 /// assert!(take_complete.parse_peek(&b"abc"[..]).is_err());
 ///
 /// // the alpha0 function takes 0 or more alphabetic characters
-/// fn alpha0_partial<'s>(i: &mut Partial<&'s str>) -> PResult<&'s str, InputError<Partial<&'s str>>> {
+/// fn alpha0_partial<'s>(i: &mut Partial<&'s str>) -> PResult<&'s str, ContextError> {
 ///   ascii::alpha0.parse_next(i)
 /// }
 ///
-/// fn alpha0_complete<'s>(i: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn alpha0_complete<'s>(i: &mut &'s str) -> PResult<&'s str, ContextError> {
 ///   ascii::alpha0.parse_next(i)
 /// }
 ///
@@ -3413,9 +3413,9 @@ impl AsChar for &char {
 /// For example, you could implement `hex_digit0` as:
 /// ```
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError};
 /// # use winnow::token::take_while;
-/// fn hex_digit1<'s>(input: &mut &'s str) -> PResult<&'s str, InputError<&'s str>> {
+/// fn hex_digit1<'s>(input: &mut &'s str) -> PResult<&'s str, ContextError> {
 ///     take_while(1.., ('a'..='f', 'A'..='F', '0'..='9')).parse_next(input)
 /// }
 ///

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -38,19 +38,17 @@ use crate::Parser;
 /// ```rust
 /// # use winnow::{token::any, error::ErrMode, error::{ContextError, ErrorKind}};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
-/// fn parser(input: &str) -> IResult<&str, char> {
-///     any.parse_peek(input)
+/// fn parser(input: &mut &str) -> PResult<char> {
+///     any.parse_next(input)
 /// }
 ///
-/// assert_eq!(parser("abc"), Ok(("bc",'a')));
-/// assert!(parser("").is_err());
+/// assert_eq!(parser.parse_peek("abc"), Ok(("bc",'a')));
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
 /// # use winnow::{token::any, error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// assert_eq!(any::<_, ContextError>.parse_peek(Partial::new("abc")), Ok((Partial::new("bc"),'a')));
 /// assert_eq!(any::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
@@ -117,50 +115,47 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// #
-/// fn parser(s: &str) -> IResult<&str, &str> {
-///   "Hello".parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<&'i str> {
+///   "Hello".parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert!(parser("Something").is_err());
-/// assert!(parser("").is_err());
+/// assert_eq!(parser.parse_peek("Hello, World!"), Ok((", World!", "Hello")));
+/// assert!(parser.parse_peek("Something").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::Partial;
 ///
-/// fn parser(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   "Hello".parse_peek(s)
+/// fn parser<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+///   "Hello".parse_next(s)
 /// }
 ///
-/// assert_eq!(parser(Partial::new("Hello, World!")), Ok((Partial::new(", World!"), "Hello")));
-/// assert!(parser(Partial::new("Something")).is_err());
-/// assert!(parser(Partial::new("S")).is_err());
-/// assert_eq!(parser(Partial::new("H")), Err(ErrMode::Incomplete(Needed::new(4))));
+/// assert_eq!(parser.parse_peek(Partial::new("Hello, World!")), Ok((Partial::new(", World!"), "Hello")));
+/// assert!(parser.parse_peek(Partial::new("Something")).is_err());
+/// assert!(parser.parse_peek(Partial::new("S")).is_err());
+/// assert_eq!(parser.parse_peek(Partial::new("H")), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// use winnow::token::literal;
 /// use winnow::ascii::Caseless;
 ///
-/// fn parser(s: &str) -> IResult<&str, &str> {
-///   literal(Caseless("hello")).parse_peek(s)
+/// fn parser<'i>(s: &mut &'i str) -> PResult<&'i str> {
+///   literal(Caseless("hello")).parse_next(s)
 /// }
 ///
-/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
-/// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert!(parser("Something").is_err());
-/// assert!(parser("").is_err());
+/// assert_eq!(parser.parse_peek("Hello, World!"), Ok((", World!", "Hello")));
+/// assert_eq!(parser.parse_peek("hello, World!"), Ok((", World!", "hello")));
+/// assert_eq!(parser.parse_peek("HeLlO, World!"), Ok((", World!", "HeLlO")));
+/// assert!(parser.parse_peek("Something").is_err());
+/// assert!(parser.parse_peek("").is_err());
 /// ```
 #[inline(always)]
 #[doc(alias = "tag")]
@@ -238,24 +233,22 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError};
 /// # use winnow::token::one_of;
 /// assert_eq!(one_of::<_, _, ContextError>(['a', 'b', 'c']).parse_peek("b"), Ok(("", 'b')));
 /// assert!(one_of::<_, _, ContextError>('a').parse_peek("bc").is_err());
 /// assert!(one_of::<_, _, ContextError>('a').parse_peek("").is_err());
 ///
-/// fn parser_fn(i: &str) -> IResult<&str, char> {
-///     one_of(|c| c == 'a' || c == 'b').parse_peek(i)
+/// fn parser_fn(i: &mut &str) -> PResult<char> {
+///     one_of(|c| c == 'a' || c == 'b').parse_next(i)
 /// }
-/// assert_eq!(parser_fn("abc"), Ok(("bc", 'a')));
-/// assert!(parser_fn("cd").is_err());
-/// assert!(parser_fn("").is_err());
+/// assert_eq!(parser_fn.parse_peek("abc"), Ok(("bc", 'a')));
+/// assert!(parser_fn.parse_peek("cd").is_err());
+/// assert!(parser_fn.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::token::one_of;
@@ -263,12 +256,12 @@ where
 /// assert!(one_of::<_, _, ContextError>('a').parse_peek(Partial::new("bc")).is_err());
 /// assert_eq!(one_of::<_, _, ContextError>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// fn parser_fn(i: Partial<&str>) -> IResult<Partial<&str>, char> {
-///     one_of(|c| c == 'a' || c == 'b').parse_peek(i)
+/// fn parser_fn(i: &mut Partial<&str>) -> PResult<char> {
+///     one_of(|c| c == 'a' || c == 'b').parse_next(i)
 /// }
-/// assert_eq!(parser_fn(Partial::new("abc")), Ok((Partial::new("bc"), 'a')));
-/// assert!(parser_fn(Partial::new("cd")).is_err());
-/// assert_eq!(parser_fn(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(parser_fn.parse_peek(Partial::new("abc")), Ok((Partial::new("bc"), 'a')));
+/// assert!(parser_fn.parse_peek(Partial::new("cd")).is_err());
+/// assert_eq!(parser_fn.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 #[doc(alias = "char")]
@@ -313,7 +306,6 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::token::none_of;
 /// assert_eq!(none_of::<_, _, ContextError>(['a', 'b', 'c']).parse_peek("z"), Ok(("", 'z')));
 /// assert!(none_of::<_, _, ContextError>(['a', 'b']).parse_peek("a").is_err());
@@ -323,7 +315,6 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// # use winnow::token::none_of;
 /// assert_eq!(none_of::<_, _, ContextError>(['a', 'b', 'c']).parse_peek(Partial::new("z")), Ok((Partial::new(""), 'z')));
@@ -375,128 +366,122 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while(0.., AsChar::is_alpha).parse_peek(s)
+/// fn alpha<'i>(s: &mut &'i [u8]) -> PResult<&'i [u8]> {
+///   take_while(0.., AsChar::is_alpha).parse_next(s)
 /// }
 ///
-/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
-/// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
+/// assert_eq!(alpha.parse_peek(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(alpha.parse_peek(b"12345"), Ok((&b"12345"[..], &b""[..])));
+/// assert_eq!(alpha.parse_peek(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert_eq!(alpha.parse_peek(b""), Ok((&b""[..], &b""[..])));
 /// ```
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn alpha(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-///   take_while(0.., AsChar::is_alpha).parse_peek(s)
+/// fn alpha<'i>(s: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+///   take_while(0.., AsChar::is_alpha).parse_next(s)
 /// }
 ///
-/// assert_eq!(alpha(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
-/// assert_eq!(alpha(Partial::new(b"12345")), Ok((Partial::new(&b"12345"[..]), &b""[..])));
-/// assert_eq!(alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(Partial::new(b"")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha.parse_peek(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(alpha.parse_peek(Partial::new(b"12345")), Ok((Partial::new(&b"12345"[..]), &b""[..])));
+/// assert_eq!(alpha.parse_peek(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(alpha.parse_peek(Partial::new(b"")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// One or more tokens:
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while(1.., AsChar::is_alpha).parse_peek(s)
+/// fn alpha<'i>(s: &mut &'i [u8]) -> PResult<&'i [u8]> {
+///   take_while(1.., AsChar::is_alpha).parse_next(s)
 /// }
 ///
-/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert!(alpha(b"12345").is_err());
+/// assert_eq!(alpha.parse_peek(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(alpha.parse_peek(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert!(alpha.parse_peek(b"12345").is_err());
 ///
-/// fn hex(s: &str) -> IResult<&str, &str> {
-///   take_while(1.., ('0'..='9', 'A'..='F')).parse_peek(s)
+/// fn hex<'i>(s: &mut &'i str) -> PResult<&'i str> {
+///   take_while(1.., ('0'..='9', 'A'..='F')).parse_next(s)
 /// }
 ///
-/// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
-/// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
-/// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
-/// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
-/// assert!(hex("").is_err());
+/// assert_eq!(hex.parse_peek("123 and voila"), Ok((" and voila", "123")));
+/// assert_eq!(hex.parse_peek("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
+/// assert_eq!(hex.parse_peek("BADBABEsomething"), Ok(("something", "BADBABE")));
+/// assert_eq!(hex.parse_peek("D15EA5E"), Ok(("", "D15EA5E")));
+/// assert!(hex.parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn alpha(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-///   take_while(1.., AsChar::is_alpha).parse_peek(s)
+/// fn alpha<'i>(s: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+///   take_while(1.., AsChar::is_alpha).parse_next(s)
 /// }
 ///
-/// assert_eq!(alpha(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
-/// assert_eq!(alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert!(alpha(Partial::new(b"12345")).is_err());
+/// assert_eq!(alpha.parse_peek(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(alpha.parse_peek(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert!(alpha.parse_peek(Partial::new(b"12345")).is_err());
 ///
-/// fn hex(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   take_while(1.., ('0'..='9', 'A'..='F')).parse_peek(s)
+/// fn hex<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+///   take_while(1.., ('0'..='9', 'A'..='F')).parse_next(s)
 /// }
 ///
-/// assert_eq!(hex(Partial::new("123 and voila")), Ok((Partial::new(" and voila"), "123")));
-/// assert_eq!(hex(Partial::new("DEADBEEF and others")), Ok((Partial::new(" and others"), "DEADBEEF")));
-/// assert_eq!(hex(Partial::new("BADBABEsomething")), Ok((Partial::new("something"), "BADBABE")));
-/// assert_eq!(hex(Partial::new("D15EA5E")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(hex(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex.parse_peek(Partial::new("123 and voila")), Ok((Partial::new(" and voila"), "123")));
+/// assert_eq!(hex.parse_peek(Partial::new("DEADBEEF and others")), Ok((Partial::new(" and others"), "DEADBEEF")));
+/// assert_eq!(hex.parse_peek(Partial::new("BADBABEsomething")), Ok((Partial::new("something"), "BADBABE")));
+/// assert_eq!(hex.parse_peek(Partial::new("D15EA5E")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(hex.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 ///
 /// Arbitrary amount of tokens:
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while(3..=6, AsChar::is_alpha).parse_peek(s)
+/// fn short_alpha<'i>(s: &mut &'i [u8]) -> PResult<&'i [u8]> {
+///   take_while(3..=6, AsChar::is_alpha).parse_next(s)
 /// }
 ///
-/// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
-/// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert!(short_alpha(b"ed").is_err());
-/// assert!(short_alpha(b"12345").is_err());
+/// assert_eq!(short_alpha.parse_peek(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+/// assert_eq!(short_alpha.parse_peek(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
+/// assert_eq!(short_alpha.parse_peek(b"latin"), Ok((&b""[..], &b"latin"[..])));
+/// assert!(short_alpha.parse_peek(b"ed").is_err());
+/// assert!(short_alpha.parse_peek(b"12345").is_err());
 /// ```
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn short_alpha(s: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-///   take_while(3..=6, AsChar::is_alpha).parse_peek(s)
+/// fn short_alpha<'i>(s: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+///   take_while(3..=6, AsChar::is_alpha).parse_next(s)
 /// }
 ///
-/// assert_eq!(short_alpha(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
-/// assert_eq!(short_alpha(Partial::new(b"lengthy")), Ok((Partial::new(&b"y"[..]), &b"length"[..])));
-/// assert_eq!(short_alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(Partial::new(b"ed")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert!(short_alpha(Partial::new(b"12345")).is_err());
+/// assert_eq!(short_alpha.parse_peek(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
+/// assert_eq!(short_alpha.parse_peek(Partial::new(b"lengthy")), Ok((Partial::new(&b"y"[..]), &b"length"[..])));
+/// assert_eq!(short_alpha.parse_peek(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(short_alpha.parse_peek(Partial::new(b"ed")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert!(short_alpha.parse_peek(Partial::new(b"12345")).is_err());
 /// ```
 #[inline(always)]
 #[doc(alias = "is_a")]
@@ -665,34 +650,32 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// use winnow::token::take_till;
 ///
-/// fn till_colon(s: &str) -> IResult<&str, &str> {
-///   take_till(0.., |c| c == ':').parse_peek(s)
+/// fn till_colon<'i>(s: &mut &'i str) -> PResult<&'i str> {
+///   take_till(0.., |c| c == ':').parse_next(s)
 /// }
 ///
-/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
-/// assert_eq!(till_colon("12345"), Ok(("", "12345")));
-/// assert_eq!(till_colon(""), Ok(("", "")));
+/// assert_eq!(till_colon.parse_peek("latin:123"), Ok((":123", "latin")));
+/// assert_eq!(till_colon.parse_peek(":empty matched"), Ok((":empty matched", ""))); //allowed
+/// assert_eq!(till_colon.parse_peek("12345"), Ok(("", "12345")));
+/// assert_eq!(till_colon.parse_peek(""), Ok(("", "")));
 /// ```
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_till;
 ///
-/// fn till_colon(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   take_till(0.., |c| c == ':').parse_peek(s)
+/// fn till_colon<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+///   take_till(0.., |c| c == ':').parse_next(s)
 /// }
 ///
-/// assert_eq!(till_colon(Partial::new("latin:123")), Ok((Partial::new(":123"), "latin")));
-/// assert_eq!(till_colon(Partial::new(":empty matched")), Ok((Partial::new(":empty matched"), ""))); //allowed
-/// assert_eq!(till_colon(Partial::new("12345")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon.parse_peek(Partial::new("latin:123")), Ok((Partial::new(":123"), "latin")));
+/// assert_eq!(till_colon.parse_peek(Partial::new(":empty matched")), Ok((Partial::new(":empty matched"), ""))); //allowed
+/// assert_eq!(till_colon.parse_peek(Partial::new("12345")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(till_colon.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 #[doc(alias = "is_not")]
@@ -767,17 +750,16 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// use winnow::token::take;
 ///
-/// fn take6(s: &str) -> IResult<&str, &str> {
-///   take(6usize).parse_peek(s)
+/// fn take6<'i>(s: &mut &'i str) -> PResult<&'i str> {
+///   take(6usize).parse_next(s)
 /// }
 ///
-/// assert_eq!(take6("1234567"), Ok(("7", "123456")));
-/// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert!(take6("short").is_err());
-/// assert!(take6("").is_err());
+/// assert_eq!(take6.parse_peek("1234567"), Ok(("7", "123456")));
+/// assert_eq!(take6.parse_peek("things"), Ok(("", "things")));
+/// assert!(take6.parse_peek("short").is_err());
+/// assert!(take6.parse_peek("").is_err());
 /// ```
 ///
 /// The units that are taken will depend on the input type. For example, for a
@@ -786,7 +768,6 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// use winnow::error::ContextError;
 /// use winnow::token::take;
 ///
@@ -796,18 +777,18 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::error::{ErrMode, ErrorKind, ContextError, Needed, IResult};
+/// # use winnow::error::{ErrMode, ErrorKind, ContextError, Needed};
 /// # use winnow::Partial;
 /// use winnow::token::take;
 ///
-/// fn take6(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   take(6usize).parse_peek(s)
+/// fn take6<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+///   take(6usize).parse_next(s)
 /// }
 ///
-/// assert_eq!(take6(Partial::new("1234567")), Ok((Partial::new("7"), "123456")));
-/// assert_eq!(take6(Partial::new("things")), Ok((Partial::new(""), "things")));
+/// assert_eq!(take6.parse_peek(Partial::new("1234567")), Ok((Partial::new("7"), "123456")));
+/// assert_eq!(take6.parse_peek(Partial::new("things")), Ok((Partial::new(""), "things")));
 /// // `Unknown` as we don't know the number of bytes that `count` corresponds to
-/// assert_eq!(take6(Partial::new("short")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(take6.parse_peek(Partial::new("short")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 #[inline(always)]
 pub fn take<UsizeLike, Input, Error>(
@@ -877,69 +858,65 @@ where
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// use winnow::token::take_until;
 ///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
-///   take_until(0.., "eof").parse_peek(s)
+/// fn until_eof<'i>(s: &mut &'i str) -> PResult<&'i str> {
+///   take_until(0.., "eof").parse_next(s)
 /// }
 ///
-/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert!(until_eof("hello, world").is_err());
-/// assert!(until_eof("").is_err());
-/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+/// assert_eq!(until_eof.parse_peek("hello, worldeof"), Ok(("eof", "hello, world")));
+/// assert!(until_eof.parse_peek("hello, world").is_err());
+/// assert!(until_eof.parse_peek("").is_err());
+/// assert_eq!(until_eof.parse_peek("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_until;
 ///
-/// fn until_eof(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   take_until(0.., "eof").parse_peek(s)
+/// fn until_eof<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+///   take_until(0.., "eof").parse_next(s)
 /// }
 ///
-/// assert_eq!(until_eof(Partial::new("hello, worldeof")), Ok((Partial::new("eof"), "hello, world")));
-/// assert_eq!(until_eof(Partial::new("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Partial::new("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Partial::new("1eof2eof")), Ok((Partial::new("eof2eof"), "1")));
+/// assert_eq!(until_eof.parse_peek(Partial::new("hello, worldeof")), Ok((Partial::new("eof"), "hello, world")));
+/// assert_eq!(until_eof.parse_peek(Partial::new("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof.parse_peek(Partial::new("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof.parse_peek(Partial::new("1eof2eof")), Ok((Partial::new("eof2eof"), "1")));
 /// ```
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// use winnow::token::take_until;
 ///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
-///   take_until(1.., "eof").parse_peek(s)
+/// fn until_eof<'i>(s: &mut &'i str) -> PResult<&'i str> {
+///   take_until(1.., "eof").parse_next(s)
 /// }
 ///
-/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert!(until_eof("hello, world").is_err());
-/// assert!(until_eof("").is_err());
-/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert!(until_eof("eof").is_err());
+/// assert_eq!(until_eof.parse_peek("hello, worldeof"), Ok(("eof", "hello, world")));
+/// assert!(until_eof.parse_peek("hello, world").is_err());
+/// assert!(until_eof.parse_peek("").is_err());
+/// assert_eq!(until_eof.parse_peek("1eof2eof"), Ok(("eof2eof", "1")));
+/// assert!(until_eof.parse_peek("eof").is_err());
 /// ```
 ///
 /// ```rust
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// use winnow::token::take_until;
 ///
-/// fn until_eof(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
-///   take_until(1.., "eof").parse_peek(s)
+/// fn until_eof<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+///   take_until(1.., "eof").parse_next(s)
 /// }
 ///
-/// assert_eq!(until_eof(Partial::new("hello, worldeof")), Ok((Partial::new("eof"), "hello, world")));
-/// assert_eq!(until_eof(Partial::new("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Partial::new("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof(Partial::new("1eof2eof")), Ok((Partial::new("eof2eof"), "1")));
-/// assert!(until_eof(Partial::new("eof")).is_err());
+/// assert_eq!(until_eof.parse_peek(Partial::new("hello, worldeof")), Ok((Partial::new("eof"), "hello, world")));
+/// assert_eq!(until_eof.parse_peek(Partial::new("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof.parse_peek(Partial::new("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
+/// assert_eq!(until_eof.parse_peek(Partial::new("1eof2eof")), Ok((Partial::new("eof2eof"), "1")));
+/// assert!(until_eof.parse_peek(Partial::new("eof")).is_err());
 /// ```
 #[inline(always)]
 pub fn take_until<Literal, Input, Error>(
@@ -1074,7 +1051,6 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::error::ErrorKind;
 /// # use winnow::error::ContextError;
 /// use winnow::token::rest;
@@ -1113,7 +1089,6 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::error::IResult;
 /// # use winnow::error::ErrorKind;
 /// # use winnow::error::ContextError;
 /// use winnow::token::rest_len;

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -36,7 +36,7 @@ use crate::Parser;
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{token::any, error::ErrMode, error::{InputError, ErrorKind}};
+/// # use winnow::{token::any, error::ErrMode, error::{ContextError, ErrorKind}};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// fn parser(input: &str) -> IResult<&str, char> {
@@ -48,12 +48,12 @@ use crate::Parser;
 /// ```
 ///
 /// ```rust
-/// # use winnow::{token::any, error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{token::any, error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::Partial;
-/// assert_eq!(any::<_, InputError<_>>.parse_peek(Partial::new("abc")), Ok((Partial::new("bc"),'a')));
-/// assert_eq!(any::<_, InputError<_>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(any::<_, ContextError>.parse_peek(Partial::new("abc")), Ok((Partial::new("bc"),'a')));
+/// assert_eq!(any::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 #[doc(alias = "token")]
@@ -93,7 +93,7 @@ where
 /// The input data will be compared to the literal combinator's argument and will return the part of
 /// the input that matches the argument
 ///
-/// It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Literal)))` if the input doesn't match the literal
+/// It will return `Err(ErrMode::Backtrack(ContextError::new(_, ErrorKind::Literal)))` if the input doesn't match the literal
 ///
 /// <div class="warning">
 ///
@@ -118,7 +118,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// #
 /// fn parser(s: &str) -> IResult<&str, &str> {
 ///   "Hello".parse_peek(s)
@@ -132,7 +132,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::Partial;
 ///
 /// fn parser(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
@@ -146,7 +146,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// use winnow::token::literal;
@@ -239,11 +239,11 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError};
 /// # use winnow::token::one_of;
-/// assert_eq!(one_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek("b"), Ok(("", 'b')));
-/// assert!(one_of::<_, _, InputError<_>>('a').parse_peek("bc").is_err());
-/// assert!(one_of::<_, _, InputError<_>>('a').parse_peek("").is_err());
+/// assert_eq!(one_of::<_, _, ContextError>(['a', 'b', 'c']).parse_peek("b"), Ok(("", 'b')));
+/// assert!(one_of::<_, _, ContextError>('a').parse_peek("bc").is_err());
+/// assert!(one_of::<_, _, ContextError>('a').parse_peek("").is_err());
 ///
 /// fn parser_fn(i: &str) -> IResult<&str, char> {
 ///     one_of(|c| c == 'a' || c == 'b').parse_peek(i)
@@ -256,12 +256,12 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::token::one_of;
-/// assert_eq!(one_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek(Partial::new("b")), Ok((Partial::new(""), 'b')));
-/// assert!(one_of::<_, _, InputError<_>>('a').parse_peek(Partial::new("bc")).is_err());
-/// assert_eq!(one_of::<_, _, InputError<_>>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(one_of::<_, _, ContextError>(['a', 'b', 'c']).parse_peek(Partial::new("b")), Ok((Partial::new(""), 'b')));
+/// assert!(one_of::<_, _, ContextError>('a').parse_peek(Partial::new("bc")).is_err());
+/// assert_eq!(one_of::<_, _, ContextError>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn parser_fn(i: Partial<&str>) -> IResult<Partial<&str>, char> {
 ///     one_of(|c| c == 'a' || c == 'b').parse_peek(i)
@@ -311,24 +311,24 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::token::none_of;
-/// assert_eq!(none_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek("z"), Ok(("", 'z')));
-/// assert!(none_of::<_, _, InputError<_>>(['a', 'b']).parse_peek("a").is_err());
-/// assert!(none_of::<_, _, InputError<_>>('a').parse_peek("").is_err());
+/// assert_eq!(none_of::<_, _, ContextError>(['a', 'b', 'c']).parse_peek("z"), Ok(("", 'z')));
+/// assert!(none_of::<_, _, ContextError>(['a', 'b']).parse_peek("a").is_err());
+/// assert!(none_of::<_, _, ContextError>('a').parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::Partial;
 /// # use winnow::token::none_of;
-/// assert_eq!(none_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek(Partial::new("z")), Ok((Partial::new(""), 'z')));
-/// assert!(none_of::<_, _, InputError<_>>(['a', 'b']).parse_peek(Partial::new("a")).is_err());
-/// assert_eq!(none_of::<_, _, InputError<_>>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(none_of::<_, _, ContextError>(['a', 'b', 'c']).parse_peek(Partial::new("z")), Ok((Partial::new(""), 'z')));
+/// assert!(none_of::<_, _, ContextError>(['a', 'b']).parse_peek(Partial::new("a")).is_err());
+/// assert_eq!(none_of::<_, _, ContextError>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn none_of<Input, Set, Error>(
@@ -348,7 +348,7 @@ where
 
 /// Recognize the longest (m <= len <= n) input slice that matches a [set of tokens][ContainsToken]
 ///
-/// It will return an `ErrMode::Backtrack(InputError::new(_, ErrorKind::Slice))` if the set of tokens wasn't met or is out
+/// It will return an `ErrMode::Backtrack(ContextError::new(_, ErrorKind::Slice))` if the set of tokens wasn't met or is out
 /// of range (m <= len <= n).
 ///
 /// *[Partial version][crate::_topic::partial]* will return a `ErrMode::Incomplete(Needed::new(1))` if a member of the set of tokens reaches the end of the input or is too short.
@@ -373,7 +373,7 @@ where
 ///
 /// Zero or more tokens:
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// use winnow::token::take_while;
@@ -390,7 +390,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::Partial;
@@ -409,7 +409,7 @@ where
 ///
 /// One or more tokens:
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// use winnow::token::take_while;
@@ -435,7 +435,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::Partial;
@@ -463,7 +463,7 @@ where
 ///
 /// Arbitrary amount of tokens:
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// use winnow::token::take_while;
@@ -481,7 +481,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::Partial;
@@ -663,7 +663,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// use winnow::token::take_till;
@@ -679,7 +679,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::Partial;
@@ -739,7 +739,7 @@ where
 
 /// Recognize an input slice containing the first N input elements (I[..N]).
 ///
-/// *Complete version*: It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Slice)))` if the input is shorter than the argument.
+/// *Complete version*: It will return `Err(ErrMode::Backtrack(ContextError::new(_, ErrorKind::Slice)))` if the input is shorter than the argument.
 ///
 /// *[Partial version][crate::_topic::partial]*: if the input has less than N elements, `take` will
 /// return a `ErrMode::Incomplete(Needed::new(M))` where M is the number of
@@ -765,7 +765,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// use winnow::token::take;
@@ -787,16 +787,16 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
-/// use winnow::error::InputError;
+/// use winnow::error::ContextError;
 /// use winnow::token::take;
 ///
-/// assert_eq!(take::<_, _, InputError<_>>(1usize).parse_peek("💙"), Ok(("", "💙")));
-/// assert_eq!(take::<_, _, InputError<_>>(1usize).parse_peek("💙".as_bytes()), Ok((b"\x9F\x92\x99".as_ref(), b"\xF0".as_ref())));
+/// assert_eq!(take::<_, _, ContextError>(1usize).parse_peek("💙"), Ok(("", "💙")));
+/// assert_eq!(take::<_, _, ContextError>(1usize).parse_peek("💙".as_bytes()), Ok((b"\x9F\x92\x99".as_ref(), b"\xF0".as_ref())));
 /// ```
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::error::{ErrMode, ErrorKind, InputError, Needed, IResult};
+/// # use winnow::error::{ErrMode, ErrorKind, ContextError, Needed, IResult};
 /// # use winnow::Partial;
 /// use winnow::token::take;
 ///
@@ -849,7 +849,7 @@ where
 ///
 /// It doesn't consume the literal.
 ///
-/// *Complete version*: It will return `Err(ErrMode::Backtrack(InputError::new(_, ErrorKind::Slice)))`
+/// *Complete version*: It will return `Err(ErrMode::Backtrack(ContextError::new(_, ErrorKind::Slice)))`
 /// if the literal wasn't met.
 ///
 /// *[Partial version][crate::_topic::partial]*: will return a `ErrMode::Incomplete(Needed::new(N))` if the input doesn't
@@ -875,7 +875,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// use winnow::token::take_until;
@@ -891,7 +891,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::Partial;
@@ -908,7 +908,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// use winnow::token::take_until;
@@ -925,7 +925,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::Partial;
@@ -1076,10 +1076,10 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::error::ErrorKind;
-/// # use winnow::error::InputError;
+/// # use winnow::error::ContextError;
 /// use winnow::token::rest;
-/// assert_eq!(rest::<_,InputError<_>>.parse_peek("abc"), Ok(("", "abc")));
-/// assert_eq!(rest::<_,InputError<_>>.parse_peek(""), Ok(("", "")));
+/// assert_eq!(rest::<_,ContextError>.parse_peek("abc"), Ok(("", "abc")));
+/// assert_eq!(rest::<_,ContextError>.parse_peek(""), Ok(("", "")));
 /// ```
 #[inline]
 pub fn rest<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
@@ -1115,10 +1115,10 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::error::ErrorKind;
-/// # use winnow::error::InputError;
+/// # use winnow::error::ContextError;
 /// use winnow::token::rest_len;
-/// assert_eq!(rest_len::<_,InputError<_>>.parse_peek("abc"), Ok(("abc", 3)));
-/// assert_eq!(rest_len::<_,InputError<_>>.parse_peek(""), Ok(("", 0)));
+/// assert_eq!(rest_len::<_,ContextError>.parse_peek("abc"), Ok(("abc", 3)));
+/// assert_eq!(rest_len::<_,ContextError>.parse_peek(""), Ok(("", 0)));
 /// ```
 #[inline]
 pub fn rest_len<Input, Error>(input: &mut Input) -> PResult<usize, Error>

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -253,7 +253,7 @@ where
 /// assert_eq!(parser_fn(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
@@ -320,7 +320,7 @@ where
 /// assert_eq!(none_of::<_, _, InputError<_>>('a').parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
 /// ```
 ///
-/// ```
+/// ```rust
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::IResult;

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -44,7 +44,7 @@ use crate::Parser;
 /// }
 ///
 /// assert_eq!(parser("abc"), Ok(("bc",'a')));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
+/// assert!(parser("").is_err());
 /// ```
 ///
 /// ```rust
@@ -125,8 +125,8 @@ where
 /// }
 ///
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(ErrMode::Backtrack(InputError::new("Something", ErrorKind::Literal))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser("Something").is_err());
+/// assert!(parser("").is_err());
 /// ```
 ///
 /// ```rust
@@ -140,8 +140,8 @@ where
 /// }
 ///
 /// assert_eq!(parser(Partial::new("Hello, World!")), Ok((Partial::new(", World!"), "Hello")));
-/// assert_eq!(parser(Partial::new("Something")), Err(ErrMode::Backtrack(InputError::new(Partial::new("Something"), ErrorKind::Literal))));
-/// assert_eq!(parser(Partial::new("S")), Err(ErrMode::Backtrack(InputError::new(Partial::new("S"), ErrorKind::Literal))));
+/// assert!(parser(Partial::new("Something")).is_err());
+/// assert!(parser(Partial::new("S")).is_err());
 /// assert_eq!(parser(Partial::new("H")), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 ///
@@ -159,8 +159,8 @@ where
 /// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
 /// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
 /// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(ErrMode::Backtrack(InputError::new("Something", ErrorKind::Literal))));
-/// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Literal))));
+/// assert!(parser("Something").is_err());
+/// assert!(parser("").is_err());
 /// ```
 #[inline(always)]
 #[doc(alias = "tag")]
@@ -242,15 +242,15 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError};
 /// # use winnow::token::one_of;
 /// assert_eq!(one_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, InputError<_>>('a').parse_peek("bc"), Err(ErrMode::Backtrack(InputError::new("bc", ErrorKind::Verify))));
-/// assert_eq!(one_of::<_, _, InputError<_>>('a').parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
+/// assert!(one_of::<_, _, InputError<_>>('a').parse_peek("bc").is_err());
+/// assert!(one_of::<_, _, InputError<_>>('a').parse_peek("").is_err());
 ///
 /// fn parser_fn(i: &str) -> IResult<&str, char> {
 ///     one_of(|c| c == 'a' || c == 'b').parse_peek(i)
 /// }
 /// assert_eq!(parser_fn("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser_fn("cd"), Err(ErrMode::Backtrack(InputError::new("cd", ErrorKind::Verify))));
-/// assert_eq!(parser_fn(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
+/// assert!(parser_fn("cd").is_err());
+/// assert!(parser_fn("").is_err());
 /// ```
 ///
 /// ```rust
@@ -260,14 +260,14 @@ where
 /// # use winnow::Partial;
 /// # use winnow::token::one_of;
 /// assert_eq!(one_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek(Partial::new("b")), Ok((Partial::new(""), 'b')));
-/// assert_eq!(one_of::<_, _, InputError<_>>('a').parse_peek(Partial::new("bc")), Err(ErrMode::Backtrack(InputError::new(Partial::new("bc"), ErrorKind::Verify))));
+/// assert!(one_of::<_, _, InputError<_>>('a').parse_peek(Partial::new("bc")).is_err());
 /// assert_eq!(one_of::<_, _, InputError<_>>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn parser_fn(i: Partial<&str>) -> IResult<Partial<&str>, char> {
 ///     one_of(|c| c == 'a' || c == 'b').parse_peek(i)
 /// }
 /// assert_eq!(parser_fn(Partial::new("abc")), Ok((Partial::new("bc"), 'a')));
-/// assert_eq!(parser_fn(Partial::new("cd")), Err(ErrMode::Backtrack(InputError::new(Partial::new("cd"), ErrorKind::Verify))));
+/// assert!(parser_fn(Partial::new("cd")).is_err());
 /// assert_eq!(parser_fn(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -316,8 +316,8 @@ where
 /// # use winnow::error::IResult;
 /// # use winnow::token::none_of;
 /// assert_eq!(none_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, InputError<_>>(['a', 'b']).parse_peek("a"), Err(ErrMode::Backtrack(InputError::new("a", ErrorKind::Verify))));
-/// assert_eq!(none_of::<_, _, InputError<_>>('a').parse_peek(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Token))));
+/// assert!(none_of::<_, _, InputError<_>>(['a', 'b']).parse_peek("a").is_err());
+/// assert!(none_of::<_, _, InputError<_>>('a').parse_peek("").is_err());
 /// ```
 ///
 /// ```rust
@@ -327,7 +327,7 @@ where
 /// # use winnow::Partial;
 /// # use winnow::token::none_of;
 /// assert_eq!(none_of::<_, _, InputError<_>>(['a', 'b', 'c']).parse_peek(Partial::new("z")), Ok((Partial::new(""), 'z')));
-/// assert_eq!(none_of::<_, _, InputError<_>>(['a', 'b']).parse_peek(Partial::new("a")), Err(ErrMode::Backtrack(InputError::new(Partial::new("a"), ErrorKind::Verify))));
+/// assert!(none_of::<_, _, InputError<_>>(['a', 'b']).parse_peek(Partial::new("a")).is_err());
 /// assert_eq!(none_of::<_, _, InputError<_>>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
@@ -421,7 +421,7 @@ where
 ///
 /// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Err(ErrMode::Backtrack(InputError::new(&b"12345"[..], ErrorKind::Slice))));
+/// assert!(alpha(b"12345").is_err());
 ///
 /// fn hex(s: &str) -> IResult<&str, &str> {
 ///   take_while(1.., ('0'..='9', 'A'..='F')).parse_peek(s)
@@ -431,7 +431,7 @@ where
 /// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
 /// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
 /// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
-/// assert_eq!(hex(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(hex("").is_err());
 /// ```
 ///
 /// ```rust
@@ -448,7 +448,7 @@ where
 ///
 /// assert_eq!(alpha(Partial::new(b"latin123")), Ok((Partial::new(&b"123"[..]), &b"latin"[..])));
 /// assert_eq!(alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(Partial::new(b"12345")), Err(ErrMode::Backtrack(InputError::new(Partial::new(&b"12345"[..]), ErrorKind::Slice))));
+/// assert!(alpha(Partial::new(b"12345")).is_err());
 ///
 /// fn hex(s: Partial<&str>) -> IResult<Partial<&str>, &str> {
 ///   take_while(1.., ('0'..='9', 'A'..='F')).parse_peek(s)
@@ -476,8 +476,8 @@ where
 /// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
 /// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
 /// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"ed"), Err(ErrMode::Backtrack(InputError::new(&b"ed"[..], ErrorKind::Slice))));
-/// assert_eq!(short_alpha(b"12345"), Err(ErrMode::Backtrack(InputError::new(&b"12345"[..], ErrorKind::Slice))));
+/// assert!(short_alpha(b"ed").is_err());
+/// assert!(short_alpha(b"12345").is_err());
 /// ```
 ///
 /// ```rust
@@ -496,7 +496,7 @@ where
 /// assert_eq!(short_alpha(Partial::new(b"lengthy")), Ok((Partial::new(&b"y"[..]), &b"length"[..])));
 /// assert_eq!(short_alpha(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert_eq!(short_alpha(Partial::new(b"ed")), Err(ErrMode::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(Partial::new(b"12345")), Err(ErrMode::Backtrack(InputError::new(Partial::new(&b"12345"[..]), ErrorKind::Slice))));
+/// assert!(short_alpha(Partial::new(b"12345")).is_err());
 /// ```
 #[inline(always)]
 #[doc(alias = "is_a")]
@@ -776,8 +776,8 @@ where
 ///
 /// assert_eq!(take6("1234567"), Ok(("7", "123456")));
 /// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(ErrMode::Backtrack(InputError::new("short", ErrorKind::Slice))));
-/// assert_eq!(take6(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(take6("short").is_err());
+/// assert!(take6("").is_err());
 /// ```
 ///
 /// The units that are taken will depend on the input type. For example, for a
@@ -885,8 +885,8 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Backtrack(InputError::new("hello, world", ErrorKind::Slice))));
-/// assert_eq!(until_eof(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(until_eof("hello, world").is_err());
+/// assert!(until_eof("").is_err());
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
 /// ```
 ///
@@ -918,10 +918,10 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(ErrMode::Backtrack(InputError::new("hello, world", ErrorKind::Slice))));
-/// assert_eq!(until_eof(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Slice))));
+/// assert!(until_eof("hello, world").is_err());
+/// assert!(until_eof("").is_err());
 /// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"), Err(ErrMode::Backtrack(InputError::new("eof", ErrorKind::Slice))));
+/// assert!(until_eof("eof").is_err());
 /// ```
 ///
 /// ```rust
@@ -939,7 +939,7 @@ where
 /// assert_eq!(until_eof(Partial::new("hello, world")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(until_eof(Partial::new("hello, worldeo")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// assert_eq!(until_eof(Partial::new("1eof2eof")), Ok((Partial::new("eof2eof"), "1")));
-/// assert_eq!(until_eof(Partial::new("eof")), Err(ErrMode::Backtrack(InputError::new(Partial::new("eof"), ErrorKind::Slice))));
+/// assert!(until_eof(Partial::new("eof")).is_err());
 /// ```
 #[inline(always)]
 pub fn take_until<Literal, Input, Error>(

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -7,10 +7,9 @@ use snapbox::str;
 use crate::ascii::Caseless;
 use crate::combinator::delimited;
 use crate::error::IResult;
-use crate::error::InputError;
+use crate::prelude::*;
 use crate::stream::AsChar;
 use crate::token::literal;
-use crate::Parser;
 use crate::Partial;
 
 #[test]
@@ -88,7 +87,7 @@ fn model_complete_take_while_m_n<'i>(
 
 #[test]
 fn complete_take_until() {
-    fn take_until_5_10<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn take_until_5_10<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_until(5..=8, "end").parse_next(i)
     }
     assert_parse!(
@@ -173,7 +172,7 @@ Err(
 
 #[test]
 fn complete_take_until_empty() {
-    fn take_until_empty<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn take_until_empty<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_until(0, "").parse_next(i)
     }
     assert_parse!(
@@ -204,7 +203,7 @@ Ok(
 
 #[test]
 fn complete_literal_case_insensitive() {
-    fn caseless_bytes<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
+    fn caseless_bytes<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], &'i [u8]> {
         literal(Caseless("ABcd")).parse_next(i)
     }
     assert_parse!(
@@ -329,7 +328,7 @@ Err(
 "#]]
     );
 
-    fn caseless_str<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn caseless_str<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
         literal(Caseless("ABcd")).parse_next(i)
     }
     assert_parse!(
@@ -411,7 +410,7 @@ Err(
 "#]]
     );
 
-    fn matches_kelvin<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn matches_kelvin<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
         literal(Caseless("k")).parse_next(i)
     }
     assert_parse!(
@@ -429,7 +428,7 @@ Err(
 "#]]
     );
 
-    fn is_kelvin<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn is_kelvin<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
         literal(Caseless("K")).parse_next(i)
     }
     assert_parse!(
@@ -450,10 +449,10 @@ Err(
 
 #[test]
 fn complete_literal_fixed_size_array() {
-    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
+    fn test<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], &'i [u8]> {
         literal([0x42]).parse_next(i)
     }
-    fn test2<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
+    fn test2<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], &'i [u8]> {
         literal(&[0x42]).parse_next(i)
     }
 
@@ -494,7 +493,7 @@ Ok(
 
 #[test]
 fn complete_literal_char() {
-    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
+    fn test<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], &'i [u8]> {
         literal('B').parse_next(i)
     }
     assert_parse!(
@@ -534,7 +533,7 @@ Err(
 
 #[test]
 fn complete_literal_byte() {
-    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
+    fn test<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], &'i [u8]> {
         literal(b'B').parse_next(i)
     }
     assert_parse!(
@@ -576,7 +575,7 @@ Err(
 fn partial_any_str() {
     use super::any;
     assert_parse!(
-        any::<_, InputError<Partial<&str>>>.parse_peek(Partial::new("Ә")),
+        any.parse_peek(Partial::new("Ә")),
         str![[r#"
 Ok(
     (
@@ -594,7 +593,7 @@ Ok(
 
 #[test]
 fn partial_one_of_test() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u8, InputError<Partial<&'i [u8]>>> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u8> {
         one_of(['a', 'b']).parse_next(i)
     }
 
@@ -642,7 +641,7 @@ Err(
 "#]]
     );
 
-    fn utf8<'i>(i: &mut Partial<&'i str>) -> PResult<char, InputError<Partial<&'i str>>> {
+    fn utf8<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, char> {
         one_of(['+', '\u{FF0B}']).parse_next(i)
     }
 
@@ -652,7 +651,7 @@ Err(
 
 #[test]
 fn char_byteslice() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<char, InputError<Partial<&'i [u8]>>> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, char> {
         'c'.parse_next(i)
     }
 
@@ -703,7 +702,7 @@ Ok(
 
 #[test]
 fn char_str() {
-    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<char, InputError<Partial<&'i str>>> {
+    fn f<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, char> {
         'c'.parse_next(i)
     }
 
@@ -746,7 +745,7 @@ Ok(
 
 #[test]
 fn partial_none_of_test() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u8, InputError<Partial<&'i [u8]>>> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, u8> {
         none_of(['a', 'b']).parse_next(i)
     }
 
@@ -797,7 +796,7 @@ Ok(
 
 #[test]
 fn partial_is_a() {
-    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         take_while(1.., ['a', 'b']).parse_next(i)
     }
 
@@ -899,7 +898,7 @@ Ok(
 
 #[test]
 fn partial_is_not() {
-    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         take_till(1.., ['a', 'b']).parse_next(i)
     }
 
@@ -1016,7 +1015,7 @@ Err(
 
 #[test]
 fn partial_take_until_incomplete() {
-    fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn y<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         take_until(0.., "end").parse_next(i)
     }
     assert_parse!(
@@ -1056,7 +1055,7 @@ Err(
 
 #[test]
 fn partial_take_until_incomplete_s() {
-    fn ys<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn ys<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_until(0.., "end").parse_next(i)
     }
     assert_parse!(
@@ -1079,7 +1078,7 @@ fn partial_take() {
         multispace1 as multispace, oct_digit1 as oct_digit, space1 as space,
     };
 
-    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn x<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         delimited("<!--", take(5_usize), "-->").take().parse_next(i)
     }
     let r = x.parse_peek(Partial::new(&b"<!-- abc --> aaa"[..]));
@@ -1117,7 +1116,7 @@ Ok(
 "#]]
     );
 
-    fn ya<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn ya<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         alpha.take().parse_next(i)
     }
     let ra = ya.parse_peek(Partial::new(&b"abc;"[..]));
@@ -1143,7 +1142,7 @@ Ok(
 "#]]
     );
 
-    fn yd<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn yd<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         digit.take().parse_next(i)
     }
     let rd = yd.parse_peek(Partial::new(&b"123;"[..]));
@@ -1169,7 +1168,7 @@ Ok(
 "#]]
     );
 
-    fn yhd<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn yhd<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         hex_digit.take().parse_next(i)
     }
     let rhd = yhd.parse_peek(Partial::new(&b"123abcDEF;"[..]));
@@ -1201,7 +1200,7 @@ Ok(
 "#]]
     );
 
-    fn yod<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn yod<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         oct_digit.take().parse_next(i)
     }
     let rod = yod.parse_peek(Partial::new(&b"1234567;"[..]));
@@ -1231,7 +1230,7 @@ Ok(
 "#]]
     );
 
-    fn yan<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn yan<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         alphanumeric.take().parse_next(i)
     }
     let ran = yan.parse_peek(Partial::new(&b"123abc;"[..]));
@@ -1260,7 +1259,7 @@ Ok(
 "#]]
     );
 
-    fn ys<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn ys<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         space.take().parse_next(i)
     }
     let rs = ys.parse_peek(Partial::new(&b" \t;"[..]));
@@ -1285,7 +1284,7 @@ Ok(
 "#]]
     );
 
-    fn yms<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn yms<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         multispace.take().parse_next(i)
     }
     let rms = yms.parse_peek(Partial::new(&b" \t\r\n;"[..]));
@@ -1315,7 +1314,7 @@ Ok(
 
 #[test]
 fn partial_take_while0() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         take_while(0.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -1396,7 +1395,7 @@ Ok(
 
 #[test]
 fn partial_take_while1() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         take_while(1.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -1479,7 +1478,7 @@ Err(
 
 #[test]
 fn partial_take_while_m_n() {
-    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn x<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         take_while(2..=4, AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -1598,7 +1597,7 @@ Err(
 
 #[test]
 fn partial_take_till0() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         take_till(0.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -1680,7 +1679,7 @@ Err(
 
 #[test]
 fn partial_take_till1() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         take_till(1.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -1764,7 +1763,7 @@ Err(
 
 #[test]
 fn partial_take_while_utf8() {
-    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn f<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_while(0.., |c| c != '點').parse_next(i)
     }
 
@@ -1825,7 +1824,7 @@ Ok(
 "#]]
     );
 
-    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn g<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_while(0.., |c| c == '點').parse_next(i)
     }
 
@@ -1876,7 +1875,7 @@ Ok(
 
 #[test]
 fn partial_take_till0_utf8() {
-    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn f<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_till(0.., |c| c == '點').parse_next(i)
     }
 
@@ -1937,7 +1936,7 @@ Ok(
 "#]]
     );
 
-    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn g<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_till(0.., |c| c != '點').parse_next(i)
     }
 
@@ -1988,7 +1987,7 @@ Ok(
 
 #[test]
 fn partial_take_utf8() {
-    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn f<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take(3_usize).parse_next(i)
     }
 
@@ -2071,7 +2070,7 @@ Ok(
 "#]]
     );
 
-    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn g<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_while(0.., |c| c == '點').parse_next(i)
     }
 
@@ -2122,7 +2121,7 @@ Ok(
 
 #[test]
 fn partial_take_while_m_n_utf8_fixed() {
-    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn parser<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_while(1, |c| c == 'A' || c == '😃').parse_next(i)
     }
     assert_parse!(
@@ -2159,7 +2158,7 @@ Ok(
 
 #[test]
 fn partial_take_while_m_n_utf8_range() {
-    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn parser<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_while(1..=2, |c| c == 'A' || c == '😃').parse_next(i)
     }
     assert_parse!(
@@ -2196,7 +2195,7 @@ Ok(
 
 #[test]
 fn partial_take_while_m_n_utf8_full_match_fixed() {
-    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn parser<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_while(1, |c: char| c.is_alphabetic()).parse_next(i)
     }
     assert_parse!(
@@ -2218,7 +2217,7 @@ Ok(
 
 #[test]
 fn partial_take_while_m_n_utf8_full_match_range() {
-    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn parser<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_while(1..=2, |c: char| c.is_alphabetic()).parse_next(i)
     }
     assert_parse!(
@@ -2241,10 +2240,10 @@ Ok(
 #[test]
 #[cfg(feature = "std")]
 fn partial_take_take_while0() {
-    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn x<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         take_while(0.., AsChar::is_alphanum).parse_next(i)
     }
-    fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn y<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         x.take().parse_next(i)
     }
     assert_parse!(
@@ -2291,9 +2290,7 @@ Ok(
 
 #[test]
 fn partial_literal_case_insensitive() {
-    fn caseless_bytes<'i>(
-        i: &mut Partial<&'i [u8]>,
-    ) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn caseless_bytes<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         literal(Caseless("ABcd")).parse_next(i)
     }
     assert_parse!(
@@ -2429,9 +2426,7 @@ Err(
 "#]]
     );
 
-    fn caseless_str<'i>(
-        i: &mut Partial<&'i str>,
-    ) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn caseless_str<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         literal(Caseless("ABcd")).parse_next(i)
     }
     assert_parse!(
@@ -2527,9 +2522,7 @@ Err(
 "#]]
     );
 
-    fn matches_kelvin<'i>(
-        i: &mut Partial<&'i str>,
-    ) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn matches_kelvin<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         literal(Caseless("k")).parse_next(i)
     }
     assert_parse!(
@@ -2550,7 +2543,7 @@ Err(
 "#]]
     );
 
-    fn is_kelvin<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn is_kelvin<'i>(i: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         literal(Caseless("K")).parse_next(i)
     }
     assert_parse!(
@@ -2574,10 +2567,10 @@ Err(
 
 #[test]
 fn partial_literal_fixed_size_array() {
-    fn test<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn test<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         literal([0x42]).parse_next(i)
     }
-    fn test2<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
+    fn test2<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, &'i [u8]> {
         literal(&[0x42]).parse_next(i)
     }
     let input = Partial::new(&[0x42, 0x00][..]);

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -36,66 +36,73 @@ fn complete_take_while_m_n_utf8_all_matching_substring() {
 }
 
 #[cfg(feature = "std")]
-fn model_complete_take_while_m_n(
-    m: usize,
-    n: usize,
-    valid: usize,
-    input: &str,
-) -> IResult<&str, &str> {
-    if n < m {
-        Err(crate::error::ErrMode::from_error_kind(
-            &input,
-            crate::error::ErrorKind::Slice,
-        ))
-    } else if m <= valid {
-        let offset = n.min(valid);
-        Ok((&input[offset..], &input[0..offset]))
-    } else {
-        Err(crate::error::ErrMode::from_error_kind(
-            &input,
-            crate::error::ErrorKind::Slice,
-        ))
-    }
-}
-
-#[cfg(feature = "std")]
 proptest! {
   #[test]
   #[cfg_attr(miri, ignore)]  // See https://github.com/AltSysrq/proptest/issues/253
   fn complete_take_while_m_n_bounds(m in 0..20usize, n in 0..20usize, valid in 0..20usize, invalid in 0..20usize) {
       let input = format!("{:a<valid$}{:b<invalid$}", "", "", valid=valid, invalid=invalid);
-      let expected = model_complete_take_while_m_n(m, n, valid, &input);
+      let mut model_input = input.as_str();
+      let expected = model_complete_take_while_m_n(m, n, valid, &mut model_input);
       if m <= n {
           let actual = take_while(m..=n, |c: char| c == 'a').parse_peek(input.as_str());
-          assert_eq!(expected, actual);
+          assert_eq!(expected.map(|o| (model_input, o)), actual);
       }
   }
 }
 
+#[cfg(feature = "std")]
+fn model_complete_take_while_m_n<'i>(
+    m: usize,
+    n: usize,
+    valid: usize,
+    input: &mut &'i str,
+) -> PResult<&'i str> {
+    if n < m {
+        Err(crate::error::ErrMode::from_error_kind(
+            input,
+            crate::error::ErrorKind::Slice,
+        ))
+    } else if m <= valid {
+        let offset = n.min(valid);
+        Ok(input.next_slice(offset))
+    } else {
+        Err(crate::error::ErrMode::from_error_kind(
+            input,
+            crate::error::ErrorKind::Slice,
+        ))
+    }
+}
+
 #[test]
 fn complete_take_until() {
-    fn take_until_5_10(i: &str) -> IResult<&str, &str> {
-        take_until(5..=8, "end").parse_peek(i)
+    fn take_until_5_10<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+        take_until(5..=8, "end").parse_next(i)
     }
     assert_eq!(
-        take_until_5_10("end"),
+        take_until_5_10.parse_peek("end"),
         Err(ErrMode::Backtrack(error_position!(
             &"end",
             ErrorKind::Slice
         )))
     );
     assert_eq!(
-        take_until_5_10("1234end"),
+        take_until_5_10.parse_peek("1234end"),
         Err(ErrMode::Backtrack(error_position!(
             &"1234end",
             ErrorKind::Slice
         )))
     );
-    assert_eq!(take_until_5_10("12345end"), Ok(("end", "12345")));
-    assert_eq!(take_until_5_10("123456end"), Ok(("end", "123456")));
-    assert_eq!(take_until_5_10("12345678end"), Ok(("end", "12345678")));
+    assert_eq!(take_until_5_10.parse_peek("12345end"), Ok(("end", "12345")));
     assert_eq!(
-        take_until_5_10("123456789end"),
+        take_until_5_10.parse_peek("123456end"),
+        Ok(("end", "123456"))
+    );
+    assert_eq!(
+        take_until_5_10.parse_peek("12345678end"),
+        Ok(("end", "12345678"))
+    );
+    assert_eq!(
+        take_until_5_10.parse_peek("123456789end"),
         Err(ErrMode::Backtrack(error_position!(
             &"123456789end",
             ErrorKind::Slice
@@ -105,96 +112,96 @@ fn complete_take_until() {
 
 #[test]
 fn complete_take_until_empty() {
-    fn take_until_empty(i: &str) -> IResult<&str, &str> {
-        take_until(0, "").parse_peek(i)
+    fn take_until_empty<'i>(i: &mut &'i str) -> PResult<&'i str> {
+        take_until(0, "").parse_next(i)
     }
-    assert_eq!(take_until_empty(""), Ok(("", "")));
-    assert_eq!(take_until_empty("end"), Ok(("end", "")));
+    assert_eq!(take_until_empty.parse_peek(""), Ok(("", "")));
+    assert_eq!(take_until_empty.parse_peek("end"), Ok(("end", "")));
 }
 
 #[test]
 fn complete_literal_case_insensitive() {
-    fn caseless_bytes(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        literal(Caseless("ABcd")).parse_peek(i)
+    fn caseless_bytes<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
+        literal(Caseless("ABcd")).parse_next(i)
     }
     assert_eq!(
-        caseless_bytes(&b"aBCdefgh"[..]),
+        caseless_bytes.parse_peek(&b"aBCdefgh"[..]),
         Ok((&b"efgh"[..], &b"aBCd"[..]))
     );
     assert_eq!(
-        caseless_bytes(&b"abcdefgh"[..]),
+        caseless_bytes.parse_peek(&b"abcdefgh"[..]),
         Ok((&b"efgh"[..], &b"abcd"[..]))
     );
     assert_eq!(
-        caseless_bytes(&b"ABCDefgh"[..]),
+        caseless_bytes.parse_peek(&b"ABCDefgh"[..]),
         Ok((&b"efgh"[..], &b"ABCD"[..]))
     );
     assert_eq!(
-        caseless_bytes(&b"ab"[..]),
+        caseless_bytes.parse_peek(&b"ab"[..]),
         Err(ErrMode::Backtrack(error_position!(
             &&b"ab"[..],
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        caseless_bytes(&b"Hello"[..]),
+        caseless_bytes.parse_peek(&b"Hello"[..]),
         Err(ErrMode::Backtrack(error_position!(
             &&b"Hello"[..],
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        caseless_bytes(&b"Hel"[..]),
+        caseless_bytes.parse_peek(&b"Hel"[..]),
         Err(ErrMode::Backtrack(error_position!(
             &&b"Hel"[..],
             ErrorKind::Literal
         )))
     );
 
-    fn caseless_str(i: &str) -> IResult<&str, &str> {
-        literal(Caseless("ABcd")).parse_peek(i)
+    fn caseless_str<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+        literal(Caseless("ABcd")).parse_next(i)
     }
-    assert_eq!(caseless_str("aBCdefgh"), Ok(("efgh", "aBCd")));
-    assert_eq!(caseless_str("abcdefgh"), Ok(("efgh", "abcd")));
-    assert_eq!(caseless_str("ABCDefgh"), Ok(("efgh", "ABCD")));
+    assert_eq!(caseless_str.parse_peek("aBCdefgh"), Ok(("efgh", "aBCd")));
+    assert_eq!(caseless_str.parse_peek("abcdefgh"), Ok(("efgh", "abcd")));
+    assert_eq!(caseless_str.parse_peek("ABCDefgh"), Ok(("efgh", "ABCD")));
     assert_eq!(
-        caseless_str("ab"),
+        caseless_str.parse_peek("ab"),
         Err(ErrMode::Backtrack(error_position!(
             &"ab",
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        caseless_str("Hello"),
+        caseless_str.parse_peek("Hello"),
         Err(ErrMode::Backtrack(error_position!(
             &"Hello",
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        caseless_str("Hel"),
+        caseless_str.parse_peek("Hel"),
         Err(ErrMode::Backtrack(error_position!(
             &"Hel",
             ErrorKind::Literal
         )))
     );
 
-    fn matches_kelvin(i: &str) -> IResult<&str, &str> {
-        literal(Caseless("k")).parse_peek(i)
+    fn matches_kelvin<'i>(i: &mut &'i str) -> PResult<&'i str> {
+        literal(Caseless("k")).parse_next(i)
     }
     assert_eq!(
-        matches_kelvin("K"),
+        matches_kelvin.parse_peek("K"),
         Err(ErrMode::Backtrack(error_position!(
             &"K",
             ErrorKind::Literal
         )))
     );
 
-    fn is_kelvin(i: &str) -> IResult<&str, &str> {
-        literal(Caseless("K")).parse_peek(i)
+    fn is_kelvin<'i>(i: &mut &'i str) -> PResult<&'i str> {
+        literal(Caseless("K")).parse_next(i)
     }
     assert_eq!(
-        is_kelvin("k"),
+        is_kelvin.parse_peek("k"),
         Err(ErrMode::Backtrack(error_position!(
             &"k",
             ErrorKind::Literal
@@ -204,26 +211,29 @@ fn complete_literal_case_insensitive() {
 
 #[test]
 fn complete_literal_fixed_size_array() {
-    fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        literal([0x42]).parse_peek(i)
+    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        literal([0x42]).parse_next(i)
     }
-    fn test2(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        literal(&[0x42]).parse_peek(i)
+    fn test2<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        literal(&[0x42]).parse_next(i)
     }
 
     let input = &[0x42, 0x00][..];
-    assert_eq!(test(input), Ok((&b"\x00"[..], &b"\x42"[..])));
-    assert_eq!(test2(input), Ok((&b"\x00"[..], &b"\x42"[..])));
+    assert_eq!(test.parse_peek(input), Ok((&b"\x00"[..], &b"\x42"[..])));
+    assert_eq!(test2.parse_peek(input), Ok((&b"\x00"[..], &b"\x42"[..])));
 }
 
 #[test]
 fn complete_literal_char() {
-    fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        literal('B').parse_peek(i)
+    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        literal('B').parse_next(i)
     }
-    assert_eq!(test(&[0x42, 0x00][..]), Ok((&b"\x00"[..], &b"\x42"[..])));
     assert_eq!(
-        test(&[b'A', b'\0'][..]),
+        test.parse_peek(&[0x42, 0x00][..]),
+        Ok((&b"\x00"[..], &b"\x42"[..]))
+    );
+    assert_eq!(
+        test.parse_peek(&[b'A', b'\0'][..]),
         Err(ErrMode::Backtrack(error_position!(
             &&b"A\0"[..],
             ErrorKind::Literal
@@ -233,12 +243,15 @@ fn complete_literal_char() {
 
 #[test]
 fn complete_literal_byte() {
-    fn test(i: &[u8]) -> IResult<&[u8], &[u8]> {
-        literal(b'B').parse_peek(i)
+    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+        literal(b'B').parse_next(i)
     }
-    assert_eq!(test(&[0x42, 0x00][..]), Ok((&b"\x00"[..], &b"\x42"[..])));
     assert_eq!(
-        test(&[b'A', b'\0'][..]),
+        test.parse_peek(&[0x42, 0x00][..]),
+        Ok((&b"\x00"[..], &b"\x42"[..]))
+    );
+    assert_eq!(
+        test.parse_peek(&[b'A', b'\0'][..]),
         Err(ErrMode::Backtrack(error_position!(
             &&b"A\0"[..],
             ErrorKind::Literal
@@ -257,39 +270,42 @@ fn partial_any_str() {
 
 #[test]
 fn partial_one_of_test() {
-    fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-        one_of(['a', 'b']).parse_peek(i)
+    fn f(i: &mut Partial<&[u8]>) -> PResult<u8> {
+        one_of(['a', 'b']).parse_next(i)
     }
 
     let a = &b"abcd"[..];
-    assert_eq!(f(Partial::new(a)), Ok((Partial::new(&b"bcd"[..]), b'a')));
+    assert_eq!(
+        f.parse_peek(Partial::new(a)),
+        Ok((Partial::new(&b"bcd"[..]), b'a'))
+    );
 
     let b = &b"cde"[..];
     assert_eq!(
-        f(Partial::new(b)),
+        f.parse_peek(Partial::new(b)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(b),
             ErrorKind::Verify
         )))
     );
 
-    fn utf8(i: Partial<&str>) -> IResult<Partial<&str>, char> {
-        one_of(['+', '\u{FF0B}']).parse_peek(i)
+    fn utf8(i: &mut Partial<&str>) -> PResult<char> {
+        one_of(['+', '\u{FF0B}']).parse_next(i)
     }
 
-    assert!(utf8(Partial::new("+")).is_ok());
-    assert!(utf8(Partial::new("\u{FF0B}")).is_ok());
+    assert!(utf8.parse_peek(Partial::new("+")).is_ok());
+    assert!(utf8.parse_peek(Partial::new("\u{FF0B}")).is_ok());
 }
 
 #[test]
 fn char_byteslice() {
-    fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, char> {
-        'c'.parse_peek(i)
+    fn f(i: &mut Partial<&[u8]>) -> PResult<char> {
+        'c'.parse_next(i)
     }
 
     let a = &b"abcd"[..];
     assert_eq!(
-        f(Partial::new(a)),
+        f.parse_peek(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(a),
             ErrorKind::Literal
@@ -297,18 +313,21 @@ fn char_byteslice() {
     );
 
     let b = &b"cde"[..];
-    assert_eq!(f(Partial::new(b)), Ok((Partial::new(&b"de"[..]), 'c')));
+    assert_eq!(
+        f.parse_peek(Partial::new(b)),
+        Ok((Partial::new(&b"de"[..]), 'c'))
+    );
 }
 
 #[test]
 fn char_str() {
-    fn f(i: Partial<&str>) -> IResult<Partial<&str>, char> {
-        'c'.parse_peek(i)
+    fn f(i: &mut Partial<&str>) -> PResult<char> {
+        'c'.parse_next(i)
     }
 
     let a = "abcd";
     assert_eq!(
-        f(Partial::new(a)),
+        f.parse_peek(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(a),
             ErrorKind::Literal
@@ -316,18 +335,18 @@ fn char_str() {
     );
 
     let b = "cde";
-    assert_eq!(f(Partial::new(b)), Ok((Partial::new("de"), 'c')));
+    assert_eq!(f.parse_peek(Partial::new(b)), Ok((Partial::new("de"), 'c')));
 }
 
 #[test]
 fn partial_none_of_test() {
-    fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, u8> {
-        none_of(['a', 'b']).parse_peek(i)
+    fn f(i: &mut Partial<&[u8]>) -> PResult<u8> {
+        none_of(['a', 'b']).parse_next(i)
     }
 
     let a = &b"abcd"[..];
     assert_eq!(
-        f(Partial::new(a)),
+        f.parse_peek(Partial::new(a)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(a),
             ErrorKind::Verify
@@ -335,82 +354,106 @@ fn partial_none_of_test() {
     );
 
     let b = &b"cde"[..];
-    assert_eq!(f(Partial::new(b)), Ok((Partial::new(&b"de"[..]), b'c')));
+    assert_eq!(
+        f.parse_peek(Partial::new(b)),
+        Ok((Partial::new(&b"de"[..]), b'c'))
+    );
 }
 
 #[test]
 fn partial_is_a() {
-    fn a_or_b(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while(1.., ['a', 'b']).parse_peek(i)
+    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        take_while(1.., ['a', 'b']).parse_next(i)
     }
 
     let a = Partial::new(&b"abcd"[..]);
-    assert_eq!(a_or_b(a), Ok((Partial::new(&b"cd"[..]), &b"ab"[..])));
+    assert_eq!(
+        a_or_b.parse_peek(a),
+        Ok((Partial::new(&b"cd"[..]), &b"ab"[..]))
+    );
 
     let b = Partial::new(&b"bcde"[..]);
-    assert_eq!(a_or_b(b), Ok((Partial::new(&b"cde"[..]), &b"b"[..])));
+    assert_eq!(
+        a_or_b.parse_peek(b),
+        Ok((Partial::new(&b"cde"[..]), &b"b"[..]))
+    );
 
     let c = Partial::new(&b"cdef"[..]);
     assert_eq!(
-        a_or_b(c),
+        a_or_b.parse_peek(c),
         Err(ErrMode::Backtrack(error_position!(&c, ErrorKind::Slice)))
     );
 
     let d = Partial::new(&b"bacdef"[..]);
-    assert_eq!(a_or_b(d), Ok((Partial::new(&b"cdef"[..]), &b"ba"[..])));
+    assert_eq!(
+        a_or_b.parse_peek(d),
+        Ok((Partial::new(&b"cdef"[..]), &b"ba"[..]))
+    );
 }
 
 #[test]
 fn partial_is_not() {
-    fn a_or_b(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_till(1.., ['a', 'b']).parse_peek(i)
+    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        take_till(1.., ['a', 'b']).parse_next(i)
     }
 
     let a = Partial::new(&b"cdab"[..]);
-    assert_eq!(a_or_b(a), Ok((Partial::new(&b"ab"[..]), &b"cd"[..])));
+    assert_eq!(
+        a_or_b.parse_peek(a),
+        Ok((Partial::new(&b"ab"[..]), &b"cd"[..]))
+    );
 
     let b = Partial::new(&b"cbde"[..]);
-    assert_eq!(a_or_b(b), Ok((Partial::new(&b"bde"[..]), &b"c"[..])));
+    assert_eq!(
+        a_or_b.parse_peek(b),
+        Ok((Partial::new(&b"bde"[..]), &b"c"[..]))
+    );
 
     let c = Partial::new(&b"abab"[..]);
     assert_eq!(
-        a_or_b(c),
+        a_or_b.parse_peek(c),
         Err(ErrMode::Backtrack(error_position!(&c, ErrorKind::Slice)))
     );
 
     let d = Partial::new(&b"cdefba"[..]);
-    assert_eq!(a_or_b(d), Ok((Partial::new(&b"ba"[..]), &b"cdef"[..])));
+    assert_eq!(
+        a_or_b.parse_peek(d),
+        Ok((Partial::new(&b"ba"[..]), &b"cdef"[..]))
+    );
 
     let e = Partial::new(&b"e"[..]);
-    assert_eq!(a_or_b(e), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        a_or_b.parse_peek(e),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
 }
 
 #[test]
 fn partial_take_until_incomplete() {
-    fn y(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_until(0.., "end").parse_peek(i)
+    fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        take_until(0.., "end").parse_next(i)
     }
     assert_eq!(
-        y(Partial::new(&b"nd"[..])),
+        y.parse_peek(Partial::new(&b"nd"[..])),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
     assert_eq!(
-        y(Partial::new(&b"123"[..])),
+        y.parse_peek(Partial::new(&b"123"[..])),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
     assert_eq!(
-        y(Partial::new(&b"123en"[..])),
+        y.parse_peek(Partial::new(&b"123en"[..])),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
 }
 
 #[test]
 fn partial_take_until_incomplete_s() {
-    fn ys(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_until(0.., "end").parse_peek(i)
+    fn ys<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_until(0.., "end").parse_next(i)
     }
     assert_eq!(
-        ys(Partial::new("123en")),
+        ys.parse_peek(Partial::new("123en")),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
 }
@@ -422,88 +465,103 @@ fn partial_take() {
         multispace1 as multispace, oct_digit1 as oct_digit, space1 as space,
     };
 
-    fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        delimited("<!--", take(5_usize), "-->").take().parse_peek(i)
+    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        delimited("<!--", take(5_usize), "-->").take().parse_next(i)
     }
-    let r = x(Partial::new(&b"<!-- abc --> aaa"[..]));
+    let r = x.parse_peek(Partial::new(&b"<!-- abc --> aaa"[..]));
     assert_eq!(r, Ok((Partial::new(&b" aaa"[..]), &b"<!-- abc -->"[..])));
 
     let semicolon = &b";"[..];
 
-    fn ya(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        alpha.take().parse_peek(i)
+    fn ya<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        alpha.take().parse_next(i)
     }
-    let ra = ya(Partial::new(&b"abc;"[..]));
+    let ra = ya.parse_peek(Partial::new(&b"abc;"[..]));
     assert_eq!(ra, Ok((Partial::new(semicolon), &b"abc"[..])));
 
-    fn yd(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        digit.take().parse_peek(i)
+    fn yd<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        digit.take().parse_next(i)
     }
-    let rd = yd(Partial::new(&b"123;"[..]));
+    let rd = yd.parse_peek(Partial::new(&b"123;"[..]));
     assert_eq!(rd, Ok((Partial::new(semicolon), &b"123"[..])));
 
-    fn yhd(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        hex_digit.take().parse_peek(i)
+    fn yhd<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        hex_digit.take().parse_next(i)
     }
-    let rhd = yhd(Partial::new(&b"123abcDEF;"[..]));
+    let rhd = yhd.parse_peek(Partial::new(&b"123abcDEF;"[..]));
     assert_eq!(rhd, Ok((Partial::new(semicolon), &b"123abcDEF"[..])));
 
-    fn yod(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        oct_digit.take().parse_peek(i)
+    fn yod<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        oct_digit.take().parse_next(i)
     }
-    let rod = yod(Partial::new(&b"1234567;"[..]));
+    let rod = yod.parse_peek(Partial::new(&b"1234567;"[..]));
     assert_eq!(rod, Ok((Partial::new(semicolon), &b"1234567"[..])));
 
-    fn yan(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        alphanumeric.take().parse_peek(i)
+    fn yan<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        alphanumeric.take().parse_next(i)
     }
-    let ran = yan(Partial::new(&b"123abc;"[..]));
+    let ran = yan.parse_peek(Partial::new(&b"123abc;"[..]));
     assert_eq!(ran, Ok((Partial::new(semicolon), &b"123abc"[..])));
 
-    fn ys(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        space.take().parse_peek(i)
+    fn ys<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        space.take().parse_next(i)
     }
-    let rs = ys(Partial::new(&b" \t;"[..]));
+    let rs = ys.parse_peek(Partial::new(&b" \t;"[..]));
     assert_eq!(rs, Ok((Partial::new(semicolon), &b" \t"[..])));
 
-    fn yms(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        multispace.take().parse_peek(i)
+    fn yms<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        multispace.take().parse_next(i)
     }
-    let rms = yms(Partial::new(&b" \t\r\n;"[..]));
+    let rms = yms.parse_peek(Partial::new(&b" \t\r\n;"[..]));
     assert_eq!(rms, Ok((Partial::new(semicolon), &b" \t\r\n"[..])));
 }
 
 #[test]
 fn partial_take_while0() {
-    fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while(0.., AsChar::is_alpha).parse_peek(i)
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        take_while(0.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"abcd"[..];
     let c = &b"abcd123"[..];
     let d = &b"123"[..];
 
-    assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial::new(b)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial::new(c)), Ok((Partial::new(d), b)));
-    assert_eq!(f(Partial::new(d)), Ok((Partial::new(d), a)));
+    assert_eq!(
+        f.parse_peek(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new(b)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(f.parse_peek(Partial::new(c)), Ok((Partial::new(d), b)));
+    assert_eq!(f.parse_peek(Partial::new(d)), Ok((Partial::new(d), a)));
 }
 
 #[test]
 fn partial_take_while1() {
-    fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while(1.., AsChar::is_alpha).parse_peek(i)
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        take_while(1.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"abcd"[..];
     let c = &b"abcd123"[..];
     let d = &b"123"[..];
 
-    assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial::new(b)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(f(Partial::new(c)), Ok((Partial::new(&b"123"[..]), b)));
     assert_eq!(
-        f(Partial::new(d)),
+        f.parse_peek(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new(b)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new(c)),
+        Ok((Partial::new(&b"123"[..]), b))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new(d)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(d),
             ErrorKind::Slice
@@ -513,8 +571,8 @@ fn partial_take_while1() {
 
 #[test]
 fn partial_take_while_m_n() {
-    fn x(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_while(2..=4, AsChar::is_alpha).parse_peek(i)
+    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        take_while(2..=4, AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"a"[..];
@@ -523,16 +581,28 @@ fn partial_take_while_m_n() {
     let e = &b"abcde"[..];
     let f = &b"123"[..];
 
-    assert_eq!(x(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(2))));
-    assert_eq!(x(Partial::new(b)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(x(Partial::new(c)), Err(ErrMode::Incomplete(Needed::new(1))));
-    assert_eq!(x(Partial::new(d)), Ok((Partial::new(&b"123"[..]), c)));
     assert_eq!(
-        x(Partial::new(e)),
+        x.parse_peek(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(2)))
+    );
+    assert_eq!(
+        x.parse_peek(Partial::new(b)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        x.parse_peek(Partial::new(c)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        x.parse_peek(Partial::new(d)),
+        Ok((Partial::new(&b"123"[..]), c))
+    );
+    assert_eq!(
+        x.parse_peek(Partial::new(e)),
         Ok((Partial::new(&b"e"[..]), &b"abcd"[..]))
     );
     assert_eq!(
-        x(Partial::new(f)),
+        x.parse_peek(Partial::new(f)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(f),
             ErrorKind::Slice
@@ -542,190 +612,244 @@ fn partial_take_while_m_n() {
 
 #[test]
 fn partial_take_till0() {
-    fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_till(0.., AsChar::is_alpha).parse_peek(i)
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        take_till(0.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"abcd"[..];
     let c = &b"123abcd"[..];
     let d = &b"123"[..];
 
-    assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(
-        f(Partial::new(b)),
+        f.parse_peek(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new(b)),
         Ok((Partial::new(&b"abcd"[..]), &b""[..]))
     );
     assert_eq!(
-        f(Partial::new(c)),
+        f.parse_peek(Partial::new(c)),
         Ok((Partial::new(&b"abcd"[..]), &b"123"[..]))
     );
-    assert_eq!(f(Partial::new(d)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        f.parse_peek(Partial::new(d)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
 }
 
 #[test]
 fn partial_take_till1() {
-    fn f(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        take_till(1.., AsChar::is_alpha).parse_peek(i)
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        take_till(1.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
     let b = &b"abcd"[..];
     let c = &b"123abcd"[..];
     let d = &b"123"[..];
 
-    assert_eq!(f(Partial::new(a)), Err(ErrMode::Incomplete(Needed::new(1))));
     assert_eq!(
-        f(Partial::new(b)),
+        f.parse_peek(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new(b)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(b),
             ErrorKind::Slice
         )))
     );
     assert_eq!(
-        f(Partial::new(c)),
+        f.parse_peek(Partial::new(c)),
         Ok((Partial::new(&b"abcd"[..]), &b"123"[..]))
     );
-    assert_eq!(f(Partial::new(d)), Err(ErrMode::Incomplete(Needed::new(1))));
+    assert_eq!(
+        f.parse_peek(Partial::new(d)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
 }
 
 #[test]
 fn partial_take_while_utf8() {
-    fn f(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while(0.., |c| c != '點').parse_peek(i)
+    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_while(0.., |c| c != '點').parse_next(i)
     }
 
     assert_eq!(
-        f(Partial::new("")),
+        f.parse_peek(Partial::new("")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        f(Partial::new("abcd")),
+        f.parse_peek(Partial::new("abcd")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(f(Partial::new("abcd點")), Ok((Partial::new("點"), "abcd")));
     assert_eq!(
-        f(Partial::new("abcd點a")),
+        f.parse_peek(Partial::new("abcd點")),
+        Ok((Partial::new("點"), "abcd"))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new("abcd點a")),
         Ok((Partial::new("點a"), "abcd"))
     );
 
-    fn g(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while(0.., |c| c == '點').parse_peek(i)
+    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_while(0.., |c| c == '點').parse_next(i)
     }
 
     assert_eq!(
-        g(Partial::new("")),
+        g.parse_peek(Partial::new("")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(g(Partial::new("點abcd")), Ok((Partial::new("abcd"), "點")));
     assert_eq!(
-        g(Partial::new("點點點a")),
+        g.parse_peek(Partial::new("點abcd")),
+        Ok((Partial::new("abcd"), "點"))
+    );
+    assert_eq!(
+        g.parse_peek(Partial::new("點點點a")),
         Ok((Partial::new("a"), "點點點"))
     );
 }
 
 #[test]
 fn partial_take_till0_utf8() {
-    fn f(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_till(0.., |c| c == '點').parse_peek(i)
+    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_till(0.., |c| c == '點').parse_next(i)
     }
 
     assert_eq!(
-        f(Partial::new("")),
+        f.parse_peek(Partial::new("")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
     assert_eq!(
-        f(Partial::new("abcd")),
+        f.parse_peek(Partial::new("abcd")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(f(Partial::new("abcd點")), Ok((Partial::new("點"), "abcd")));
     assert_eq!(
-        f(Partial::new("abcd點a")),
+        f.parse_peek(Partial::new("abcd點")),
+        Ok((Partial::new("點"), "abcd"))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new("abcd點a")),
         Ok((Partial::new("點a"), "abcd"))
     );
 
-    fn g(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_till(0.., |c| c != '點').parse_peek(i)
+    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_till(0.., |c| c != '點').parse_next(i)
     }
 
     assert_eq!(
-        g(Partial::new("")),
+        g.parse_peek(Partial::new("")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(g(Partial::new("點abcd")), Ok((Partial::new("abcd"), "點")));
     assert_eq!(
-        g(Partial::new("點點點a")),
+        g.parse_peek(Partial::new("點abcd")),
+        Ok((Partial::new("abcd"), "點"))
+    );
+    assert_eq!(
+        g.parse_peek(Partial::new("點點點a")),
         Ok((Partial::new("a"), "點點點"))
     );
 }
 
 #[test]
 fn partial_take_utf8() {
-    fn f(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take(3_usize).parse_peek(i)
+    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take(3_usize).parse_next(i)
     }
 
     assert_eq!(
-        f(Partial::new("")),
+        f.parse_peek(Partial::new("")),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
     assert_eq!(
-        f(Partial::new("ab")),
+        f.parse_peek(Partial::new("ab")),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
     assert_eq!(
-        f(Partial::new("點")),
+        f.parse_peek(Partial::new("點")),
         Err(ErrMode::Incomplete(Needed::Unknown))
     );
-    assert_eq!(f(Partial::new("ab點cd")), Ok((Partial::new("cd"), "ab點")));
-    assert_eq!(f(Partial::new("a點bcd")), Ok((Partial::new("cd"), "a點b")));
-    assert_eq!(f(Partial::new("a點b")), Ok((Partial::new(""), "a點b")));
+    assert_eq!(
+        f.parse_peek(Partial::new("ab點cd")),
+        Ok((Partial::new("cd"), "ab點"))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new("a點bcd")),
+        Ok((Partial::new("cd"), "a點b"))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new("a點b")),
+        Ok((Partial::new(""), "a點b"))
+    );
 
-    fn g(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while(0.., |c| c == '點').parse_peek(i)
+    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_while(0.., |c| c == '點').parse_next(i)
     }
 
     assert_eq!(
-        g(Partial::new("")),
+        g.parse_peek(Partial::new("")),
         Err(ErrMode::Incomplete(Needed::new(1)))
     );
-    assert_eq!(g(Partial::new("點abcd")), Ok((Partial::new("abcd"), "點")));
     assert_eq!(
-        g(Partial::new("點點點a")),
+        g.parse_peek(Partial::new("點abcd")),
+        Ok((Partial::new("abcd"), "點"))
+    );
+    assert_eq!(
+        g.parse_peek(Partial::new("點點點a")),
         Ok((Partial::new("a"), "點點點"))
     );
 }
 
 #[test]
 fn partial_take_while_m_n_utf8_fixed() {
-    fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while(1, |c| c == 'A' || c == '😃').parse_peek(i)
+    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_while(1, |c| c == 'A' || c == '😃').parse_next(i)
     }
-    assert_eq!(parser(Partial::new("A!")), Ok((Partial::new("!"), "A")));
-    assert_eq!(parser(Partial::new("😃!")), Ok((Partial::new("!"), "😃")));
+    assert_eq!(
+        parser.parse_peek(Partial::new("A!")),
+        Ok((Partial::new("!"), "A"))
+    );
+    assert_eq!(
+        parser.parse_peek(Partial::new("😃!")),
+        Ok((Partial::new("!"), "😃"))
+    );
 }
 
 #[test]
 fn partial_take_while_m_n_utf8_range() {
-    fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while(1..=2, |c| c == 'A' || c == '😃').parse_peek(i)
+    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_while(1..=2, |c| c == 'A' || c == '😃').parse_next(i)
     }
-    assert_eq!(parser(Partial::new("A!")), Ok((Partial::new("!"), "A")));
-    assert_eq!(parser(Partial::new("😃!")), Ok((Partial::new("!"), "😃")));
+    assert_eq!(
+        parser.parse_peek(Partial::new("A!")),
+        Ok((Partial::new("!"), "A"))
+    );
+    assert_eq!(
+        parser.parse_peek(Partial::new("😃!")),
+        Ok((Partial::new("!"), "😃"))
+    );
 }
 
 #[test]
 fn partial_take_while_m_n_utf8_full_match_fixed() {
-    fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while(1, |c: char| c.is_alphabetic()).parse_peek(i)
+    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_while(1, |c: char| c.is_alphabetic()).parse_next(i)
     }
-    assert_eq!(parser(Partial::new("øn")), Ok((Partial::new("n"), "ø")));
+    assert_eq!(
+        parser.parse_peek(Partial::new("øn")),
+        Ok((Partial::new("n"), "ø"))
+    );
 }
 
 #[test]
 fn partial_take_while_m_n_utf8_full_match_range() {
-    fn parser(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        take_while(1..=2, |c: char| c.is_alphabetic()).parse_peek(i)
+    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        take_while(1..=2, |c: char| c.is_alphabetic()).parse_next(i)
     }
-    assert_eq!(parser(Partial::new("øn")), Ok((Partial::new(""), "øn")));
+    assert_eq!(
+        parser.parse_peek(Partial::new("øn")),
+        Ok((Partial::new(""), "øn"))
+    );
 }
 
 #[test]
@@ -749,90 +873,92 @@ fn partial_take_take_while0() {
 
 #[test]
 fn partial_literal_case_insensitive() {
-    fn caseless_bytes(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        literal(Caseless("ABcd")).parse_peek(i)
+    fn caseless_bytes<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        literal(Caseless("ABcd")).parse_next(i)
     }
     assert_eq!(
-        caseless_bytes(Partial::new(&b"aBCdefgh"[..])),
+        caseless_bytes.parse_peek(Partial::new(&b"aBCdefgh"[..])),
         Ok((Partial::new(&b"efgh"[..]), &b"aBCd"[..]))
     );
     assert_eq!(
-        caseless_bytes(Partial::new(&b"abcdefgh"[..])),
+        caseless_bytes.parse_peek(Partial::new(&b"abcdefgh"[..])),
         Ok((Partial::new(&b"efgh"[..]), &b"abcd"[..]))
     );
     assert_eq!(
-        caseless_bytes(Partial::new(&b"ABCDefgh"[..])),
+        caseless_bytes.parse_peek(Partial::new(&b"ABCDefgh"[..])),
         Ok((Partial::new(&b"efgh"[..]), &b"ABCD"[..]))
     );
     assert_eq!(
-        caseless_bytes(Partial::new(&b"ab"[..])),
+        caseless_bytes.parse_peek(Partial::new(&b"ab"[..])),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        caseless_bytes(Partial::new(&b"Hello"[..])),
+        caseless_bytes.parse_peek(Partial::new(&b"Hello"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"Hello"[..]),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        caseless_bytes(Partial::new(&b"Hel"[..])),
+        caseless_bytes.parse_peek(Partial::new(&b"Hel"[..])),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(&b"Hel"[..]),
             ErrorKind::Literal
         )))
     );
 
-    fn caseless_str(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        literal(Caseless("ABcd")).parse_peek(i)
+    fn caseless_str<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+        literal(Caseless("ABcd")).parse_next(i)
     }
     assert_eq!(
-        caseless_str(Partial::new("aBCdefgh")),
+        caseless_str.parse_peek(Partial::new("aBCdefgh")),
         Ok((Partial::new("efgh"), "aBCd"))
     );
     assert_eq!(
-        caseless_str(Partial::new("abcdefgh")),
+        caseless_str.parse_peek(Partial::new("abcdefgh")),
         Ok((Partial::new("efgh"), "abcd"))
     );
     assert_eq!(
-        caseless_str(Partial::new("ABCDefgh")),
+        caseless_str.parse_peek(Partial::new("ABCDefgh")),
         Ok((Partial::new("efgh"), "ABCD"))
     );
     assert_eq!(
-        caseless_str(Partial::new("ab")),
+        caseless_str.parse_peek(Partial::new("ab")),
         Err(ErrMode::Incomplete(Needed::new(2)))
     );
     assert_eq!(
-        caseless_str(Partial::new("Hello")),
+        caseless_str.parse_peek(Partial::new("Hello")),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new("Hello"),
             ErrorKind::Literal
         )))
     );
     assert_eq!(
-        caseless_str(Partial::new("Hel")),
+        caseless_str.parse_peek(Partial::new("Hel")),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new("Hel"),
             ErrorKind::Literal
         )))
     );
 
-    fn matches_kelvin(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        literal(Caseless("k")).parse_peek(i)
+    fn matches_kelvin<'i>(
+        i: &mut Partial<&'i str>,
+    ) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+        literal(Caseless("k")).parse_next(i)
     }
     assert_eq!(
-        matches_kelvin(Partial::new("K")),
+        matches_kelvin.parse_peek(Partial::new("K")),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new("K"),
             ErrorKind::Literal
         )))
     );
 
-    fn is_kelvin(i: Partial<&str>) -> IResult<Partial<&str>, &str> {
-        literal(Caseless("K")).parse_peek(i)
+    fn is_kelvin<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+        literal(Caseless("K")).parse_next(i)
     }
     assert_eq!(
-        is_kelvin(Partial::new("k")),
+        is_kelvin.parse_peek(Partial::new("k")),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new("k"),
             ErrorKind::Literal
@@ -842,15 +968,21 @@ fn partial_literal_case_insensitive() {
 
 #[test]
 fn partial_literal_fixed_size_array() {
-    fn test(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        literal([0x42]).parse_peek(i)
+    fn test<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        literal([0x42]).parse_next(i)
     }
-    fn test2(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, &[u8]> {
-        literal(&[0x42]).parse_peek(i)
+    fn test2<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+        literal(&[0x42]).parse_next(i)
     }
     let input = Partial::new(&[0x42, 0x00][..]);
-    assert_eq!(test(input), Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..])));
-    assert_eq!(test2(input), Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..])));
+    assert_eq!(
+        test.parse_peek(input),
+        Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..]))
+    );
+    assert_eq!(
+        test2.parse_peek(input),
+        Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..]))
+    );
 }
 
 #[test]

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -15,13 +15,6 @@ use crate::token::literal;
 use crate::Parser;
 use crate::Partial;
 
-macro_rules! assert_parse(
-  ($left: expr, $right: expr) => {
-    let res: $crate::error::IResult<_, _, InputError<_>> = $left;
-    assert_eq!(res, $right);
-  };
-);
-
 #[test]
 fn complete_take_while_m_n_utf8_all_matching() {
     let result: IResult<&str, &str> =

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -2,14 +2,12 @@ use super::*;
 
 #[cfg(feature = "std")]
 use proptest::prelude::*;
+use snapbox::str;
 
 use crate::ascii::Caseless;
 use crate::combinator::delimited;
-use crate::error::ErrMode;
-use crate::error::ErrorKind;
 use crate::error::IResult;
 use crate::error::InputError;
-use crate::error::Needed;
 use crate::stream::AsChar;
 use crate::token::literal;
 use crate::Parser;
@@ -19,13 +17,35 @@ use crate::Partial;
 fn complete_take_while_m_n_utf8_all_matching() {
     let result: IResult<&str, &str> =
         take_while(1..=4, |c: char| c.is_alphabetic()).parse_peek("øn");
-    assert_eq!(result, Ok(("", "øn")));
+    assert_parse!(
+        result,
+        str![[r#"
+Ok(
+    (
+        "",
+        "øn",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn complete_take_while_m_n_utf8_all_matching_substring() {
     let result: IResult<&str, &str> = take_while(1, |c: char| c.is_alphabetic()).parse_peek("øn");
-    assert_eq!(result, Ok(("n", "ø")));
+    assert_parse!(
+        result,
+        str![[r#"
+Ok(
+    (
+        "n",
+        "ø",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[cfg(feature = "std")]
@@ -71,45 +91,115 @@ fn complete_take_until() {
     fn take_until_5_10<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_until(5..=8, "end").parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         take_until_5_10.parse_peek("end"),
-        Err(ErrMode::Backtrack(error_position!(
-            &"end",
-            ErrorKind::Slice
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "end",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         take_until_5_10.parse_peek("1234end"),
-        Err(ErrMode::Backtrack(error_position!(
-            &"1234end",
-            ErrorKind::Slice
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "1234end",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
     );
-    assert_eq!(take_until_5_10.parse_peek("12345end"), Ok(("end", "12345")));
-    assert_eq!(
+    assert_parse!(
+        take_until_5_10.parse_peek("12345end"),
+        str![[r#"
+Ok(
+    (
+        "end",
+        "12345",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
         take_until_5_10.parse_peek("123456end"),
-        Ok(("end", "123456"))
+        str![[r#"
+Ok(
+    (
+        "end",
+        "123456",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         take_until_5_10.parse_peek("12345678end"),
-        Ok(("end", "12345678"))
+        str![[r#"
+Ok(
+    (
+        "end",
+        "12345678",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         take_until_5_10.parse_peek("123456789end"),
-        Err(ErrMode::Backtrack(error_position!(
-            &"123456789end",
-            ErrorKind::Slice
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "123456789end",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn complete_take_until_empty() {
-    fn take_until_empty<'i>(i: &mut &'i str) -> PResult<&'i str> {
+    fn take_until_empty<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_until(0, "").parse_next(i)
     }
-    assert_eq!(take_until_empty.parse_peek(""), Ok(("", "")));
-    assert_eq!(take_until_empty.parse_peek("end"), Ok(("end", "")));
+    assert_parse!(
+        take_until_empty.parse_peek(""),
+        str![[r#"
+Ok(
+    (
+        "",
+        "",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
+        take_until_empty.parse_peek("end"),
+        str![[r#"
+Ok(
+    (
+        "end",
+        "",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
@@ -117,172 +207,442 @@ fn complete_literal_case_insensitive() {
     fn caseless_bytes<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
         literal(Caseless("ABcd")).parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(&b"aBCdefgh"[..]),
-        Ok((&b"efgh"[..], &b"aBCd"[..]))
+        str![[r#"
+Ok(
+    (
+        [
+            101,
+            102,
+            103,
+            104,
+        ],
+        [
+            97,
+            66,
+            67,
+            100,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(&b"abcdefgh"[..]),
-        Ok((&b"efgh"[..], &b"abcd"[..]))
+        str![[r#"
+Ok(
+    (
+        [
+            101,
+            102,
+            103,
+            104,
+        ],
+        [
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(&b"ABCDefgh"[..]),
-        Ok((&b"efgh"[..], &b"ABCD"[..]))
+        str![[r#"
+Ok(
+    (
+        [
+            101,
+            102,
+            103,
+            104,
+        ],
+        [
+            65,
+            66,
+            67,
+            68,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(&b"ab"[..]),
-        Err(ErrMode::Backtrack(error_position!(
-            &&b"ab"[..],
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                97,
+                98,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(&b"Hello"[..]),
-        Err(ErrMode::Backtrack(error_position!(
-            &&b"Hello"[..],
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                72,
+                101,
+                108,
+                108,
+                111,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(&b"Hel"[..]),
-        Err(ErrMode::Backtrack(error_position!(
-            &&b"Hel"[..],
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                72,
+                101,
+                108,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 
     fn caseless_str<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         literal(Caseless("ABcd")).parse_next(i)
     }
-    assert_eq!(caseless_str.parse_peek("aBCdefgh"), Ok(("efgh", "aBCd")));
-    assert_eq!(caseless_str.parse_peek("abcdefgh"), Ok(("efgh", "abcd")));
-    assert_eq!(caseless_str.parse_peek("ABCDefgh"), Ok(("efgh", "ABCD")));
-    assert_eq!(
+    assert_parse!(
+        caseless_str.parse_peek("aBCdefgh"),
+        str![[r#"
+Ok(
+    (
+        "efgh",
+        "aBCd",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
+        caseless_str.parse_peek("abcdefgh"),
+        str![[r#"
+Ok(
+    (
+        "efgh",
+        "abcd",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
+        caseless_str.parse_peek("ABCDefgh"),
+        str![[r#"
+Ok(
+    (
+        "efgh",
+        "ABCD",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
         caseless_str.parse_peek("ab"),
-        Err(ErrMode::Backtrack(error_position!(
-            &"ab",
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "ab",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_str.parse_peek("Hello"),
-        Err(ErrMode::Backtrack(error_position!(
-            &"Hello",
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "Hello",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_str.parse_peek("Hel"),
-        Err(ErrMode::Backtrack(error_position!(
-            &"Hel",
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "Hel",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 
-    fn matches_kelvin<'i>(i: &mut &'i str) -> PResult<&'i str> {
+    fn matches_kelvin<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         literal(Caseless("k")).parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         matches_kelvin.parse_peek("K"),
-        Err(ErrMode::Backtrack(error_position!(
-            &"K",
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "K",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 
-    fn is_kelvin<'i>(i: &mut &'i str) -> PResult<&'i str> {
+    fn is_kelvin<'i>(i: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         literal(Caseless("K")).parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         is_kelvin.parse_peek("k"),
-        Err(ErrMode::Backtrack(error_position!(
-            &"k",
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "k",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn complete_literal_fixed_size_array() {
-    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
         literal([0x42]).parse_next(i)
     }
-    fn test2<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+    fn test2<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
         literal(&[0x42]).parse_next(i)
     }
 
     let input = &[0x42, 0x00][..];
-    assert_eq!(test.parse_peek(input), Ok((&b"\x00"[..], &b"\x42"[..])));
-    assert_eq!(test2.parse_peek(input), Ok((&b"\x00"[..], &b"\x42"[..])));
+    assert_parse!(
+        test.parse_peek(input),
+        str![[r#"
+Ok(
+    (
+        [
+            0,
+        ],
+        [
+            66,
+        ],
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
+        test2.parse_peek(input),
+        str![[r#"
+Ok(
+    (
+        [
+            0,
+        ],
+        [
+            66,
+        ],
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn complete_literal_char() {
-    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
         literal('B').parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         test.parse_peek(&[0x42, 0x00][..]),
-        Ok((&b"\x00"[..], &b"\x42"[..]))
+        str![[r#"
+Ok(
+    (
+        [
+            0,
+        ],
+        [
+            66,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         test.parse_peek(&[b'A', b'\0'][..]),
-        Err(ErrMode::Backtrack(error_position!(
-            &&b"A\0"[..],
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                65,
+                0,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn complete_literal_byte() {
-    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8]> {
+    fn test<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], InputError<&'i [u8]>> {
         literal(b'B').parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         test.parse_peek(&[0x42, 0x00][..]),
-        Ok((&b"\x00"[..], &b"\x42"[..]))
+        str![[r#"
+Ok(
+    (
+        [
+            0,
+        ],
+        [
+            66,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         test.parse_peek(&[b'A', b'\0'][..]),
-        Err(ErrMode::Backtrack(error_position!(
-            &&b"A\0"[..],
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: [
+                65,
+                0,
+            ],
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_any_str() {
     use super::any;
-    assert_eq!(
+    assert_parse!(
         any::<_, InputError<Partial<&str>>>.parse_peek(Partial::new("Ә")),
-        Ok((Partial::new(""), 'Ә'))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "",
+            partial: true,
+        },
+        'Ә',
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_one_of_test() {
-    fn f(i: &mut Partial<&[u8]>) -> PResult<u8> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u8, InputError<Partial<&'i [u8]>>> {
         one_of(['a', 'b']).parse_next(i)
     }
 
     let a = &b"abcd"[..];
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Ok((Partial::new(&b"bcd"[..]), b'a'))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                98,
+                99,
+                100,
+            ],
+            partial: true,
+        },
+        97,
+    ),
+)
+
+"#]]
     );
 
     let b = &b"cde"[..];
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(b)),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new(b),
-            ErrorKind::Verify
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    99,
+                    100,
+                    101,
+                ],
+                partial: true,
+            },
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
     );
 
-    fn utf8(i: &mut Partial<&str>) -> PResult<char> {
+    fn utf8<'i>(i: &mut Partial<&'i str>) -> PResult<char, InputError<Partial<&'i str>>> {
         one_of(['+', '\u{FF0B}']).parse_next(i)
     }
 
@@ -292,162 +652,423 @@ fn partial_one_of_test() {
 
 #[test]
 fn char_byteslice() {
-    fn f(i: &mut Partial<&[u8]>) -> PResult<char> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<char, InputError<Partial<&'i [u8]>>> {
         'c'.parse_next(i)
     }
 
     let a = &b"abcd"[..];
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new(a),
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    98,
+                    99,
+                    100,
+                ],
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 
     let b = &b"cde"[..];
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(b)),
-        Ok((Partial::new(&b"de"[..]), 'c'))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                100,
+                101,
+            ],
+            partial: true,
+        },
+        'c',
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn char_str() {
-    fn f(i: &mut Partial<&str>) -> PResult<char> {
+    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<char, InputError<Partial<&'i str>>> {
         'c'.parse_next(i)
     }
 
     let a = "abcd";
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new(a),
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "abcd",
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 
     let b = "cde";
-    assert_eq!(f.parse_peek(Partial::new(b)), Ok((Partial::new("de"), 'c')));
+    assert_parse!(
+        f.parse_peek(Partial::new(b)),
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "de",
+            partial: true,
+        },
+        'c',
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn partial_none_of_test() {
-    fn f(i: &mut Partial<&[u8]>) -> PResult<u8> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<u8, InputError<Partial<&'i [u8]>>> {
         none_of(['a', 'b']).parse_next(i)
     }
 
     let a = &b"abcd"[..];
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new(a),
-            ErrorKind::Verify
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    98,
+                    99,
+                    100,
+                ],
+                partial: true,
+            },
+            kind: Verify,
+        },
+    ),
+)
+
+"#]]
     );
 
     let b = &b"cde"[..];
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(b)),
-        Ok((Partial::new(&b"de"[..]), b'c'))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                100,
+                101,
+            ],
+            partial: true,
+        },
+        99,
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_is_a() {
-    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         take_while(1.., ['a', 'b']).parse_next(i)
     }
 
     let a = Partial::new(&b"abcd"[..]);
-    assert_eq!(
+    assert_parse!(
         a_or_b.parse_peek(a),
-        Ok((Partial::new(&b"cd"[..]), &b"ab"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                99,
+                100,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+        ],
+    ),
+)
+
+"#]]
     );
 
     let b = Partial::new(&b"bcde"[..]);
-    assert_eq!(
+    assert_parse!(
         a_or_b.parse_peek(b),
-        Ok((Partial::new(&b"cde"[..]), &b"b"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                99,
+                100,
+                101,
+            ],
+            partial: true,
+        },
+        [
+            98,
+        ],
+    ),
+)
+
+"#]]
     );
 
     let c = Partial::new(&b"cdef"[..]);
-    assert_eq!(
+    assert_parse!(
         a_or_b.parse_peek(c),
-        Err(ErrMode::Backtrack(error_position!(&c, ErrorKind::Slice)))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    99,
+                    100,
+                    101,
+                    102,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
     );
 
     let d = Partial::new(&b"bacdef"[..]);
-    assert_eq!(
+    assert_parse!(
         a_or_b.parse_peek(d),
-        Ok((Partial::new(&b"cdef"[..]), &b"ba"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                99,
+                100,
+                101,
+                102,
+            ],
+            partial: true,
+        },
+        [
+            98,
+            97,
+        ],
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_is_not() {
-    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn a_or_b<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         take_till(1.., ['a', 'b']).parse_next(i)
     }
 
     let a = Partial::new(&b"cdab"[..]);
-    assert_eq!(
+    assert_parse!(
         a_or_b.parse_peek(a),
-        Ok((Partial::new(&b"ab"[..]), &b"cd"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                97,
+                98,
+            ],
+            partial: true,
+        },
+        [
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
     );
 
     let b = Partial::new(&b"cbde"[..]);
-    assert_eq!(
+    assert_parse!(
         a_or_b.parse_peek(b),
-        Ok((Partial::new(&b"bde"[..]), &b"c"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                98,
+                100,
+                101,
+            ],
+            partial: true,
+        },
+        [
+            99,
+        ],
+    ),
+)
+
+"#]]
     );
 
     let c = Partial::new(&b"abab"[..]);
-    assert_eq!(
+    assert_parse!(
         a_or_b.parse_peek(c),
-        Err(ErrMode::Backtrack(error_position!(&c, ErrorKind::Slice)))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    98,
+                    97,
+                    98,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
     );
 
     let d = Partial::new(&b"cdefba"[..]);
-    assert_eq!(
+    assert_parse!(
         a_or_b.parse_peek(d),
-        Ok((Partial::new(&b"ba"[..]), &b"cdef"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                98,
+                97,
+            ],
+            partial: true,
+        },
+        [
+            99,
+            100,
+            101,
+            102,
+        ],
+    ),
+)
+
+"#]]
     );
 
     let e = Partial::new(&b"e"[..]);
-    assert_eq!(
+    assert_parse!(
         a_or_b.parse_peek(e),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_until_incomplete() {
-    fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         take_until(0.., "end").parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         y.parse_peek(Partial::new(&b"nd"[..])),
-        Err(ErrMode::Incomplete(Needed::Unknown))
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         y.parse_peek(Partial::new(&b"123"[..])),
-        Err(ErrMode::Incomplete(Needed::Unknown))
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         y.parse_peek(Partial::new(&b"123en"[..])),
-        Err(ErrMode::Incomplete(Needed::Unknown))
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_until_incomplete_s() {
-    fn ys<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn ys<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_until(0.., "end").parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         ys.parse_peek(Partial::new("123en")),
-        Err(ErrMode::Incomplete(Needed::Unknown))
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
     );
 }
 
@@ -458,60 +1079,243 @@ fn partial_take() {
         multispace1 as multispace, oct_digit1 as oct_digit, space1 as space,
     };
 
-    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         delimited("<!--", take(5_usize), "-->").take().parse_next(i)
     }
     let r = x.parse_peek(Partial::new(&b"<!-- abc --> aaa"[..]));
-    assert_eq!(r, Ok((Partial::new(&b" aaa"[..]), &b"<!-- abc -->"[..])));
+    assert_parse!(
+        r,
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                32,
+                97,
+                97,
+                97,
+            ],
+            partial: true,
+        },
+        [
+            60,
+            33,
+            45,
+            45,
+            32,
+            97,
+            98,
+            99,
+            32,
+            45,
+            45,
+            62,
+        ],
+    ),
+)
 
-    let semicolon = &b";"[..];
+"#]]
+    );
 
-    fn ya<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn ya<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         alpha.take().parse_next(i)
     }
     let ra = ya.parse_peek(Partial::new(&b"abc;"[..]));
-    assert_eq!(ra, Ok((Partial::new(semicolon), &b"abc"[..])));
+    assert_parse!(
+        ra,
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            99,
+        ],
+    ),
+)
 
-    fn yd<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+"#]]
+    );
+
+    fn yd<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         digit.take().parse_next(i)
     }
     let rd = yd.parse_peek(Partial::new(&b"123;"[..]));
-    assert_eq!(rd, Ok((Partial::new(semicolon), &b"123"[..])));
+    assert_parse!(
+        rd,
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            49,
+            50,
+            51,
+        ],
+    ),
+)
 
-    fn yhd<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+"#]]
+    );
+
+    fn yhd<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         hex_digit.take().parse_next(i)
     }
     let rhd = yhd.parse_peek(Partial::new(&b"123abcDEF;"[..]));
-    assert_eq!(rhd, Ok((Partial::new(semicolon), &b"123abcDEF"[..])));
+    assert_parse!(
+        rhd,
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            49,
+            50,
+            51,
+            97,
+            98,
+            99,
+            68,
+            69,
+            70,
+        ],
+    ),
+)
 
-    fn yod<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+"#]]
+    );
+
+    fn yod<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         oct_digit.take().parse_next(i)
     }
     let rod = yod.parse_peek(Partial::new(&b"1234567;"[..]));
-    assert_eq!(rod, Ok((Partial::new(semicolon), &b"1234567"[..])));
+    assert_parse!(
+        rod,
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+        ],
+    ),
+)
 
-    fn yan<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+"#]]
+    );
+
+    fn yan<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         alphanumeric.take().parse_next(i)
     }
     let ran = yan.parse_peek(Partial::new(&b"123abc;"[..]));
-    assert_eq!(ran, Ok((Partial::new(semicolon), &b"123abc"[..])));
+    assert_parse!(
+        ran,
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            49,
+            50,
+            51,
+            97,
+            98,
+            99,
+        ],
+    ),
+)
 
-    fn ys<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+"#]]
+    );
+
+    fn ys<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         space.take().parse_next(i)
     }
     let rs = ys.parse_peek(Partial::new(&b" \t;"[..]));
-    assert_eq!(rs, Ok((Partial::new(semicolon), &b" \t"[..])));
+    assert_parse!(
+        rs,
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            32,
+            9,
+        ],
+    ),
+)
 
-    fn yms<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+"#]]
+    );
+
+    fn yms<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         multispace.take().parse_next(i)
     }
     let rms = yms.parse_peek(Partial::new(&b" \t\r\n;"[..]));
-    assert_eq!(rms, Ok((Partial::new(semicolon), &b" \t\r\n"[..])));
+    assert_parse!(
+        rms,
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                59,
+            ],
+            partial: true,
+        },
+        [
+            32,
+            9,
+            13,
+            10,
+        ],
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn partial_take_while0() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         take_while(0.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -519,21 +1323,80 @@ fn partial_take_while0() {
     let c = &b"abcd123"[..];
     let d = &b"123"[..];
 
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(b)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(f.parse_peek(Partial::new(c)), Ok((Partial::new(d), b)));
-    assert_eq!(f.parse_peek(Partial::new(d)), Ok((Partial::new(d), a)));
+    assert_parse!(
+        f.parse_peek(Partial::new(c)),
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                49,
+                50,
+                51,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
+        f.parse_peek(Partial::new(d)),
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                49,
+                50,
+                51,
+            ],
+            partial: true,
+        },
+        [],
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn partial_take_while1() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         take_while(1.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -541,30 +1404,82 @@ fn partial_take_while1() {
     let c = &b"abcd123"[..];
     let d = &b"123"[..];
 
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(b)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(c)),
-        Ok((Partial::new(&b"123"[..]), b))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                49,
+                50,
+                51,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(d)),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new(d),
-            ErrorKind::Slice
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    49,
+                    50,
+                    51,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_while_m_n() {
-    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         take_while(2..=4, AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -574,38 +1489,116 @@ fn partial_take_while_m_n() {
     let e = &b"abcde"[..];
     let f = &b"123"[..];
 
-    assert_eq!(
+    assert_parse!(
         x.parse_peek(Partial::new(a)),
-        Err(ErrMode::Incomplete(Needed::new(2)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         x.parse_peek(Partial::new(b)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         x.parse_peek(Partial::new(c)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         x.parse_peek(Partial::new(d)),
-        Ok((Partial::new(&b"123"[..]), c))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                49,
+                50,
+                51,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            99,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         x.parse_peek(Partial::new(e)),
-        Ok((Partial::new(&b"e"[..]), &b"abcd"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                101,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         x.parse_peek(Partial::new(f)),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new(f),
-            ErrorKind::Slice
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    49,
+                    50,
+                    51,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_till0() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         take_till(0.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -613,27 +1606,81 @@ fn partial_take_till0() {
     let c = &b"123abcd"[..];
     let d = &b"123"[..];
 
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(b)),
-        Ok((Partial::new(&b"abcd"[..]), &b""[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                97,
+                98,
+                99,
+                100,
+            ],
+            partial: true,
+        },
+        [],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(c)),
-        Ok((Partial::new(&b"abcd"[..]), &b"123"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                97,
+                98,
+                99,
+                100,
+            ],
+            partial: true,
+        },
+        [
+            49,
+            50,
+            51,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(d)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_till1() {
-    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn f<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         take_till(1.., AsChar::is_alpha).parse_next(i)
     }
     let a = &b""[..];
@@ -641,297 +1688,843 @@ fn partial_take_till1() {
     let c = &b"123abcd"[..];
     let d = &b"123"[..];
 
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(b)),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new(b),
-            ErrorKind::Slice
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    97,
+                    98,
+                    99,
+                    100,
+                ],
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(c)),
-        Ok((Partial::new(&b"abcd"[..]), &b"123"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                97,
+                98,
+                99,
+                100,
+            ],
+            partial: true,
+        },
+        [
+            49,
+            50,
+            51,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(d)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_while_utf8() {
-    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_while(0.., |c| c != '點').parse_next(i)
     }
 
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("")),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("abcd")),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("abcd點")),
-        Ok((Partial::new("點"), "abcd"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "點",
+            partial: true,
+        },
+        "abcd",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("abcd點a")),
-        Ok((Partial::new("點a"), "abcd"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "點a",
+            partial: true,
+        },
+        "abcd",
+    ),
+)
+
+"#]]
     );
 
-    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_while(0.., |c| c == '點').parse_next(i)
     }
 
-    assert_eq!(
+    assert_parse!(
         g.parse_peek(Partial::new("")),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         g.parse_peek(Partial::new("點abcd")),
-        Ok((Partial::new("abcd"), "點"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "abcd",
+            partial: true,
+        },
+        "點",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         g.parse_peek(Partial::new("點點點a")),
-        Ok((Partial::new("a"), "點點點"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "a",
+            partial: true,
+        },
+        "點點點",
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_till0_utf8() {
-    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_till(0.., |c| c == '點').parse_next(i)
     }
 
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("")),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("abcd")),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("abcd點")),
-        Ok((Partial::new("點"), "abcd"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "點",
+            partial: true,
+        },
+        "abcd",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("abcd點a")),
-        Ok((Partial::new("點a"), "abcd"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "點a",
+            partial: true,
+        },
+        "abcd",
+    ),
+)
+
+"#]]
     );
 
-    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_till(0.., |c| c != '點').parse_next(i)
     }
 
-    assert_eq!(
+    assert_parse!(
         g.parse_peek(Partial::new("")),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         g.parse_peek(Partial::new("點abcd")),
-        Ok((Partial::new("abcd"), "點"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "abcd",
+            partial: true,
+        },
+        "點",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         g.parse_peek(Partial::new("點點點a")),
-        Ok((Partial::new("a"), "點點點"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "a",
+            partial: true,
+        },
+        "點點點",
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_utf8() {
-    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn f<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take(3_usize).parse_next(i)
     }
 
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("")),
-        Err(ErrMode::Incomplete(Needed::Unknown))
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("ab")),
-        Err(ErrMode::Incomplete(Needed::Unknown))
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("點")),
-        Err(ErrMode::Incomplete(Needed::Unknown))
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("ab點cd")),
-        Ok((Partial::new("cd"), "ab點"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "cd",
+            partial: true,
+        },
+        "ab點",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("a點bcd")),
-        Ok((Partial::new("cd"), "a點b"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "cd",
+            partial: true,
+        },
+        "a點b",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new("a點b")),
-        Ok((Partial::new(""), "a點b"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "",
+            partial: true,
+        },
+        "a點b",
+    ),
+)
+
+"#]]
     );
 
-    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn g<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_while(0.., |c| c == '點').parse_next(i)
     }
 
-    assert_eq!(
+    assert_parse!(
         g.parse_peek(Partial::new("")),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         g.parse_peek(Partial::new("點abcd")),
-        Ok((Partial::new("abcd"), "點"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "abcd",
+            partial: true,
+        },
+        "點",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         g.parse_peek(Partial::new("點點點a")),
-        Ok((Partial::new("a"), "點點點"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "a",
+            partial: true,
+        },
+        "點點點",
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_while_m_n_utf8_fixed() {
-    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_while(1, |c| c == 'A' || c == '😃').parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         parser.parse_peek(Partial::new("A!")),
-        Ok((Partial::new("!"), "A"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "!",
+            partial: true,
+        },
+        "A",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         parser.parse_peek(Partial::new("😃!")),
-        Ok((Partial::new("!"), "😃"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "!",
+            partial: true,
+        },
+        "😃",
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_while_m_n_utf8_range() {
-    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_while(1..=2, |c| c == 'A' || c == '😃').parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         parser.parse_peek(Partial::new("A!")),
-        Ok((Partial::new("!"), "A"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "!",
+            partial: true,
+        },
+        "A",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         parser.parse_peek(Partial::new("😃!")),
-        Ok((Partial::new("!"), "😃"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "!",
+            partial: true,
+        },
+        "😃",
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_while_m_n_utf8_full_match_fixed() {
-    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_while(1, |c: char| c.is_alphabetic()).parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         parser.parse_peek(Partial::new("øn")),
-        Ok((Partial::new("n"), "ø"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "n",
+            partial: true,
+        },
+        "ø",
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_take_while_m_n_utf8_full_match_range() {
-    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn parser<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_while(1..=2, |c: char| c.is_alphabetic()).parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         parser.parse_peek(Partial::new("øn")),
-        Ok((Partial::new(""), "øn"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "",
+            partial: true,
+        },
+        "øn",
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 #[cfg(feature = "std")]
 fn partial_take_take_while0() {
-    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn x<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         take_while(0.., AsChar::is_alphanum).parse_next(i)
     }
-    fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn y<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         x.take().parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         x.parse_peek(Partial::new(&b"ab."[..])),
-        Ok((Partial::new(&b"."[..]), &b"ab"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                46,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         y.parse_peek(Partial::new(&b"ab."[..])),
-        Ok((Partial::new(&b"."[..]), &b"ab"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                46,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+        ],
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_literal_case_insensitive() {
-    fn caseless_bytes<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn caseless_bytes<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         literal(Caseless("ABcd")).parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(Partial::new(&b"aBCdefgh"[..])),
-        Ok((Partial::new(&b"efgh"[..]), &b"aBCd"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                101,
+                102,
+                103,
+                104,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            66,
+            67,
+            100,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(Partial::new(&b"abcdefgh"[..])),
-        Ok((Partial::new(&b"efgh"[..]), &b"abcd"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                101,
+                102,
+                103,
+                104,
+            ],
+            partial: true,
+        },
+        [
+            97,
+            98,
+            99,
+            100,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(Partial::new(&b"ABCDefgh"[..])),
-        Ok((Partial::new(&b"efgh"[..]), &b"ABCD"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                101,
+                102,
+                103,
+                104,
+            ],
+            partial: true,
+        },
+        [
+            65,
+            66,
+            67,
+            68,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(Partial::new(&b"ab"[..])),
-        Err(ErrMode::Incomplete(Needed::new(2)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(Partial::new(&b"Hello"[..])),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new(&b"Hello"[..]),
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    72,
+                    101,
+                    108,
+                    108,
+                    111,
+                ],
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_bytes.parse_peek(Partial::new(&b"Hel"[..])),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new(&b"Hel"[..]),
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: [
+                    72,
+                    101,
+                    108,
+                ],
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 
-    fn caseless_str<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str> {
+    fn caseless_str<'i>(
+        i: &mut Partial<&'i str>,
+    ) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         literal(Caseless("ABcd")).parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         caseless_str.parse_peek(Partial::new("aBCdefgh")),
-        Ok((Partial::new("efgh"), "aBCd"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "efgh",
+            partial: true,
+        },
+        "aBCd",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_str.parse_peek(Partial::new("abcdefgh")),
-        Ok((Partial::new("efgh"), "abcd"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "efgh",
+            partial: true,
+        },
+        "abcd",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_str.parse_peek(Partial::new("ABCDefgh")),
-        Ok((Partial::new("efgh"), "ABCD"))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "efgh",
+            partial: true,
+        },
+        "ABCD",
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_str.parse_peek(Partial::new("ab")),
-        Err(ErrMode::Incomplete(Needed::new(2)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            2,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_str.parse_peek(Partial::new("Hello")),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new("Hello"),
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "Hello",
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         caseless_str.parse_peek(Partial::new("Hel")),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new("Hel"),
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "Hel",
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 
     fn matches_kelvin<'i>(
@@ -939,61 +2532,170 @@ fn partial_literal_case_insensitive() {
     ) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         literal(Caseless("k")).parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         matches_kelvin.parse_peek(Partial::new("K")),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new("K"),
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "K",
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 
     fn is_kelvin<'i>(i: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         literal(Caseless("K")).parse_next(i)
     }
-    assert_eq!(
+    assert_parse!(
         is_kelvin.parse_peek(Partial::new("k")),
-        Err(ErrMode::Backtrack(error_position!(
-            &Partial::new("k"),
-            ErrorKind::Literal
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "k",
+                partial: true,
+            },
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn partial_literal_fixed_size_array() {
-    fn test<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn test<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         literal([0x42]).parse_next(i)
     }
-    fn test2<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+    fn test2<'i>(i: &mut Partial<&'i [u8]>) -> PResult<&'i [u8], InputError<Partial<&'i [u8]>>> {
         literal(&[0x42]).parse_next(i)
     }
     let input = Partial::new(&[0x42, 0x00][..]);
-    assert_eq!(
+    assert_parse!(
         test.parse_peek(input),
-        Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                0,
+            ],
+            partial: true,
+        },
+        [
+            66,
+        ],
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         test2.parse_peek(input),
-        Ok((Partial::new(&b"\x00"[..]), &b"\x42"[..]))
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: [
+                0,
+            ],
+            partial: true,
+        },
+        [
+            66,
+        ],
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 fn rest_on_slices() {
     let input: &[u8] = &b"Hello, world!"[..];
-    let empty: &[u8] = &b""[..];
-    assert_parse!(rest.parse_peek(input), Ok((empty, input)));
+    assert_parse!(
+        rest.parse_peek(input),
+        str![[r#"
+Ok(
+    (
+        [],
+        [
+            72,
+            101,
+            108,
+            108,
+            111,
+            44,
+            32,
+            119,
+            111,
+            114,
+            108,
+            100,
+            33,
+        ],
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn rest_on_strs() {
     let input: &str = "Hello, world!";
-    let empty: &str = "";
-    assert_parse!(rest.parse_peek(input), Ok((empty, input)));
+    assert_parse!(
+        rest.parse_peek(input),
+        str![[r#"
+Ok(
+    (
+        "",
+        "Hello, world!",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn rest_len_on_slices() {
     let input: &[u8] = &b"Hello, world!"[..];
-    assert_parse!(rest_len.parse_peek(input), Ok((input, input.len())));
+    assert_parse!(
+        rest_len.parse_peek(input),
+        str![[r#"
+Ok(
+    (
+        [
+            72,
+            101,
+            108,
+            108,
+            111,
+            44,
+            32,
+            119,
+            111,
+            114,
+            108,
+            100,
+            33,
+        ],
+        13,
+    ),
+)
+
+"#]]
+    );
 }

--- a/tests/testsuite/float.rs
+++ b/tests/testsuite/float.rs
@@ -1,13 +1,16 @@
+use std::str;
+use std::str::FromStr;
+
+use snapbox::str;
+
 use winnow::ascii::digit1 as digit;
 use winnow::combinator::alt;
 use winnow::combinator::delimited;
 use winnow::combinator::opt;
+use winnow::error::InputError;
 use winnow::prelude::*;
 
-use std::str;
-use std::str::FromStr;
-
-fn unsigned_float(i: &mut &[u8]) -> PResult<f32> {
+fn unsigned_float<'i>(i: &mut &'i [u8]) -> PResult<f32, InputError<&'i [u8]>> {
     let float_bytes = alt((
         delimited(digit, ".", opt(digit)),
         delimited(opt(digit), ".", digit),
@@ -17,7 +20,7 @@ fn unsigned_float(i: &mut &[u8]) -> PResult<f32> {
     float_str.try_map(FromStr::from_str).parse_next(i)
 }
 
-fn float(i: &mut &[u8]) -> PResult<f32> {
+fn float<'i>(i: &mut &'i [u8]) -> PResult<f32, InputError<&'i [u8]>> {
     (opt(alt(("+", "-"))), unsigned_float)
         .map(|(sign, value)| {
             sign.and_then(|s| if s[0] == b'-' { Some(-1f32) } else { None })
@@ -29,37 +32,96 @@ fn float(i: &mut &[u8]) -> PResult<f32> {
 
 #[test]
 fn unsigned_float_test() {
-    assert_eq!(
-        unsigned_float.parse_peek(&b"123.456;"[..]),
-        Ok((&b";"[..], 123.456))
-    );
-    assert_eq!(
-        unsigned_float.parse_peek(&b"0.123;"[..]),
-        Ok((&b";"[..], 0.123))
-    );
-    assert_eq!(
-        unsigned_float.parse_peek(&b"123.0;"[..]),
-        Ok((&b";"[..], 123.0))
-    );
-    assert_eq!(
-        unsigned_float.parse_peek(&b"123.;"[..]),
-        Ok((&b";"[..], 123.0))
-    );
-    assert_eq!(
-        unsigned_float.parse_peek(&b".123;"[..]),
-        Ok((&b";"[..], 0.123))
-    );
+    assert_parse!(unsigned_float.parse_peek(&b"123.456;"[..]), str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        123.456,
+    ),
+)
+
+"#]]);
+    assert_parse!(unsigned_float.parse_peek(&b"0.123;"[..]), str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        0.123,
+    ),
+)
+
+"#]]);
+    assert_parse!(unsigned_float.parse_peek(&b"123.0;"[..]), str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        123.0,
+    ),
+)
+
+"#]]);
+    assert_parse!(unsigned_float.parse_peek(&b"123.;"[..]), str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        123.0,
+    ),
+)
+
+"#]]);
+    assert_parse!(unsigned_float.parse_peek(&b".123;"[..]), str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        0.123,
+    ),
+)
+
+"#]]);
 }
 
 #[test]
 fn float_test() {
-    assert_eq!(float.parse_peek(&b"123.456;"[..]), Ok((&b";"[..], 123.456)));
-    assert_eq!(
-        float.parse_peek(&b"+123.456;"[..]),
-        Ok((&b";"[..], 123.456))
-    );
-    assert_eq!(
-        float.parse_peek(&b"-123.456;"[..]),
-        Ok((&b";"[..], -123.456))
-    );
+    assert_parse!(float.parse_peek(&b"123.456;"[..]), str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        123.456,
+    ),
+)
+
+"#]]);
+    assert_parse!(float.parse_peek(&b"+123.456;"[..]), str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        123.456,
+    ),
+)
+
+"#]]);
+    assert_parse!(float.parse_peek(&b"-123.456;"[..]), str![[r#"
+Ok(
+    (
+        [
+            59,
+        ],
+        -123.456,
+    ),
+)
+
+"#]]);
 }

--- a/tests/testsuite/float.rs
+++ b/tests/testsuite/float.rs
@@ -7,10 +7,11 @@ use winnow::ascii::digit1 as digit;
 use winnow::combinator::alt;
 use winnow::combinator::delimited;
 use winnow::combinator::opt;
-use winnow::error::InputError;
 use winnow::prelude::*;
 
-fn unsigned_float<'i>(i: &mut &'i [u8]) -> PResult<f32, InputError<&'i [u8]>> {
+use crate::TestResult;
+
+fn unsigned_float<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], f32> {
     let float_bytes = alt((
         delimited(digit, ".", opt(digit)),
         delimited(opt(digit), ".", digit),
@@ -20,7 +21,7 @@ fn unsigned_float<'i>(i: &mut &'i [u8]) -> PResult<f32, InputError<&'i [u8]>> {
     float_str.try_map(FromStr::from_str).parse_next(i)
 }
 
-fn float<'i>(i: &mut &'i [u8]) -> PResult<f32, InputError<&'i [u8]>> {
+fn float<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], f32> {
     (opt(alt(("+", "-"))), unsigned_float)
         .map(|(sign, value)| {
             sign.and_then(|s| if s[0] == b'-' { Some(-1f32) } else { None })
@@ -32,7 +33,9 @@ fn float<'i>(i: &mut &'i [u8]) -> PResult<f32, InputError<&'i [u8]>> {
 
 #[test]
 fn unsigned_float_test() {
-    assert_parse!(unsigned_float.parse_peek(&b"123.456;"[..]), str![[r#"
+    assert_parse!(
+        unsigned_float.parse_peek(&b"123.456;"[..]),
+        str![[r#"
 Ok(
     (
         [
@@ -42,8 +45,11 @@ Ok(
     ),
 )
 
-"#]]);
-    assert_parse!(unsigned_float.parse_peek(&b"0.123;"[..]), str![[r#"
+"#]]
+    );
+    assert_parse!(
+        unsigned_float.parse_peek(&b"0.123;"[..]),
+        str![[r#"
 Ok(
     (
         [
@@ -53,8 +59,11 @@ Ok(
     ),
 )
 
-"#]]);
-    assert_parse!(unsigned_float.parse_peek(&b"123.0;"[..]), str![[r#"
+"#]]
+    );
+    assert_parse!(
+        unsigned_float.parse_peek(&b"123.0;"[..]),
+        str![[r#"
 Ok(
     (
         [
@@ -64,8 +73,11 @@ Ok(
     ),
 )
 
-"#]]);
-    assert_parse!(unsigned_float.parse_peek(&b"123.;"[..]), str![[r#"
+"#]]
+    );
+    assert_parse!(
+        unsigned_float.parse_peek(&b"123.;"[..]),
+        str![[r#"
 Ok(
     (
         [
@@ -75,8 +87,11 @@ Ok(
     ),
 )
 
-"#]]);
-    assert_parse!(unsigned_float.parse_peek(&b".123;"[..]), str![[r#"
+"#]]
+    );
+    assert_parse!(
+        unsigned_float.parse_peek(&b".123;"[..]),
+        str![[r#"
 Ok(
     (
         [
@@ -86,12 +101,15 @@ Ok(
     ),
 )
 
-"#]]);
+"#]]
+    );
 }
 
 #[test]
 fn float_test() {
-    assert_parse!(float.parse_peek(&b"123.456;"[..]), str![[r#"
+    assert_parse!(
+        float.parse_peek(&b"123.456;"[..]),
+        str![[r#"
 Ok(
     (
         [
@@ -101,8 +119,11 @@ Ok(
     ),
 )
 
-"#]]);
-    assert_parse!(float.parse_peek(&b"+123.456;"[..]), str![[r#"
+"#]]
+    );
+    assert_parse!(
+        float.parse_peek(&b"+123.456;"[..]),
+        str![[r#"
 Ok(
     (
         [
@@ -112,8 +133,11 @@ Ok(
     ),
 )
 
-"#]]);
-    assert_parse!(float.parse_peek(&b"-123.456;"[..]), str![[r#"
+"#]]
+    );
+    assert_parse!(
+        float.parse_peek(&b"-123.456;"[..]),
+        str![[r#"
 Ok(
     (
         [
@@ -123,5 +147,6 @@ Ok(
     ),
 )
 
-"#]]);
+"#]]
+    );
 }

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,9 +1,11 @@
 #[cfg(test)]
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {
-     let res: winnow::error::IResult<_, _, InputError<_>> = $left;
+     let res: winnow::error::IResult<_, _, winnow::error::InputError<_>> = $left;
      snapbox::assert_data_eq!(snapbox::data::ToDebug::to_debug(&res), $right);
   };
 );
+
+type TestResult<I, O> = winnow::PResult<O, winnow::error::InputError<I>>;
 
 automod::dir!("tests/testsuite");

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,1 +1,9 @@
+#[cfg(test)]
+macro_rules! assert_parse(
+  ($left: expr, $right: expr) => {
+     let res: winnow::error::IResult<_, _, InputError<_>> = $left;
+     snapbox::assert_data_eq!(snapbox::data::ToDebug::to_debug(&res), $right);
+  };
+);
+
 automod::dir!("tests/testsuite");

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -7,23 +7,23 @@ use winnow::binary::be_u64;
 use winnow::binary::length_take;
 #[cfg(feature = "alloc")]
 use winnow::combinator::repeat;
-use winnow::error::{ErrMode, IResult, Needed};
+use winnow::error::{ErrMode, Needed};
 use winnow::prelude::*;
 use winnow::token::take;
 use winnow::Partial;
 
 // Parser definition
 
-// We request a length that would trigger an overflow if computing consumed + requested
-#[allow(clippy::type_complexity)]
-fn parser02(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (&[u8], &[u8])> {
-    (take(1_usize), take(18446744073709551615_usize)).parse_peek(i)
-}
-
 #[test]
 fn overflow_incomplete_tuple() {
+    // We request a length that would trigger an overflow if computing consumed + requested
+    #[allow(clippy::type_complexity)]
+    fn parser02<'i>(i: &mut Partial<&'i [u8]>) -> PResult<(&'i [u8], &'i [u8])> {
+        (take(1_usize), take(18446744073709551615_usize)).parse_next(i)
+    }
+
     assert_eq!(
-        parser02(Partial::new(&b"3"[..])),
+        parser02.parse_peek(Partial::new(&b"3"[..])),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
     );
 }
@@ -31,13 +31,13 @@ fn overflow_incomplete_tuple() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_bytes() {
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(0.., length_take(be_u64)).parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(0.., length_take(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in length_take
     assert_eq!(
-        multi(Partial::new(
+        multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
@@ -47,13 +47,13 @@ fn overflow_incomplete_length_bytes() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many0() {
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(0.., length_take(be_u64)).parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(0.., length_take(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in repeat
     assert_eq!(
-        multi(Partial::new(
+        multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -65,13 +65,13 @@ fn overflow_incomplete_many0() {
 fn overflow_incomplete_many1() {
     use winnow::combinator::repeat;
 
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(1.., length_take(be_u64)).parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(1.., length_take(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in repeat
     assert_eq!(
-        multi(Partial::new(
+        multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -84,13 +84,13 @@ fn overflow_incomplete_many_till0() {
     use winnow::combinator::repeat_till;
 
     #[allow(clippy::type_complexity)]
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, (Vec<&[u8]>, &[u8])> {
-        repeat_till(0.., length_take(be_u64), "abc").parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<(Vec<&'i [u8]>, &'i [u8])> {
+        repeat_till(0.., length_take(be_u64), "abc").parse_next(i)
     }
 
     // Trigger an overflow in repeat_till
     assert_eq!(
-        multi(Partial::new(
+        multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -102,13 +102,13 @@ fn overflow_incomplete_many_till0() {
 fn overflow_incomplete_many_m_n() {
     use winnow::combinator::repeat;
 
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(2..=4, length_take(be_u64)).parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(2..=4, length_take(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in repeat
     assert_eq!(
-        multi(Partial::new(
+        multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -118,12 +118,12 @@ fn overflow_incomplete_many_m_n() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_count() {
-    fn counter(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(2, length_take(be_u64)).parse_peek(i)
+    fn counter<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(2, length_take(be_u64)).parse_next(i)
     }
 
     assert_eq!(
-        counter(Partial::new(
+        counter.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
@@ -136,12 +136,12 @@ fn overflow_incomplete_length_repeat() {
     use winnow::binary::be_u8;
     use winnow::binary::length_repeat;
 
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        length_repeat(be_u8, length_take(be_u64)).parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        length_repeat(be_u8, length_take(be_u64)).parse_next(i)
     }
 
     assert_eq!(
-        multi(Partial::new(
+        multi.parse_peek(Partial::new(
             &b"\x04\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xee"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551598)))
@@ -151,12 +151,12 @@ fn overflow_incomplete_length_repeat() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_take() {
-    fn multi(i: Partial<&[u8]>) -> IResult<Partial<&[u8]>, Vec<&[u8]>> {
-        repeat(0.., length_take(be_u64)).parse_peek(i)
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+        repeat(0.., length_take(be_u64)).parse_next(i)
     }
 
     assert_eq!(
-        multi(Partial::new(
+        multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]
         )),
         Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -1,13 +1,15 @@
 #![allow(clippy::unreadable_literal)]
 #![cfg(target_pointer_width = "64")]
 
+use snapbox::str;
+
 #[cfg(feature = "alloc")]
 use winnow::binary::be_u64;
 #[cfg(feature = "alloc")]
 use winnow::binary::length_take;
 #[cfg(feature = "alloc")]
 use winnow::combinator::repeat;
-use winnow::error::{ErrMode, Needed};
+use winnow::error::InputError;
 use winnow::prelude::*;
 use winnow::token::take;
 use winnow::Partial;
@@ -18,45 +20,75 @@ use winnow::Partial;
 fn overflow_incomplete_tuple() {
     // We request a length that would trigger an overflow if computing consumed + requested
     #[allow(clippy::type_complexity)]
-    fn parser02<'i>(i: &mut Partial<&'i [u8]>) -> PResult<(&'i [u8], &'i [u8])> {
+    fn parser02<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<(&'i [u8], &'i [u8]), InputError<Partial<&'i [u8]>>> {
         (take(1_usize), take(18446744073709551615_usize)).parse_next(i)
     }
 
-    assert_eq!(
-        parser02.parse_peek(Partial::new(&b"3"[..])),
-        Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
-    );
+    assert_parse!(parser02.parse_peek(Partial::new(&b"3"[..])), str![[r#"
+Err(
+    Incomplete(
+        Size(
+            18446744073709551615,
+        ),
+    ),
+)
+
+"#]]);
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_bytes() {
-    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+    fn multi<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
         repeat(0.., length_take(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in length_take
-    assert_eq!(
+    assert_parse!(
         multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]
         )),
-        Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            18446744073709551615,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many0() {
-    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+    fn multi<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
         repeat(0.., length_take(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in repeat
-    assert_eq!(
+    assert_parse!(
         multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
-        Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            18446744073709551599,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
@@ -65,16 +97,27 @@ fn overflow_incomplete_many0() {
 fn overflow_incomplete_many1() {
     use winnow::combinator::repeat;
 
-    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+    fn multi<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
         repeat(1.., length_take(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in repeat
-    assert_eq!(
+    assert_parse!(
         multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
-        Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            18446744073709551599,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
@@ -84,16 +127,27 @@ fn overflow_incomplete_many_till0() {
     use winnow::combinator::repeat_till;
 
     #[allow(clippy::type_complexity)]
-    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<(Vec<&'i [u8]>, &'i [u8])> {
+    fn multi<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<(Vec<&'i [u8]>, &'i [u8]), InputError<Partial<&'i [u8]>>> {
         repeat_till(0.., length_take(be_u64), "abc").parse_next(i)
     }
 
     // Trigger an overflow in repeat_till
-    assert_eq!(
+    assert_parse!(
         multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
-        Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            18446744073709551599,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
@@ -102,31 +156,53 @@ fn overflow_incomplete_many_till0() {
 fn overflow_incomplete_many_m_n() {
     use winnow::combinator::repeat;
 
-    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+    fn multi<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
         repeat(2..=4, length_take(be_u64)).parse_next(i)
     }
 
     // Trigger an overflow in repeat
-    assert_eq!(
+    assert_parse!(
         multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
-        Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            18446744073709551599,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_count() {
-    fn counter<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+    fn counter<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
         repeat(2, length_take(be_u64)).parse_next(i)
     }
 
-    assert_eq!(
+    assert_parse!(
         counter.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xef"[..]
         )),
-        Err(ErrMode::Incomplete(Needed::new(18446744073709551599)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            18446744073709551599,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
@@ -136,29 +212,51 @@ fn overflow_incomplete_length_repeat() {
     use winnow::binary::be_u8;
     use winnow::binary::length_repeat;
 
-    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+    fn multi<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
         length_repeat(be_u8, length_take(be_u64)).parse_next(i)
     }
 
-    assert_eq!(
+    assert_parse!(
         multi.parse_peek(Partial::new(
             &b"\x04\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xee"[..]
         )),
-        Err(ErrMode::Incomplete(Needed::new(18446744073709551598)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            18446744073709551598,
+        ),
+    ),
+)
+
+"#]]
     );
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_take() {
-    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> PResult<Vec<&'i [u8]>> {
+    fn multi<'i>(
+        i: &mut Partial<&'i [u8]>,
+    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
         repeat(0.., length_take(be_u64)).parse_next(i)
     }
 
-    assert_eq!(
+    assert_parse!(
         multi.parse_peek(Partial::new(
             &b"\x00\x00\x00\x00\x00\x00\x00\x01\xaa\xff\xff\xff\xff\xff\xff\xff\xff"[..]
         )),
-        Err(ErrMode::Incomplete(Needed::new(18446744073709551615)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            18446744073709551615,
+        ),
+    ),
+)
+
+"#]]
     );
 }

--- a/tests/testsuite/overflow.rs
+++ b/tests/testsuite/overflow.rs
@@ -9,10 +9,11 @@ use winnow::binary::be_u64;
 use winnow::binary::length_take;
 #[cfg(feature = "alloc")]
 use winnow::combinator::repeat;
-use winnow::error::InputError;
 use winnow::prelude::*;
 use winnow::token::take;
 use winnow::Partial;
+
+use crate::TestResult;
 
 // Parser definition
 
@@ -22,11 +23,13 @@ fn overflow_incomplete_tuple() {
     #[allow(clippy::type_complexity)]
     fn parser02<'i>(
         i: &mut Partial<&'i [u8]>,
-    ) -> PResult<(&'i [u8], &'i [u8]), InputError<Partial<&'i [u8]>>> {
+    ) -> TestResult<Partial<&'i [u8]>, (&'i [u8], &'i [u8])> {
         (take(1_usize), take(18446744073709551615_usize)).parse_next(i)
     }
 
-    assert_parse!(parser02.parse_peek(Partial::new(&b"3"[..])), str![[r#"
+    assert_parse!(
+        parser02.parse_peek(Partial::new(&b"3"[..])),
+        str![[r#"
 Err(
     Incomplete(
         Size(
@@ -35,15 +38,14 @@ Err(
     ),
 )
 
-"#]]);
+"#]]
+    );
 }
 
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_bytes() {
-    fn multi<'i>(
-        i: &mut Partial<&'i [u8]>,
-    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, Vec<&'i [u8]>> {
         repeat(0.., length_take(be_u64)).parse_next(i)
     }
 
@@ -68,9 +70,7 @@ Err(
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many0() {
-    fn multi<'i>(
-        i: &mut Partial<&'i [u8]>,
-    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, Vec<&'i [u8]>> {
         repeat(0.., length_take(be_u64)).parse_next(i)
     }
 
@@ -97,9 +97,7 @@ Err(
 fn overflow_incomplete_many1() {
     use winnow::combinator::repeat;
 
-    fn multi<'i>(
-        i: &mut Partial<&'i [u8]>,
-    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, Vec<&'i [u8]>> {
         repeat(1.., length_take(be_u64)).parse_next(i)
     }
 
@@ -129,7 +127,7 @@ fn overflow_incomplete_many_till0() {
     #[allow(clippy::type_complexity)]
     fn multi<'i>(
         i: &mut Partial<&'i [u8]>,
-    ) -> PResult<(Vec<&'i [u8]>, &'i [u8]), InputError<Partial<&'i [u8]>>> {
+    ) -> TestResult<Partial<&'i [u8]>, (Vec<&'i [u8]>, &'i [u8])> {
         repeat_till(0.., length_take(be_u64), "abc").parse_next(i)
     }
 
@@ -156,9 +154,7 @@ Err(
 fn overflow_incomplete_many_m_n() {
     use winnow::combinator::repeat;
 
-    fn multi<'i>(
-        i: &mut Partial<&'i [u8]>,
-    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, Vec<&'i [u8]>> {
         repeat(2..=4, length_take(be_u64)).parse_next(i)
     }
 
@@ -183,9 +179,7 @@ Err(
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_count() {
-    fn counter<'i>(
-        i: &mut Partial<&'i [u8]>,
-    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
+    fn counter<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, Vec<&'i [u8]>> {
         repeat(2, length_take(be_u64)).parse_next(i)
     }
 
@@ -212,9 +206,7 @@ fn overflow_incomplete_length_repeat() {
     use winnow::binary::be_u8;
     use winnow::binary::length_repeat;
 
-    fn multi<'i>(
-        i: &mut Partial<&'i [u8]>,
-    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, Vec<&'i [u8]>> {
         length_repeat(be_u8, length_take(be_u64)).parse_next(i)
     }
 
@@ -238,9 +230,7 @@ Err(
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_take() {
-    fn multi<'i>(
-        i: &mut Partial<&'i [u8]>,
-    ) -> PResult<Vec<&'i [u8]>, InputError<Partial<&'i [u8]>>> {
+    fn multi<'i>(i: &mut Partial<&'i [u8]>) -> TestResult<Partial<&'i [u8]>, Vec<&'i [u8]>> {
         repeat(0.., length_take(be_u64)).parse_next(i)
     }
 

--- a/tests/testsuite/reborrow_fold.rs
+++ b/tests/testsuite/reborrow_fold.rs
@@ -5,7 +5,6 @@ use std::str;
 
 use winnow::combinator::delimited;
 use winnow::combinator::repeat;
-use winnow::error::IResult;
 use winnow::error::InputError;
 use winnow::prelude::*;
 use winnow::token::take_till;
@@ -17,7 +16,7 @@ fn atom<'a>(_tomb: &mut ()) -> impl Parser<&'a [u8], String, InputError<&'a [u8]
 }
 
 // FIXME: should we support the use case of borrowing data mutably in a parser?
-fn list<'a>(i: &'a [u8], tomb: &mut ()) -> IResult<&'a [u8], String> {
+fn list<'a>(i: &mut &'a [u8], tomb: &mut ()) -> PResult<String, InputError<&'a [u8]>> {
     delimited(
         '(',
         repeat(0.., atom(tomb)).fold(String::new, |mut acc: String, next: String| {
@@ -26,5 +25,5 @@ fn list<'a>(i: &'a [u8], tomb: &mut ()) -> IResult<&'a [u8], String> {
         }),
         ')',
     )
-    .parse_peek(i)
+    .parse_next(i)
 }

--- a/tests/testsuite/reborrow_fold.rs
+++ b/tests/testsuite/reborrow_fold.rs
@@ -9,6 +9,8 @@ use winnow::error::InputError;
 use winnow::prelude::*;
 use winnow::token::take_till;
 
+use crate::TestResult;
+
 fn atom<'a>(_tomb: &mut ()) -> impl Parser<&'a [u8], String, InputError<&'a [u8]>> {
     take_till(1.., [' ', '\t', '\r', '\n'])
         .try_map(str::from_utf8)
@@ -16,7 +18,7 @@ fn atom<'a>(_tomb: &mut ()) -> impl Parser<&'a [u8], String, InputError<&'a [u8]
 }
 
 // FIXME: should we support the use case of borrowing data mutably in a parser?
-fn list<'a>(i: &mut &'a [u8], tomb: &mut ()) -> PResult<String, InputError<&'a [u8]>> {
+fn list<'a>(i: &mut &'a [u8], tomb: &mut ()) -> TestResult<&'a [u8], String> {
     delimited(
         '(',
         repeat(0.., atom(tomb)).fold(String::new, |mut acc: String, next: String| {

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -1,105 +1,136 @@
+use snapbox::str;
+
 use winnow::ascii::Caseless;
 use winnow::prelude::*;
 use winnow::Partial;
 #[cfg(feature = "alloc")]
 use winnow::{combinator::alt, combinator::repeat, token::literal};
 use winnow::{
-    error::ErrMode,
-    error::{ErrorKind, IResult, InputError},
+    error::InputError,
     token::{take, take_till, take_until, take_while},
 };
 
 #[test]
 fn literal_succeed_str() {
     const INPUT: &str = "Hello World!";
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         "Hello".parse_next(input)
     }
 
-    match test.parse_peek(INPUT) {
-        Ok((extra, output)) => {
-            assert!(
-                extra == " World!",
-                "Parser `literal` consumed leftover input."
-            );
-            assert!(
-                output == "Hello",
-                "Parser `literal` doesn't return the literal it matched on success. \
-           Expected `{}`, got `{}`.",
-                "Hello",
-                output
-            );
-        }
-        other => panic!(
-            "Parser `literal` didn't succeed when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Ok(
+    (
+        " World!",
+        "Hello",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn literal_incomplete_str() {
     const INPUT: &str = "Hello";
 
-    let res: IResult<_, _, InputError<_>> = "Hello World!".parse_peek(Partial::new(INPUT));
-    match res {
-        Err(ErrMode::Incomplete(_)) => (),
-        other => {
-            panic!(
-                "Parser `literal` didn't require more input when it should have. \
-           Got `{other:?}`."
-            );
-        }
-    };
+    assert_parse!(
+        "Hello World!".parse_peek(INPUT),
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "Hello",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn literal_error_str() {
     const INPUT: &str = "Hello World!";
 
-    let res: IResult<_, _, InputError<_>> = "Random".parse_peek(INPUT);
-    match res {
-        Err(ErrMode::Backtrack(_)) => (),
-        other => {
-            panic!("Parser `literal` didn't fail when it should have. Got `{other:?}`.`");
-        }
-    };
+    assert_parse!(
+        "Random".parse_peek(INPUT),
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "Hello World!",
+            kind: Literal,
+        },
+    ),
+)
+
+"#]]
+    );
 }
 
 #[cfg(feature = "alloc")]
 #[test]
 fn literal_case_insensitive_str() {
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         literal(Caseless("ABcd")).parse_next(input)
     }
-    assert_eq!(test.parse_peek("aBCdefgh"), Ok(("efgh", "aBCd")));
-    assert_eq!(test.parse_peek("abcdefgh"), Ok(("efgh", "abcd")));
-    assert_eq!(test.parse_peek("ABCDefgh"), Ok(("efgh", "ABCD")));
+    assert_parse!(
+        test.parse_peek("aBCdefgh"),
+        str![[r#"
+Ok(
+    (
+        "efgh",
+        "aBCd",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
+        test.parse_peek("abcdefgh"),
+        str![[r#"
+Ok(
+    (
+        "efgh",
+        "abcd",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
+        test.parse_peek("ABCDefgh"),
+        str![[r#"
+Ok(
+    (
+        "efgh",
+        "ABCD",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn take_succeed_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-    const CONSUMED: &str = "βèƒôřèÂßÇ";
-    const LEFTOVER: &str = "áƒƭèř";
 
-    let res: IResult<_, _, InputError<_>> = take(9_usize).parse_peek(INPUT);
-    match res {
-        Ok((extra, output)) => {
-            assert!(
-                extra == LEFTOVER,
-                "Parser `take_s` consumed leftover input. Leftover `{extra}`."
-            );
-            assert!(
-          output == CONSUMED,
-          "Parser `take_s` doesn't return the string it consumed on success. Expected `{CONSUMED}`, got `{output}`."
-        );
-        }
-        other => panic!(
-            "Parser `take_s` didn't succeed when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        take(9_usize).parse_peek(INPUT),
+        str![[r#"
+Ok(
+    (
+        "áƒƭèř",
+        "βèƒôřèÂßÇ",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
@@ -108,42 +139,36 @@ fn take_incomplete_str() {
 
     const INPUT: &str = "βèƒôřèÂßÇá";
 
-    let res: IResult<_, _, InputError<_>> = take(13_usize).parse_peek(Partial::new(INPUT));
-    match res {
-        Err(ErrMode::Incomplete(_)) => (),
-        other => panic!(
-            "Parser `take` didn't require more input when it should have. \
-         Got `{other:?}`."
-        ),
-    }
+    assert_parse!(
+        take(13_usize).parse_peek(Partial::new(INPUT)),
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn take_until_succeed_str() {
     const INPUT: &str = "βèƒôřèÂßÇ∂áƒƭèř";
     const FIND: &str = "ÂßÇ∂";
-    const CONSUMED: &str = "βèƒôřè";
-    const LEFTOVER: &str = "ÂßÇ∂áƒƭèř";
 
-    let res: IResult<_, _, InputError<_>> = take_until(0.., FIND).parse_peek(INPUT);
-    match res {
-        Ok((extra, output)) => {
-            assert!(
-                extra == LEFTOVER,
-                "Parser `take_until`\
-           consumed leftover input. Leftover `{extra}`."
-            );
-            assert!(
-                    output == CONSUMED,
-                    "Parser `take_until`\
-           doesn't return the string it consumed on success. Expected `{CONSUMED}`, got `{output}`."
-                );
-        }
-        other => panic!(
-            "Parser `take_until` didn't succeed when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        take_until(0.., FIND).parse_peek(INPUT),
+        str![[r#"
+Ok(
+    (
+        "ÂßÇ∂áƒƭèř",
+        "βèƒôřè",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
@@ -153,14 +178,17 @@ fn take_until_incomplete_str() {
     const INPUT: &str = "βèƒôřè";
     const FIND: &str = "βèƒôřèÂßÇ";
 
-    let res: IResult<_, _, InputError<_>> = take_until(0.., FIND).parse_peek(Partial::new(INPUT));
-    match res {
-        Err(ErrMode::Incomplete(_)) => (),
-        other => panic!(
-            "Parser `take_until` didn't require more input when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        take_until(0.., FIND).parse_peek(Partial::new(INPUT)),
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
@@ -170,14 +198,17 @@ fn take_until_error_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const FIND: &str = "Ráñδô₥";
 
-    let res: IResult<_, _, InputError<_>> = take_until(0.., FIND).parse_peek(Partial::new(INPUT));
-    match res {
-        Err(ErrMode::Incomplete(_)) => (),
-        other => panic!(
-            "Parser `take_until` didn't fail when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        take_until(0.., FIND).parse_peek(Partial::new(INPUT)),
+        str![[r#"
+Err(
+    Incomplete(
+        Unknown,
+    ),
+)
+
+"#]]
+    );
 }
 
 fn is_alphabetic(c: char) -> bool {
@@ -186,8 +217,6 @@ fn is_alphabetic(c: char) -> bool {
 
 #[test]
 fn take_while_str() {
-    use winnow::error::Needed;
-
     use winnow::token::take_while;
 
     fn f<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
@@ -198,16 +227,62 @@ fn take_while_str() {
     let c = "abcd123";
     let d = "123";
 
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(b)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(f.parse_peek(Partial::new(c)), Ok((Partial::new(d), b)));
-    assert_eq!(f.parse_peek(Partial::new(d)), Ok((Partial::new(d), a)));
+    assert_parse!(
+        f.parse_peek(Partial::new(c)),
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "123",
+            partial: true,
+        },
+        "abcd",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
+        f.parse_peek(Partial::new(d)),
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "123",
+            partial: true,
+        },
+        "",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
@@ -215,31 +290,24 @@ fn take_while_succeed_none_str() {
     use winnow::token::take_while;
 
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-    const CONSUMED: &str = "";
-    const LEFTOVER: &str = "βèƒôřèÂßÇáƒƭèř";
     fn while_s(c: char) -> bool {
         c == '9'
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_while(0.., while_s).parse_next(input)
     }
-    match test.parse_peek(INPUT) {
-        Ok((extra, output)) => {
-            assert!(
-                extra == LEFTOVER,
-                "Parser `take_while` consumed leftover input."
-            );
-            assert!(
-                output == CONSUMED,
-                "Parser `take_while` doesn't return the string it consumed on success. \
-           Expected `{CONSUMED}`, got `{output}`."
-            );
-        }
-        other => panic!(
-            "Parser `take_while` didn't succeed when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Ok(
+    (
+        "βèƒôřèÂßÇáƒƭèř",
+        "",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
@@ -247,37 +315,28 @@ fn take_while_succeed_some_str() {
     use winnow::token::take_while;
 
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-    const CONSUMED: &str = "βèƒôřèÂßÇ";
-    const LEFTOVER: &str = "áƒƭèř";
     fn while_s(c: char) -> bool {
         matches!(c, 'β' | 'è' | 'ƒ' | 'ô' | 'ř' | 'Â' | 'ß' | 'Ç')
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_while(0.., while_s).parse_next(input)
     }
-    match test.parse_peek(INPUT) {
-        Ok((extra, output)) => {
-            assert!(
-                extra == LEFTOVER,
-                "Parser `take_while` consumed leftover input."
-            );
-            assert!(
-                output == CONSUMED,
-                "Parser `take_while` doesn't return the string it consumed on success. \
-           Expected `{CONSUMED}`, got `{output}`."
-            );
-        }
-        other => panic!(
-            "Parser `take_while` didn't succeed when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Ok(
+    (
+        "áƒƭèř",
+        "βèƒôřèÂßÇ",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn test_take_while1_str() {
-    use winnow::error::Needed;
-
     fn f<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
         take_while(1.., is_alphabetic).parse_next(input)
     }
@@ -286,21 +345,63 @@ fn test_take_while1_str() {
     let c = "abcd123";
     let d = "123";
 
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(a)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(
+    assert_parse!(
         f.parse_peek(Partial::new(b)),
-        Err(ErrMode::Incomplete(Needed::new(1)))
+        str![[r#"
+Err(
+    Incomplete(
+        Size(
+            1,
+        ),
+    ),
+)
+
+"#]]
     );
-    assert_eq!(f.parse_peek(Partial::new(c)), Ok((Partial::new("123"), b)));
-    assert_eq!(
+    assert_parse!(
+        f.parse_peek(Partial::new(c)),
+        str![[r#"
+Ok(
+    (
+        Partial {
+            input: "123",
+            partial: true,
+        },
+        "abcd",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
         f.parse_peek(Partial::new(d)),
-        Err(ErrMode::Backtrack(InputError::new(
-            Partial::new(d),
-            ErrorKind::Slice
-        )))
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: Partial {
+                input: "123",
+                partial: true,
+            },
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
     );
 }
 
@@ -309,58 +410,45 @@ fn take_while1_fn_succeed_str() {
     use winnow::token::take_while;
 
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-    const CONSUMED: &str = "βèƒôřèÂßÇ";
-    const LEFTOVER: &str = "áƒƭèř";
     fn while1_s(c: char) -> bool {
         matches!(c, 'β' | 'è' | 'ƒ' | 'ô' | 'ř' | 'Â' | 'ß' | 'Ç')
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_while(1.., while1_s).parse_next(input)
     }
-    match test.parse_peek(INPUT) {
-        Ok((extra, output)) => {
-            assert!(
-                extra == LEFTOVER,
-                "Parser `take_while` consumed leftover input."
-            );
-            assert!(
-                output == CONSUMED,
-                "Parser `take_while` doesn't return the string it consumed on success. \
-           Expected `{CONSUMED}`, got `{output}`."
-            );
-        }
-        other => panic!(
-            "Parser `take_while` didn't succeed when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Ok(
+    (
+        "áƒƭèř",
+        "βèƒôřèÂßÇ",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn take_while1_set_succeed_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const MATCH: &[char] = &['β', 'è', 'ƒ', 'ô', 'ř', 'è', 'Â', 'ß', 'Ç'];
-    const CONSUMED: &str = "βèƒôřèÂßÇ";
-    const LEFTOVER: &str = "áƒƭèř";
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_while(1.., MATCH).parse_next(input)
     }
-    match test.parse_peek(INPUT) {
-        Ok((extra, output)) => {
-            assert!(
-                extra == LEFTOVER,
-                "Parser `is_a` consumed leftover input. Leftover `{extra}`."
-            );
-            assert!(
-          output == CONSUMED,
-          "Parser `is_a` doesn't return the string it consumed on success. Expected `{CONSUMED}`, got `{output}`."
-        );
-        }
-        other => panic!(
-            "Parser `is_a` didn't succeed when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Ok(
+    (
+        "áƒƭèř",
+        "βèƒôřèÂßÇ",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
@@ -371,99 +459,113 @@ fn take_while1_fn_fail_str() {
     fn while1_s(c: char) -> bool {
         c == '9'
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_while(1.., while1_s).parse_next(input)
     }
-    match test.parse_peek(INPUT) {
-        Err(ErrMode::Backtrack(_)) => (),
-        other => panic!(
-            "Parser `take_while` didn't fail when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "βèƒôřèÂßÇáƒƭèř",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn take_while1_set_fail_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const MATCH: &[char] = &['Û', 'ñ', 'ℓ', 'ú', 'ç', 'ƙ', '¥'];
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_while(1.., MATCH).parse_next(input)
     }
-    match test.parse_peek(INPUT) {
-        Err(ErrMode::Backtrack(_)) => (),
-        other => panic!("Parser `is_a` didn't fail when it should have. Got `{other:?}`."),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "βèƒôřèÂßÇáƒƭèř",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn take_till0_succeed_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-    const CONSUMED: &str = "βèƒôřèÂßÇ";
-    const LEFTOVER: &str = "áƒƭèř";
     fn till_s(c: char) -> bool {
         c == 'á'
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_till(0.., till_s).parse_next(input)
     }
-    match test.parse_peek(INPUT) {
-        Ok((extra, output)) => {
-            assert!(
-                extra == LEFTOVER,
-                "Parser `take_till0` consumed leftover input."
-            );
-            assert!(
-                output == CONSUMED,
-                "Parser `take_till0` doesn't return the string it consumed on success. \
-           Expected `{CONSUMED}`, got `{output}`."
-            );
-        }
-        other => panic!(
-            "Parser `take_till0` didn't succeed when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Ok(
+    (
+        "áƒƭèř",
+        "βèƒôřèÂßÇ",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn take_till1_succeed_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const AVOID: &[char] = &['£', 'ú', 'ç', 'ƙ', '¥', 'á'];
-    const CONSUMED: &str = "βèƒôřèÂßÇ";
-    const LEFTOVER: &str = "áƒƭèř";
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_till(1.., AVOID).parse_next(input)
     }
-    match test.parse_peek(INPUT) {
-        Ok((extra, output)) => {
-            assert!(
-                extra == LEFTOVER,
-                "Parser `take_till1` consumed leftover input. Leftover `{extra}`."
-            );
-            assert!(
-          output == CONSUMED,
-          "Parser `take_till1` doesn't return the string it consumed on success. Expected `{CONSUMED}`, got `{output}`."
-        );
-        }
-        other => panic!(
-            "Parser `take_till1` didn't succeed when it should have. \
-         Got `{other:?}`."
-        ),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Ok(
+    (
+        "áƒƭèř",
+        "βèƒôřèÂßÇ",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn take_till1_failed_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const AVOID: &[char] = &['β', 'ú', 'ç', 'ƙ', '¥'];
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         take_till(1.., AVOID).parse_next(input)
     }
-    match test.parse_peek(INPUT) {
-        Err(ErrMode::Backtrack(_)) => (),
-        other => panic!("Parser `is_not` didn't fail when it should have. Got `{other:?}`."),
-    };
+    assert_parse!(
+        test.parse_peek(INPUT),
+        str![[r#"
+Err(
+    Backtrack(
+        InputError {
+            input: "βèƒôřèÂßÇáƒƭèř",
+            kind: Slice,
+        },
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
@@ -474,19 +576,41 @@ fn take_is_a_str() {
     let a = "aabbab";
     let b = "ababcd";
 
-    fn f<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn f<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         repeat::<_, _, (), _, _>(1.., alt(("a", "b")))
             .take()
             .parse_next(input)
     }
 
-    assert_eq!(f.parse_peek(a), Ok((&a[6..], a)));
-    assert_eq!(f.parse_peek(b), Ok((&b[4..], &b[..4])));
+    assert_parse!(
+        f.parse_peek(a),
+        str![[r#"
+Ok(
+    (
+        "",
+        "aabbab",
+    ),
+)
+
+"#]]
+    );
+    assert_parse!(
+        f.parse_peek(b),
+        str![[r#"
+Ok(
+    (
+        "cd",
+        "abab",
+    ),
+)
+
+"#]]
+    );
 }
 
 #[test]
 fn utf8_indexing_str() {
-    fn dot<'i>(input: &mut &'i str) -> PResult<&'i str> {
+    fn dot<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
         ".".parse_next(input)
     }
 

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -1,499 +1,494 @@
-#[cfg(test)]
-mod test {
-    use winnow::ascii::Caseless;
-    use winnow::prelude::*;
-    use winnow::Partial;
-    #[cfg(feature = "alloc")]
-    use winnow::{combinator::alt, combinator::repeat, token::literal};
-    use winnow::{
-        error::ErrMode,
-        error::{ErrorKind, IResult, InputError},
-        token::{take, take_till, take_until, take_while},
-    };
+use winnow::ascii::Caseless;
+use winnow::prelude::*;
+use winnow::Partial;
+#[cfg(feature = "alloc")]
+use winnow::{combinator::alt, combinator::repeat, token::literal};
+use winnow::{
+    error::ErrMode,
+    error::{ErrorKind, IResult, InputError},
+    token::{take, take_till, take_until, take_while},
+};
 
-    #[test]
-    fn literal_succeed_str() {
-        const INPUT: &str = "Hello World!";
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            "Hello".parse_next(input)
-        }
+#[test]
+fn literal_succeed_str() {
+    const INPUT: &str = "Hello World!";
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        "Hello".parse_next(input)
+    }
 
-        match test.parse_peek(INPUT) {
-            Ok((extra, output)) => {
-                assert!(
-                    extra == " World!",
-                    "Parser `literal` consumed leftover input."
-                );
-                assert!(
-                    output == "Hello",
-                    "Parser `literal` doesn't return the literal it matched on success. \
+    match test.parse_peek(INPUT) {
+        Ok((extra, output)) => {
+            assert!(
+                extra == " World!",
+                "Parser `literal` consumed leftover input."
+            );
+            assert!(
+                output == "Hello",
+                "Parser `literal` doesn't return the literal it matched on success. \
            Expected `{}`, got `{}`.",
-                    "Hello",
-                    output
-                );
-            }
-            other => panic!(
-                "Parser `literal` didn't succeed when it should have. \
-         Got `{other:?}`."
-            ),
-        };
-    }
-
-    #[test]
-    fn literal_incomplete_str() {
-        const INPUT: &str = "Hello";
-
-        let res: IResult<_, _, InputError<_>> = "Hello World!".parse_peek(Partial::new(INPUT));
-        match res {
-            Err(ErrMode::Incomplete(_)) => (),
-            other => {
-                panic!(
-                    "Parser `literal` didn't require more input when it should have. \
-           Got `{other:?}`."
-                );
-            }
-        };
-    }
-
-    #[test]
-    fn literal_error_str() {
-        const INPUT: &str = "Hello World!";
-
-        let res: IResult<_, _, InputError<_>> = "Random".parse_peek(INPUT);
-        match res {
-            Err(ErrMode::Backtrack(_)) => (),
-            other => {
-                panic!("Parser `literal` didn't fail when it should have. Got `{other:?}`.`");
-            }
-        };
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn literal_case_insensitive_str() {
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            literal(Caseless("ABcd")).parse_next(input)
+                "Hello",
+                output
+            );
         }
-        assert_eq!(test.parse_peek("aBCdefgh"), Ok(("efgh", "aBCd")));
-        assert_eq!(test.parse_peek("abcdefgh"), Ok(("efgh", "abcd")));
-        assert_eq!(test.parse_peek("ABCDefgh"), Ok(("efgh", "ABCD")));
+        other => panic!(
+            "Parser `literal` didn't succeed when it should have. \
+         Got `{other:?}`."
+        ),
+    };
+}
+
+#[test]
+fn literal_incomplete_str() {
+    const INPUT: &str = "Hello";
+
+    let res: IResult<_, _, InputError<_>> = "Hello World!".parse_peek(Partial::new(INPUT));
+    match res {
+        Err(ErrMode::Incomplete(_)) => (),
+        other => {
+            panic!(
+                "Parser `literal` didn't require more input when it should have. \
+           Got `{other:?}`."
+            );
+        }
+    };
+}
+
+#[test]
+fn literal_error_str() {
+    const INPUT: &str = "Hello World!";
+
+    let res: IResult<_, _, InputError<_>> = "Random".parse_peek(INPUT);
+    match res {
+        Err(ErrMode::Backtrack(_)) => (),
+        other => {
+            panic!("Parser `literal` didn't fail when it should have. Got `{other:?}`.`");
+        }
+    };
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn literal_case_insensitive_str() {
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        literal(Caseless("ABcd")).parse_next(input)
     }
+    assert_eq!(test.parse_peek("aBCdefgh"), Ok(("efgh", "aBCd")));
+    assert_eq!(test.parse_peek("abcdefgh"), Ok(("efgh", "abcd")));
+    assert_eq!(test.parse_peek("ABCDefgh"), Ok(("efgh", "ABCD")));
+}
 
-    #[test]
-    fn take_succeed_str() {
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const CONSUMED: &str = "βèƒôřèÂßÇ";
-        const LEFTOVER: &str = "áƒƭèř";
+#[test]
+fn take_succeed_str() {
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const CONSUMED: &str = "βèƒôřèÂßÇ";
+    const LEFTOVER: &str = "áƒƭèř";
 
-        let res: IResult<_, _, InputError<_>> = take(9_usize).parse_peek(INPUT);
-        match res {
-            Ok((extra, output)) => {
-                assert!(
-                    extra == LEFTOVER,
-                    "Parser `take_s` consumed leftover input. Leftover `{extra}`."
-                );
-                assert!(
+    let res: IResult<_, _, InputError<_>> = take(9_usize).parse_peek(INPUT);
+    match res {
+        Ok((extra, output)) => {
+            assert!(
+                extra == LEFTOVER,
+                "Parser `take_s` consumed leftover input. Leftover `{extra}`."
+            );
+            assert!(
           output == CONSUMED,
           "Parser `take_s` doesn't return the string it consumed on success. Expected `{CONSUMED}`, got `{output}`."
         );
-            }
-            other => panic!(
-                "Parser `take_s` didn't succeed when it should have. \
-         Got `{other:?}`."
-            ),
-        };
-    }
-
-    #[test]
-    fn take_incomplete_str() {
-        use winnow::token::take;
-
-        const INPUT: &str = "βèƒôřèÂßÇá";
-
-        let res: IResult<_, _, InputError<_>> = take(13_usize).parse_peek(Partial::new(INPUT));
-        match res {
-            Err(ErrMode::Incomplete(_)) => (),
-            other => panic!(
-                "Parser `take` didn't require more input when it should have. \
-         Got `{other:?}`."
-            ),
         }
+        other => panic!(
+            "Parser `take_s` didn't succeed when it should have. \
+         Got `{other:?}`."
+        ),
+    };
+}
+
+#[test]
+fn take_incomplete_str() {
+    use winnow::token::take;
+
+    const INPUT: &str = "βèƒôřèÂßÇá";
+
+    let res: IResult<_, _, InputError<_>> = take(13_usize).parse_peek(Partial::new(INPUT));
+    match res {
+        Err(ErrMode::Incomplete(_)) => (),
+        other => panic!(
+            "Parser `take` didn't require more input when it should have. \
+         Got `{other:?}`."
+        ),
     }
+}
 
-    #[test]
-    fn take_until_succeed_str() {
-        const INPUT: &str = "βèƒôřèÂßÇ∂áƒƭèř";
-        const FIND: &str = "ÂßÇ∂";
-        const CONSUMED: &str = "βèƒôřè";
-        const LEFTOVER: &str = "ÂßÇ∂áƒƭèř";
+#[test]
+fn take_until_succeed_str() {
+    const INPUT: &str = "βèƒôřèÂßÇ∂áƒƭèř";
+    const FIND: &str = "ÂßÇ∂";
+    const CONSUMED: &str = "βèƒôřè";
+    const LEFTOVER: &str = "ÂßÇ∂áƒƭèř";
 
-        let res: IResult<_, _, InputError<_>> = take_until(0.., FIND).parse_peek(INPUT);
-        match res {
-            Ok((extra, output)) => {
-                assert!(
-                    extra == LEFTOVER,
-                    "Parser `take_until`\
+    let res: IResult<_, _, InputError<_>> = take_until(0.., FIND).parse_peek(INPUT);
+    match res {
+        Ok((extra, output)) => {
+            assert!(
+                extra == LEFTOVER,
+                "Parser `take_until`\
            consumed leftover input. Leftover `{extra}`."
-                );
-                assert!(
+            );
+            assert!(
                     output == CONSUMED,
                     "Parser `take_until`\
            doesn't return the string it consumed on success. Expected `{CONSUMED}`, got `{output}`."
                 );
-            }
-            other => panic!(
-                "Parser `take_until` didn't succeed when it should have. \
-         Got `{other:?}`."
-            ),
-        };
-    }
-
-    #[test]
-    fn take_until_incomplete_str() {
-        use winnow::token::take_until;
-
-        const INPUT: &str = "βèƒôřè";
-        const FIND: &str = "βèƒôřèÂßÇ";
-
-        let res: IResult<_, _, InputError<_>> =
-            take_until(0.., FIND).parse_peek(Partial::new(INPUT));
-        match res {
-            Err(ErrMode::Incomplete(_)) => (),
-            other => panic!(
-                "Parser `take_until` didn't require more input when it should have. \
-         Got `{other:?}`."
-            ),
-        };
-    }
-
-    #[test]
-    fn take_until_error_str() {
-        use winnow::token::take_until;
-
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const FIND: &str = "Ráñδô₥";
-
-        let res: IResult<_, _, InputError<_>> =
-            take_until(0.., FIND).parse_peek(Partial::new(INPUT));
-        match res {
-            Err(ErrMode::Incomplete(_)) => (),
-            other => panic!(
-                "Parser `take_until` didn't fail when it should have. \
-         Got `{other:?}`."
-            ),
-        };
-    }
-
-    fn is_alphabetic(c: char) -> bool {
-        (c as u8 >= 0x41 && c as u8 <= 0x5A) || (c as u8 >= 0x61 && c as u8 <= 0x7A)
-    }
-
-    #[test]
-    fn take_while_str() {
-        use winnow::error::Needed;
-
-        use winnow::token::take_while;
-
-        fn f<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
-            take_while(0.., is_alphabetic).parse_next(input)
         }
-        let a = "";
-        let b = "abcd";
-        let c = "abcd123";
-        let d = "123";
+        other => panic!(
+            "Parser `take_until` didn't succeed when it should have. \
+         Got `{other:?}`."
+        ),
+    };
+}
 
-        assert_eq!(
-            f.parse_peek(Partial::new(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(
-            f.parse_peek(Partial::new(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(f.parse_peek(Partial::new(c)), Ok((Partial::new(d), b)));
-        assert_eq!(f.parse_peek(Partial::new(d)), Ok((Partial::new(d), a)));
+#[test]
+fn take_until_incomplete_str() {
+    use winnow::token::take_until;
+
+    const INPUT: &str = "βèƒôřè";
+    const FIND: &str = "βèƒôřèÂßÇ";
+
+    let res: IResult<_, _, InputError<_>> = take_until(0.., FIND).parse_peek(Partial::new(INPUT));
+    match res {
+        Err(ErrMode::Incomplete(_)) => (),
+        other => panic!(
+            "Parser `take_until` didn't require more input when it should have. \
+         Got `{other:?}`."
+        ),
+    };
+}
+
+#[test]
+fn take_until_error_str() {
+    use winnow::token::take_until;
+
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const FIND: &str = "Ráñδô₥";
+
+    let res: IResult<_, _, InputError<_>> = take_until(0.., FIND).parse_peek(Partial::new(INPUT));
+    match res {
+        Err(ErrMode::Incomplete(_)) => (),
+        other => panic!(
+            "Parser `take_until` didn't fail when it should have. \
+         Got `{other:?}`."
+        ),
+    };
+}
+
+fn is_alphabetic(c: char) -> bool {
+    (c as u8 >= 0x41 && c as u8 <= 0x5A) || (c as u8 >= 0x61 && c as u8 <= 0x7A)
+}
+
+#[test]
+fn take_while_str() {
+    use winnow::error::Needed;
+
+    use winnow::token::take_while;
+
+    fn f<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+        take_while(0.., is_alphabetic).parse_next(input)
     }
+    let a = "";
+    let b = "abcd";
+    let c = "abcd123";
+    let d = "123";
 
-    #[test]
-    fn take_while_succeed_none_str() {
-        use winnow::token::take_while;
+    assert_eq!(
+        f.parse_peek(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new(b)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(f.parse_peek(Partial::new(c)), Ok((Partial::new(d), b)));
+    assert_eq!(f.parse_peek(Partial::new(d)), Ok((Partial::new(d), a)));
+}
 
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const CONSUMED: &str = "";
-        const LEFTOVER: &str = "βèƒôřèÂßÇáƒƭèř";
-        fn while_s(c: char) -> bool {
-            c == '9'
-        }
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            take_while(0.., while_s).parse_next(input)
-        }
-        match test.parse_peek(INPUT) {
-            Ok((extra, output)) => {
-                assert!(
-                    extra == LEFTOVER,
-                    "Parser `take_while` consumed leftover input."
-                );
-                assert!(
-                    output == CONSUMED,
-                    "Parser `take_while` doesn't return the string it consumed on success. \
+#[test]
+fn take_while_succeed_none_str() {
+    use winnow::token::take_while;
+
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const CONSUMED: &str = "";
+    const LEFTOVER: &str = "βèƒôřèÂßÇáƒƭèř";
+    fn while_s(c: char) -> bool {
+        c == '9'
+    }
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        take_while(0.., while_s).parse_next(input)
+    }
+    match test.parse_peek(INPUT) {
+        Ok((extra, output)) => {
+            assert!(
+                extra == LEFTOVER,
+                "Parser `take_while` consumed leftover input."
+            );
+            assert!(
+                output == CONSUMED,
+                "Parser `take_while` doesn't return the string it consumed on success. \
            Expected `{CONSUMED}`, got `{output}`."
-                );
-            }
-            other => panic!(
-                "Parser `take_while` didn't succeed when it should have. \
+            );
+        }
+        other => panic!(
+            "Parser `take_while` didn't succeed when it should have. \
          Got `{other:?}`."
-            ),
-        };
+        ),
+    };
+}
+
+#[test]
+fn take_while_succeed_some_str() {
+    use winnow::token::take_while;
+
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const CONSUMED: &str = "βèƒôřèÂßÇ";
+    const LEFTOVER: &str = "áƒƭèř";
+    fn while_s(c: char) -> bool {
+        matches!(c, 'β' | 'è' | 'ƒ' | 'ô' | 'ř' | 'Â' | 'ß' | 'Ç')
     }
-
-    #[test]
-    fn take_while_succeed_some_str() {
-        use winnow::token::take_while;
-
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const CONSUMED: &str = "βèƒôřèÂßÇ";
-        const LEFTOVER: &str = "áƒƭèř";
-        fn while_s(c: char) -> bool {
-            matches!(c, 'β' | 'è' | 'ƒ' | 'ô' | 'ř' | 'Â' | 'ß' | 'Ç')
-        }
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            take_while(0.., while_s).parse_next(input)
-        }
-        match test.parse_peek(INPUT) {
-            Ok((extra, output)) => {
-                assert!(
-                    extra == LEFTOVER,
-                    "Parser `take_while` consumed leftover input."
-                );
-                assert!(
-                    output == CONSUMED,
-                    "Parser `take_while` doesn't return the string it consumed on success. \
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        take_while(0.., while_s).parse_next(input)
+    }
+    match test.parse_peek(INPUT) {
+        Ok((extra, output)) => {
+            assert!(
+                extra == LEFTOVER,
+                "Parser `take_while` consumed leftover input."
+            );
+            assert!(
+                output == CONSUMED,
+                "Parser `take_while` doesn't return the string it consumed on success. \
            Expected `{CONSUMED}`, got `{output}`."
-                );
-            }
-            other => panic!(
-                "Parser `take_while` didn't succeed when it should have. \
+            );
+        }
+        other => panic!(
+            "Parser `take_while` didn't succeed when it should have. \
          Got `{other:?}`."
-            ),
-        };
+        ),
+    };
+}
+
+#[test]
+fn test_take_while1_str() {
+    use winnow::error::Needed;
+
+    fn f<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+        take_while(1.., is_alphabetic).parse_next(input)
     }
+    let a = "";
+    let b = "abcd";
+    let c = "abcd123";
+    let d = "123";
 
-    #[test]
-    fn test_take_while1_str() {
-        use winnow::error::Needed;
+    assert_eq!(
+        f.parse_peek(Partial::new(a)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+        f.parse_peek(Partial::new(b)),
+        Err(ErrMode::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(f.parse_peek(Partial::new(c)), Ok((Partial::new("123"), b)));
+    assert_eq!(
+        f.parse_peek(Partial::new(d)),
+        Err(ErrMode::Backtrack(InputError::new(
+            Partial::new(d),
+            ErrorKind::Slice
+        )))
+    );
+}
 
-        fn f<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
-            take_while(1.., is_alphabetic).parse_next(input)
-        }
-        let a = "";
-        let b = "abcd";
-        let c = "abcd123";
-        let d = "123";
+#[test]
+fn take_while1_fn_succeed_str() {
+    use winnow::token::take_while;
 
-        assert_eq!(
-            f.parse_peek(Partial::new(a)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(
-            f.parse_peek(Partial::new(b)),
-            Err(ErrMode::Incomplete(Needed::new(1)))
-        );
-        assert_eq!(f.parse_peek(Partial::new(c)), Ok((Partial::new("123"), b)));
-        assert_eq!(
-            f.parse_peek(Partial::new(d)),
-            Err(ErrMode::Backtrack(InputError::new(
-                Partial::new(d),
-                ErrorKind::Slice
-            )))
-        );
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const CONSUMED: &str = "βèƒôřèÂßÇ";
+    const LEFTOVER: &str = "áƒƭèř";
+    fn while1_s(c: char) -> bool {
+        matches!(c, 'β' | 'è' | 'ƒ' | 'ô' | 'ř' | 'Â' | 'ß' | 'Ç')
     }
-
-    #[test]
-    fn take_while1_fn_succeed_str() {
-        use winnow::token::take_while;
-
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const CONSUMED: &str = "βèƒôřèÂßÇ";
-        const LEFTOVER: &str = "áƒƭèř";
-        fn while1_s(c: char) -> bool {
-            matches!(c, 'β' | 'è' | 'ƒ' | 'ô' | 'ř' | 'Â' | 'ß' | 'Ç')
-        }
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            take_while(1.., while1_s).parse_next(input)
-        }
-        match test.parse_peek(INPUT) {
-            Ok((extra, output)) => {
-                assert!(
-                    extra == LEFTOVER,
-                    "Parser `take_while` consumed leftover input."
-                );
-                assert!(
-                    output == CONSUMED,
-                    "Parser `take_while` doesn't return the string it consumed on success. \
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        take_while(1.., while1_s).parse_next(input)
+    }
+    match test.parse_peek(INPUT) {
+        Ok((extra, output)) => {
+            assert!(
+                extra == LEFTOVER,
+                "Parser `take_while` consumed leftover input."
+            );
+            assert!(
+                output == CONSUMED,
+                "Parser `take_while` doesn't return the string it consumed on success. \
            Expected `{CONSUMED}`, got `{output}`."
-                );
-            }
-            other => panic!(
-                "Parser `take_while` didn't succeed when it should have. \
-         Got `{other:?}`."
-            ),
-        };
-    }
-
-    #[test]
-    fn take_while1_set_succeed_str() {
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const MATCH: &[char] = &['β', 'è', 'ƒ', 'ô', 'ř', 'è', 'Â', 'ß', 'Ç'];
-        const CONSUMED: &str = "βèƒôřèÂßÇ";
-        const LEFTOVER: &str = "áƒƭèř";
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            take_while(1.., MATCH).parse_next(input)
+            );
         }
-        match test.parse_peek(INPUT) {
-            Ok((extra, output)) => {
-                assert!(
-                    extra == LEFTOVER,
-                    "Parser `is_a` consumed leftover input. Leftover `{extra}`."
-                );
-                assert!(
+        other => panic!(
+            "Parser `take_while` didn't succeed when it should have. \
+         Got `{other:?}`."
+        ),
+    };
+}
+
+#[test]
+fn take_while1_set_succeed_str() {
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const MATCH: &[char] = &['β', 'è', 'ƒ', 'ô', 'ř', 'è', 'Â', 'ß', 'Ç'];
+    const CONSUMED: &str = "βèƒôřèÂßÇ";
+    const LEFTOVER: &str = "áƒƭèř";
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        take_while(1.., MATCH).parse_next(input)
+    }
+    match test.parse_peek(INPUT) {
+        Ok((extra, output)) => {
+            assert!(
+                extra == LEFTOVER,
+                "Parser `is_a` consumed leftover input. Leftover `{extra}`."
+            );
+            assert!(
           output == CONSUMED,
           "Parser `is_a` doesn't return the string it consumed on success. Expected `{CONSUMED}`, got `{output}`."
         );
-            }
-            other => panic!(
-                "Parser `is_a` didn't succeed when it should have. \
+        }
+        other => panic!(
+            "Parser `is_a` didn't succeed when it should have. \
          Got `{other:?}`."
-            ),
-        };
+        ),
+    };
+}
+
+#[test]
+fn take_while1_fn_fail_str() {
+    use winnow::token::take_while;
+
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    fn while1_s(c: char) -> bool {
+        c == '9'
     }
-
-    #[test]
-    fn take_while1_fn_fail_str() {
-        use winnow::token::take_while;
-
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        fn while1_s(c: char) -> bool {
-            c == '9'
-        }
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            take_while(1.., while1_s).parse_next(input)
-        }
-        match test.parse_peek(INPUT) {
-            Err(ErrMode::Backtrack(_)) => (),
-            other => panic!(
-                "Parser `take_while` didn't fail when it should have. \
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        take_while(1.., while1_s).parse_next(input)
+    }
+    match test.parse_peek(INPUT) {
+        Err(ErrMode::Backtrack(_)) => (),
+        other => panic!(
+            "Parser `take_while` didn't fail when it should have. \
          Got `{other:?}`."
-            ),
-        };
-    }
+        ),
+    };
+}
 
-    #[test]
-    fn take_while1_set_fail_str() {
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const MATCH: &[char] = &['Û', 'ñ', 'ℓ', 'ú', 'ç', 'ƙ', '¥'];
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            take_while(1.., MATCH).parse_next(input)
-        }
-        match test.parse_peek(INPUT) {
-            Err(ErrMode::Backtrack(_)) => (),
-            other => panic!("Parser `is_a` didn't fail when it should have. Got `{other:?}`."),
-        };
+#[test]
+fn take_while1_set_fail_str() {
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const MATCH: &[char] = &['Û', 'ñ', 'ℓ', 'ú', 'ç', 'ƙ', '¥'];
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        take_while(1.., MATCH).parse_next(input)
     }
+    match test.parse_peek(INPUT) {
+        Err(ErrMode::Backtrack(_)) => (),
+        other => panic!("Parser `is_a` didn't fail when it should have. Got `{other:?}`."),
+    };
+}
 
-    #[test]
-    fn take_till0_succeed_str() {
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const CONSUMED: &str = "βèƒôřèÂßÇ";
-        const LEFTOVER: &str = "áƒƭèř";
-        fn till_s(c: char) -> bool {
-            c == 'á'
-        }
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            take_till(0.., till_s).parse_next(input)
-        }
-        match test.parse_peek(INPUT) {
-            Ok((extra, output)) => {
-                assert!(
-                    extra == LEFTOVER,
-                    "Parser `take_till0` consumed leftover input."
-                );
-                assert!(
-                    output == CONSUMED,
-                    "Parser `take_till0` doesn't return the string it consumed on success. \
+#[test]
+fn take_till0_succeed_str() {
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const CONSUMED: &str = "βèƒôřèÂßÇ";
+    const LEFTOVER: &str = "áƒƭèř";
+    fn till_s(c: char) -> bool {
+        c == 'á'
+    }
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        take_till(0.., till_s).parse_next(input)
+    }
+    match test.parse_peek(INPUT) {
+        Ok((extra, output)) => {
+            assert!(
+                extra == LEFTOVER,
+                "Parser `take_till0` consumed leftover input."
+            );
+            assert!(
+                output == CONSUMED,
+                "Parser `take_till0` doesn't return the string it consumed on success. \
            Expected `{CONSUMED}`, got `{output}`."
-                );
-            }
-            other => panic!(
-                "Parser `take_till0` didn't succeed when it should have. \
-         Got `{other:?}`."
-            ),
-        };
-    }
-
-    #[test]
-    fn take_till1_succeed_str() {
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const AVOID: &[char] = &['£', 'ú', 'ç', 'ƙ', '¥', 'á'];
-        const CONSUMED: &str = "βèƒôřèÂßÇ";
-        const LEFTOVER: &str = "áƒƭèř";
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            take_till(1.., AVOID).parse_next(input)
+            );
         }
-        match test.parse_peek(INPUT) {
-            Ok((extra, output)) => {
-                assert!(
-                    extra == LEFTOVER,
-                    "Parser `take_till1` consumed leftover input. Leftover `{extra}`."
-                );
-                assert!(
+        other => panic!(
+            "Parser `take_till0` didn't succeed when it should have. \
+         Got `{other:?}`."
+        ),
+    };
+}
+
+#[test]
+fn take_till1_succeed_str() {
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const AVOID: &[char] = &['£', 'ú', 'ç', 'ƙ', '¥', 'á'];
+    const CONSUMED: &str = "βèƒôřèÂßÇ";
+    const LEFTOVER: &str = "áƒƭèř";
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        take_till(1.., AVOID).parse_next(input)
+    }
+    match test.parse_peek(INPUT) {
+        Ok((extra, output)) => {
+            assert!(
+                extra == LEFTOVER,
+                "Parser `take_till1` consumed leftover input. Leftover `{extra}`."
+            );
+            assert!(
           output == CONSUMED,
           "Parser `take_till1` doesn't return the string it consumed on success. Expected `{CONSUMED}`, got `{output}`."
         );
-            }
-            other => panic!(
-                "Parser `take_till1` didn't succeed when it should have. \
+        }
+        other => panic!(
+            "Parser `take_till1` didn't succeed when it should have. \
          Got `{other:?}`."
-            ),
-        };
+        ),
+    };
+}
+
+#[test]
+fn take_till1_failed_str() {
+    const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
+    const AVOID: &[char] = &['β', 'ú', 'ç', 'ƙ', '¥'];
+    fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        take_till(1.., AVOID).parse_next(input)
+    }
+    match test.parse_peek(INPUT) {
+        Err(ErrMode::Backtrack(_)) => (),
+        other => panic!("Parser `is_not` didn't fail when it should have. Got `{other:?}`."),
+    };
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn take_is_a_str() {
+    use winnow::prelude::*;
+
+    let a = "aabbab";
+    let b = "ababcd";
+
+    fn f<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        repeat::<_, _, (), _, _>(1.., alt(("a", "b")))
+            .take()
+            .parse_next(input)
     }
 
-    #[test]
-    fn take_till1_failed_str() {
-        const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
-        const AVOID: &[char] = &['β', 'ú', 'ç', 'ƙ', '¥'];
-        fn test<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            take_till(1.., AVOID).parse_next(input)
-        }
-        match test.parse_peek(INPUT) {
-            Err(ErrMode::Backtrack(_)) => (),
-            other => panic!("Parser `is_not` didn't fail when it should have. Got `{other:?}`."),
-        };
+    assert_eq!(f.parse_peek(a), Ok((&a[6..], a)));
+    assert_eq!(f.parse_peek(b), Ok((&b[4..], &b[..4])));
+}
+
+#[test]
+fn utf8_indexing_str() {
+    fn dot<'i>(input: &mut &'i str) -> PResult<&'i str> {
+        ".".parse_next(input)
     }
 
-    #[test]
-    #[cfg(feature = "alloc")]
-    fn take_is_a_str() {
-        use winnow::prelude::*;
-
-        let a = "aabbab";
-        let b = "ababcd";
-
-        fn f<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            repeat::<_, _, (), _, _>(1.., alt(("a", "b")))
-                .take()
-                .parse_next(input)
-        }
-
-        assert_eq!(f.parse_peek(a), Ok((&a[6..], a)));
-        assert_eq!(f.parse_peek(b), Ok((&b[4..], &b[..4])));
-    }
-
-    #[test]
-    fn utf8_indexing_str() {
-        fn dot<'i>(input: &mut &'i str) -> PResult<&'i str> {
-            ".".parse_next(input)
-        }
-
-        let _ = dot.parse_peek("點");
-    }
+    let _ = dot.parse_peek("點");
 }

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -2,18 +2,17 @@ use snapbox::str;
 
 use winnow::ascii::Caseless;
 use winnow::prelude::*;
+use winnow::token::{take, take_till, take_until, take_while};
 use winnow::Partial;
 #[cfg(feature = "alloc")]
 use winnow::{combinator::alt, combinator::repeat, token::literal};
-use winnow::{
-    error::InputError,
-    token::{take, take_till, take_until, take_while},
-};
+
+use crate::TestResult;
 
 #[test]
 fn literal_succeed_str() {
     const INPUT: &str = "Hello World!";
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         "Hello".parse_next(input)
     }
 
@@ -74,7 +73,7 @@ Err(
 #[cfg(feature = "alloc")]
 #[test]
 fn literal_case_insensitive_str() {
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         literal(Caseless("ABcd")).parse_next(input)
     }
     assert_parse!(
@@ -219,7 +218,7 @@ fn is_alphabetic(c: char) -> bool {
 fn take_while_str() {
     use winnow::token::take_while;
 
-    fn f<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn f<'i>(input: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_while(0.., is_alphabetic).parse_next(input)
     }
     let a = "";
@@ -293,7 +292,7 @@ fn take_while_succeed_none_str() {
     fn while_s(c: char) -> bool {
         c == '9'
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_while(0.., while_s).parse_next(input)
     }
     assert_parse!(
@@ -318,7 +317,7 @@ fn take_while_succeed_some_str() {
     fn while_s(c: char) -> bool {
         matches!(c, 'β' | 'è' | 'ƒ' | 'ô' | 'ř' | 'Â' | 'ß' | 'Ç')
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_while(0.., while_s).parse_next(input)
     }
     assert_parse!(
@@ -337,7 +336,7 @@ Ok(
 
 #[test]
 fn test_take_while1_str() {
-    fn f<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, InputError<Partial<&'i str>>> {
+    fn f<'i>(input: &mut Partial<&'i str>) -> TestResult<Partial<&'i str>, &'i str> {
         take_while(1.., is_alphabetic).parse_next(input)
     }
     let a = "";
@@ -413,7 +412,7 @@ fn take_while1_fn_succeed_str() {
     fn while1_s(c: char) -> bool {
         matches!(c, 'β' | 'è' | 'ƒ' | 'ô' | 'ř' | 'Â' | 'ß' | 'Ç')
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_while(1.., while1_s).parse_next(input)
     }
     assert_parse!(
@@ -434,7 +433,7 @@ Ok(
 fn take_while1_set_succeed_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const MATCH: &[char] = &['β', 'è', 'ƒ', 'ô', 'ř', 'è', 'Â', 'ß', 'Ç'];
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_while(1.., MATCH).parse_next(input)
     }
     assert_parse!(
@@ -459,7 +458,7 @@ fn take_while1_fn_fail_str() {
     fn while1_s(c: char) -> bool {
         c == '9'
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_while(1.., while1_s).parse_next(input)
     }
     assert_parse!(
@@ -482,7 +481,7 @@ Err(
 fn take_while1_set_fail_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const MATCH: &[char] = &['Û', 'ñ', 'ℓ', 'ú', 'ç', 'ƙ', '¥'];
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_while(1.., MATCH).parse_next(input)
     }
     assert_parse!(
@@ -507,7 +506,7 @@ fn take_till0_succeed_str() {
     fn till_s(c: char) -> bool {
         c == 'á'
     }
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_till(0.., till_s).parse_next(input)
     }
     assert_parse!(
@@ -528,7 +527,7 @@ Ok(
 fn take_till1_succeed_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const AVOID: &[char] = &['£', 'ú', 'ç', 'ƙ', '¥', 'á'];
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_till(1.., AVOID).parse_next(input)
     }
     assert_parse!(
@@ -549,7 +548,7 @@ Ok(
 fn take_till1_failed_str() {
     const INPUT: &str = "βèƒôřèÂßÇáƒƭèř";
     const AVOID: &[char] = &['β', 'ú', 'ç', 'ƙ', '¥'];
-    fn test<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn test<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         take_till(1.., AVOID).parse_next(input)
     }
     assert_parse!(
@@ -576,7 +575,7 @@ fn take_is_a_str() {
     let a = "aabbab";
     let b = "ababcd";
 
-    fn f<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn f<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         repeat::<_, _, (), _, _>(1.., alt(("a", "b")))
             .take()
             .parse_next(input)
@@ -610,7 +609,7 @@ Ok(
 
 #[test]
 fn utf8_indexing_str() {
-    fn dot<'i>(input: &mut &'i str) -> PResult<&'i str, InputError<&'i str>> {
+    fn dot<'i>(input: &mut &'i str) -> TestResult<&'i str, &'i str> {
         ".".parse_next(input)
     }
 


### PR DESCRIPTION
Overall, this is to move us off of IResult and make it easier to change `ErrMode`