### PR TITLE
fix(comb): Fix repeat().fold(1..) to append errors on first failure

### DIFF
--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -1397,9 +1397,9 @@ where
     E: ParserError<I>,
 {
     let init = init();
+    let start = input.checkpoint();
     match f.parse_next(input) {
-        Err(ErrMode::Backtrack(_)) => Err(ErrMode::from_error_kind(input, ErrorKind::Repeat)),
-        Err(e) => Err(e),
+        Err(e) => Err(e.append(input, &start, ErrorKind::Repeat)),
         Ok(o1) => {
             let mut acc = g(init, o1);
 

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -3712,7 +3712,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Repeat,
+            kind: Literal,
         },
     ),
 )


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
