### PR TITLE
fix(comb): Fix repeat().fold(1..) to append errors

### DIFF
--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -221,8 +221,8 @@ where
     ///
     /// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
     /// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-    /// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(InputError::new("123123", ErrorKind::Many))));
-    /// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Many))));
+    /// assert_eq!(parser("123123"), Err(ErrMode::Backtrack(InputError::new("123123", ErrorKind::Tag))));
+    /// assert_eq!(parser(""), Err(ErrMode::Backtrack(InputError::new("", ErrorKind::Tag))));
     /// ```
     ///
     /// Arbitrary number of repetitions:
@@ -1387,9 +1387,9 @@ where
     E: ParserError<I>,
 {
     let init = init();
+    let start = input.checkpoint();
     match f.parse_next(input) {
-        Err(ErrMode::Backtrack(_)) => Err(ErrMode::from_error_kind(input, ErrorKind::Many)),
-        Err(e) => Err(e),
+        Err(e) => Err(e.append(input, &start, ErrorKind::Many)),
         Ok(o1) => {
             let mut acc = g(init, o1);
 

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -1276,7 +1276,7 @@ fn fold_repeat1_test() {
         multi(Partial::new(c)),
         Err(ErrMode::Backtrack(error_position!(
             &Partial::new(c),
-            ErrorKind::Many
+            ErrorKind::Tag
         )))
     );
     assert_eq!(


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
