### PR TITLE
fix!: Make ErrMode optional by using Result

### DIFF
--- a/benches/contains_token.rs
+++ b/benches/contains_token.rs
@@ -50,7 +50,7 @@ fn contains_token(c: &mut criterion::Criterion) {
     group.finish();
 }
 
-fn parser_slice(input: &mut &str) -> PResult<usize> {
+fn parser_slice(input: &mut &str) -> ModalResult<usize> {
     let contains = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'][..];
     repeat(
         0..,
@@ -59,7 +59,7 @@ fn parser_slice(input: &mut &str) -> PResult<usize> {
     .parse_next(input)
 }
 
-fn parser_array(input: &mut &str) -> PResult<usize> {
+fn parser_array(input: &mut &str) -> ModalResult<usize> {
     let contains = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
     repeat(
         0..,
@@ -68,7 +68,7 @@ fn parser_array(input: &mut &str) -> PResult<usize> {
     .parse_next(input)
 }
 
-fn parser_tuple(input: &mut &str) -> PResult<usize> {
+fn parser_tuple(input: &mut &str) -> ModalResult<usize> {
     let contains = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9');
     repeat(
         0..,
@@ -77,7 +77,7 @@ fn parser_tuple(input: &mut &str) -> PResult<usize> {
     .parse_next(input)
 }
 
-fn parser_closure_or(input: &mut &str) -> PResult<usize> {
+fn parser_closure_or(input: &mut &str) -> ModalResult<usize> {
     let contains = |c: char| {
         c == '0'
             || c == '1'
@@ -97,7 +97,7 @@ fn parser_closure_or(input: &mut &str) -> PResult<usize> {
     .parse_next(input)
 }
 
-fn parser_closure_matches(input: &mut &str) -> PResult<usize> {
+fn parser_closure_matches(input: &mut &str) -> ModalResult<usize> {
     let contains = |c: char| matches!(c, '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9');
     repeat(
         0..,

--- a/benches/find_slice.rs
+++ b/benches/find_slice.rs
@@ -38,11 +38,11 @@ fn find_slice(c: &mut criterion::Criterion) {
     group.finish();
 }
 
-fn parser_byte(input: &mut &str) -> PResult<usize> {
+fn parser_byte(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., (take_until(0.., "\r"), "\r")).parse_next(input)
 }
 
-fn parser_slice(input: &mut &str) -> PResult<usize> {
+fn parser_slice(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., (take_until(0.., "\r\n"), "\r\n")).parse_next(input)
 }
 

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -51,7 +51,7 @@ fn iter(c: &mut criterion::Criterion) {
     group.finish();
 }
 
-fn iterate(input: &mut &[u8]) -> PResult<usize> {
+fn iterate(input: &mut &[u8]) -> ModalResult<usize> {
     let mut count = 0;
     for byte in input.iter() {
         if byte.is_dec_digit() {
@@ -62,7 +62,7 @@ fn iterate(input: &mut &[u8]) -> PResult<usize> {
     Ok(count)
 }
 
-fn next_token(input: &mut &[u8]) -> PResult<usize> {
+fn next_token(input: &mut &[u8]) -> ModalResult<usize> {
     let mut count = 0;
     while let Some(byte) = input.next_token() {
         if byte.is_dec_digit() {
@@ -72,7 +72,7 @@ fn next_token(input: &mut &[u8]) -> PResult<usize> {
     Ok(count)
 }
 
-fn opt_one_of(input: &mut &[u8]) -> PResult<usize> {
+fn opt_one_of(input: &mut &[u8]) -> ModalResult<usize> {
     let mut count = 0;
     while !input.is_empty() {
         while opt(one_of(AsChar::is_dec_digit))
@@ -89,7 +89,7 @@ fn opt_one_of(input: &mut &[u8]) -> PResult<usize> {
     Ok(count)
 }
 
-fn take_while(input: &mut &[u8]) -> PResult<usize> {
+fn take_while(input: &mut &[u8]) -> ModalResult<usize> {
     let mut count = 0;
     while !input.is_empty() {
         count += winnow::token::take_while(0.., AsChar::is_dec_digit)
@@ -100,7 +100,7 @@ fn take_while(input: &mut &[u8]) -> PResult<usize> {
     Ok(count)
 }
 
-fn repeat(input: &mut &[u8]) -> PResult<usize> {
+fn repeat(input: &mut &[u8]) -> ModalResult<usize> {
     let mut count = 0;
     while !input.is_empty() {
         count += winnow::combinator::repeat(0.., one_of(AsChar::is_dec_digit))

--- a/benches/next_slice.rs
+++ b/benches/next_slice.rs
@@ -89,43 +89,43 @@ fn next_slice(c: &mut criterion::Criterion) {
     group.finish();
 }
 
-fn parser_ascii_char(input: &mut &str) -> PResult<usize> {
+fn parser_ascii_char(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., 'h').parse_next(input)
 }
 
-fn parser_ascii_str(input: &mut &str) -> PResult<usize> {
+fn parser_ascii_str(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., "h").parse_next(input)
 }
 
-fn parser_ascii_one_of(input: &mut &str) -> PResult<usize> {
+fn parser_ascii_one_of(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., one_of('h')).parse_next(input)
 }
 
-fn parser_ascii_tag_char(input: &mut &str) -> PResult<usize> {
+fn parser_ascii_tag_char(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., literal('h')).parse_next(input)
 }
 
-fn parser_ascii_tag_str(input: &mut &str) -> PResult<usize> {
+fn parser_ascii_tag_str(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., literal("h")).parse_next(input)
 }
 
-fn parser_utf8_char(input: &mut &str) -> PResult<usize> {
+fn parser_utf8_char(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., '🧑').parse_next(input)
 }
 
-fn parser_utf8_str(input: &mut &str) -> PResult<usize> {
+fn parser_utf8_str(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., "🧑").parse_next(input)
 }
 
-fn parser_utf8_one_of(input: &mut &str) -> PResult<usize> {
+fn parser_utf8_one_of(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., one_of('🧑')).parse_next(input)
 }
 
-fn parser_utf8_tag_char(input: &mut &str) -> PResult<usize> {
+fn parser_utf8_tag_char(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., literal('🧑')).parse_next(input)
 }
 
-fn parser_utf8_tag_str(input: &mut &str) -> PResult<usize> {
+fn parser_utf8_tag_str(input: &mut &str) -> ModalResult<usize> {
     repeat(0.., literal("🧑")).parse_next(input)
 }
 

--- a/benches/number.rs
+++ b/benches/number.rs
@@ -14,7 +14,7 @@ use winnow::stream::ParseSlice;
 
 type Stream<'i> = &'i [u8];
 
-fn parser(i: &mut Stream<'_>) -> PResult<u64> {
+fn parser(i: &mut Stream<'_>) -> ModalResult<u64> {
     be_u64.parse_next(i)
 }
 
@@ -49,7 +49,7 @@ fn float_str(c: &mut Criterion) {
     });
 }
 
-fn std_float(input: &mut &[u8]) -> PResult<f64> {
+fn std_float(input: &mut &[u8]) -> ModalResult<f64> {
     match input.parse_slice() {
         Some(n) => Ok(n),
         None => Err(ErrMode::from_error_kind(input, ErrorKind::Slice)),

--- a/benches/number.rs
+++ b/benches/number.rs
@@ -5,7 +5,6 @@ use criterion::Criterion;
 
 use winnow::ascii::float;
 use winnow::binary::be_u64;
-use winnow::error::ErrMode;
 use winnow::error::ErrorKind;
 use winnow::error::InputError;
 use winnow::error::ParserError;
@@ -52,7 +51,7 @@ fn float_str(c: &mut Criterion) {
 fn std_float(input: &mut &[u8]) -> ModalResult<f64> {
     match input.parse_slice() {
         Some(n) => Ok(n),
-        None => Err(ErrMode::from_error_kind(input, ErrorKind::Slice)),
+        None => Err(ParserError::from_error_kind(input, ErrorKind::Slice)),
     }
 }
 

--- a/examples/arithmetic/parser.rs
+++ b/examples/arithmetic/parser.rs
@@ -11,7 +11,7 @@ use winnow::{
 
 // Parser definition
 
-pub(crate) fn expr(i: &mut &str) -> PResult<i64> {
+pub(crate) fn expr(i: &mut &str) -> ModalResult<i64> {
     let init = term.parse_next(i)?;
 
     repeat(0.., (one_of(['+', '-']), term))
@@ -31,7 +31,7 @@ pub(crate) fn expr(i: &mut &str) -> PResult<i64> {
 // We read an initial factor and for each time we find
 // a * or / operator followed by another factor, we do
 // the math by folding everything
-fn term(i: &mut &str) -> PResult<i64> {
+fn term(i: &mut &str) -> ModalResult<i64> {
     let init = factor.parse_next(i)?;
 
     repeat(0.., (one_of(['*', '/']), factor))
@@ -52,7 +52,7 @@ fn term(i: &mut &str) -> PResult<i64> {
 // We look for a digit suite, and try to convert it.
 // If either str::from_utf8 or FromStr::from_str fail,
 // we fallback to the parens parser defined above
-fn factor(i: &mut &str) -> PResult<i64> {
+fn factor(i: &mut &str) -> ModalResult<i64> {
     delimited(
         multispaces,
         alt((digits.try_map(FromStr::from_str), parens)),
@@ -62,7 +62,7 @@ fn factor(i: &mut &str) -> PResult<i64> {
 }
 
 // We parse any expr surrounded by parens, ignoring all whitespace around those
-fn parens(i: &mut &str) -> PResult<i64> {
+fn parens(i: &mut &str) -> ModalResult<i64> {
     delimited('(', expr, ')').parse_next(i)
 }
 

--- a/examples/arithmetic/parser.rs
+++ b/examples/arithmetic/parser.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use winnow::prelude::*;
+use winnow::Result;
 use winnow::{
     ascii::{digit1 as digits, multispace0 as multispaces},
     combinator::alt,
@@ -11,7 +12,7 @@ use winnow::{
 
 // Parser definition
 
-pub(crate) fn expr(i: &mut &str) -> ModalResult<i64> {
+pub(crate) fn expr(i: &mut &str) -> Result<i64> {
     let init = term.parse_next(i)?;
 
     repeat(0.., (one_of(['+', '-']), term))
@@ -31,7 +32,7 @@ pub(crate) fn expr(i: &mut &str) -> ModalResult<i64> {
 // We read an initial factor and for each time we find
 // a * or / operator followed by another factor, we do
 // the math by folding everything
-fn term(i: &mut &str) -> ModalResult<i64> {
+fn term(i: &mut &str) -> Result<i64> {
     let init = factor.parse_next(i)?;
 
     repeat(0.., (one_of(['*', '/']), factor))
@@ -52,7 +53,7 @@ fn term(i: &mut &str) -> ModalResult<i64> {
 // We look for a digit suite, and try to convert it.
 // If either str::from_utf8 or FromStr::from_str fail,
 // we fallback to the parens parser defined above
-fn factor(i: &mut &str) -> ModalResult<i64> {
+fn factor(i: &mut &str) -> Result<i64> {
     delimited(
         multispaces,
         alt((digits.try_map(FromStr::from_str), parens)),
@@ -62,7 +63,7 @@ fn factor(i: &mut &str) -> ModalResult<i64> {
 }
 
 // We parse any expr surrounded by parens, ignoring all whitespace around those
-fn parens(i: &mut &str) -> ModalResult<i64> {
+fn parens(i: &mut &str) -> Result<i64> {
     delimited('(', expr, ')').parse_next(i)
 }
 

--- a/examples/arithmetic/parser_ast.rs
+++ b/examples/arithmetic/parser_ast.rs
@@ -4,6 +4,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
 use winnow::prelude::*;
+use winnow::Result;
 use winnow::{
     ascii::{digit1 as digits, multispace0 as multispaces},
     combinator::alt,
@@ -49,7 +50,7 @@ impl Display for Expr {
     }
 }
 
-pub(crate) fn expr(i: &mut &str) -> ModalResult<Expr> {
+pub(crate) fn expr(i: &mut &str) -> Result<Expr> {
     let init = term.parse_next(i)?;
 
     repeat(0.., (one_of(['+', '-']), term))
@@ -66,7 +67,7 @@ pub(crate) fn expr(i: &mut &str) -> ModalResult<Expr> {
         .parse_next(i)
 }
 
-fn term(i: &mut &str) -> ModalResult<Expr> {
+fn term(i: &mut &str) -> Result<Expr> {
     let init = factor.parse_next(i)?;
 
     repeat(0.., (one_of(['*', '/']), factor))
@@ -83,7 +84,7 @@ fn term(i: &mut &str) -> ModalResult<Expr> {
         .parse_next(i)
 }
 
-fn factor(i: &mut &str) -> ModalResult<Expr> {
+fn factor(i: &mut &str) -> Result<Expr> {
     delimited(
         multispaces,
         alt((digits.try_map(FromStr::from_str).map(Expr::Value), parens)),
@@ -92,7 +93,7 @@ fn factor(i: &mut &str) -> ModalResult<Expr> {
     .parse_next(i)
 }
 
-fn parens(i: &mut &str) -> ModalResult<Expr> {
+fn parens(i: &mut &str) -> Result<Expr> {
     delimited("(", expr, ")")
         .map(|e| Expr::Paren(Box::new(e)))
         .parse_next(i)

--- a/examples/arithmetic/parser_ast.rs
+++ b/examples/arithmetic/parser_ast.rs
@@ -49,7 +49,7 @@ impl Display for Expr {
     }
 }
 
-pub(crate) fn expr(i: &mut &str) -> PResult<Expr> {
+pub(crate) fn expr(i: &mut &str) -> ModalResult<Expr> {
     let init = term.parse_next(i)?;
 
     repeat(0.., (one_of(['+', '-']), term))
@@ -66,7 +66,7 @@ pub(crate) fn expr(i: &mut &str) -> PResult<Expr> {
         .parse_next(i)
 }
 
-fn term(i: &mut &str) -> PResult<Expr> {
+fn term(i: &mut &str) -> ModalResult<Expr> {
     let init = factor.parse_next(i)?;
 
     repeat(0.., (one_of(['*', '/']), factor))
@@ -83,7 +83,7 @@ fn term(i: &mut &str) -> PResult<Expr> {
         .parse_next(i)
 }
 
-fn factor(i: &mut &str) -> PResult<Expr> {
+fn factor(i: &mut &str) -> ModalResult<Expr> {
     delimited(
         multispaces,
         alt((digits.try_map(FromStr::from_str).map(Expr::Value), parens)),
@@ -92,7 +92,7 @@ fn factor(i: &mut &str) -> PResult<Expr> {
     .parse_next(i)
 }
 
-fn parens(i: &mut &str) -> PResult<Expr> {
+fn parens(i: &mut &str) -> ModalResult<Expr> {
     delimited("(", expr, ")")
         .map(|e| Expr::Paren(Box::new(e)))
         .parse_next(i)

--- a/examples/arithmetic/parser_lexer.rs
+++ b/examples/arithmetic/parser_lexer.rs
@@ -98,16 +98,16 @@ impl<const LEN: usize> winnow::stream::ContainsToken<Token> for [Token; LEN] {
 }
 
 #[allow(dead_code)]
-pub(crate) fn expr2(i: &mut &str) -> PResult<Expr> {
+pub(crate) fn expr2(i: &mut &str) -> ModalResult<Expr> {
     let tokens = lex.parse_next(i)?;
     expr.parse_next(&mut tokens.as_slice())
 }
 
-pub(crate) fn lex(i: &mut &str) -> PResult<Vec<Token>> {
+pub(crate) fn lex(i: &mut &str) -> ModalResult<Vec<Token>> {
     preceded(multispaces, repeat(1.., terminated(token, multispaces))).parse_next(i)
 }
 
-fn token(i: &mut &str) -> PResult<Token> {
+fn token(i: &mut &str) -> ModalResult<Token> {
     dispatch! {peek(any);
         '0'..='9' => digits.try_map(FromStr::from_str).map(Token::Value),
         '(' => '('.value(Token::OpenParen),
@@ -121,7 +121,7 @@ fn token(i: &mut &str) -> PResult<Token> {
     .parse_next(i)
 }
 
-pub(crate) fn expr(i: &mut &[Token]) -> PResult<Expr> {
+pub(crate) fn expr(i: &mut &[Token]) -> ModalResult<Expr> {
     let init = term.parse_next(i)?;
 
     repeat(
@@ -144,7 +144,7 @@ pub(crate) fn expr(i: &mut &[Token]) -> PResult<Expr> {
     .parse_next(i)
 }
 
-fn term(i: &mut &[Token]) -> PResult<Expr> {
+fn term(i: &mut &[Token]) -> ModalResult<Expr> {
     let init = factor.parse_next(i)?;
 
     repeat(
@@ -167,7 +167,7 @@ fn term(i: &mut &[Token]) -> PResult<Expr> {
     .parse_next(i)
 }
 
-fn factor(i: &mut &[Token]) -> PResult<Expr> {
+fn factor(i: &mut &[Token]) -> ModalResult<Expr> {
     alt((
         one_of(|t| matches!(t, Token::Value(_))).map(|t| match t {
             Token::Value(v) => Expr::Value(v),
@@ -178,7 +178,7 @@ fn factor(i: &mut &[Token]) -> PResult<Expr> {
     .parse_next(i)
 }
 
-fn parens(i: &mut &[Token]) -> PResult<Expr> {
+fn parens(i: &mut &[Token]) -> ModalResult<Expr> {
     delimited(one_of(Token::OpenParen), expr, one_of(Token::CloseParen))
         .map(|e| Expr::Paren(Box::new(e)))
         .parse_next(i)

--- a/examples/arithmetic/parser_lexer.rs
+++ b/examples/arithmetic/parser_lexer.rs
@@ -4,6 +4,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 
 use winnow::prelude::*;
+use winnow::Result;
 use winnow::{
     ascii::{digit1 as digits, multispace0 as multispaces},
     combinator::alt,
@@ -98,16 +99,16 @@ impl<const LEN: usize> winnow::stream::ContainsToken<Token> for [Token; LEN] {
 }
 
 #[allow(dead_code)]
-pub(crate) fn expr2(i: &mut &str) -> ModalResult<Expr> {
+pub(crate) fn expr2(i: &mut &str) -> Result<Expr> {
     let tokens = lex.parse_next(i)?;
     expr.parse_next(&mut tokens.as_slice())
 }
 
-pub(crate) fn lex(i: &mut &str) -> ModalResult<Vec<Token>> {
+pub(crate) fn lex(i: &mut &str) -> Result<Vec<Token>> {
     preceded(multispaces, repeat(1.., terminated(token, multispaces))).parse_next(i)
 }
 
-fn token(i: &mut &str) -> ModalResult<Token> {
+fn token(i: &mut &str) -> Result<Token> {
     dispatch! {peek(any);
         '0'..='9' => digits.try_map(FromStr::from_str).map(Token::Value),
         '(' => '('.value(Token::OpenParen),
@@ -121,7 +122,7 @@ fn token(i: &mut &str) -> ModalResult<Token> {
     .parse_next(i)
 }
 
-pub(crate) fn expr(i: &mut &[Token]) -> ModalResult<Expr> {
+pub(crate) fn expr(i: &mut &[Token]) -> Result<Expr> {
     let init = term.parse_next(i)?;
 
     repeat(
@@ -144,7 +145,7 @@ pub(crate) fn expr(i: &mut &[Token]) -> ModalResult<Expr> {
     .parse_next(i)
 }
 
-fn term(i: &mut &[Token]) -> ModalResult<Expr> {
+fn term(i: &mut &[Token]) -> Result<Expr> {
     let init = factor.parse_next(i)?;
 
     repeat(
@@ -167,7 +168,7 @@ fn term(i: &mut &[Token]) -> ModalResult<Expr> {
     .parse_next(i)
 }
 
-fn factor(i: &mut &[Token]) -> ModalResult<Expr> {
+fn factor(i: &mut &[Token]) -> Result<Expr> {
     alt((
         one_of(|t| matches!(t, Token::Value(_))).map(|t| match t {
             Token::Value(v) => Expr::Value(v),
@@ -178,7 +179,7 @@ fn factor(i: &mut &[Token]) -> ModalResult<Expr> {
     .parse_next(i)
 }
 
-fn parens(i: &mut &[Token]) -> ModalResult<Expr> {
+fn parens(i: &mut &[Token]) -> Result<Expr> {
     delimited(one_of(Token::OpenParen), expr, one_of(Token::CloseParen))
         .map(|e| Expr::Paren(Box::new(e)))
         .parse_next(i)

--- a/examples/css/parser.rs
+++ b/examples/css/parser.rs
@@ -18,7 +18,7 @@ impl std::str::FromStr for Color {
     }
 }
 
-pub(crate) fn hex_color(input: &mut &str) -> PResult<Color> {
+pub(crate) fn hex_color(input: &mut &str) -> ModalResult<Color> {
     seq!(Color {
         _: '#',
         red: hex_primary,
@@ -28,7 +28,7 @@ pub(crate) fn hex_color(input: &mut &str) -> PResult<Color> {
     .parse_next(input)
 }
 
-fn hex_primary(input: &mut &str) -> PResult<u8> {
+fn hex_primary(input: &mut &str) -> ModalResult<u8> {
     take_while(2, |c: char| c.is_ascii_hexdigit())
         .try_map(|input| u8::from_str_radix(input, 16))
         .parse_next(input)

--- a/examples/css/parser.rs
+++ b/examples/css/parser.rs
@@ -1,6 +1,7 @@
 use winnow::combinator::seq;
 use winnow::prelude::*;
 use winnow::token::take_while;
+use winnow::Result;
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct Color {
@@ -18,7 +19,7 @@ impl std::str::FromStr for Color {
     }
 }
 
-pub(crate) fn hex_color(input: &mut &str) -> ModalResult<Color> {
+pub(crate) fn hex_color(input: &mut &str) -> Result<Color> {
     seq!(Color {
         _: '#',
         red: hex_primary,
@@ -28,7 +29,7 @@ pub(crate) fn hex_color(input: &mut &str) -> ModalResult<Color> {
     .parse_next(input)
 }
 
-fn hex_primary(input: &mut &str) -> ModalResult<u8> {
+fn hex_primary(input: &mut &str) -> Result<u8> {
     take_while(2, |c: char| c.is_ascii_hexdigit())
         .try_map(|input| u8::from_str_radix(input, 16))
         .parse_next(input)

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -18,8 +18,14 @@ pub enum CustomError<I> {
 }
 
 impl<I: Stream + Clone> ParserError<I> for CustomError<I> {
+    type Inner = Self;
+
     fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
         CustomError::Winnow(input.clone(), kind)
+    }
+
+    fn into_inner(self) -> Result<Self::Inner, Self> {
+        Ok(self)
     }
 }
 

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -48,7 +48,7 @@ impl<I: Stream + Clone, E: std::error::Error + Send + Sync + 'static> FromExtern
     }
 }
 
-pub fn parse<'s>(_input: &mut &'s str) -> PResult<&'s str, CustomError<&'s str>> {
+pub fn parse<'s>(_input: &mut &'s str) -> ModalResult<&'s str, CustomError<&'s str>> {
     Err(ErrMode::Backtrack(CustomError::MyError))
 }
 

--- a/examples/http/parser.rs
+++ b/examples/http/parser.rs
@@ -43,7 +43,7 @@ pub(crate) fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> 
     Some(v)
 }
 
-fn request<'s>(input: &mut Stream<'s>) -> PResult<(Request<'s>, Vec<Header<'s>>)> {
+fn request<'s>(input: &mut Stream<'s>) -> ModalResult<(Request<'s>, Vec<Header<'s>>)> {
     let req = request_line(input)?;
     let h = repeat(1.., message_header).parse_next(input)?;
     let _ = line_ending.parse_next(input)?;
@@ -51,7 +51,7 @@ fn request<'s>(input: &mut Stream<'s>) -> PResult<(Request<'s>, Vec<Header<'s>>)
     Ok((req, h))
 }
 
-fn request_line<'s>(input: &mut Stream<'s>) -> PResult<Request<'s>> {
+fn request_line<'s>(input: &mut Stream<'s>) -> ModalResult<Request<'s>> {
     seq!( Request {
         method: take_while(1.., is_token),
         _: take_while(1.., is_space),
@@ -63,14 +63,14 @@ fn request_line<'s>(input: &mut Stream<'s>) -> PResult<Request<'s>> {
     .parse_next(input)
 }
 
-fn http_version<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
+fn http_version<'s>(input: &mut Stream<'s>) -> ModalResult<&'s [u8]> {
     let _ = "HTTP/".parse_next(input)?;
     let version = take_while(1.., is_version).parse_next(input)?;
 
     Ok(version)
 }
 
-fn message_header_value<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
+fn message_header_value<'s>(input: &mut Stream<'s>) -> ModalResult<&'s [u8]> {
     let _ = take_while(1.., is_horizontal_space).parse_next(input)?;
     let data = take_while(1.., till_line_ending).parse_next(input)?;
     let _ = line_ending.parse_next(input)?;
@@ -78,7 +78,7 @@ fn message_header_value<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
     Ok(data)
 }
 
-fn message_header<'s>(input: &mut Stream<'s>) -> PResult<Header<'s>> {
+fn message_header<'s>(input: &mut Stream<'s>) -> ModalResult<Header<'s>> {
     seq!(Header {
         name: take_while(1.., is_token),
         _: ':',

--- a/examples/http/parser_streaming.rs
+++ b/examples/http/parser_streaming.rs
@@ -44,7 +44,7 @@ pub(crate) fn parse(data: &[u8]) -> Option<Vec<(Request<'_>, Vec<Header<'_>>)>> 
     Some(v)
 }
 
-fn request<'s>(input: &mut Stream<'s>) -> PResult<(Request<'s>, Vec<Header<'s>>)> {
+fn request<'s>(input: &mut Stream<'s>) -> ModalResult<(Request<'s>, Vec<Header<'s>>)> {
     let req = request_line(input)?;
     let h = repeat(1.., message_header).parse_next(input)?;
     let _ = line_ending.parse_next(input)?;
@@ -52,7 +52,7 @@ fn request<'s>(input: &mut Stream<'s>) -> PResult<(Request<'s>, Vec<Header<'s>>)
     Ok((req, h))
 }
 
-fn request_line<'s>(input: &mut Stream<'s>) -> PResult<Request<'s>> {
+fn request_line<'s>(input: &mut Stream<'s>) -> ModalResult<Request<'s>> {
     seq!( Request {
         method: take_while(1.., is_token),
         _: take_while(1.., is_space),
@@ -64,14 +64,14 @@ fn request_line<'s>(input: &mut Stream<'s>) -> PResult<Request<'s>> {
     .parse_next(input)
 }
 
-fn http_version<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
+fn http_version<'s>(input: &mut Stream<'s>) -> ModalResult<&'s [u8]> {
     let _ = "HTTP/".parse_next(input)?;
     let version = take_while(1.., is_version).parse_next(input)?;
 
     Ok(version)
 }
 
-fn message_header_value<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
+fn message_header_value<'s>(input: &mut Stream<'s>) -> ModalResult<&'s [u8]> {
     let _ = take_while(1.., is_horizontal_space).parse_next(input)?;
     let data = take_while(1.., till_line_ending).parse_next(input)?;
     let _ = line_ending.parse_next(input)?;
@@ -79,7 +79,7 @@ fn message_header_value<'s>(input: &mut Stream<'s>) -> PResult<&'s [u8]> {
     Ok(data)
 }
 
-fn message_header<'s>(input: &mut Stream<'s>) -> PResult<Header<'s>> {
+fn message_header<'s>(input: &mut Stream<'s>) -> ModalResult<Header<'s>> {
     seq!(Header {
         name: take_while(1.., is_token),
         _: ':',

--- a/examples/ini/bench.rs
+++ b/examples/ini/bench.rs
@@ -31,7 +31,7 @@ port=143
 file=payroll.dat
 \0";
 
-    fn acc<'s>(i: &mut parser::Stream<'s>) -> PResult<Vec<(&'s str, &'s str)>> {
+    fn acc<'s>(i: &mut parser::Stream<'s>) -> ModalResult<Vec<(&'s str, &'s str)>> {
         repeat(0.., parser::key_value).parse_next(i)
     }
 

--- a/examples/ini/bench.rs
+++ b/examples/ini/bench.rs
@@ -1,5 +1,6 @@
 use winnow::combinator::repeat;
 use winnow::prelude::*;
+use winnow::Result;
 
 mod parser;
 mod parser_str;
@@ -31,7 +32,7 @@ port=143
 file=payroll.dat
 \0";
 
-    fn acc<'s>(i: &mut parser::Stream<'s>) -> ModalResult<Vec<(&'s str, &'s str)>> {
+    fn acc<'s>(i: &mut parser::Stream<'s>) -> Result<Vec<(&'s str, &'s str)>> {
         repeat(0.., parser::key_value).parse_next(i)
     }
 

--- a/examples/ini/parser.rs
+++ b/examples/ini/parser.rs
@@ -14,7 +14,7 @@ pub(crate) type Stream<'i> = &'i [u8];
 
 pub(crate) fn categories<'s>(
     i: &mut Stream<'s>,
-) -> PResult<HashMap<&'s str, HashMap<&'s str, &'s str>>> {
+) -> ModalResult<HashMap<&'s str, HashMap<&'s str, &'s str>>> {
     repeat(
         0..,
         separated_pair(
@@ -26,13 +26,13 @@ pub(crate) fn categories<'s>(
     .parse_next(i)
 }
 
-fn category<'s>(i: &mut Stream<'s>) -> PResult<&'s str> {
+fn category<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
     delimited('[', take_while(0.., |c| c != b']'), ']')
         .try_map(str::from_utf8)
         .parse_next(i)
 }
 
-pub(crate) fn key_value<'s>(i: &mut Stream<'s>) -> PResult<(&'s str, &'s str)> {
+pub(crate) fn key_value<'s>(i: &mut Stream<'s>) -> ModalResult<(&'s str, &'s str)> {
     let key = alphanumeric.try_map(str::from_utf8).parse_next(i)?;
     let _ = (opt(space), '=', opt(space)).parse_next(i)?;
     let val = take_while(0.., |c| c != b'\n' && c != b';')

--- a/examples/ini/parser.rs
+++ b/examples/ini/parser.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::str;
 
 use winnow::prelude::*;
+use winnow::Result;
 use winnow::{
     ascii::{alphanumeric1 as alphanumeric, multispace0 as multispace, space0 as space},
     combinator::opt,
@@ -14,7 +15,7 @@ pub(crate) type Stream<'i> = &'i [u8];
 
 pub(crate) fn categories<'s>(
     i: &mut Stream<'s>,
-) -> ModalResult<HashMap<&'s str, HashMap<&'s str, &'s str>>> {
+) -> Result<HashMap<&'s str, HashMap<&'s str, &'s str>>> {
     repeat(
         0..,
         separated_pair(
@@ -26,13 +27,13 @@ pub(crate) fn categories<'s>(
     .parse_next(i)
 }
 
-fn category<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
+fn category<'s>(i: &mut Stream<'s>) -> Result<&'s str> {
     delimited('[', take_while(0.., |c| c != b']'), ']')
         .try_map(str::from_utf8)
         .parse_next(i)
 }
 
-pub(crate) fn key_value<'s>(i: &mut Stream<'s>) -> ModalResult<(&'s str, &'s str)> {
+pub(crate) fn key_value<'s>(i: &mut Stream<'s>) -> Result<(&'s str, &'s str)> {
     let key = alphanumeric.try_map(str::from_utf8).parse_next(i)?;
     let _ = (opt(space), '=', opt(space)).parse_next(i)?;
     let val = take_while(0.., |c| c != b'\n' && c != b';')

--- a/examples/ini/parser_str.rs
+++ b/examples/ini/parser_str.rs
@@ -13,15 +13,15 @@ pub(crate) type Stream<'i> = &'i str;
 
 pub(crate) fn categories<'s>(
     input: &mut Stream<'s>,
-) -> PResult<HashMap<&'s str, HashMap<&'s str, &'s str>>> {
+) -> ModalResult<HashMap<&'s str, HashMap<&'s str, &'s str>>> {
     repeat(0.., category_and_keys).parse_next(input)
 }
 
-fn category_and_keys<'s>(i: &mut Stream<'s>) -> PResult<(&'s str, HashMap<&'s str, &'s str>)> {
+fn category_and_keys<'s>(i: &mut Stream<'s>) -> ModalResult<(&'s str, HashMap<&'s str, &'s str>)> {
     (category, keys_and_values).parse_next(i)
 }
 
-fn category<'s>(i: &mut Stream<'s>) -> PResult<&'s str> {
+fn category<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
     terminated(
         delimited('[', take_while(0.., |c| c != ']'), ']'),
         opt(take_while(1.., [' ', '\r', '\n'])),
@@ -29,11 +29,11 @@ fn category<'s>(i: &mut Stream<'s>) -> PResult<&'s str> {
     .parse_next(i)
 }
 
-fn keys_and_values<'s>(input: &mut Stream<'s>) -> PResult<HashMap<&'s str, &'s str>> {
+fn keys_and_values<'s>(input: &mut Stream<'s>) -> ModalResult<HashMap<&'s str, &'s str>> {
     repeat(0.., key_value).parse_next(input)
 }
 
-fn key_value<'s>(i: &mut Stream<'s>) -> PResult<(&'s str, &'s str)> {
+fn key_value<'s>(i: &mut Stream<'s>) -> ModalResult<(&'s str, &'s str)> {
     let key = alphanumeric.parse_next(i)?;
     let _ = (opt(space), "=", opt(space)).parse_next(i)?;
     let val = take_till(0.., is_line_ending_or_comment).parse_next(i)?;
@@ -48,11 +48,11 @@ fn is_line_ending_or_comment(chr: char) -> bool {
     chr == ';' || chr == '\n'
 }
 
-fn till_line_ending<'s>(i: &mut Stream<'s>) -> PResult<&'s str> {
+fn till_line_ending<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
     take_while(0.., |c| c != '\r' && c != '\n').parse_next(i)
 }
 
-fn space_or_line_ending<'s>(i: &mut Stream<'s>) -> PResult<&'s str> {
+fn space_or_line_ending<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
     take_while(1.., [' ', '\r', '\n']).parse_next(i)
 }
 

--- a/examples/ini/parser_str.rs
+++ b/examples/ini/parser_str.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use winnow::prelude::*;
+use winnow::Result;
 use winnow::{
     ascii::{alphanumeric1 as alphanumeric, space0 as space},
     combinator::opt,
@@ -13,15 +14,15 @@ pub(crate) type Stream<'i> = &'i str;
 
 pub(crate) fn categories<'s>(
     input: &mut Stream<'s>,
-) -> ModalResult<HashMap<&'s str, HashMap<&'s str, &'s str>>> {
+) -> Result<HashMap<&'s str, HashMap<&'s str, &'s str>>> {
     repeat(0.., category_and_keys).parse_next(input)
 }
 
-fn category_and_keys<'s>(i: &mut Stream<'s>) -> ModalResult<(&'s str, HashMap<&'s str, &'s str>)> {
+fn category_and_keys<'s>(i: &mut Stream<'s>) -> Result<(&'s str, HashMap<&'s str, &'s str>)> {
     (category, keys_and_values).parse_next(i)
 }
 
-fn category<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
+fn category<'s>(i: &mut Stream<'s>) -> Result<&'s str> {
     terminated(
         delimited('[', take_while(0.., |c| c != ']'), ']'),
         opt(take_while(1.., [' ', '\r', '\n'])),
@@ -29,11 +30,11 @@ fn category<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
     .parse_next(i)
 }
 
-fn keys_and_values<'s>(input: &mut Stream<'s>) -> ModalResult<HashMap<&'s str, &'s str>> {
+fn keys_and_values<'s>(input: &mut Stream<'s>) -> Result<HashMap<&'s str, &'s str>> {
     repeat(0.., key_value).parse_next(input)
 }
 
-fn key_value<'s>(i: &mut Stream<'s>) -> ModalResult<(&'s str, &'s str)> {
+fn key_value<'s>(i: &mut Stream<'s>) -> Result<(&'s str, &'s str)> {
     let key = alphanumeric.parse_next(i)?;
     let _ = (opt(space), "=", opt(space)).parse_next(i)?;
     let val = take_till(0.., is_line_ending_or_comment).parse_next(i)?;
@@ -48,11 +49,11 @@ fn is_line_ending_or_comment(chr: char) -> bool {
     chr == ';' || chr == '\n'
 }
 
-fn till_line_ending<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
+fn till_line_ending<'s>(i: &mut Stream<'s>) -> Result<&'s str> {
     take_while(0.., |c| c != '\r' && c != '\n').parse_next(i)
 }
 
-fn space_or_line_ending<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
+fn space_or_line_ending<'s>(i: &mut Stream<'s>) -> Result<&'s str> {
     take_while(1.., [' ', '\r', '\n']).parse_next(i)
 }
 

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -9,7 +9,7 @@ use winnow::prelude::*;
 fn main() {
     let mut data = "abcabcabcabc";
 
-    fn parser<'s>(i: &mut &'s str) -> PResult<&'s str> {
+    fn parser<'s>(i: &mut &'s str) -> ModalResult<&'s str> {
         "abc".parse_next(i)
     }
 
@@ -66,7 +66,7 @@ fn main() {
         .map(|(k, v)| (k.to_uppercase(), v))
         .collect::<HashMap<_, _>>();
 
-    let parser_result: PResult<(_, _), ()> = winnow_it.finish();
+    let parser_result: ModalResult<(_, _), ()> = winnow_it.finish();
     let (remaining_input, ()) = parser_result.unwrap();
 
     // will print "iterator returned {"key1": "value1", "key3": "value3", "key2": "value2"}, remaining input is ';'"

--- a/examples/json/parser.rs
+++ b/examples/json/parser.rs
@@ -19,8 +19,8 @@ pub(crate) type Stream<'i> = &'i str;
 /// The root element of a JSON parser is any value
 ///
 /// A parser has the following signature:
-/// `&mut Stream -> PResult<Output, ContextError>`, with `PResult` defined as:
-/// `type PResult<O, E = (I, ErrorKind)> = Result<O, Err<E>>;`
+/// `&mut Stream -> ModalResult<Output, ContextError>`, with `ModalResult` defined as:
+/// `type ModalResult<O, E = (I, ErrorKind)> = Result<O, Err<E>>;`
 ///
 /// most of the times you can ignore the error type and use the default (but this
 /// examples shows custom error types later on!)
@@ -30,7 +30,7 @@ pub(crate) type Stream<'i> = &'i str;
 /// implements the required traits.
 pub(crate) fn json<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<JsonValue, E> {
+) -> ModalResult<JsonValue, E> {
     delimited(ws, json_value, ws).parse_next(input)
 }
 
@@ -38,7 +38,7 @@ pub(crate) fn json<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrCo
 /// one of them succeeds
 fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<JsonValue, E> {
+) -> ModalResult<JsonValue, E> {
     // `alt` combines the each value parser. It returns the result of the first
     // successful parser, or an error
     alt((
@@ -55,7 +55,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext
 /// `literal(string)` generates a parser that takes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
-fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
+fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<&'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
     "null".parse_next(input)
@@ -63,7 +63,7 @@ fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i s
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
 /// success.
-fn boolean<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool, E> {
+fn boolean<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
     let parse_true = "true".value(true);
@@ -79,7 +79,7 @@ fn boolean<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bo
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<String, E> {
+) -> ModalResult<String, E> {
     preceded(
         '\"',
         // `cut_err` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
@@ -102,7 +102,7 @@ fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
 
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
-fn character<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+fn character<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<char, E> {
     let c = none_of('\"').parse_next(input)?;
     if c == '\\' {
         alt((
@@ -125,7 +125,7 @@ fn character<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<
     }
 }
 
-fn unicode_escape<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+fn unicode_escape<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<char, E> {
     alt((
         // Not a surrogate
         u16_hex
@@ -147,7 +147,7 @@ fn unicode_escape<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PRe
     .parse_next(input)
 }
 
-fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u16, E> {
+fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<u16, E> {
     take(4usize)
         .verify_map(|s| u16::from_str_radix(s, 16).ok())
         .parse_next(input)
@@ -159,7 +159,7 @@ fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u1
 /// combinator (cf `examples/iterator.rs`)
 fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<Vec<JsonValue>, E> {
+) -> ModalResult<Vec<JsonValue>, E> {
     preceded(
         ('[', ws),
         cut_err(terminated(
@@ -173,7 +173,7 @@ fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
 
 fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<HashMap<String, JsonValue>, E> {
+) -> ModalResult<HashMap<String, JsonValue>, E> {
     preceded(
         ('{', ws),
         cut_err(terminated(
@@ -187,14 +187,14 @@ fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
 
 fn key_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<(String, JsonValue), E> {
+) -> ModalResult<(String, JsonValue), E> {
     separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
 /// first we write parsers for the smallest elements (here a space character),
 /// then we'll combine them in larger parsers
-fn ws<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
+fn ws<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<&'i str, E> {
     // Combinators like `take_while` return a function. That function is the
     // parser,to which we can pass the input
     take_while(0.., WS).parse_next(input)

--- a/examples/json/parser_dispatch.rs
+++ b/examples/json/parser_dispatch.rs
@@ -22,8 +22,8 @@ pub(crate) type Stream<'i> = &'i str;
 /// The root element of a JSON parser is any value
 ///
 /// A parser has the following signature:
-/// `&mut Stream -> PResult<Output ContextError>`, with `PResult` defined as:
-/// `type PResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;`
+/// `&mut Stream -> ModalResult<Output ContextError>`, with `ModalResult` defined as:
+/// `type ModalResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;`
 ///
 /// most of the times you can ignore the error type and use the default (but this
 /// examples shows custom error types later on!)
@@ -33,7 +33,7 @@ pub(crate) type Stream<'i> = &'i str;
 /// implements the required traits.
 pub(crate) fn json<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<JsonValue, E> {
+) -> ModalResult<JsonValue, E> {
     delimited(ws, json_value, ws).parse_next(input)
 }
 
@@ -41,7 +41,7 @@ pub(crate) fn json<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrCo
 /// one of them succeeds
 fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<JsonValue, E> {
+) -> ModalResult<JsonValue, E> {
     // `dispatch` gives you `match`-like behavior compared to `alt` successively trying different
     // implementations.
     dispatch!(peek(any);
@@ -62,7 +62,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext
 /// `literal(string)` generates a parser that takes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
-fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
+fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<&'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
     "null".parse_next(input)
@@ -70,7 +70,7 @@ fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i s
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
 /// success.
-fn true_<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool, E> {
+fn true_<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
     "true".value(true).parse_next(input)
@@ -78,7 +78,7 @@ fn true_<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
 /// success.
-fn false_<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool, E> {
+fn false_<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<bool, E> {
     // This is a parser that returns `false` if it sees the string "false", and
     // an error otherwise
     "false".value(false).parse_next(input)
@@ -88,7 +88,7 @@ fn false_<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<boo
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<String, E> {
+) -> ModalResult<String, E> {
     preceded(
         '\"',
         // `cut_err` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
@@ -111,7 +111,7 @@ fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
 
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
-fn character<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+fn character<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<char, E> {
     let c = none_of('\"').parse_next(input)?;
     if c == '\\' {
         dispatch!(any;
@@ -132,7 +132,7 @@ fn character<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<
     }
 }
 
-fn unicode_escape<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+fn unicode_escape<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<char, E> {
     alt((
         // Not a surrogate
         u16_hex
@@ -154,7 +154,7 @@ fn unicode_escape<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PRe
     .parse_next(input)
 }
 
-fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u16, E> {
+fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<u16, E> {
     take(4usize)
         .verify_map(|s| u16::from_str_radix(s, 16).ok())
         .parse_next(input)
@@ -166,7 +166,7 @@ fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u1
 /// combinator (cf `examples/iterator.rs`)
 fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<Vec<JsonValue>, E> {
+) -> ModalResult<Vec<JsonValue>, E> {
     preceded(
         ('[', ws),
         cut_err(terminated(
@@ -180,7 +180,7 @@ fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
 
 fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<HashMap<String, JsonValue>, E> {
+) -> ModalResult<HashMap<String, JsonValue>, E> {
     preceded(
         ('{', ws),
         cut_err(terminated(
@@ -194,14 +194,14 @@ fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
 
 fn key_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<(String, JsonValue), E> {
+) -> ModalResult<(String, JsonValue), E> {
     separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
 /// first we write parsers for the smallest elements (here a space character),
 /// then we'll combine them in larger parsers
-fn ws<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
+fn ws<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<&'i str, E> {
     // Combinators like `take_while` return a function. That function is the
     // parser,to which we can pass the input
     take_while(0.., WS).parse_next(input)

--- a/examples/json/parser_partial.rs
+++ b/examples/json/parser_partial.rs
@@ -20,8 +20,8 @@ pub(crate) type Stream<'i> = Partial<&'i str>;
 /// The root element of a JSON parser is any value
 ///
 /// A parser has the following signature:
-/// `&mut Stream -> PResult<Output, ContextError>`, with `PResult` defined as:
-/// `type PResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;`
+/// `&mut Stream -> ModalResult<Output, ContextError>`, with `ModalResult` defined as:
+/// `type ModalResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;`
 ///
 /// most of the times you can ignore the error type and use the default (but this
 /// examples shows custom error types later on!)
@@ -31,7 +31,7 @@ pub(crate) type Stream<'i> = Partial<&'i str>;
 /// implements the required traits.
 pub(crate) fn json<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<JsonValue, E> {
+) -> ModalResult<JsonValue, E> {
     delimited(ws, json_value, ws_or_eof).parse_next(input)
 }
 
@@ -39,7 +39,7 @@ pub(crate) fn json<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrCo
 /// one of them succeeds
 fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<JsonValue, E> {
+) -> ModalResult<JsonValue, E> {
     // `alt` combines the each value parser. It returns the result of the first
     // successful parser, or an error
     alt((
@@ -56,7 +56,7 @@ fn json_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext
 /// `literal(string)` generates a parser that takes the argument string.
 ///
 /// This also shows returning a sub-slice of the original input
-fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
+fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<&'i str, E> {
     // This is a parser that returns `"null"` if it sees the string "null", and
     // an error otherwise
     "null".parse_next(input)
@@ -64,7 +64,7 @@ fn null<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i s
 
 /// We can combine `tag` with other functions, like `value` which returns a given constant value on
 /// success.
-fn boolean<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bool, E> {
+fn boolean<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<bool, E> {
     // This is a parser that returns `true` if it sees the string "true", and
     // an error otherwise
     let parse_true = "true".value(true);
@@ -80,7 +80,7 @@ fn boolean<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<bo
 /// character, before the string (using `preceded`) and after the string (using `terminated`).
 fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<String, E> {
+) -> ModalResult<String, E> {
     preceded(
         '\"',
         // `cut_err` transforms an `ErrMode::Backtrack(e)` to `ErrMode::Cut(e)`, signaling to
@@ -103,7 +103,7 @@ fn string<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
 
 /// You can mix the above declarative parsing with an imperative style to handle more unique cases,
 /// like escaping
-fn character<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+fn character<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<char, E> {
     let c = none_of('\"').parse_next(input)?;
     if c == '\\' {
         alt((
@@ -126,7 +126,7 @@ fn character<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<
     }
 }
 
-fn unicode_escape<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<char, E> {
+fn unicode_escape<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<char, E> {
     alt((
         // Not a surrogate
         u16_hex
@@ -148,7 +148,7 @@ fn unicode_escape<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PRe
     .parse_next(input)
 }
 
-fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u16, E> {
+fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<u16, E> {
     take(4usize)
         .verify_map(|s| u16::from_str_radix(s, 16).ok())
         .parse_next(input)
@@ -160,7 +160,7 @@ fn u16_hex<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<u1
 /// combinator (cf `examples/iterator.rs`)
 fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<Vec<JsonValue>, E> {
+) -> ModalResult<Vec<JsonValue>, E> {
     preceded(
         ('[', ws),
         cut_err(terminated(
@@ -174,7 +174,7 @@ fn array<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
 
 fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<HashMap<String, JsonValue>, E> {
+) -> ModalResult<HashMap<String, JsonValue>, E> {
     preceded(
         ('{', ws),
         cut_err(terminated(
@@ -188,20 +188,20 @@ fn object<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
 
 fn key_value<'i, E: ParserError<Stream<'i>> + AddContext<Stream<'i>, StrContext>>(
     input: &mut Stream<'i>,
-) -> PResult<(String, JsonValue), E> {
+) -> ModalResult<(String, JsonValue), E> {
     separated_pair(string, cut_err((ws, ':', ws)), json_value).parse_next(input)
 }
 
 /// Parser combinators are constructed from the bottom up:
 /// first we write parsers for the smallest elements (here a space character),
 /// then we'll combine them in larger parsers
-fn ws<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
+fn ws<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<&'i str, E> {
     // Combinators like `take_while` return a function. That function is the
     // parser,to which we can pass the input
     take_while(0.., WS).parse_next(input)
 }
 
-fn ws_or_eof<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> PResult<&'i str, E> {
+fn ws_or_eof<'i, E: ParserError<Stream<'i>>>(input: &mut Stream<'i>) -> ModalResult<&'i str, E> {
     rest.verify(|s: &str| s.chars().all(|c| WS.contains(&c)))
         .parse_next(input)
 }

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -209,27 +209,27 @@ impl<'a, 'b: 'a> JsonValue<'a, 'b> {
     }
 }
 
-fn sp<'a, E: ParserError<&'a str>>(i: &mut &'a str) -> PResult<&'a str, E> {
+fn sp<'a, E: ParserError<&'a str>>(i: &mut &'a str) -> ModalResult<&'a str, E> {
     let chars = " \t\r\n";
 
     take_while(0.., move |c| chars.contains(c)).parse_next(i)
 }
 
-fn parse_str<'a, E: ParserError<&'a str>>(i: &mut &'a str) -> PResult<&'a str, E> {
+fn parse_str<'a, E: ParserError<&'a str>>(i: &mut &'a str) -> ModalResult<&'a str, E> {
     take_escaped(alphanumeric, '\\', one_of(['"', 'n', '\\'])).parse_next(i)
 }
 
-fn string<'s>(i: &mut &'s str) -> PResult<&'s str> {
+fn string<'s>(i: &mut &'s str) -> ModalResult<&'s str> {
     preceded('\"', cut_err(terminated(parse_str, '\"')))
         .context(StrContext::Label("string"))
         .parse_next(i)
 }
 
-fn boolean(input: &mut &str) -> PResult<bool> {
+fn boolean(input: &mut &str) -> ModalResult<bool> {
     alt(("false".map(|_| false), "true".map(|_| true))).parse_next(input)
 }
 
-fn array(i: &mut &str) -> PResult<()> {
+fn array(i: &mut &str) -> ModalResult<()> {
     preceded(
         '[',
         cut_err(terminated(
@@ -241,11 +241,11 @@ fn array(i: &mut &str) -> PResult<()> {
     .parse_next(i)
 }
 
-fn key_value<'s>(i: &mut &'s str) -> PResult<(&'s str, ())> {
+fn key_value<'s>(i: &mut &'s str) -> ModalResult<(&'s str, ())> {
     separated_pair(preceded(sp, string), cut_err(preceded(sp, ':')), value).parse_next(i)
 }
 
-fn hash(i: &mut &str) -> PResult<()> {
+fn hash(i: &mut &str) -> ModalResult<()> {
     preceded(
         '{',
         cut_err(terminated(
@@ -257,7 +257,7 @@ fn hash(i: &mut &str) -> PResult<()> {
     .parse_next(i)
 }
 
-fn value(i: &mut &str) -> PResult<()> {
+fn value(i: &mut &str) -> ModalResult<()> {
     preceded(
         sp,
         alt((

--- a/examples/s_expression/parser.rs
+++ b/examples/s_expression/parser.rs
@@ -2,7 +2,6 @@
 //! parser and tiny [lisp](https://en.wikipedia.org/wiki/Lisp_(programming_language)) interpreter.
 //! Lisp is a simple type of language made up of Atoms and Lists, forming easily parsable trees.
 
-use winnow::error::ErrMode;
 use winnow::{
     ascii::{alpha1, digit1, multispace0, multispace1},
     combinator::alt,
@@ -225,9 +224,9 @@ fn parse_quote(i: &mut &'_ str) -> ModalResult<Expr> {
 //.parse_next/
 /// Unlike the previous functions, this function doesn't take or consume input, instead it
 /// takes a parsing function and returns a new parsing function.
-fn s_exp<'a, O1, F>(inner: F) -> impl Parser<&'a str, O1, ErrMode<ContextError>>
+fn s_exp<'a, O1, F>(inner: F) -> impl ModalParser<&'a str, O1, ContextError>
 where
-    F: Parser<&'a str, O1, ErrMode<ContextError>>,
+    F: ModalParser<&'a str, O1, ContextError>,
 {
     delimited(
         '(',

--- a/examples/s_expression/parser.rs
+++ b/examples/s_expression/parser.rs
@@ -70,7 +70,7 @@ pub(crate) enum BuiltIn {
 }
 
 /// With types defined, we move onto the top-level expression parser!
-fn parse_expr(i: &mut &'_ str) -> PResult<Expr> {
+fn parse_expr(i: &mut &'_ str) -> ModalResult<Expr> {
     preceded(
         multispace0,
         alt((parse_constant, parse_application, parse_if, parse_quote)),
@@ -79,13 +79,13 @@ fn parse_expr(i: &mut &'_ str) -> PResult<Expr> {
 }
 
 /// We then add the Expr layer on top
-fn parse_constant(i: &mut &'_ str) -> PResult<Expr> {
+fn parse_constant(i: &mut &'_ str) -> ModalResult<Expr> {
     parse_atom.map(Expr::Constant).parse_next(i)
 }
 
 /// Now we take all these simple parsers and connect them.
 /// We can now parse half of our language!
-fn parse_atom(i: &mut &'_ str) -> PResult<Atom> {
+fn parse_atom(i: &mut &'_ str) -> ModalResult<Atom> {
     alt((
         parse_num,
         parse_bool,
@@ -97,7 +97,7 @@ fn parse_atom(i: &mut &'_ str) -> PResult<Atom> {
 
 /// Next up is number parsing. We're keeping it simple here by accepting any number (> 1)
 /// of digits but ending the program if it doesn't fit into an i32.
-fn parse_num(i: &mut &'_ str) -> PResult<Atom> {
+fn parse_num(i: &mut &'_ str) -> ModalResult<Atom> {
     alt((
         digit1.try_map(|digit_str: &str| digit_str.parse::<i32>().map(Atom::Num)),
         preceded("-", digit1).map(|digit_str: &str| Atom::Num(-digit_str.parse::<i32>().unwrap())),
@@ -106,7 +106,7 @@ fn parse_num(i: &mut &'_ str) -> PResult<Atom> {
 }
 
 /// Our boolean values are also constant, so we can do it the same way
-fn parse_bool(i: &mut &'_ str) -> PResult<Atom> {
+fn parse_bool(i: &mut &'_ str) -> ModalResult<Atom> {
     alt((
         "#t".map(|_| Atom::Boolean(true)),
         "#f".map(|_| Atom::Boolean(false)),
@@ -114,7 +114,7 @@ fn parse_bool(i: &mut &'_ str) -> PResult<Atom> {
     .parse_next(i)
 }
 
-fn parse_builtin(i: &mut &'_ str) -> PResult<BuiltIn> {
+fn parse_builtin(i: &mut &'_ str) -> ModalResult<BuiltIn> {
     // alt gives us the result of first parser that succeeds, of the series of
     // parsers we give it
     alt((
@@ -128,7 +128,7 @@ fn parse_builtin(i: &mut &'_ str) -> PResult<BuiltIn> {
 
 /// Continuing the trend of starting from the simplest piece and building up,
 /// we start by creating a parser for the built-in operator functions.
-fn parse_builtin_op(i: &mut &'_ str) -> PResult<BuiltIn> {
+fn parse_builtin_op(i: &mut &'_ str) -> ModalResult<BuiltIn> {
     // one_of matches one of the characters we give it
     let t = one_of(['+', '-', '*', '/', '=']).parse_next(i)?;
 
@@ -150,7 +150,7 @@ fn parse_builtin_op(i: &mut &'_ str) -> PResult<BuiltIn> {
 ///
 /// Put plainly: `preceded(":", cut_err(alpha1))` means that once we see the `:`
 /// character, we have to see one or more alphabetic characters or the input is invalid.
-fn parse_keyword(i: &mut &'_ str) -> PResult<Atom> {
+fn parse_keyword(i: &mut &'_ str) -> ModalResult<Atom> {
     preceded(":", cut_err(alpha1))
         .context(StrContext::Label("keyword"))
         .map(|sym_str: &str| Atom::Keyword(sym_str.to_owned()))
@@ -166,7 +166,7 @@ fn parse_keyword(i: &mut &'_ str) -> PResult<Atom> {
 ///
 /// tuples are themselves a parser, used to sequence parsers together, so we can translate this
 /// directly and then map over it to transform the output into an `Expr::Application`
-fn parse_application(i: &mut &'_ str) -> PResult<Expr> {
+fn parse_application(i: &mut &'_ str) -> ModalResult<Expr> {
     let application_inner = (parse_expr, repeat(0.., parse_expr))
         .map(|(head, tail)| Expr::Application(Box::new(head), tail));
     // finally, we wrap it in an s-expression
@@ -179,7 +179,7 @@ fn parse_application(i: &mut &'_ str) -> PResult<Expr> {
 ///
 /// In fact, we define our parser as if `Expr::If` was defined with an Option in it,
 /// we have the `opt` combinator which fits very nicely here.
-fn parse_if(i: &mut &'_ str) -> PResult<Expr> {
+fn parse_if(i: &mut &'_ str) -> ModalResult<Expr> {
     let if_inner = preceded(
         // here to avoid ambiguity with other names starting with `if`, if we added
         // variables to our language, we say that if must be terminated by at least
@@ -207,7 +207,7 @@ fn parse_if(i: &mut &'_ str) -> PResult<Expr> {
 /// This example doesn't have the symbol atom, but by adding variables and changing
 /// the definition of quote to not always be around an S-expression, we'd get them
 /// naturally.
-fn parse_quote(i: &mut &'_ str) -> PResult<Expr> {
+fn parse_quote(i: &mut &'_ str) -> ModalResult<Expr> {
     // this should look very straight-forward after all we've done:
     // we find the `'` (quote) character, use cut_err to say that we're unambiguously
     // looking for an s-expression of 0 or more expressions, and then parse them

--- a/examples/s_expression/parser.rs
+++ b/examples/s_expression/parser.rs
@@ -2,6 +2,7 @@
 //! parser and tiny [lisp](https://en.wikipedia.org/wiki/Lisp_(programming_language)) interpreter.
 //! Lisp is a simple type of language made up of Atoms and Lists, forming easily parsable trees.
 
+use winnow::error::ErrMode;
 use winnow::{
     ascii::{alpha1, digit1, multispace0, multispace1},
     combinator::alt,
@@ -224,9 +225,9 @@ fn parse_quote(i: &mut &'_ str) -> ModalResult<Expr> {
 //.parse_next/
 /// Unlike the previous functions, this function doesn't take or consume input, instead it
 /// takes a parsing function and returns a new parsing function.
-fn s_exp<'a, O1, F>(inner: F) -> impl Parser<&'a str, O1, ContextError>
+fn s_exp<'a, O1, F>(inner: F) -> impl Parser<&'a str, O1, ErrMode<ContextError>>
 where
-    F: Parser<&'a str, O1, ContextError>,
+    F: Parser<&'a str, O1, ErrMode<ContextError>>,
 {
     delimited(
         '(',

--- a/examples/string/parser.rs
+++ b/examples/string/parser.rs
@@ -19,7 +19,7 @@ use winnow::token::{take_till, take_while};
 
 /// Parse a string. Use a loop of `parse_fragment` and push all of the fragments
 /// into an output string.
-pub(crate) fn parse_string<'a, E>(input: &mut &'a str) -> PResult<String, E>
+pub(crate) fn parse_string<'a, E>(input: &mut &'a str) -> ModalResult<String, E>
 where
     E: ParserError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
@@ -64,7 +64,7 @@ enum StringFragment<'a> {
 
 /// Combine `parse_literal`, `parse_escaped_whitespace`, and `parse_escaped_char`
 /// into a `StringFragment`.
-fn parse_fragment<'a, E>(input: &mut &'a str) -> PResult<StringFragment<'a>, E>
+fn parse_fragment<'a, E>(input: &mut &'a str) -> ModalResult<StringFragment<'a>, E>
 where
     E: ParserError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
@@ -79,7 +79,7 @@ where
 }
 
 /// Parse a non-empty block of text that doesn't include \ or "
-fn parse_literal<'a, E: ParserError<&'a str>>(input: &mut &'a str) -> PResult<&'a str, E> {
+fn parse_literal<'a, E: ParserError<&'a str>>(input: &mut &'a str) -> ModalResult<&'a str, E> {
     // `take_till` parses a string of 0 or more characters that aren't one of the
     // given characters.
     let not_quote_slash = take_till(1.., ['"', '\\']);
@@ -98,7 +98,7 @@ fn parse_literal<'a, E: ParserError<&'a str>>(input: &mut &'a str) -> PResult<&'
 // then combine them into larger parsers.
 
 /// Parse an escaped character: \n, \t, \r, \u{00AC}, etc.
-fn parse_escaped_char<'a, E>(input: &mut &'a str) -> PResult<char, E>
+fn parse_escaped_char<'a, E>(input: &mut &'a str) -> ModalResult<char, E>
 where
     E: ParserError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
@@ -128,7 +128,7 @@ where
 /// Parse a unicode sequence, of the form u{XXXX}, where XXXX is 1 to 6
 /// hexadecimal numerals. We will combine this later with `parse_escaped_char`
 /// to parse sequences like \u{00AC}.
-fn parse_unicode<'a, E>(input: &mut &'a str) -> PResult<char, E>
+fn parse_unicode<'a, E>(input: &mut &'a str) -> ModalResult<char, E>
 where
     E: ParserError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
@@ -162,6 +162,6 @@ where
 /// to discard any escaped whitespace.
 fn parse_escaped_whitespace<'a, E: ParserError<&'a str>>(
     input: &mut &'a str,
-) -> PResult<&'a str, E> {
+) -> ModalResult<&'a str, E> {
     preceded('\\', multispace1).parse_next(input)
 }

--- a/examples/string/parser.rs
+++ b/examples/string/parser.rs
@@ -16,10 +16,11 @@ use winnow::combinator::{delimited, preceded};
 use winnow::error::{FromExternalError, ParserError};
 use winnow::prelude::*;
 use winnow::token::{take_till, take_while};
+use winnow::Result;
 
 /// Parse a string. Use a loop of `parse_fragment` and push all of the fragments
 /// into an output string.
-pub(crate) fn parse_string<'a, E>(input: &mut &'a str) -> ModalResult<String, E>
+pub(crate) fn parse_string<'a, E>(input: &mut &'a str) -> Result<String, E>
 where
     E: ParserError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
@@ -64,7 +65,7 @@ enum StringFragment<'a> {
 
 /// Combine `parse_literal`, `parse_escaped_whitespace`, and `parse_escaped_char`
 /// into a `StringFragment`.
-fn parse_fragment<'a, E>(input: &mut &'a str) -> ModalResult<StringFragment<'a>, E>
+fn parse_fragment<'a, E>(input: &mut &'a str) -> Result<StringFragment<'a>, E>
 where
     E: ParserError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
@@ -79,7 +80,7 @@ where
 }
 
 /// Parse a non-empty block of text that doesn't include \ or "
-fn parse_literal<'a, E: ParserError<&'a str>>(input: &mut &'a str) -> ModalResult<&'a str, E> {
+fn parse_literal<'a, E: ParserError<&'a str>>(input: &mut &'a str) -> Result<&'a str, E> {
     // `take_till` parses a string of 0 or more characters that aren't one of the
     // given characters.
     let not_quote_slash = take_till(1.., ['"', '\\']);
@@ -98,7 +99,7 @@ fn parse_literal<'a, E: ParserError<&'a str>>(input: &mut &'a str) -> ModalResul
 // then combine them into larger parsers.
 
 /// Parse an escaped character: \n, \t, \r, \u{00AC}, etc.
-fn parse_escaped_char<'a, E>(input: &mut &'a str) -> ModalResult<char, E>
+fn parse_escaped_char<'a, E>(input: &mut &'a str) -> Result<char, E>
 where
     E: ParserError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
@@ -128,7 +129,7 @@ where
 /// Parse a unicode sequence, of the form u{XXXX}, where XXXX is 1 to 6
 /// hexadecimal numerals. We will combine this later with `parse_escaped_char`
 /// to parse sequences like \u{00AC}.
-fn parse_unicode<'a, E>(input: &mut &'a str) -> ModalResult<char, E>
+fn parse_unicode<'a, E>(input: &mut &'a str) -> Result<char, E>
 where
     E: ParserError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
@@ -162,6 +163,6 @@ where
 /// to discard any escaped whitespace.
 fn parse_escaped_whitespace<'a, E: ParserError<&'a str>>(
     input: &mut &'a str,
-) -> ModalResult<&'a str, E> {
+) -> Result<&'a str, E> {
     preceded('\\', multispace1).parse_next(input)
 }

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -23,7 +23,7 @@ fn reset() {
     });
 }
 
-fn incr(i: &mut &str) -> PResult<()> {
+fn incr(i: &mut &str) -> ModalResult<()> {
     LEVEL.with(|l| {
         *l.borrow_mut() += 1;
 
@@ -45,7 +45,7 @@ fn decr() {
     });
 }
 
-fn parens(i: &mut &str) -> PResult<i64> {
+fn parens(i: &mut &str) -> ModalResult<i64> {
     delimited(
         space,
         delimited(terminated("(", incr), expr, ")".map(|_| decr())),
@@ -54,11 +54,11 @@ fn parens(i: &mut &str) -> PResult<i64> {
     .parse_next(i)
 }
 
-fn factor(i: &mut &str) -> PResult<i64> {
+fn factor(i: &mut &str) -> ModalResult<i64> {
     alt((delimited(space, digit, space).parse_to(), parens)).parse_next(i)
 }
 
-fn term(i: &mut &str) -> PResult<i64> {
+fn term(i: &mut &str) -> ModalResult<i64> {
     incr(i)?;
     let init = factor(i).inspect_err(|_e| {
         decr();
@@ -86,7 +86,7 @@ fn term(i: &mut &str) -> PResult<i64> {
     res
 }
 
-fn expr(i: &mut &str) -> PResult<i64> {
+fn expr(i: &mut &str) -> ModalResult<i64> {
     incr(i)?;
     let init = term(i).inspect_err(|_e| {
         decr();

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -1,7 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use std::str;
-use winnow::error::ParserError;
 
 use winnow::prelude::*;
 use winnow::{
@@ -29,7 +28,7 @@ fn incr(i: &mut &str) -> ModalResult<()> {
 
         // limit the number of recursions, the fuzzer keeps running into them
         if *l.borrow() >= 8192 {
-            Err(winnow::error::ErrMode::from_error_kind(
+            Err(winnow::error::ParserError::from_error_kind(
                 i,
                 winnow::error::ErrorKind::Repeat,
             ))

--- a/src/_topic/language.rs
+++ b/src/_topic/language.rs
@@ -65,7 +65,7 @@
 //!   token::take_till,
 //! };
 //!
-//! pub fn peol_comment<'a, E: ParserError<&'a str>>(i: &mut &'a str) -> PResult<(), E>
+//! pub fn peol_comment<'a, E: ParserError<&'a str>>(i: &mut &'a str) -> ModalResult<(), E>
 //! {
 //!   ('%', take_till(1.., ['\n', '\r']))
 //!     .void() // Output is thrown away.
@@ -85,7 +85,7 @@
 //!   token::take_until,
 //! };
 //!
-//! pub fn pinline_comment<'a, E: ParserError<&'a str>>(i: &mut &'a str) -> PResult<(), E> {
+//! pub fn pinline_comment<'a, E: ParserError<&'a str>>(i: &mut &'a str) -> ModalResult<(), E> {
 //!   (
 //!     "(*",
 //!     take_until(0.., "*)"),
@@ -111,7 +111,7 @@
 //!   token::one_of,
 //! };
 //!
-//! pub fn identifier<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! pub fn identifier<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!   (
 //!       one_of(|c: char| c.is_alpha() || c == '_'),
 //!       take_while(0.., |c: char| c.is_alphanum() || c == '_')
@@ -161,7 +161,7 @@
 //!   token::one_of,
 //! };
 //!
-//! fn hexadecimal<'s>(input: &mut &'s str) -> PResult<&'s str> { // <'a, E: ParserError<&'a str>>
+//! fn hexadecimal<'s>(input: &mut &'s str) -> ModalResult<&'s str> { // <'a, E: ParserError<&'a str>>
 //!   preceded(
 //!     alt(("0x", "0X")),
 //!     repeat(1..,
@@ -182,7 +182,7 @@
 //!   token::one_of,
 //! };
 //!
-//! fn hexadecimal_value(input: &mut &str) -> PResult<i64> {
+//! fn hexadecimal_value(input: &mut &str) -> ModalResult<i64> {
 //!   preceded(
 //!     alt(("0x", "0X")),
 //!     repeat(1..,
@@ -207,7 +207,7 @@
 //!   token::one_of,
 //! };
 //!
-//! fn octal<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn octal<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!   preceded(
 //!     alt(("0o", "0O")),
 //!     repeat(1..,
@@ -228,7 +228,7 @@
 //!   token::one_of,
 //! };
 //!
-//! fn binary<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn binary<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!   preceded(
 //!     alt(("0b", "0B")),
 //!     repeat(1..,
@@ -248,7 +248,7 @@
 //!   token::one_of,
 //! };
 //!
-//! fn decimal<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn decimal<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!   repeat(1..,
 //!     terminated(one_of('0'..='9'), repeat(0.., '_').map(|()| ()))
 //!   ).map(|()| ())
@@ -273,7 +273,7 @@
 //!   token::one_of,
 //! };
 //!
-//! fn float<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn float<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!   alt((
 //!     // Case one: .42
 //!     (
@@ -305,7 +305,7 @@
 //!   )).parse_next(input)
 //! }
 //!
-//! fn decimal<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn decimal<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!   repeat(1..,
 //!     terminated(one_of('0'..='9'), repeat(0.., '_').map(|()| ()))
 //!   ).

--- a/src/_topic/nom.rs
+++ b/src/_topic/nom.rs
@@ -64,6 +64,13 @@
 //! - Search the docs for the `nom` parser
 //! - See the [List of combinators][crate::combinator]
 //!
+//! ### Partial/streaming parsers
+//!
+//! `nom` differentiated some parsers by being `streaming` or `complete`.
+//! Instead, we tag the input type (`I`) by wrapping it in [`Partial<I>`] and parsers will adjust
+//! their behavior accordingly.
+//! See [partial] special topic.
+//!
 //! ### `&mut I`
 //!
 //! For an explanation of this change, see [Why `winnow`][super::why]
@@ -111,6 +118,8 @@
 //! type for using [`ErrMode`].
 
 #![allow(unused_imports)]
+use crate::_topic::partial;
 use crate::error::ErrMode;
 use crate::error::ModalResult;
+use crate::stream::Partial;
 use crate::stream::Stream;

--- a/src/_topic/nom.rs
+++ b/src/_topic/nom.rs
@@ -82,7 +82,7 @@
 //! When the Output of a parser is a slice, you have to add a lifetime:
 //! ```rust
 //! # use winnow::prelude::*;
-//! fn foo<'i>(i: &mut &'i str) -> PResult<&'i str> {
+//! fn foo<'i>(i: &mut &'i str) -> ModalResult<&'i str> {
 //!     // ...
 //! #   winnow::token::rest.parse_next(i)
 //! }
@@ -92,7 +92,7 @@
 //! ```rust
 //! # use winnow::prelude::*;
 //! # use winnow::combinator::trace;
-//! fn foo(i: &mut &str) -> PResult<usize> {
+//! fn foo(i: &mut &str) -> ModalResult<usize> {
 //!     trace("foo", |i: &mut _| {
 //!         // ...
 //! #       Ok(0)

--- a/src/_topic/nom.rs
+++ b/src/_topic/nom.rs
@@ -99,6 +99,18 @@
 //!     }).parse_next(i)
 //! }
 //! ```
+//!
+//! ### Optional [`ErrMode`]
+//!
+//! Called `Err` in `nom`, [`ErrMode`] is responsible for
+//! - Deciding whether to backtrack and try another branch in cases like `alt` or report back to
+//!   the error back to users
+//! - Tracking incomplete input on partial parsing
+//!
+//! As this isn't needed in every parser, it was made optional.  [`ModalResult`] is a convenience
+//! type for using [`ErrMode`].
 
 #![allow(unused_imports)]
+use crate::error::ErrMode;
+use crate::error::ModalResult;
 use crate::stream::Stream;

--- a/src/_topic/stream.rs
+++ b/src/_topic/stream.rs
@@ -15,12 +15,12 @@
 //! Let's assume we have an input type we'll call `MyStream`.
 //! `MyStream` is a sequence of `MyItem` type.
 //!
-//! The goal is to define parsers with this signature: `&mut MyStream -> PResult<Output>`.
+//! The goal is to define parsers with this signature: `&mut MyStream -> ModalResult<Output>`.
 //! ```rust
 //! # use winnow::prelude::*;
 //! # type MyStream<'i> = &'i str;
 //! # type Output<'i> = &'i str;
-//! fn parser<'s>(i: &mut MyStream<'s>) -> PResult<Output<'s>> {
+//! fn parser<'s>(i: &mut MyStream<'s>) -> ModalResult<Output<'s>> {
 //!     "test".parse_next(i)
 //! }
 //! ```

--- a/src/_topic/why.rs
+++ b/src/_topic/why.rs
@@ -90,7 +90,7 @@
 //!   See also [#72](https://github.com/winnow-rs/winnow/issues/72).
 //!
 //! Downsides:
-//! - When returning a slice, you have to add a lifetime (`fn foo<'i>(i: &mut &i str) -> PResult<&i str>`)
+//! - When returning a slice, you have to add a lifetime (`fn foo<'i>(i: &mut &i str) -> ModalResult<&i str>`)
 //! - When writing a closure, you need to annotate the type (`|i: &mut _|`, at least the full type isn't needed)
 //!
 //! ## `chumsky`

--- a/src/_tutorial/chapter_1.rs
+++ b/src/_tutorial/chapter_1.rs
@@ -23,14 +23,14 @@
 //! ```
 //!
 //!
-//! To represent this model of the world, winnow uses the [`PResult<O>`] type.
+//! To represent this model of the world, winnow uses the [`ModalResult<O>`] type.
 //! The `Ok` variant has `output: O`;
 //! whereas the `Err` variant stores an error.
 //!
 //! You can import that from:
 //!
 //! ```rust
-//! use winnow::PResult;
+//! use winnow::ModalResult;
 //! ```
 //!
 //! To combine parsers, we need a common way to refer to them which is where the [`Parser<I, O, E>`]
@@ -49,7 +49,7 @@
 //! The simplest parser we can write is one which successfully does nothing.
 //!
 //! To make it easier to implement a [`Parser`], the trait is implemented for
-//! functions of the form `Fn(&mut I) -> PResult<O>`.
+//! functions of the form `Fn(&mut I) -> ModalResult<O>`.
 //!
 //! This parser function should take in a `&str`:
 //!
@@ -58,10 +58,10 @@
 //!  - Since it doesn't parse anything, it also should just return an empty string.
 //!
 //! ```rust
-//! use winnow::PResult;
+//! use winnow::ModalResult;
 //! use winnow::Parser;
 //!
-//! pub fn do_nothing_parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! pub fn do_nothing_parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     Ok("")
 //! }
 //!
@@ -80,7 +80,7 @@
 #![allow(unused_imports)]
 use super::chapter_6;
 use super::chapter_7;
-use crate::PResult;
+use crate::ModalResult;
 use crate::Parser;
 
 pub use super::chapter_0 as previous;

--- a/src/_tutorial/chapter_1.rs
+++ b/src/_tutorial/chapter_1.rs
@@ -23,14 +23,14 @@
 //! ```
 //!
 //!
-//! To represent this model of the world, winnow uses the [`ModalResult<O>`] type.
+//! To represent this model of the world, winnow uses the [`Result<O>`] type.
 //! The `Ok` variant has `output: O`;
 //! whereas the `Err` variant stores an error.
 //!
 //! You can import that from:
 //!
 //! ```rust
-//! use winnow::ModalResult;
+//! use winnow::Result;
 //! ```
 //!
 //! To combine parsers, we need a common way to refer to them which is where the [`Parser<I, O, E>`]
@@ -49,7 +49,7 @@
 //! The simplest parser we can write is one which successfully does nothing.
 //!
 //! To make it easier to implement a [`Parser`], the trait is implemented for
-//! functions of the form `Fn(&mut I) -> ModalResult<O>`.
+//! functions of the form `Fn(&mut I) -> Result<O>`.
 //!
 //! This parser function should take in a `&str`:
 //!
@@ -58,10 +58,10 @@
 //!  - Since it doesn't parse anything, it also should just return an empty string.
 //!
 //! ```rust
-//! use winnow::ModalResult;
+//! use winnow::Result;
 //! use winnow::Parser;
 //!
-//! pub fn do_nothing_parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! pub fn do_nothing_parser<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     Ok("")
 //! }
 //!
@@ -80,7 +80,6 @@
 #![allow(unused_imports)]
 use super::chapter_6;
 use super::chapter_7;
-use crate::ModalResult;
 use crate::Parser;
 
 pub use super::chapter_0 as previous;

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -16,10 +16,10 @@
 //!
 //! fn parse_prefix(input: &mut &str) -> ModalResult<char> {
 //!     let c = input.next_token().ok_or_else(|| {
-//!         ErrMode::from_error_kind(input, ErrorKind::Token)
+//!         ParserError::from_error_kind(input, ErrorKind::Token)
 //!     })?;
 //!     if c != '0' {
-//!         return Err(ErrMode::from_error_kind(input, ErrorKind::Verify));
+//!         return Err(ParserError::from_error_kind(input, ErrorKind::Verify));
 //!     }
 //!     Ok(c)
 //! }
@@ -49,7 +49,7 @@
 //!     let c = any
 //!         .parse_next(input)?;
 //!     if c != '0' {
-//!         return Err(ErrMode::from_error_kind(input, ErrorKind::Verify));
+//!         return Err(ParserError::from_error_kind(input, ErrorKind::Verify));
 //!     }
 //!     Ok(c)
 //! }
@@ -129,11 +129,11 @@
 //! fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     let expected = "0x";
 //!     if input.len() < expected.len() {
-//!         return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+//!         return Err(ParserError::from_error_kind(input, ErrorKind::Slice));
 //!     }
 //!     let actual = input.next_slice(expected.len());
 //!     if actual != expected {
-//!         return Err(ErrMode::from_error_kind(input, ErrorKind::Verify));
+//!         return Err(ParserError::from_error_kind(input, ErrorKind::Verify));
 //!     }
 //!     Ok(actual)
 //! }

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -8,13 +8,13 @@
 //! single token, you can do:
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! use winnow::stream::Stream;
 //! use winnow::error::ParserError;
 //! use winnow::error::ErrorKind;
 //! use winnow::error::ErrMode;
 //!
-//! fn parse_prefix(input: &mut &str) -> PResult<char> {
+//! fn parse_prefix(input: &mut &str) -> ModalResult<char> {
 //!     let c = input.next_token().ok_or_else(|| {
 //!         ErrMode::from_error_kind(input, ErrorKind::Token)
 //!     })?;
@@ -38,14 +38,14 @@
 //!
 //! This extraction of a token is encapsulated in the [`any`] parser:
 //! ```rust
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! # use winnow::error::ParserError;
 //! # use winnow::error::ErrorKind;
 //! # use winnow::error::ErrMode;
 //! use winnow::Parser;
 //! use winnow::token::any;
 //!
-//! fn parse_prefix(input: &mut &str) -> PResult<char> {
+//! fn parse_prefix(input: &mut &str) -> ModalResult<char> {
 //!     let c = any
 //!         .parse_next(input)?;
 //!     if c != '0' {
@@ -69,11 +69,11 @@
 //! Using the higher level [`any`] parser opens `parse_prefix` to the helpers on the [`Parser`] trait,
 //! like [`Parser::verify`] which fails a parse if a condition isn't met, like our check above:
 //! ```rust
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! use winnow::Parser;
 //! use winnow::token::any;
 //!
-//! fn parse_prefix(input: &mut &str) -> PResult<char> {
+//! fn parse_prefix(input: &mut &str) -> ModalResult<char> {
 //!     let c = any
 //!         .verify(|c| *c == '0')
 //!         .parse_next(input)?;
@@ -95,10 +95,10 @@
 //! Matching a single token literal is common enough that [`Parser`] is implemented for
 //! the `char` type, encapsulating both [`any`] and [`Parser::verify`]:
 //! ```rust
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! use winnow::Parser;
 //!
-//! fn parse_prefix(input: &mut &str) -> PResult<char> {
+//! fn parse_prefix(input: &mut &str) -> ModalResult<char> {
 //!     let c = '0'.parse_next(input)?;
 //!     Ok(c)
 //! }
@@ -120,13 +120,13 @@
 //! [`Stream`] also supports processing slices of tokens:
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! use winnow::stream::Stream;
 //! use winnow::error::ParserError;
 //! use winnow::error::ErrorKind;
 //! use winnow::error::ErrMode;
 //!
-//! fn parse_prefix<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     let expected = "0x";
 //!     if input.len() < expected.len() {
 //!         return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
@@ -151,11 +151,11 @@
 //!
 //! Matching the input position against a string literal is encapsulated in the [`literal`] parser:
 //! ```rust
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! # use winnow::Parser;
 //! use winnow::token::literal;
 //!
-//! fn parse_prefix<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     let expected = "0x";
 //!     let actual = literal(expected).parse_next(input)?;
 //!     Ok(actual)
@@ -174,10 +174,10 @@
 //!
 //! Like for a single token, matching a string literal is common enough that [`Parser`] is implemented for the `&str` type:
 //! ```rust
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! use winnow::Parser;
 //!
-//! fn parse_prefix<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     let actual = "0x".parse_next(input)?;
 //!     Ok(actual)
 //! }
@@ -202,10 +202,10 @@
 //!
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! use winnow::token::one_of;
 //!
-//! fn parse_digits(input: &mut &str) -> PResult<char> {
+//! fn parse_digits(input: &mut &str) -> ModalResult<char> {
 //!     one_of(('0'..='9', 'a'..='f', 'A'..='F')).parse_next(input)
 //! }
 //!
@@ -235,7 +235,7 @@
 //! > If you have not programmed in a language where functions are values, the type signature of the
 //! > [`one_of`] function might be a surprise.
 //! > The function [`one_of`] *returns a function*. The function it returns is a
-//! > `Parser`, taking a `&str` and returning an `PResult`. This is a common pattern in winnow for
+//! > `Parser`, taking a `&str` and returning an `ModalResult`. This is a common pattern in winnow for
 //! > configurable or stateful parsers.
 //!
 //! Some of character classes are common enough that a named parser is provided, like with:
@@ -246,10 +246,10 @@
 //! You can then capture sequences of these characters with parsers like [`take_while`].
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! use winnow::token::take_while;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     take_while(1.., ('0'..='9', 'a'..='f', 'A'..='F')).parse_next(input)
 //! }
 //!
@@ -267,10 +267,10 @@
 //! We could simplify this further by using one of the built-in character classes, [`hex_digit1`]:
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! use winnow::ascii::hex_digit1;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     hex_digit1.parse_next(input)
 //! }
 //!

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -8,13 +8,12 @@
 //! single token, you can do:
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! use winnow::stream::Stream;
 //! use winnow::error::ParserError;
 //! use winnow::error::ErrorKind;
-//! use winnow::error::ErrMode;
 //!
-//! fn parse_prefix(input: &mut &str) -> ModalResult<char> {
+//! fn parse_prefix(input: &mut &str) -> Result<char> {
 //!     let c = input.next_token().ok_or_else(|| {
 //!         ParserError::from_error_kind(input, ErrorKind::Token)
 //!     })?;
@@ -38,14 +37,13 @@
 //!
 //! This extraction of a token is encapsulated in the [`any`] parser:
 //! ```rust
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! # use winnow::error::ParserError;
 //! # use winnow::error::ErrorKind;
-//! # use winnow::error::ErrMode;
 //! use winnow::Parser;
 //! use winnow::token::any;
 //!
-//! fn parse_prefix(input: &mut &str) -> ModalResult<char> {
+//! fn parse_prefix(input: &mut &str) -> Result<char> {
 //!     let c = any
 //!         .parse_next(input)?;
 //!     if c != '0' {
@@ -69,11 +67,11 @@
 //! Using the higher level [`any`] parser opens `parse_prefix` to the helpers on the [`Parser`] trait,
 //! like [`Parser::verify`] which fails a parse if a condition isn't met, like our check above:
 //! ```rust
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! use winnow::Parser;
 //! use winnow::token::any;
 //!
-//! fn parse_prefix(input: &mut &str) -> ModalResult<char> {
+//! fn parse_prefix(input: &mut &str) -> Result<char> {
 //!     let c = any
 //!         .verify(|c| *c == '0')
 //!         .parse_next(input)?;
@@ -95,10 +93,10 @@
 //! Matching a single token literal is common enough that [`Parser`] is implemented for
 //! the `char` type, encapsulating both [`any`] and [`Parser::verify`]:
 //! ```rust
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! use winnow::Parser;
 //!
-//! fn parse_prefix(input: &mut &str) -> ModalResult<char> {
+//! fn parse_prefix(input: &mut &str) -> Result<char> {
 //!     let c = '0'.parse_next(input)?;
 //!     Ok(c)
 //! }
@@ -120,13 +118,12 @@
 //! [`Stream`] also supports processing slices of tokens:
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! use winnow::stream::Stream;
 //! use winnow::error::ParserError;
 //! use winnow::error::ErrorKind;
-//! use winnow::error::ErrMode;
 //!
-//! fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! fn parse_prefix<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     let expected = "0x";
 //!     if input.len() < expected.len() {
 //!         return Err(ParserError::from_error_kind(input, ErrorKind::Slice));
@@ -151,11 +148,11 @@
 //!
 //! Matching the input position against a string literal is encapsulated in the [`literal`] parser:
 //! ```rust
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! # use winnow::Parser;
 //! use winnow::token::literal;
 //!
-//! fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! fn parse_prefix<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     let expected = "0x";
 //!     let actual = literal(expected).parse_next(input)?;
 //!     Ok(actual)
@@ -174,10 +171,10 @@
 //!
 //! Like for a single token, matching a string literal is common enough that [`Parser`] is implemented for the `&str` type:
 //! ```rust
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! use winnow::Parser;
 //!
-//! fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! fn parse_prefix<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     let actual = "0x".parse_next(input)?;
 //!     Ok(actual)
 //! }
@@ -202,10 +199,10 @@
 //!
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! use winnow::token::one_of;
 //!
-//! fn parse_digits(input: &mut &str) -> ModalResult<char> {
+//! fn parse_digits(input: &mut &str) -> Result<char> {
 //!     one_of(('0'..='9', 'a'..='f', 'A'..='F')).parse_next(input)
 //! }
 //!
@@ -235,7 +232,7 @@
 //! > If you have not programmed in a language where functions are values, the type signature of the
 //! > [`one_of`] function might be a surprise.
 //! > The function [`one_of`] *returns a function*. The function it returns is a
-//! > `Parser`, taking a `&str` and returning an `ModalResult`. This is a common pattern in winnow for
+//! > [`Parser`], taking a `&str` and returning an [`Result`]. This is a common pattern in winnow for
 //! > configurable or stateful parsers.
 //!
 //! Some of character classes are common enough that a named parser is provided, like with:
@@ -246,10 +243,10 @@
 //! You can then capture sequences of these characters with parsers like [`take_while`].
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! use winnow::token::take_while;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     take_while(1.., ('0'..='9', 'a'..='f', 'A'..='F')).parse_next(input)
 //! }
 //!
@@ -267,10 +264,10 @@
 //! We could simplify this further by using one of the built-in character classes, [`hex_digit1`]:
 //! ```rust
 //! # use winnow::Parser;
-//! # use winnow::ModalResult;
+//! # use winnow::Result;
 //! use winnow::ascii::hex_digit1;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     hex_digit1.parse_next(input)
 //! }
 //!
@@ -298,6 +295,7 @@ use crate::token::literal;
 use crate::token::one_of;
 use crate::token::take_while;
 use crate::Parser;
+use crate::Result;
 use std::ops::RangeInclusive;
 
 pub use super::chapter_1 as previous;

--- a/src/_tutorial/chapter_3.rs
+++ b/src/_tutorial/chapter_3.rs
@@ -13,11 +13,11 @@
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
 //! #
-//! fn parse_prefix<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     "0x".parse_next(input)
 //! }
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     take_while(1.., (
 //!         ('0'..='9'),
 //!         ('A'..='F'),
@@ -42,11 +42,11 @@
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
 //! #
-//! # fn parse_prefix<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     "0x".parse_next(input)
 //! # }
 //! #
-//! # fn parse_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -77,11 +77,11 @@
 //! # use winnow::token::take_while;
 //! use winnow::combinator::preceded;
 //!
-//! # fn parse_prefix<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     "0x".parse_next(input)
 //! # }
 //! #
-//! # fn parse_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -118,7 +118,7 @@
 //! # use winnow::token::take_while;
 //! use winnow::stream::Stream;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //!     let start = input.checkpoint();
 //!     if let Ok(output) = ("0b", parse_bin_digits).parse_next(input) {
 //!         return Ok(output);
@@ -139,25 +139,25 @@
 //! }
 //!
 //! // ...
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -192,7 +192,7 @@
 //! # use winnow::token::take_while;
 //! use winnow::combinator::opt;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //!     if let Some(output) = opt(("0b", parse_bin_digits)).parse_next(input)? {
 //!         Ok(output)
 //!     } else if let Some(output) = opt(("0o", parse_oct_digits)).parse_next(input)? {
@@ -204,25 +204,25 @@
 //!     }
 //! }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -249,7 +249,7 @@
 //! # use winnow::token::take_while;
 //! use winnow::combinator::alt;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //!     alt((
 //!         ("0b", parse_bin_digits),
 //!         ("0o", parse_oct_digits),
@@ -258,25 +258,25 @@
 //!     )).parse_next(input)
 //! }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -314,7 +314,7 @@
 //! use winnow::token::take;
 //! use winnow::combinator::fail;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     dispatch!(take(2usize);
 //!         "0b" => parse_bin_digits,
 //!         "0o" => parse_oct_digits,
@@ -324,25 +324,25 @@
 //!     ).parse_next(input)
 //! }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),

--- a/src/_tutorial/chapter_3.rs
+++ b/src/_tutorial/chapter_3.rs
@@ -11,13 +11,14 @@
 //!
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! #
-//! fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! fn parse_prefix<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     "0x".parse_next(input)
 //! }
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     take_while(1.., (
 //!         ('0'..='9'),
 //!         ('A'..='F'),
@@ -40,13 +41,14 @@
 //! To sequence these together, you can just put them in a tuple:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! #
-//! # fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_prefix<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     "0x".parse_next(input)
 //! # }
 //! #
-//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -74,14 +76,15 @@
 //! like [`preceded`]:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! use winnow::combinator::preceded;
 //!
-//! # fn parse_prefix<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_prefix<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     "0x".parse_next(input)
 //! # }
 //! #
-//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -115,10 +118,11 @@
 //! back to that position with [`Stream::reset`]:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! use winnow::stream::Stream;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> Result<(&'s str, &'s str)> {
 //!     let start = input.checkpoint();
 //!     if let Ok(output) = ("0b", parse_bin_digits).parse_next(input) {
 //!         return Ok(output);
@@ -139,25 +143,25 @@
 //! }
 //!
 //! // ...
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -189,10 +193,11 @@
 //! [`opt`] is a parser that encapsulates this pattern of "retry on failure":
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! use winnow::combinator::opt;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> Result<(&'s str, &'s str)> {
 //!     if let Some(output) = opt(("0b", parse_bin_digits)).parse_next(input)? {
 //!         Ok(output)
 //!     } else if let Some(output) = opt(("0o", parse_oct_digits)).parse_next(input)? {
@@ -204,25 +209,25 @@
 //!     }
 //! }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -246,10 +251,11 @@
 //! [`alt`] encapsulates this if/else-if ladder pattern, with the last case being the "else":
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! use winnow::combinator::alt;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> Result<(&'s str, &'s str)> {
 //!     alt((
 //!         ("0b", parse_bin_digits),
 //!         ("0o", parse_oct_digits),
@@ -258,25 +264,25 @@
 //!     )).parse_next(input)
 //! }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -309,12 +315,13 @@
 //!
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! use winnow::combinator::dispatch;
 //! use winnow::token::take;
 //! use winnow::combinator::fail;
 //!
-//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     dispatch!(take(2usize);
 //!         "0b" => parse_bin_digits,
 //!         "0o" => parse_oct_digits,
@@ -324,25 +331,25 @@
 //!     ).parse_next(input)
 //! }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),

--- a/src/_tutorial/chapter_4.rs
+++ b/src/_tutorial/chapter_4.rs
@@ -1,15 +1,15 @@
 //! # Chapter 4: Parsers With Custom Return Types
 //!
 //! So far, we have seen mostly functions that take an `&str`, and return a
-//! `PResult<&str>`. Splitting strings into smaller strings and characters is certainly
+//! `ModalResult<&str>`. Splitting strings into smaller strings and characters is certainly
 //! useful, but it's not the only thing winnow is capable of!
 //!
 //! A useful operation when parsing is to convert between types; for example
 //! parsing from `&str` to another primitive, like [`usize`].
 //!
 //! All we need to do for our parser to return a different type is to change
-//! the type parameter of [`PResult`] to the desired return type.
-//! For example, to return a `usize`, return a `PResult<usize>`.
+//! the type parameter of [`ModalResult`] to the desired return type.
+//! For example, to return a `usize`, return a `ModalResult<usize>`.
 //!
 //! One winnow-native way of doing a type conversion is to use the
 //! [`Parser::parse_to`] combinator
@@ -20,7 +20,7 @@
 //! # use winnow::prelude::*;
 //! # use winnow::ascii::digit1;
 //! #
-//! fn parse_digits(input: &mut &str) -> PResult<usize> {
+//! fn parse_digits(input: &mut &str) -> ModalResult<usize> {
 //!     digit1
 //!         .parse_to()
 //!         .parse_next(input)
@@ -46,7 +46,7 @@
 //! use winnow::token::take;
 //! use winnow::combinator::fail;
 //!
-//! fn parse_digits(input: &mut &str) -> PResult<usize> {
+//! fn parse_digits(input: &mut &str) -> ModalResult<usize> {
 //!     dispatch!(take(2usize);
 //!         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //!         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -57,25 +57,25 @@
 //! }
 //!
 //! // ...
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -98,7 +98,7 @@
 //! See also [`Parser`] for more output-modifying parsers.
 
 #![allow(unused_imports)]
-use crate::PResult;
+use crate::ModalResult;
 use crate::Parser;
 use std::str::FromStr;
 

--- a/src/_tutorial/chapter_4.rs
+++ b/src/_tutorial/chapter_4.rs
@@ -1,15 +1,15 @@
 //! # Chapter 4: Parsers With Custom Return Types
 //!
 //! So far, we have seen mostly functions that take an `&str`, and return a
-//! `ModalResult<&str>`. Splitting strings into smaller strings and characters is certainly
+//! [`Result<&str>`]. Splitting strings into smaller strings and characters is certainly
 //! useful, but it's not the only thing winnow is capable of!
 //!
 //! A useful operation when parsing is to convert between types; for example
 //! parsing from `&str` to another primitive, like [`usize`].
 //!
 //! All we need to do for our parser to return a different type is to change
-//! the type parameter of [`ModalResult`] to the desired return type.
-//! For example, to return a `usize`, return a `ModalResult<usize>`.
+//! the type parameter of [`Result`] to the desired return type.
+//! For example, to return a `usize`, return a `Result<usize>`.
 //!
 //! One winnow-native way of doing a type conversion is to use the
 //! [`Parser::parse_to`] combinator
@@ -18,9 +18,10 @@
 //! The following code converts from a string containing a number to `usize`:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::ascii::digit1;
 //! #
-//! fn parse_digits(input: &mut &str) -> ModalResult<usize> {
+//! fn parse_digits(input: &mut &str) -> Result<usize> {
 //!     digit1
 //!         .parse_to()
 //!         .parse_next(input)
@@ -41,12 +42,13 @@
 //! all radices of numbers:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! use winnow::combinator::dispatch;
 //! use winnow::token::take;
 //! use winnow::combinator::fail;
 //!
-//! fn parse_digits(input: &mut &str) -> ModalResult<usize> {
+//! fn parse_digits(input: &mut &str) -> Result<usize> {
 //!     dispatch!(take(2usize);
 //!         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //!         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -57,25 +59,25 @@
 //! }
 //!
 //! // ...
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -98,8 +100,8 @@
 //! See also [`Parser`] for more output-modifying parsers.
 
 #![allow(unused_imports)]
-use crate::ModalResult;
 use crate::Parser;
+use crate::Result;
 use std::str::FromStr;
 
 pub use super::chapter_3 as previous;

--- a/src/_tutorial/chapter_5.rs
+++ b/src/_tutorial/chapter_5.rs
@@ -14,7 +14,7 @@
 //! use winnow::combinator::repeat;
 //! use winnow::combinator::terminated;
 //!
-//! fn parse_list(input: &mut &str) -> PResult<Vec<usize>> {
+//! fn parse_list(input: &mut &str) -> ModalResult<Vec<usize>> {
 //!     let mut list = Vec::new();
 //!     while let Some(output) = opt(terminated(parse_digits, opt(','))).parse_next(input)? {
 //!         list.push(output);
@@ -23,7 +23,7 @@
 //! }
 //!
 //! // ...
-//! # fn parse_digits(input: &mut &str) -> PResult<usize> {
+//! # fn parse_digits(input: &mut &str) -> ModalResult<usize> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -33,25 +33,25 @@
 //! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -82,13 +82,13 @@
 //! use winnow::combinator::repeat;
 //! use winnow::combinator::terminated;
 //!
-//! fn parse_list(input: &mut &str) -> PResult<Vec<usize>> {
+//! fn parse_list(input: &mut &str) -> ModalResult<Vec<usize>> {
 //!     repeat(0..,
 //!         terminated(parse_digits, opt(','))
 //!     ).parse_next(input)
 //! }
 //! #
-//! # fn parse_digits(input: &mut &str) -> PResult<usize> {
+//! # fn parse_digits(input: &mut &str) -> ModalResult<usize> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -98,25 +98,25 @@
 //! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -146,12 +146,12 @@
 //! # use winnow::combinator::fail;
 //! use winnow::combinator::separated;
 //!
-//! fn parse_list(input: &mut &str) -> PResult<Vec<usize>> {
+//! fn parse_list(input: &mut &str) -> ModalResult<Vec<usize>> {
 //!     separated(0.., parse_digits, ",").parse_next(input)
 //! }
 //!
 //! // ...
-//! # fn parse_digits(input: &mut &str) -> PResult<usize> {
+//! # fn parse_digits(input: &mut &str) -> ModalResult<usize> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -161,25 +161,25 @@
 //! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -223,15 +223,15 @@
 //! # use winnow::combinator::fail;
 //! # use winnow::combinator::separated;
 //! #
-//! fn take_list<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! fn take_list<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     parse_list.take().parse_next(input)
 //! }
 //!
-//! fn parse_list(input: &mut &str) -> PResult<()> {
+//! fn parse_list(input: &mut &str) -> ModalResult<()> {
 //!     separated(0.., parse_digits, ",").parse_next(input)
 //! }
 //!
-//! # fn parse_digits(input: &mut &str) -> PResult<usize> {
+//! # fn parse_digits(input: &mut &str) -> ModalResult<usize> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -241,25 +241,25 @@
 //! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),

--- a/src/_tutorial/chapter_5.rs
+++ b/src/_tutorial/chapter_5.rs
@@ -6,6 +6,7 @@
 //! Let's collect the result of `parse_digits`:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
@@ -14,7 +15,7 @@
 //! use winnow::combinator::repeat;
 //! use winnow::combinator::terminated;
 //!
-//! fn parse_list(input: &mut &str) -> ModalResult<Vec<usize>> {
+//! fn parse_list(input: &mut &str) -> Result<Vec<usize>> {
 //!     let mut list = Vec::new();
 //!     while let Some(output) = opt(terminated(parse_digits, opt(','))).parse_next(input)? {
 //!         list.push(output);
@@ -23,7 +24,7 @@
 //! }
 //!
 //! // ...
-//! # fn parse_digits(input: &mut &str) -> ModalResult<usize> {
+//! # fn parse_digits(input: &mut &str) -> Result<usize> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -33,25 +34,25 @@
 //! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -74,6 +75,7 @@
 //! We can implement this declaratively with [`repeat`]:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
@@ -82,13 +84,13 @@
 //! use winnow::combinator::repeat;
 //! use winnow::combinator::terminated;
 //!
-//! fn parse_list(input: &mut &str) -> ModalResult<Vec<usize>> {
+//! fn parse_list(input: &mut &str) -> Result<Vec<usize>> {
 //!     repeat(0..,
 //!         terminated(parse_digits, opt(','))
 //!     ).parse_next(input)
 //! }
 //! #
-//! # fn parse_digits(input: &mut &str) -> ModalResult<usize> {
+//! # fn parse_digits(input: &mut &str) -> Result<usize> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -98,25 +100,25 @@
 //! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -140,18 +142,19 @@
 //! can easily be fixed by using [`separated`] instead of [`repeat`]:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
 //! # use winnow::combinator::fail;
 //! use winnow::combinator::separated;
 //!
-//! fn parse_list(input: &mut &str) -> ModalResult<Vec<usize>> {
+//! fn parse_list(input: &mut &str) -> Result<Vec<usize>> {
 //!     separated(0.., parse_digits, ",").parse_next(input)
 //! }
 //!
 //! // ...
-//! # fn parse_digits(input: &mut &str) -> ModalResult<usize> {
+//! # fn parse_digits(input: &mut &str) -> Result<usize> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -161,25 +164,25 @@
 //! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -217,21 +220,22 @@
 //!
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::dispatch;
 //! # use winnow::token::take;
 //! # use winnow::combinator::fail;
 //! # use winnow::combinator::separated;
 //! #
-//! fn take_list<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! fn take_list<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     parse_list.take().parse_next(input)
 //! }
 //!
-//! fn parse_list(input: &mut &str) -> ModalResult<()> {
+//! fn parse_list(input: &mut &str) -> Result<()> {
 //!     separated(0.., parse_digits, ",").parse_next(input)
 //! }
 //!
-//! # fn parse_digits(input: &mut &str) -> ModalResult<usize> {
+//! # fn parse_digits(input: &mut &str) -> Result<usize> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -241,25 +245,25 @@
 //! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),

--- a/src/_tutorial/chapter_6.rs
+++ b/src/_tutorial/chapter_6.rs
@@ -8,15 +8,15 @@
 //! # use winnow::error::ContextError;
 //! # use winnow::error::ErrMode;
 //! # use winnow::Parser;
-//! use winnow::PResult;
+//! use winnow::ModalResult;
 //!
-//! pub fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! pub fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     // ...
 //! #     Ok("")
 //! }
 //! ```
 //! 1. We have to decide what to do about the "remainder" of the `input`.
-//! 2. The [`PResult`] is not compatible with the rest of the Rust ecosystem.
+//! 2. The [`ModalResult`] is not compatible with the rest of the Rust ecosystem.
 //!     Normally, Rust applications want errors that are `std::error::Error + Send + Sync + 'static`
 //!     meaning:
 //!     - They implement the [`std::error::Error`] trait
@@ -26,7 +26,7 @@
 //!
 //! winnow provides [`Parser::parse`] to help with this:
 //! - Ensures we hit [`eof`]
-//! - Converts from [`PResult`] to [`Result`]
+//! - Converts from [`ModalResult`] to [`Result`]
 //! - Wraps the error in [`ParseError`]
 //!   - For simple cases, [`ParseError`] provides a [`std::fmt::Display`] impl to render the error.
 //!   - For more involved cases, [`ParseError`] provides the original [`input`][ParseError::input] and the
@@ -59,7 +59,7 @@
 //! }
 //!
 //! // ...
-//! # fn parse_digits<'s>(input: &mut &'s str) -> PResult<usize> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<usize> {
 //! #     dispatch!(take(2usize);
 //! #         "0b" => parse_bin_digits.try_map(|s| usize::from_str_radix(s, 2)),
 //! #         "0o" => parse_oct_digits.try_map(|s| usize::from_str_radix(s, 8)),
@@ -69,25 +69,25 @@
 //! #     ).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -112,7 +112,7 @@ use super::chapter_7;
 use crate::combinator::eof;
 use crate::error::ErrMode;
 use crate::error::ParseError;
-use crate::PResult;
+use crate::ModalResult;
 use crate::Parser;
 
 pub use super::chapter_5 as previous;

--- a/src/_tutorial/chapter_7.rs
+++ b/src/_tutorial/chapter_7.rs
@@ -35,7 +35,7 @@
 //! #
 //! // ...
 //!
-//! # fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //! #     alt((
 //! #         ("0b", parse_bin_digits),
 //! #         ("0o", parse_oct_digits),
@@ -44,25 +44,25 @@
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -79,8 +79,8 @@
 //! }
 //! ```
 //!
-//! Back in [`chapter_1`], we glossed over the `Err` variant of [`PResult`].  `PResult<O>` is
-//! actually short for `PResult<O, E=ContextError>` where [`ContextError`] is a relatively cheap
+//! Back in [`chapter_1`], we glossed over the `Err` variant of [`ModalResult`].  `ModalResult<O>` is
+//! actually short for `ModalResult<O, E=ContextError>` where [`ContextError`] is a relatively cheap
 //! way of building up reasonable errors for humans.
 //!
 //! You can use [`Parser::context`] to annotate the error with custom types
@@ -117,7 +117,7 @@
 //! #     }
 //! # }
 //! #
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //!     alt((
 //!         ("0b", parse_bin_digits)
 //!           .context(StrContext::Label("digit"))
@@ -137,25 +137,25 @@
 //! // ...
 //!
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -208,7 +208,7 @@
 //! #     }
 //! # }
 //! #
-//! # fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //! #     alt((
 //! #         ("0b", parse_bin_digits)
 //! #           .context(StrContext::Label("digit"))
@@ -225,25 +225,25 @@
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -293,7 +293,7 @@
 //! #     }
 //! # }
 //! #
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //!     alt((
 //!         ("0b", parse_bin_digits)
 //!           .context(StrContext::Label("digit"))
@@ -319,25 +319,25 @@
 //! // ...
 //!
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -391,7 +391,7 @@
 //! #     }
 //! # }
 //! #
-//! # fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //! #     alt((
 //! #         ("0b", parse_bin_digits)
 //! #           .context(StrContext::Label("digit"))
@@ -414,25 +414,25 @@
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -450,13 +450,13 @@
 //! }
 //! ```
 //!
-//! Let's break down `PResult<O, E>` one step further:
+//! Let's break down `ModalResult<O, E>` one step further:
 //! ```rust
 //! # use winnow::error::ErrorKind;
 //! # use winnow::error::ErrMode;
-//! pub type PResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;
+//! pub type ModalResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;
 //! ```
-//! [`PResult`] is just a fancy wrapper around `Result` that wraps our error in an [`ErrMode`]
+//! [`ModalResult`] is just a fancy wrapper around `Result` that wraps our error in an [`ErrMode`]
 //! type.
 //!
 //! [`ErrMode`] is an enum with [`Backtrack`] and [`Cut`] variants (ignore [`Incomplete`] as its only
@@ -498,7 +498,7 @@
 //! #     }
 //! # }
 //! #
-//! fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //!     alt((
 //!         ("0b", cut_err(parse_bin_digits))
 //!           .context(StrContext::Label("digit"))
@@ -524,25 +524,25 @@
 //! // ...
 //!
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -648,7 +648,7 @@
 //!
 //! impl std::error::Error for HexError {}
 //!
-//! # fn parse_digits<'s>(input: &mut &'s str) -> PResult<(&'s str, &'s str)> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
 //! #     alt((
 //! #         ("0b", cut_err(parse_bin_digits))
 //! #           .context(StrContext::Label("digit"))
@@ -671,25 +671,25 @@
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -719,7 +719,7 @@ use crate::error::ContextError;
 use crate::error::ErrMode;
 use crate::error::ErrMode::*;
 use crate::error::ErrorKind;
-use crate::PResult;
+use crate::ModalResult;
 use crate::Parser;
 use crate::_topic;
 

--- a/src/_tutorial/chapter_7.rs
+++ b/src/_tutorial/chapter_7.rs
@@ -6,6 +6,7 @@
 //! the failure:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::alt;
 //! # use winnow::token::take;
@@ -35,7 +36,7 @@
 //! #
 //! // ...
 //!
-//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> Result<(&'s str, &'s str)> {
 //! #     alt((
 //! #         ("0b", parse_bin_digits),
 //! #         ("0o", parse_oct_digits),
@@ -44,25 +45,25 @@
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -79,14 +80,15 @@
 //! }
 //! ```
 //!
-//! Back in [`chapter_1`], we glossed over the `Err` variant of [`ModalResult`].  `ModalResult<O>` is
-//! actually short for `ModalResult<O, E=ContextError>` where [`ContextError`] is a relatively cheap
+//! Back in [`chapter_1`], we glossed over the `Err` variant of [`Result`].  `Result<O>` is
+//! actually short for `Result<O, E=ContextError>` where [`ContextError`] is a relatively cheap
 //! way of building up reasonable errors for humans.
 //!
 //! You can use [`Parser::context`] to annotate the error with custom types
 //! while unwinding to further clarify the error:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::alt;
 //! # use winnow::token::take;
@@ -117,7 +119,7 @@
 //! #     }
 //! # }
 //! #
-//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> Result<(&'s str, &'s str)> {
 //!     alt((
 //!         ("0b", parse_bin_digits)
 //!           .context(StrContext::Label("digit"))
@@ -137,25 +139,25 @@
 //! // ...
 //!
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -178,6 +180,7 @@
 //! hexadecimal value:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::alt;
 //! # use winnow::token::take;
@@ -208,7 +211,7 @@
 //! #     }
 //! # }
 //! #
-//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> Result<(&'s str, &'s str)> {
 //! #     alt((
 //! #         ("0b", parse_bin_digits)
 //! #           .context(StrContext::Label("digit"))
@@ -225,25 +228,25 @@
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -263,6 +266,7 @@
 //! We can improve this with [`fail`]:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::alt;
 //! # use winnow::token::take;
@@ -293,7 +297,7 @@
 //! #     }
 //! # }
 //! #
-//! fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
+//! fn parse_digits<'s>(input: &mut &'s str) -> Result<(&'s str, &'s str)> {
 //!     alt((
 //!         ("0b", parse_bin_digits)
 //!           .context(StrContext::Label("digit"))
@@ -319,25 +323,25 @@
 //! // ...
 //!
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -361,6 +365,7 @@
 //! don't match it:
 //! ```rust
 //! # use winnow::prelude::*;
+//! # use winnow::Result;
 //! # use winnow::token::take_while;
 //! # use winnow::combinator::alt;
 //! # use winnow::token::take;
@@ -391,7 +396,7 @@
 //! #     }
 //! # }
 //! #
-//! # fn parse_digits<'s>(input: &mut &'s str) -> ModalResult<(&'s str, &'s str)> {
+//! # fn parse_digits<'s>(input: &mut &'s str) -> Result<(&'s str, &'s str)> {
 //! #     alt((
 //! #         ("0b", parse_bin_digits)
 //! #           .context(StrContext::Label("digit"))
@@ -414,25 +419,25 @@
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_bin_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='1'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_oct_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='7'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_dec_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #     )).parse_next(input)
 //! # }
 //! #
-//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+//! # fn parse_hex_digits<'s>(input: &mut &'s str) -> Result<&'s str> {
 //! #     take_while(1.., (
 //! #         ('0'..='9'),
 //! #         ('A'..='F'),
@@ -450,21 +455,20 @@
 //! }
 //! ```
 //!
-//! Let's break down `ModalResult<O, E>` one step further:
-//! ```rust
-//! # use winnow::error::ErrorKind;
-//! # use winnow::error::ErrMode;
-//! pub type ModalResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;
-//! ```
-//! [`ModalResult`] is just a fancy wrapper around `Result` that wraps our error in an [`ErrMode`]
-//! type.
-//!
+//! Winnow provides an error wrapper, [`ErrMode<ContextError>`], so different failure modes can affect parsing.
 //! [`ErrMode`] is an enum with [`Backtrack`] and [`Cut`] variants (ignore [`Incomplete`] as its only
 //! relevant for [streaming][_topic::stream]). By default, errors are [`Backtrack`], meaning that
 //! other parsing branches will be attempted on failure, like the next case of an [`alt`].  [`Cut`]
 //! shortcircuits all other branches, immediately reporting the error.
 //!
-//! So we can get the correct `context` by modifying the above example with [`cut_err`]:
+//! To make [`ErrMode`] more convenient, Winnow provides [`ModalResult`]:
+//! ```rust
+//! # use winnow::error::ErrorKind;
+//! # use winnow::error::ErrMode;
+//! pub type ModalResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;
+//! ```
+//!
+//! So we can get the correct `context` by changing to [`ModalResult`] and adding [`cut_err`]:
 //! ```rust
 //! # use winnow::prelude::*;
 //! # use winnow::token::take_while;
@@ -721,6 +725,7 @@ use crate::error::ErrMode::*;
 use crate::error::ErrorKind;
 use crate::ModalResult;
 use crate::Parser;
+use crate::Result;
 use crate::_topic;
 
 pub use super::chapter_6 as previous;

--- a/src/_tutorial/chapter_8.rs
+++ b/src/_tutorial/chapter_8.rs
@@ -9,11 +9,11 @@
 //! You can extend your own parsers to show up by wrapping their body with
 //! [`trace`][crate::combinator::trace].  Going back to [`do_nothing_parser`][super::chapter_1].
 //! ```rust
-//! # use winnow::PResult;
+//! # use winnow::ModalResult;
 //! # use winnow::Parser;
 //! use winnow::combinator::trace;
 //!
-//! pub fn do_nothing_parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+//! pub fn do_nothing_parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 //!     trace(
 //!         "do_nothing_parser",
 //!         |i: &mut _| Ok("")

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -23,7 +23,7 @@ use crate::token::any;
 use crate::token::one_of;
 use crate::token::take_until;
 use crate::token::take_while;
-use crate::PResult;
+use crate::ModalResult;
 use crate::Parser;
 
 /// Mark a value as case-insensitive for ASCII characters
@@ -34,7 +34,7 @@ use crate::Parser;
 /// # use winnow::{error::ErrMode, error::{ErrorKind}};
 /// # use winnow::ascii::Caseless;
 ///
-/// fn parser<'s>(s: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(s: &mut &'s str) -> ModalResult<&'s str> {
 ///   Caseless("hello").parse_next(s)
 /// }
 ///
@@ -66,7 +66,7 @@ impl Caseless<&str> {
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn crlf<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn crlf<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::crlf.parse_next(input)
 /// # }
@@ -77,7 +77,7 @@ impl Caseless<&str> {
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::crlf;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     crlf.parse_next(input)
 /// }
 ///
@@ -96,7 +96,7 @@ impl Caseless<&str> {
 /// assert_eq!(crlf::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn crlf<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn crlf<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream + Compare<&'static str>,
     Error: ParserError<Input>,
@@ -115,7 +115,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn till_line_ending<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn till_line_ending<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::till_line_ending.parse_next(input)
 /// # }
@@ -126,7 +126,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::till_line_ending;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     till_line_ending.parse_next(input)
 /// }
 ///
@@ -150,7 +150,9 @@ where
 /// assert!(till_line_ending::<_, ContextError>.parse_peek(Partial::new("a\rbc")).is_err());
 /// ```
 #[inline(always)]
-pub fn till_line_ending<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn till_line_ending<Input, Error>(
+    input: &mut Input,
+) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream + Compare<&'static str> + FindSlice<(char, char)>,
     <Input as Stream>::Token: AsChar + Clone,
@@ -168,7 +170,7 @@ where
 
 fn till_line_ending_<I, E: ParserError<I>, const PARTIAL: bool>(
     input: &mut I,
-) -> PResult<<I as Stream>::Slice, E>
+) -> ModalResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -210,7 +212,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn line_ending<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn line_ending<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::line_ending.parse_next(input)
 /// # }
@@ -221,7 +223,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::line_ending;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     line_ending.parse_next(input)
 /// }
 ///
@@ -240,7 +242,7 @@ where
 /// assert_eq!(line_ending::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn line_ending<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn line_ending<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream + Compare<&'static str>,
     Error: ParserError<Input>,
@@ -259,7 +261,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn newline(input: &mut &str) -> PResult<char>
+/// pub fn newline(input: &mut &str) -> ModalResult<char>
 /// # {
 /// #     winnow::ascii::newline.parse_next(input)
 /// # }
@@ -270,7 +272,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::newline;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<char> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<char> {
 ///     newline.parse_next(input)
 /// }
 ///
@@ -289,7 +291,7 @@ where
 /// assert_eq!(newline::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn newline<I, Error: ParserError<I>>(input: &mut I) -> PResult<char, Error>
+pub fn newline<I, Error: ParserError<I>>(input: &mut I) -> ModalResult<char, Error>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -309,7 +311,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn tab(input: &mut &str) -> PResult<char>
+/// pub fn tab(input: &mut &str) -> ModalResult<char>
 /// # {
 /// #     winnow::ascii::tab.parse_next(input)
 /// # }
@@ -320,7 +322,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::tab;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<char> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<char> {
 ///     tab.parse_next(input)
 /// }
 ///
@@ -339,7 +341,7 @@ where
 /// assert_eq!(tab::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn tab<Input, Error>(input: &mut Input) -> PResult<char, Error>
+pub fn tab<Input, Error>(input: &mut Input) -> ModalResult<char, Error>
 where
     Input: StreamIsPartial + Stream + Compare<char>,
     Error: ParserError<Input>,
@@ -360,7 +362,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn alpha0<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn alpha0<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::alpha0.parse_next(input)
 /// # }
@@ -371,7 +373,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::alpha0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     alpha0.parse_next(input)
 /// }
 ///
@@ -390,7 +392,7 @@ where
 /// assert_eq!(alpha0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn alpha0<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -412,7 +414,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn alpha1<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn alpha1<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::alpha1.parse_next(input)
 /// # }
@@ -423,7 +425,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::alpha1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     alpha1.parse_next(input)
 /// }
 ///
@@ -442,7 +444,7 @@ where
 /// assert_eq!(alpha1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alpha1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn alpha1<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -464,7 +466,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn digit0<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn digit0<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::digit0.parse_next(input)
 /// # }
@@ -475,7 +477,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::digit0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     digit0.parse_next(input)
 /// }
 ///
@@ -495,7 +497,7 @@ where
 /// assert_eq!(digit0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn digit0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn digit0<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -517,7 +519,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn digit1<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn digit1<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::digit1.parse_next(input)
 /// # }
@@ -528,7 +530,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::digit1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     digit1.parse_next(input)
 /// }
 ///
@@ -554,7 +556,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::digit1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<u32> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<u32> {
 ///   digit1.try_map(str::parse).parse_next(input)
 /// }
 ///
@@ -563,7 +565,7 @@ where
 /// assert!(parser.parse_peek("b").is_err());
 /// ```
 #[inline(always)]
-pub fn digit1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn digit1<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -585,7 +587,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn hex_digit0<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn hex_digit0<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::hex_digit0.parse_next(input)
 /// # }
@@ -596,7 +598,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::hex_digit0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     hex_digit0.parse_next(input)
 /// }
 ///
@@ -615,7 +617,7 @@ where
 /// assert_eq!(hex_digit0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn hex_digit0<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -638,7 +640,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn hex_digit1<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn hex_digit1<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::hex_digit1.parse_next(input)
 /// # }
@@ -649,7 +651,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::hex_digit1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     hex_digit1.parse_next(input)
 /// }
 ///
@@ -668,7 +670,7 @@ where
 /// assert_eq!(hex_digit1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn hex_digit1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn hex_digit1<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -690,7 +692,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn oct_digit0<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn oct_digit0<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::oct_digit0.parse_next(input)
 /// # }
@@ -701,7 +703,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::oct_digit0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     oct_digit0.parse_next(input)
 /// }
 ///
@@ -720,7 +722,7 @@ where
 /// assert_eq!(oct_digit0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn oct_digit0<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial,
     Input: Stream,
@@ -743,7 +745,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn oct_digit1<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn oct_digit1<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::oct_digit1.parse_next(input)
 /// # }
@@ -754,7 +756,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::oct_digit1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     oct_digit1.parse_next(input)
 /// }
 ///
@@ -773,7 +775,7 @@ where
 /// assert_eq!(oct_digit1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn oct_digit1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn oct_digit1<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -795,7 +797,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn alphanumeric0<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn alphanumeric0<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::alphanumeric0.parse_next(input)
 /// # }
@@ -806,7 +808,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::alphanumeric0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     alphanumeric0.parse_next(input)
 /// }
 ///
@@ -825,7 +827,9 @@ where
 /// assert_eq!(alphanumeric0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn alphanumeric0<Input, Error>(
+    input: &mut Input,
+) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -847,7 +851,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn alphanumeric1<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn alphanumeric1<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::alphanumeric1.parse_next(input)
 /// # }
@@ -858,7 +862,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::alphanumeric1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     alphanumeric1.parse_next(input)
 /// }
 ///
@@ -877,7 +881,9 @@ where
 /// assert_eq!(alphanumeric1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn alphanumeric1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn alphanumeric1<Input, Error>(
+    input: &mut Input,
+) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -899,7 +905,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn space0<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn space0<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::space0.parse_next(input)
 /// # }
@@ -917,7 +923,7 @@ where
 /// assert_eq!(space0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn space0<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -939,7 +945,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn space1<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn space1<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::space1.parse_next(input)
 /// # }
@@ -950,7 +956,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::space1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     space1.parse_next(input)
 /// }
 ///
@@ -969,7 +975,7 @@ where
 /// assert_eq!(space1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn space1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn space1<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -991,7 +997,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn multispace0<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn multispace0<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::multispace0.parse_next(input)
 /// # }
@@ -1002,7 +1008,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::multispace0;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     multispace0.parse_next(input)
 /// }
 ///
@@ -1021,7 +1027,7 @@ where
 /// assert_eq!(multispace0::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace0<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn multispace0<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar + Clone,
@@ -1043,7 +1049,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn multispace1<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn multispace1<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::ascii::multispace1.parse_next(input)
 /// # }
@@ -1054,7 +1060,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::ascii::multispace1;
-/// fn parser<'s>(input: &mut &'s str) -> PResult<&'s str> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
 ///     multispace1.parse_next(input)
 /// }
 ///
@@ -1073,7 +1079,7 @@ where
 /// assert_eq!(multispace1::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn multispace1<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn multispace1<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar + Clone,
@@ -1093,7 +1099,7 @@ where
 /// Assuming you are parsing a `&str` [Stream] into a `u32`:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn dec_uint(input: &mut &str) -> PResult<u32>
+/// pub fn dec_uint(input: &mut &str) -> ModalResult<u32>
 /// # {
 /// #     winnow::ascii::dec_uint.parse_next(input)
 /// # }
@@ -1103,7 +1109,7 @@ where
 #[doc(alias = "u32")]
 #[doc(alias = "u64")]
 #[doc(alias = "u128")]
-pub fn dec_uint<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
+pub fn dec_uint<Input, Output, Error>(input: &mut Input) -> ModalResult<Output, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Slice: AsBStr,
@@ -1178,7 +1184,7 @@ impl Uint for usize {
 /// Assuming you are parsing a `&str` [Stream] into an `i32`:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn dec_int(input: &mut &str) -> PResult<i32>
+/// pub fn dec_int(input: &mut &str) -> ModalResult<i32>
 /// # {
 /// #     winnow::ascii::dec_int.parse_next(input)
 /// # }
@@ -1188,7 +1194,7 @@ impl Uint for usize {
 #[doc(alias = "i32")]
 #[doc(alias = "i64")]
 #[doc(alias = "i128")]
-pub fn dec_int<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
+pub fn dec_int<Input, Output, Error>(input: &mut Input) -> ModalResult<Output, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Slice: AsBStr,
@@ -1270,7 +1276,7 @@ impl Int for isize {
 /// Assuming you are parsing a `&str` [Stream] into a `u32`:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn hex_uint(input: &mut &str) -> PResult<u32>
+/// pub fn hex_uint(input: &mut &str) -> ModalResult<u32>
 /// # {
 /// #     winnow::ascii::hex_uint.parse_next(input)
 /// # }
@@ -1282,7 +1288,7 @@ impl Int for isize {
 /// # use winnow::prelude::*;
 /// use winnow::ascii::hex_uint;
 ///
-/// fn parser<'s>(s: &mut &'s [u8]) -> PResult<u32> {
+/// fn parser<'s>(s: &mut &'s [u8]) -> ModalResult<u32> {
 ///   hex_uint(s)
 /// }
 ///
@@ -1297,7 +1303,7 @@ impl Int for isize {
 /// # use winnow::Partial;
 /// use winnow::ascii::hex_uint;
 ///
-/// fn parser<'s>(s: &mut Partial<&'s [u8]>) -> PResult<u32> {
+/// fn parser<'s>(s: &mut Partial<&'s [u8]>) -> ModalResult<u32> {
 ///   hex_uint(s)
 /// }
 ///
@@ -1306,7 +1312,7 @@ impl Int for isize {
 /// assert!(parser.parse_peek(Partial::new(&b"ggg"[..])).is_err());
 /// ```
 #[inline]
-pub fn hex_uint<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
+pub fn hex_uint<Input, Output, Error>(input: &mut Input) -> ModalResult<Output, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: AsChar,
@@ -1417,7 +1423,7 @@ impl HexUint for u128 {
 /// Assuming you are parsing a `&str` [Stream] into an `f64`:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn float(input: &mut &str) -> PResult<f64>
+/// pub fn float(input: &mut &str) -> ModalResult<f64>
 /// # {
 /// #     winnow::ascii::float.parse_next(input)
 /// # }
@@ -1430,7 +1436,7 @@ impl HexUint for u128 {
 /// # use winnow::error::Needed::Size;
 /// use winnow::ascii::float;
 ///
-/// fn parser<'s>(s: &mut &'s str) -> PResult<f64> {
+/// fn parser<'s>(s: &mut &'s str) -> ModalResult<f64> {
 ///   float(s)
 /// }
 ///
@@ -1447,7 +1453,7 @@ impl HexUint for u128 {
 /// # use winnow::Partial;
 /// use winnow::ascii::float;
 ///
-/// fn parser<'s>(s: &mut Partial<&'s str>) -> PResult<f64> {
+/// fn parser<'s>(s: &mut Partial<&'s str>) -> ModalResult<f64> {
 ///   float(s)
 /// }
 ///
@@ -1461,7 +1467,7 @@ impl HexUint for u128 {
 #[doc(alias = "f32")]
 #[doc(alias = "double")]
 #[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
-pub fn float<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
+pub fn float<Input, Output, Error>(input: &mut Input) -> ModalResult<Output, Error>
 where
     Input: StreamIsPartial + Stream + Compare<Caseless<&'static str>> + Compare<char> + AsBStr,
     <Input as Stream>::Slice: ParseSlice<Output>,
@@ -1478,7 +1484,9 @@ where
 }
 
 #[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
-fn take_float_or_exceptions<I, E: ParserError<I>>(input: &mut I) -> PResult<<I as Stream>::Slice, E>
+fn take_float_or_exceptions<I, E: ParserError<I>>(
+    input: &mut I,
+) -> ModalResult<<I as Stream>::Slice, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1498,7 +1506,7 @@ where
 }
 
 #[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
-fn take_unsigned_float_or_exceptions<I, E: ParserError<I>>(input: &mut I) -> PResult<(), E>
+fn take_unsigned_float_or_exceptions<I, E: ParserError<I>>(input: &mut I) -> ModalResult<(), E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1517,7 +1525,7 @@ where
 }
 
 #[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
-fn take_exp<I, E: ParserError<I>>(input: &mut I) -> PResult<(), E>
+fn take_exp<I, E: ParserError<I>>(input: &mut I) -> ModalResult<(), E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1566,7 +1574,7 @@ where
 /// use winnow::ascii::take_escaped;
 /// use winnow::token::one_of;
 ///
-/// fn esc<'i>(input: &mut &'i str) -> PResult<&'i str> {
+/// fn esc<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 ///   take_escaped(digit1, '\\', one_of(['"', 'n', '\\'])).parse_next(input)
 /// }
 ///
@@ -1583,7 +1591,7 @@ where
 /// use winnow::ascii::take_escaped;
 /// use winnow::token::one_of;
 ///
-/// fn esc<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str> {
+/// fn esc<'i>(input: &mut Partial<&'i str>) -> ModalResult<&'i str> {
 ///   take_escaped(digit1, '\\', one_of(['"', 'n', '\\'])).parse_next(input)
 /// }
 ///
@@ -1643,7 +1651,7 @@ fn escaped_internal<I, Error, F, G, O1, O2, const PARTIAL: bool>(
     normal: &mut F,
     control_char: char,
     escapable: &mut G,
-) -> PResult<<I as Stream>::Slice, Error>
+) -> ModalResult<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -1719,7 +1727,7 @@ where
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;
 ///
-/// fn parser<'s>(input: &mut &'s str) -> PResult<String> {
+/// fn parser<'s>(input: &mut &'s str) -> ModalResult<String> {
 ///   escaped_transform(
 ///     alpha1,
 ///     '\\',
@@ -1747,7 +1755,7 @@ where
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;
 ///
-/// fn parser<'s>(input: &mut Partial<&'s str>) -> PResult<String> {
+/// fn parser<'s>(input: &mut Partial<&'s str>) -> ModalResult<String> {
 ///   escaped_transform(
 ///     alpha1,
 ///     '\\',
@@ -1799,7 +1807,7 @@ fn escaped_transform_internal<I, Error, F, G, Output, const PARTIAL: bool>(
     normal: &mut F,
     control_char: char,
     transform: &mut G,
-) -> PResult<Output, Error>
+) -> ModalResult<Output, Error>
 where
     I: StreamIsPartial,
     I: Stream,

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -180,7 +180,7 @@ where
 {
     let res = match take_until(0.., ('\r', '\n')).parse_next(input) {
         Ok(slice) => slice,
-        Err(ErrMode::Backtrack(_)) => input.finish(),
+        Err(err) if err.is_backtrack() => input.finish(),
         Err(err) => {
             return Err(err);
         }

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -190,7 +190,7 @@ where
         match comp {
             CompareResult::Ok(_) => {}
             CompareResult::Incomplete if PARTIAL && input.is_partial() => {
-                return Err(ErrMode::Incomplete(Needed::Unknown));
+                return Err(ErrMode::incomplete(input, Needed::Unknown));
             }
             CompareResult::Incomplete | CompareResult::Error => {
                 let e: ErrorKind = ErrorKind::Literal;
@@ -1344,7 +1344,7 @@ where
                     && invalid_offset == input.eof_offset()
                 {
                     // Only the next byte is guaranteed required
-                    return Err(ErrMode::Incomplete(Needed::new(1)));
+                    return Err(ErrMode::incomplete(input, Needed::new(1)));
                 } else {
                     invalid_offset
                 }
@@ -1688,7 +1688,7 @@ where
     }
 
     if PARTIAL && input.is_partial() {
-        Err(ErrMode::Incomplete(Needed::Unknown))
+        Err(ErrMode::incomplete(input, Needed::Unknown))
     } else {
         input.reset(&start);
         Ok(input.finish())
@@ -1845,7 +1845,7 @@ where
     }
 
     if PARTIAL && input.is_partial() {
-        Err(ErrMode::Incomplete(Needed::Unknown))
+        Err(ErrMode::incomplete(input, Needed::Unknown))
     } else {
         Ok(res)
     }

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -2076,7 +2076,7 @@ Err(
       fn floats(s in "\\PC*") {
           println!("testing {s}");
           let res1 = parse_f64.parse_peek(&s);
-          let res2 = float::<_, f64, ()>.parse_peek(s.as_str());
+          let res2 = float::<_, f64, ErrMode<()>>.parse_peek(s.as_str());
           assert_eq!(res1, res2);
       }
     }

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -2082,7 +2082,7 @@ Err(
     }
 
     #[cfg(feature = "std")]
-    fn parse_f64(i: &mut &str) -> PResult<f64, ()> {
+    fn parse_f64(i: &mut &str) -> ModalResult<f64, ()> {
         match take_float_or_exceptions.parse_next(i) {
             Err(e) => Err(e),
             Ok(s) => {

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -8,7 +8,7 @@ use crate::combinator::trace;
 use crate::error::{ErrorConvert, ErrorKind, Needed, ParserError};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
 use crate::stream::{Stream, StreamIsPartial, ToUsize};
-use crate::{ModalResult, Parser};
+use crate::{Parser, Result};
 
 /// Number of bits in a byte
 const BYTE: usize = u8::BITS as usize;
@@ -23,6 +23,7 @@ const BYTE: usize = u8::BITS as usize;
 /// # use winnow::Bytes;
 /// # use winnow::binary::bits::{bits, take};
 /// # use winnow::error::ContextError;
+/// # use winnow::error::ErrMode;
 /// type Stream<'i> = &'i Bytes;
 ///
 /// fn stream(b: &[u8]) -> Stream<'_> {
@@ -30,7 +31,7 @@ const BYTE: usize = u8::BITS as usize;
 /// }
 ///
 /// fn parse(input: &mut Stream<'_>) -> ModalResult<(u8, u8)> {
-///     bits::<_, _, ContextError, _, _>((take(4usize), take(8usize))).parse_next(input)
+///     bits::<_, _, ErrMode<ContextError>, _, _>((take(4usize), take(8usize))).parse_next(input)
 /// }
 ///
 /// let input = stream(&[0x12, 0x34, 0xff, 0xff]);
@@ -91,11 +92,12 @@ where
 /// # Examples
 ///
 /// ```
-/// use winnow::prelude::*;
-/// use winnow::Bytes;
+/// # use winnow::prelude::*;
+/// # use winnow::Bytes;
+/// # use winnow::token::rest;
+/// # use winnow::error::ContextError;
+/// # use winnow::error::ErrMode;
 /// use winnow::binary::bits::{bits, bytes, take};
-/// use winnow::token::rest;
-/// use winnow::error::ContextError;
 ///
 /// type Stream<'i> = &'i Bytes;
 ///
@@ -104,10 +106,10 @@ where
 /// }
 ///
 /// fn parse<'i>(input: &mut Stream<'i>) -> ModalResult<(u8, u8, &'i [u8])> {
-///   bits::<_, _, ContextError, _, _>((
+///   bits::<_, _, ErrMode<ContextError>, _, _>((
 ///     take(4usize),
 ///     take(8usize),
-///     bytes::<_, _, ContextError, _, _>(rest)
+///     bytes::<_, _, ErrMode<ContextError>, _, _>(rest)
 ///   )).parse_next(input)
 /// }
 ///
@@ -211,7 +213,7 @@ where
 fn take_<I, O, E: ParserError<(I, usize)>, const PARTIAL: bool>(
     bit_input: &mut (I, usize),
     count: usize,
-) -> ModalResult<O, E>
+) -> Result<O, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8> + Clone,
@@ -387,7 +389,7 @@ where
 #[doc(alias = "any")]
 pub fn bool<Input, Error: ParserError<(Input, usize)>>(
     input: &mut (Input, usize),
-) -> ModalResult<bool, Error>
+) -> Result<bool, Error>
 where
     Input: Stream<Token = u8> + StreamIsPartial + Clone,
 {

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -8,7 +8,7 @@ use crate::combinator::trace;
 use crate::error::{ErrMode, ErrorConvert, ErrorKind, Needed, ParserError};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
 use crate::stream::{Stream, StreamIsPartial, ToUsize};
-use crate::{PResult, Parser};
+use crate::{ModalResult, Parser};
 
 /// Number of bits in a byte
 const BYTE: usize = u8::BITS as usize;
@@ -29,7 +29,7 @@ const BYTE: usize = u8::BITS as usize;
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parse(input: &mut Stream<'_>) -> PResult<(u8, u8)> {
+/// fn parse(input: &mut Stream<'_>) -> ModalResult<(u8, u8)> {
 ///     bits::<_, _, ContextError, _, _>((take(4usize), take(8usize))).parse_next(input)
 /// }
 ///
@@ -98,7 +98,7 @@ where
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parse<'i>(input: &mut Stream<'i>) -> PResult<(u8, u8, &'i [u8])> {
+/// fn parse<'i>(input: &mut Stream<'i>) -> ModalResult<(u8, u8, &'i [u8])> {
 ///   bits::<_, _, ContextError, _, _>((
 ///     take(4usize),
 ///     take(8usize),
@@ -204,7 +204,7 @@ where
 fn take_<I, O, E: ParserError<(I, usize)>, const PARTIAL: bool>(
     bit_input: &mut (I, usize),
     count: usize,
-) -> PResult<O, E>
+) -> ModalResult<O, E>
 where
     I: StreamIsPartial,
     I: Stream<Token = u8> + Clone,
@@ -288,7 +288,7 @@ where
 /// /// Compare the lowest `count` bits of `input` against the lowest `count` bits of `pattern`.
 /// /// Return Ok and the matching section of `input` if there's a match.
 /// /// Return Err if there's no match.
-/// fn parser(bits: u8, count: u8, input: &mut (Stream<'_>, usize)) -> PResult<u8> {
+/// fn parser(bits: u8, count: u8, input: &mut (Stream<'_>, usize)) -> ModalResult<u8> {
 ///     pattern(bits, count).parse_next(input)
 /// }
 ///
@@ -350,7 +350,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;;
 /// # use winnow::error::ContextError;
-/// pub fn bool(input: &mut (&[u8], usize)) -> PResult<bool>
+/// pub fn bool(input: &mut (&[u8], usize)) -> ModalResult<bool>
 /// # {
 /// #     winnow::binary::bits::bool.parse_next(input)
 /// # }
@@ -370,7 +370,7 @@ where
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parse(input: &mut (Stream<'_>, usize)) -> PResult<bool> {
+/// fn parse(input: &mut (Stream<'_>, usize)) -> ModalResult<bool> {
 ///     bool.parse_next(input)
 /// }
 ///
@@ -380,7 +380,7 @@ where
 #[doc(alias = "any")]
 pub fn bool<Input, Error: ParserError<(Input, usize)>>(
     input: &mut (Input, usize),
-) -> PResult<bool, Error>
+) -> ModalResult<bool, Error>
 where
     Input: Stream<Token = u8> + StreamIsPartial + Clone,
 {

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -216,7 +216,7 @@ where
         let (mut input, bit_offset) = bit_input.clone();
         if input.eof_offset() * BYTE < count + bit_offset {
             if PARTIAL && input.is_partial() {
-                Err(ErrMode::Incomplete(Needed::new(count)))
+                Err(ErrMode::incomplete(bit_input, Needed::new(count)))
             } else {
                 Err(ErrMode::from_error_kind(
                     &(input, bit_offset),

--- a/src/binary/bits/tests.rs
+++ b/src/binary/bits/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::error::ErrMode;
 use crate::error::InputError;
+use crate::prelude::*;
 use crate::Partial;
 
 #[test]
@@ -11,8 +13,12 @@ fn test_complete_byte_consumption_bits() {
     // Take 3 bit slices with sizes [4, 8, 4].
     #[allow(clippy::type_complexity)]
     let result: ModalResult<(&[u8], (u8, u8, u8)), InputError<_>> =
-        bits::<_, _, InputError<(&[u8], usize)>, _, _>((take(4usize), take(8usize), take(4usize)))
-            .parse_peek(input);
+        bits::<_, _, ErrMode<InputError<(&[u8], usize)>>, _, _>((
+            take(4usize),
+            take(8usize),
+            take(4usize),
+        ))
+        .parse_peek(input);
 
     let output = result.expect("We take 2 bytes and the input is longer than 2 bytes");
 
@@ -35,7 +41,7 @@ fn test_partial_byte_consumption_bits() {
 
     // Take bit slices with sizes [4, 8].
     let result: ModalResult<(&[u8], (u8, u8)), InputError<_>> =
-        bits::<_, _, InputError<(&[u8], usize)>, _, _>((take(4usize), take(8usize)))
+        bits::<_, _, ErrMode<InputError<(&[u8], usize)>>, _, _>((take(4usize), take(8usize)))
             .parse_peek(input);
 
     let output = result.expect("We take 1.5 bytes and the input is longer than 2 bytes");
@@ -56,7 +62,8 @@ fn test_incomplete_bits() {
 
     // Take bit slices with sizes [4, 8].
     let result: ModalResult<(_, (u8, u8)), InputError<_>> =
-        bits::<_, _, InputError<(_, usize)>, _, _>((take(4usize), take(8usize))).parse_peek(input);
+        bits::<_, _, ErrMode<InputError<(_, usize)>>, _, _>((take(4usize), take(8usize)))
+            .parse_peek(input);
 
     assert!(result.is_err());
     let error = result.err().unwrap();

--- a/src/binary/bits/tests.rs
+++ b/src/binary/bits/tests.rs
@@ -10,7 +10,7 @@ fn test_complete_byte_consumption_bits() {
 
     // Take 3 bit slices with sizes [4, 8, 4].
     #[allow(clippy::type_complexity)]
-    let result: PResult<(&[u8], (u8, u8, u8)), InputError<_>> =
+    let result: ModalResult<(&[u8], (u8, u8, u8)), InputError<_>> =
         bits::<_, _, InputError<(&[u8], usize)>, _, _>((take(4usize), take(8usize), take(4usize)))
             .parse_peek(input);
 
@@ -34,7 +34,7 @@ fn test_partial_byte_consumption_bits() {
     let input = &[0x12, 0x34, 0x56, 0x78][..];
 
     // Take bit slices with sizes [4, 8].
-    let result: PResult<(&[u8], (u8, u8)), InputError<_>> =
+    let result: ModalResult<(&[u8], (u8, u8)), InputError<_>> =
         bits::<_, _, InputError<(&[u8], usize)>, _, _>((take(4usize), take(8usize)))
             .parse_peek(input);
 
@@ -55,7 +55,7 @@ fn test_incomplete_bits() {
     let input = Partial::new(&[0x12][..]);
 
     // Take bit slices with sizes [4, 8].
-    let result: PResult<(_, (u8, u8)), InputError<_>> =
+    let result: ModalResult<(_, (u8, u8)), InputError<_>> =
         bits::<_, _, InputError<(_, usize)>, _, _>((take(4usize), take(8usize))).parse_peek(input);
 
     assert!(result.is_err());
@@ -70,7 +70,7 @@ fn test_take_complete_0() {
     assert_eq!(count, 0usize);
     let offset = 0usize;
 
-    let result: PResult<((&[u8], usize), usize), InputError<_>> =
+    let result: ModalResult<((&[u8], usize), usize), InputError<_>> =
         take(count).parse_peek((input, offset));
 
     assert_eq!(result, Ok(((input, offset), 0)));
@@ -80,7 +80,7 @@ fn test_take_complete_0() {
 fn test_take_complete_eof() {
     let input = &[0b00010010][..];
 
-    let result: PResult<((&[u8], usize), usize), InputError<_>> =
+    let result: ModalResult<((&[u8], usize), usize), InputError<_>> =
         take(1usize).parse_peek((input, 8));
 
     assert_eq!(
@@ -96,7 +96,7 @@ fn test_take_complete_eof() {
 fn test_take_complete_span_over_multiple_bytes() {
     let input = &[0b00010010, 0b00110100, 0b11111111, 0b11111111][..];
 
-    let result: PResult<((&[u8], usize), usize), InputError<_>> =
+    let result: ModalResult<((&[u8], usize), usize), InputError<_>> =
         take(24usize).parse_peek((input, 4));
 
     assert_eq!(
@@ -112,7 +112,7 @@ fn test_take_partial_0() {
     assert_eq!(count, 0usize);
     let offset = 0usize;
 
-    let result: PResult<((_, usize), usize), InputError<_>> =
+    let result: ModalResult<((_, usize), usize), InputError<_>> =
         take(count).parse_peek((input, offset));
 
     assert_eq!(result, Ok(((input, offset), 0)));
@@ -125,7 +125,7 @@ fn test_pattern_partial_ok() {
     let bits_to_take = 4usize;
     let value_to_pattern = 0b0001;
 
-    let result: PResult<((_, usize), usize), InputError<_>> =
+    let result: ModalResult<((_, usize), usize), InputError<_>> =
         pattern(value_to_pattern, bits_to_take).parse_peek((input, offset));
 
     assert_eq!(result, Ok(((input, bits_to_take), value_to_pattern)));
@@ -138,7 +138,7 @@ fn test_pattern_partial_err() {
     let bits_to_take = 4usize;
     let value_to_pattern = 0b1111;
 
-    let result: PResult<((_, usize), usize), InputError<_>> =
+    let result: ModalResult<((_, usize), usize), InputError<_>> =
         pattern(value_to_pattern, bits_to_take).parse_peek((input, offset));
 
     assert_eq!(
@@ -154,7 +154,7 @@ fn test_pattern_partial_err() {
 fn test_bool_0_complete() {
     let input = [0b10000000].as_ref();
 
-    let result: PResult<((&[u8], usize), bool), InputError<_>> = bool.parse_peek((input, 0));
+    let result: ModalResult<((&[u8], usize), bool), InputError<_>> = bool.parse_peek((input, 0));
 
     assert_eq!(result, Ok(((input, 1), true)));
 }
@@ -163,7 +163,7 @@ fn test_bool_0_complete() {
 fn test_bool_eof_complete() {
     let input = [0b10000000].as_ref();
 
-    let result: PResult<((&[u8], usize), bool), InputError<_>> = bool.parse_peek((input, 8));
+    let result: ModalResult<((&[u8], usize), bool), InputError<_>> = bool.parse_peek((input, 8));
 
     assert_eq!(
         result,
@@ -179,7 +179,7 @@ fn test_bool_0_partial() {
     let input = Partial::new([0b10000000].as_ref());
 
     #[allow(clippy::type_complexity)]
-    let result: PResult<((Partial<&[u8]>, usize), bool), InputError<_>> =
+    let result: ModalResult<((Partial<&[u8]>, usize), bool), InputError<_>> =
         bool.parse_peek((input, 0));
 
     assert_eq!(result, Ok(((input, 1), true)));
@@ -190,7 +190,7 @@ fn test_bool_eof_partial() {
     let input = Partial::new([0b10000000].as_ref());
 
     #[allow(clippy::type_complexity)]
-    let result: PResult<((Partial<&[u8]>, usize), bool), InputError<_>> =
+    let result: ModalResult<((Partial<&[u8]>, usize), bool), InputError<_>> =
         bool.parse_peek((input, 8));
 
     assert_eq!(

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -17,7 +17,7 @@ use crate::lib::std::ops::{Add, Shl};
 use crate::stream::Accumulate;
 use crate::stream::{Stream, StreamIsPartial};
 use crate::stream::{ToUsize, UpdateSlice};
-use crate::PResult;
+use crate::ModalResult;
 use crate::Parser;
 
 /// Configurable endianness
@@ -45,7 +45,7 @@ pub enum Endianness {
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u8;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u8> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u8> {
 ///     be_u8.parse_next(s)
 /// }
 ///
@@ -59,7 +59,7 @@ pub enum Endianness {
 /// # use winnow::Partial;
 /// use winnow::binary::be_u8;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u8> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u8> {
 ///     be_u8.parse_next(s)
 /// }
 ///
@@ -67,7 +67,7 @@ pub enum Endianness {
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_u8<Input, Error>(input: &mut Input) -> PResult<u8, Error>
+pub fn be_u8<Input, Error>(input: &mut Input) -> ModalResult<u8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -89,7 +89,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u16;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u16> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u16> {
 ///     be_u16.parse_next(s)
 /// }
 ///
@@ -103,7 +103,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_u16;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u16> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u16> {
 ///     be_u16.parse_next(s)
 /// }
 ///
@@ -111,7 +111,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_u16<Input, Error>(input: &mut Input) -> PResult<u16, Error>
+pub fn be_u16<Input, Error>(input: &mut Input) -> ModalResult<u16, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -133,7 +133,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u24;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u32> {
 ///     be_u24.parse_next(s)
 /// }
 ///
@@ -147,7 +147,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_u24;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u32> {
 ///     be_u24.parse_next(s)
 /// }
 ///
@@ -155,7 +155,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn be_u24<Input, Error>(input: &mut Input) -> PResult<u32, Error>
+pub fn be_u24<Input, Error>(input: &mut Input) -> ModalResult<u32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -177,7 +177,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u32;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u32> {
 ///     be_u32.parse_next(s)
 /// }
 ///
@@ -191,7 +191,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_u32;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u32> {
 ///     be_u32.parse_next(s)
 /// }
 ///
@@ -199,7 +199,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_u32<Input, Error>(input: &mut Input) -> PResult<u32, Error>
+pub fn be_u32<Input, Error>(input: &mut Input) -> ModalResult<u32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -221,7 +221,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u64;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u64> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u64> {
 ///     be_u64.parse_next(s)
 /// }
 ///
@@ -235,7 +235,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_u64;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u64> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u64> {
 ///     be_u64.parse_next(s)
 /// }
 ///
@@ -243,7 +243,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_u64<Input, Error>(input: &mut Input) -> PResult<u64, Error>
+pub fn be_u64<Input, Error>(input: &mut Input) -> ModalResult<u64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -265,7 +265,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u128;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u128> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u128> {
 ///     be_u128.parse_next(s)
 /// }
 ///
@@ -279,7 +279,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_u128;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u128> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u128> {
 ///     be_u128.parse_next(s)
 /// }
 ///
@@ -287,7 +287,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn be_u128<Input, Error>(input: &mut Input) -> PResult<u128, Error>
+pub fn be_u128<Input, Error>(input: &mut Input) -> ModalResult<u128, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -296,7 +296,7 @@ where
 }
 
 #[inline]
-fn be_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> PResult<Uint, Error>
+fn be_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> ModalResult<Uint, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
@@ -347,7 +347,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i8;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i8> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i8> {
 ///     be_i8.parse_next(s)
 /// }
 ///
@@ -361,7 +361,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_i8;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i8> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i8> {
 ///       be_i8.parse_next(s)
 /// }
 ///
@@ -369,7 +369,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_i8<Input, Error>(input: &mut Input) -> PResult<i8, Error>
+pub fn be_i8<Input, Error>(input: &mut Input) -> ModalResult<i8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -391,7 +391,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i16;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i16> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i16> {
 ///     be_i16.parse_next(s)
 /// }
 ///
@@ -405,7 +405,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_i16;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i16> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i16> {
 ///       be_i16.parse_next(s)
 /// }
 ///
@@ -413,7 +413,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn be_i16<Input, Error>(input: &mut Input) -> PResult<i16, Error>
+pub fn be_i16<Input, Error>(input: &mut Input) -> ModalResult<i16, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -438,7 +438,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i24;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i32> {
 ///     be_i24.parse_next(s)
 /// }
 ///
@@ -452,7 +452,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_i24;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i32> {
 ///       be_i24.parse_next(s)
 /// }
 ///
@@ -460,7 +460,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_i24<Input, Error>(input: &mut Input) -> PResult<i32, Error>
+pub fn be_i24<Input, Error>(input: &mut Input) -> ModalResult<i32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -493,7 +493,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i32;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i32> {
 ///       be_i32.parse_next(s)
 /// }
 ///
@@ -507,7 +507,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_i32;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i32> {
 ///       be_i32.parse_next(s)
 /// }
 ///
@@ -515,7 +515,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
-pub fn be_i32<Input, Error>(input: &mut Input) -> PResult<i32, Error>
+pub fn be_i32<Input, Error>(input: &mut Input) -> ModalResult<i32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -540,7 +540,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i64;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i64> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i64> {
 ///       be_i64.parse_next(s)
 /// }
 ///
@@ -554,7 +554,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_i64;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i64> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i64> {
 ///       be_i64.parse_next(s)
 /// }
 ///
@@ -562,7 +562,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_i64<Input, Error>(input: &mut Input) -> PResult<i64, Error>
+pub fn be_i64<Input, Error>(input: &mut Input) -> ModalResult<i64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -587,7 +587,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i128;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i128> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i128> {
 ///       be_i128.parse_next(s)
 /// }
 ///
@@ -601,7 +601,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_i128;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i128> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i128> {
 ///       be_i128.parse_next(s)
 /// }
 ///
@@ -609,7 +609,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn be_i128<Input, Error>(input: &mut Input) -> PResult<i128, Error>
+pub fn be_i128<Input, Error>(input: &mut Input) -> ModalResult<i128, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -634,7 +634,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u8;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u8> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u8> {
 ///       le_u8.parse_next(s)
 /// }
 ///
@@ -648,7 +648,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_u8;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u8> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u8> {
 ///       le_u8.parse_next(s)
 /// }
 ///
@@ -656,7 +656,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_u8<Input, Error>(input: &mut Input) -> PResult<u8, Error>
+pub fn le_u8<Input, Error>(input: &mut Input) -> ModalResult<u8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -678,7 +678,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u16;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u16> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u16> {
 ///       le_u16.parse_next(s)
 /// }
 ///
@@ -692,7 +692,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_u16;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u16> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u16> {
 ///       le_u16.parse_next(s)
 /// }
 ///
@@ -700,7 +700,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_u16<Input, Error>(input: &mut Input) -> PResult<u16, Error>
+pub fn le_u16<Input, Error>(input: &mut Input) -> ModalResult<u16, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -722,7 +722,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u24;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u32> {
 ///       le_u24.parse_next(s)
 /// }
 ///
@@ -736,7 +736,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_u24;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u32> {
 ///       le_u24.parse_next(s)
 /// }
 ///
@@ -744,7 +744,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn le_u24<Input, Error>(input: &mut Input) -> PResult<u32, Error>
+pub fn le_u24<Input, Error>(input: &mut Input) -> ModalResult<u32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -766,7 +766,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u32;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u32> {
 ///       le_u32.parse_next(s)
 /// }
 ///
@@ -780,7 +780,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_u32;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u32> {
 ///       le_u32.parse_next(s)
 /// }
 ///
@@ -788,7 +788,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_u32<Input, Error>(input: &mut Input) -> PResult<u32, Error>
+pub fn le_u32<Input, Error>(input: &mut Input) -> ModalResult<u32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -810,7 +810,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u64;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u64> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u64> {
 ///       le_u64.parse_next(s)
 /// }
 ///
@@ -824,7 +824,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_u64;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u64> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u64> {
 ///       le_u64.parse_next(s)
 /// }
 ///
@@ -832,7 +832,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_u64<Input, Error>(input: &mut Input) -> PResult<u64, Error>
+pub fn le_u64<Input, Error>(input: &mut Input) -> ModalResult<u64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -854,7 +854,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u128;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u128> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u128> {
 ///       le_u128.parse_next(s)
 /// }
 ///
@@ -868,7 +868,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_u128;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u128> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u128> {
 ///       le_u128.parse_next(s)
 /// }
 ///
@@ -876,7 +876,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn le_u128<Input, Error>(input: &mut Input) -> PResult<u128, Error>
+pub fn le_u128<Input, Error>(input: &mut Input) -> ModalResult<u128, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -885,7 +885,7 @@ where
 }
 
 #[inline]
-fn le_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> PResult<Uint, Error>
+fn le_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> ModalResult<Uint, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
@@ -935,7 +935,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i8;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i8> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i8> {
 ///       le_i8.parse_next(s)
 /// }
 ///
@@ -949,7 +949,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_i8;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i8> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i8> {
 ///       le_i8.parse_next(s)
 /// }
 ///
@@ -957,7 +957,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_i8<Input, Error>(input: &mut Input) -> PResult<i8, Error>
+pub fn le_i8<Input, Error>(input: &mut Input) -> ModalResult<i8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -979,7 +979,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i16;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i16> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i16> {
 ///       le_i16.parse_next(s)
 /// }
 ///
@@ -993,7 +993,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_i16;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i16> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i16> {
 ///       le_i16.parse_next(s)
 /// }
 ///
@@ -1001,7 +1001,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_i16<Input, Error>(input: &mut Input) -> PResult<i16, Error>
+pub fn le_i16<Input, Error>(input: &mut Input) -> ModalResult<i16, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1026,7 +1026,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i24;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i32> {
 ///       le_i24.parse_next(s)
 /// }
 ///
@@ -1040,7 +1040,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_i24;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i32> {
 ///       le_i24.parse_next(s)
 /// }
 ///
@@ -1048,7 +1048,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn le_i24<Input, Error>(input: &mut Input) -> PResult<i32, Error>
+pub fn le_i24<Input, Error>(input: &mut Input) -> ModalResult<i32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1081,7 +1081,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i32;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i32> {
 ///       le_i32.parse_next(s)
 /// }
 ///
@@ -1095,7 +1095,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_i32;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i32> {
 ///       le_i32.parse_next(s)
 /// }
 ///
@@ -1103,7 +1103,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_i32<Input, Error>(input: &mut Input) -> PResult<i32, Error>
+pub fn le_i32<Input, Error>(input: &mut Input) -> ModalResult<i32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1128,7 +1128,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i64;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i64> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i64> {
 ///       le_i64.parse_next(s)
 /// }
 ///
@@ -1142,7 +1142,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_i64;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i64> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i64> {
 ///       le_i64.parse_next(s)
 /// }
 ///
@@ -1150,7 +1150,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_i64<Input, Error>(input: &mut Input) -> PResult<i64, Error>
+pub fn le_i64<Input, Error>(input: &mut Input) -> ModalResult<i64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1175,7 +1175,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i128;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i128> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i128> {
 ///       le_i128.parse_next(s)
 /// }
 ///
@@ -1189,7 +1189,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_i128;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i128> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i128> {
 ///       le_i128.parse_next(s)
 /// }
 ///
@@ -1197,7 +1197,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn le_i128<Input, Error>(input: &mut Input) -> PResult<i128, Error>
+pub fn le_i128<Input, Error>(input: &mut Input) -> ModalResult<i128, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1228,7 +1228,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u8;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<u8> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<u8> {
 ///       u8.parse_next(s)
 /// }
 ///
@@ -1243,7 +1243,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u8;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<u8> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<u8> {
 ///       u8.parse_next(s)
 /// }
 ///
@@ -1251,7 +1251,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn u8<Input, Error>(input: &mut Input) -> PResult<u8, Error>
+pub fn u8<Input, Error>(input: &mut Input) -> ModalResult<u8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1266,7 +1266,7 @@ where
     .parse_next(input)
 }
 
-fn u8_<Input, Error, const PARTIAL: bool>(input: &mut Input) -> PResult<u8, Error>
+fn u8_<Input, Error, const PARTIAL: bool>(input: &mut Input) -> ModalResult<u8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1297,14 +1297,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u16;
 ///
-/// fn be_u16(input: &mut &[u8]) -> PResult<u16> {
+/// fn be_u16(input: &mut &[u8]) -> ModalResult<u16> {
 ///     u16(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u16.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert!(be_u16.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u16(input: &mut &[u8]) -> PResult<u16> {
+/// fn le_u16(input: &mut &[u8]) -> ModalResult<u16> {
 ///     u16(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1319,14 +1319,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u16;
 ///
-/// fn be_u16(input: &mut Partial<&[u8]>) -> PResult<u16> {
+/// fn be_u16(input: &mut Partial<&[u8]>) -> ModalResult<u16> {
 ///     u16(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u16.parse_peek(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_u16.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// fn le_u16(input: &mut Partial<&[u8]>) -> PResult< u16> {
+/// fn le_u16(input: &mut Partial<&[u8]>) -> ModalResult< u16> {
 ///     u16(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1368,14 +1368,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u24;
 ///
-/// fn be_u24(input: &mut &[u8]) -> PResult<u32> {
+/// fn be_u24(input: &mut &[u8]) -> ModalResult<u32> {
 ///     u24(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u24.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert!(be_u24.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u24(input: &mut &[u8]) -> PResult<u32> {
+/// fn le_u24(input: &mut &[u8]) -> ModalResult<u32> {
 ///     u24(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1390,14 +1390,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u24;
 ///
-/// fn be_u24(input: &mut Partial<&[u8]>) -> PResult<u32> {
+/// fn be_u24(input: &mut Partial<&[u8]>) -> ModalResult<u32> {
 ///     u24(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u24.parse_peek(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_u24.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
-/// fn le_u24(input: &mut Partial<&[u8]>) -> PResult<u32> {
+/// fn le_u24(input: &mut Partial<&[u8]>) -> ModalResult<u32> {
 ///     u24(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1439,14 +1439,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u32;
 ///
-/// fn be_u32(input: &mut &[u8]) -> PResult<u32> {
+/// fn be_u32(input: &mut &[u8]) -> ModalResult<u32> {
 ///     u32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u32.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert!(be_u32.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u32(input: &mut &[u8]) -> PResult<u32> {
+/// fn le_u32(input: &mut &[u8]) -> ModalResult<u32> {
 ///     u32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1461,14 +1461,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u32;
 ///
-/// fn be_u32(input: &mut Partial<&[u8]>) -> PResult<u32> {
+/// fn be_u32(input: &mut Partial<&[u8]>) -> ModalResult<u32> {
 ///     u32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u32.parse_peek(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_u32.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
-/// fn le_u32(input: &mut Partial<&[u8]>) -> PResult<u32> {
+/// fn le_u32(input: &mut Partial<&[u8]>) -> ModalResult<u32> {
 ///     u32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1510,14 +1510,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u64;
 ///
-/// fn be_u64(input: &mut &[u8]) -> PResult<u64> {
+/// fn be_u64(input: &mut &[u8]) -> ModalResult<u64> {
 ///     u64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u64.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert!(be_u64.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u64(input: &mut &[u8]) -> PResult<u64> {
+/// fn le_u64(input: &mut &[u8]) -> ModalResult<u64> {
 ///     u64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1532,14 +1532,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u64;
 ///
-/// fn be_u64(input: &mut Partial<&[u8]>) -> PResult<u64> {
+/// fn be_u64(input: &mut Partial<&[u8]>) -> ModalResult<u64> {
 ///     u64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u64.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_u64.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
-/// fn le_u64(input: &mut Partial<&[u8]>) -> PResult<u64> {
+/// fn le_u64(input: &mut Partial<&[u8]>) -> ModalResult<u64> {
 ///     u64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1581,14 +1581,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u128;
 ///
-/// fn be_u128(input: &mut &[u8]) -> PResult<u128> {
+/// fn be_u128(input: &mut &[u8]) -> ModalResult<u128> {
 ///     u128(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u128.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert!(be_u128.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_u128(input: &mut &[u8]) -> PResult<u128> {
+/// fn le_u128(input: &mut &[u8]) -> ModalResult<u128> {
 ///     u128(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1603,14 +1603,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::u128;
 ///
-/// fn be_u128(input: &mut Partial<&[u8]>) -> PResult<u128> {
+/// fn be_u128(input: &mut Partial<&[u8]>) -> ModalResult<u128> {
 ///     u128(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_u128.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_u128.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
-/// fn le_u128(input: &mut Partial<&[u8]>) -> PResult<u128> {
+/// fn le_u128(input: &mut Partial<&[u8]>) -> ModalResult<u128> {
 ///     u128(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1655,7 +1655,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i8;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<i8> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<i8> {
 ///       i8.parse_next(s)
 /// }
 ///
@@ -1670,7 +1670,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i8;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<i8> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<i8> {
 ///       i8.parse_next(s)
 /// }
 ///
@@ -1678,7 +1678,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn i8<Input, Error>(input: &mut Input) -> PResult<i8, Error>
+pub fn i8<Input, Error>(input: &mut Input) -> ModalResult<i8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1711,14 +1711,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i16;
 ///
-/// fn be_i16(input: &mut &[u8]) -> PResult<i16> {
+/// fn be_i16(input: &mut &[u8]) -> ModalResult<i16> {
 ///     i16(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i16.parse_peek(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
 /// assert!(be_i16.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i16(input: &mut &[u8]) -> PResult<i16> {
+/// fn le_i16(input: &mut &[u8]) -> ModalResult<i16> {
 ///     i16(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1733,14 +1733,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i16;
 ///
-/// fn be_i16(input: &mut Partial<&[u8]>) -> PResult<i16> {
+/// fn be_i16(input: &mut Partial<&[u8]>) -> ModalResult<i16> {
 ///     i16(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i16.parse_peek(Partial::new(&b"\x00\x03abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0003)));
 /// assert_eq!(be_i16.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// fn le_i16(input: &mut Partial<&[u8]>) -> PResult<i16> {
+/// fn le_i16(input: &mut Partial<&[u8]>) -> ModalResult<i16> {
 ///     i16(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1782,14 +1782,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i24;
 ///
-/// fn be_i24(input: &mut &[u8]) -> PResult<i32> {
+/// fn be_i24(input: &mut &[u8]) -> ModalResult<i32> {
 ///     i24(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i24.parse_peek(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
 /// assert!(be_i24.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i24(input: &mut &[u8]) -> PResult<i32> {
+/// fn le_i24(input: &mut &[u8]) -> ModalResult<i32> {
 ///     i24(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1804,14 +1804,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i24;
 ///
-/// fn be_i24(input: &mut Partial<&[u8]>) -> PResult<i32> {
+/// fn be_i24(input: &mut Partial<&[u8]>) -> ModalResult<i32> {
 ///     i24(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i24.parse_peek(Partial::new(&b"\x00\x03\x05abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x000305)));
 /// assert_eq!(be_i24.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 ///
-/// fn le_i24(input: &mut Partial<&[u8]>) -> PResult<i32> {
+/// fn le_i24(input: &mut Partial<&[u8]>) -> ModalResult<i32> {
 ///     i24(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1853,14 +1853,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i32;
 ///
-/// fn be_i32(input: &mut &[u8]) -> PResult<i32> {
+/// fn be_i32(input: &mut &[u8]) -> ModalResult<i32> {
 ///     i32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i32.parse_peek(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
 /// assert!(be_i32.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i32(input: &mut &[u8]) -> PResult<i32> {
+/// fn le_i32(input: &mut &[u8]) -> ModalResult<i32> {
 ///     i32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1875,14 +1875,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i32;
 ///
-/// fn be_i32(input: &mut Partial<&[u8]>) -> PResult<i32> {
+/// fn be_i32(input: &mut Partial<&[u8]>) -> ModalResult<i32> {
 ///     i32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i32.parse_peek(Partial::new(&b"\x00\x03\x05\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00030507)));
 /// assert_eq!(be_i32.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 ///
-/// fn le_i32(input: &mut Partial<&[u8]>) -> PResult<i32> {
+/// fn le_i32(input: &mut Partial<&[u8]>) -> ModalResult<i32> {
 ///     i32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1924,14 +1924,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i64;
 ///
-/// fn be_i64(input: &mut &[u8]) -> PResult<i64> {
+/// fn be_i64(input: &mut &[u8]) -> ModalResult<i64> {
 ///     i64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i64.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
 /// assert!(be_i64.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i64(input: &mut &[u8]) -> PResult<i64> {
+/// fn le_i64(input: &mut &[u8]) -> ModalResult<i64> {
 ///     i64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1946,14 +1946,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i64;
 ///
-/// fn be_i64(input: &mut Partial<&[u8]>) -> PResult<i64> {
+/// fn be_i64(input: &mut Partial<&[u8]>) -> ModalResult<i64> {
 ///     i64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i64.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x0001020304050607)));
 /// assert_eq!(be_i64.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 ///
-/// fn le_i64(input: &mut Partial<&[u8]>) -> PResult<i64> {
+/// fn le_i64(input: &mut Partial<&[u8]>) -> ModalResult<i64> {
 ///     i64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -1995,14 +1995,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i128;
 ///
-/// fn be_i128(input: &mut &[u8]) -> PResult<i128> {
+/// fn be_i128(input: &mut &[u8]) -> ModalResult<i128> {
 ///     i128(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i128.parse_peek(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
 /// assert!(be_i128.parse_peek(&b"\x01"[..]).is_err());
 ///
-/// fn le_i128(input: &mut &[u8]) -> PResult<i128> {
+/// fn le_i128(input: &mut &[u8]) -> ModalResult<i128> {
 ///     i128(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -2017,14 +2017,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::i128;
 ///
-/// fn be_i128(input: &mut Partial<&[u8]>) -> PResult<i128> {
+/// fn be_i128(input: &mut Partial<&[u8]>) -> ModalResult<i128> {
 ///     i128(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_i128.parse_peek(Partial::new(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..])), Ok((Partial::new(&b"abcefg"[..]), 0x00010203040506070001020304050607)));
 /// assert_eq!(be_i128.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 ///
-/// fn le_i128(input: &mut Partial<&[u8]>) -> PResult<i128> {
+/// fn le_i128(input: &mut Partial<&[u8]>) -> ModalResult<i128> {
 ///     i128(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -2064,7 +2064,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_f32;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<f32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<f32> {
 ///       be_f32.parse_next(s)
 /// }
 ///
@@ -2078,7 +2078,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_f32;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<f32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<f32> {
 ///       be_f32.parse_next(s)
 /// }
 ///
@@ -2086,7 +2086,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_f32<Input, Error>(input: &mut Input) -> PResult<f32, Error>
+pub fn be_f32<Input, Error>(input: &mut Input) -> ModalResult<f32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -2111,7 +2111,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_f64;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<f64> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<f64> {
 ///       be_f64.parse_next(s)
 /// }
 ///
@@ -2125,7 +2125,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::be_f64;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<f64> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<f64> {
 ///       be_f64.parse_next(s)
 /// }
 ///
@@ -2133,7 +2133,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_f64<Input, Error>(input: &mut Input) -> PResult<f64, Error>
+pub fn be_f64<Input, Error>(input: &mut Input) -> ModalResult<f64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -2158,7 +2158,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_f32;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<f32> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<f32> {
 ///       le_f32.parse_next(s)
 /// }
 ///
@@ -2172,7 +2172,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_f32;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<f32> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<f32> {
 ///       le_f32.parse_next(s)
 /// }
 ///
@@ -2180,7 +2180,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_f32<Input, Error>(input: &mut Input) -> PResult<f32, Error>
+pub fn le_f32<Input, Error>(input: &mut Input) -> ModalResult<f32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -2205,7 +2205,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_f64;
 ///
-/// fn parser(s: &mut &[u8]) -> PResult<f64> {
+/// fn parser(s: &mut &[u8]) -> ModalResult<f64> {
 ///       le_f64.parse_next(s)
 /// }
 ///
@@ -2219,7 +2219,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::le_f64;
 ///
-/// fn parser(s: &mut Partial<&[u8]>) -> PResult<f64> {
+/// fn parser(s: &mut Partial<&[u8]>) -> ModalResult<f64> {
 ///       le_f64.parse_next(s)
 /// }
 ///
@@ -2227,7 +2227,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_f64<Input, Error>(input: &mut Input) -> PResult<f64, Error>
+pub fn le_f64<Input, Error>(input: &mut Input) -> ModalResult<f64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -2255,14 +2255,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::f32;
 ///
-/// fn be_f32(input: &mut &[u8]) -> PResult<f32> {
+/// fn be_f32(input: &mut &[u8]) -> ModalResult<f32> {
 ///     f32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_f32.parse_peek(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert!(be_f32.parse_peek(&b"abc"[..]).is_err());
 ///
-/// fn le_f32(input: &mut &[u8]) -> PResult<f32> {
+/// fn le_f32(input: &mut &[u8]) -> ModalResult<f32> {
 ///     f32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -2277,14 +2277,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::f32;
 ///
-/// fn be_f32(input: &mut Partial<&[u8]>) -> PResult<f32> {
+/// fn be_f32(input: &mut Partial<&[u8]>) -> ModalResult<f32> {
 ///     f32(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_f32.parse_peek(Partial::new(&[0x41, 0x48, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(be_f32.parse_peek(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// fn le_f32(input: &mut Partial<&[u8]>) -> PResult<f32> {
+/// fn le_f32(input: &mut Partial<&[u8]>) -> ModalResult<f32> {
 ///     f32(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -2326,14 +2326,14 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::f64;
 ///
-/// fn be_f64(input: &mut &[u8]) -> PResult<f64> {
+/// fn be_f64(input: &mut &[u8]) -> ModalResult<f64> {
 ///     f64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_f64.parse_peek(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
 /// assert!(be_f64.parse_peek(&b"abc"[..]).is_err());
 ///
-/// fn le_f64(input: &mut &[u8]) -> PResult<f64> {
+/// fn le_f64(input: &mut &[u8]) -> ModalResult<f64> {
 ///     f64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -2348,14 +2348,14 @@ where
 /// # use winnow::Partial;
 /// use winnow::binary::f64;
 ///
-/// fn be_f64(input: &mut Partial<&[u8]>) -> PResult<f64> {
+/// fn be_f64(input: &mut Partial<&[u8]>) -> ModalResult<f64> {
 ///     f64(winnow::binary::Endianness::Big).parse_next(input)
 /// };
 ///
 /// assert_eq!(be_f64.parse_peek(Partial::new(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..])), Ok((Partial::new(&b""[..]), 12.5)));
 /// assert_eq!(be_f64.parse_peek(Partial::new(&b"abc"[..])), Err(ErrMode::Incomplete(Needed::new(5))));
 ///
-/// fn le_f64(input: &mut Partial<&[u8]>) -> PResult<f64> {
+/// fn le_f64(input: &mut Partial<&[u8]>) -> ModalResult<f64> {
 ///     f64(winnow::binary::Endianness::Little).parse_next(input)
 /// };
 ///
@@ -2405,7 +2405,7 @@ where
 ///     Partial::new(Bytes::new(b))
 /// }
 ///
-/// fn parser<'i>(s: &mut Stream<'i>) -> PResult<&'i [u8]> {
+/// fn parser<'i>(s: &mut Stream<'i>) -> ModalResult<&'i [u8]> {
 ///   length_take(be_u16).parse_next(s)
 /// }
 ///
@@ -2455,7 +2455,7 @@ where
 ///     p
 /// }
 ///
-/// fn parser<'i>(s: &mut Stream<'i>) -> PResult<&'i [u8]> {
+/// fn parser<'i>(s: &mut Stream<'i>) -> ModalResult<&'i [u8]> {
 ///   length_and_then(be_u16, "abc").parse_next(s)
 /// }
 ///
@@ -2504,7 +2504,7 @@ where
 ///     Bytes::new(b)
 /// }
 ///
-/// fn parser<'i>(s: &mut Stream<'i>) -> PResult<Vec<&'i [u8]>> {
+/// fn parser<'i>(s: &mut Stream<'i>) -> ModalResult<Vec<&'i [u8]>> {
 ///   length_repeat(u8.map(|i| {
 ///      println!("got number: {}", i);
 ///      i

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -9,7 +9,6 @@ mod tests;
 
 use crate::combinator::repeat;
 use crate::combinator::trace;
-use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::Needed;
 use crate::error::ParserError;
@@ -310,9 +309,9 @@ where
             Ok(res)
         }
         Err(e) if <Input as StreamIsPartial>::is_partial_supported() && input.is_partial() => {
-            Err(ErrMode::incomplete(input, e))
+            Err(ParserError::incomplete(input, e))
         }
-        Err(_needed) => Err(ErrMode::from_error_kind(input, ErrorKind::Slice)),
+        Err(_needed) => Err(ParserError::from_error_kind(input, ErrorKind::Slice)),
     }
 }
 
@@ -898,9 +897,9 @@ where
             Ok(res)
         }
         Err(e) if <Input as StreamIsPartial>::is_partial_supported() && input.is_partial() => {
-            Err(ErrMode::incomplete(input, e))
+            Err(ParserError::incomplete(input, e))
         }
-        Err(_needed) => Err(ErrMode::from_error_kind(input, ErrorKind::Slice)),
+        Err(_needed) => Err(ParserError::from_error_kind(input, ErrorKind::Slice)),
     }
 }
 
@@ -1273,9 +1272,9 @@ where
 {
     input.next_token().ok_or_else(|| {
         if PARTIAL && input.is_partial() {
-            ErrMode::incomplete(input, Needed::new(1))
+            ParserError::incomplete(input, Needed::new(1))
         } else {
-            ErrMode::from_error_kind(input, ErrorKind::Token)
+            ParserError::from_error_kind(input, ErrorKind::Token)
         }
     })
 }

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -16,8 +16,8 @@ use crate::lib::std::ops::{Add, Shl};
 use crate::stream::Accumulate;
 use crate::stream::{Stream, StreamIsPartial};
 use crate::stream::{ToUsize, UpdateSlice};
-use crate::ModalResult;
 use crate::Parser;
+use crate::Result;
 
 /// Configurable endianness
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -66,7 +66,7 @@ pub enum Endianness {
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_u8<Input, Error>(input: &mut Input) -> ModalResult<u8, Error>
+pub fn be_u8<Input, Error>(input: &mut Input) -> Result<u8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -110,7 +110,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_u16<Input, Error>(input: &mut Input) -> ModalResult<u16, Error>
+pub fn be_u16<Input, Error>(input: &mut Input) -> Result<u16, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -154,7 +154,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn be_u24<Input, Error>(input: &mut Input) -> ModalResult<u32, Error>
+pub fn be_u24<Input, Error>(input: &mut Input) -> Result<u32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -198,7 +198,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_u32<Input, Error>(input: &mut Input) -> ModalResult<u32, Error>
+pub fn be_u32<Input, Error>(input: &mut Input) -> Result<u32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -242,7 +242,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_u64<Input, Error>(input: &mut Input) -> ModalResult<u64, Error>
+pub fn be_u64<Input, Error>(input: &mut Input) -> Result<u64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -286,7 +286,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn be_u128<Input, Error>(input: &mut Input) -> ModalResult<u128, Error>
+pub fn be_u128<Input, Error>(input: &mut Input) -> Result<u128, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -295,7 +295,7 @@ where
 }
 
 #[inline]
-fn be_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> ModalResult<Uint, Error>
+fn be_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> Result<Uint, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
@@ -368,7 +368,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn be_i8<Input, Error>(input: &mut Input) -> ModalResult<i8, Error>
+pub fn be_i8<Input, Error>(input: &mut Input) -> Result<i8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -412,7 +412,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn be_i16<Input, Error>(input: &mut Input) -> ModalResult<i16, Error>
+pub fn be_i16<Input, Error>(input: &mut Input) -> Result<i16, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -459,7 +459,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_i24<Input, Error>(input: &mut Input) -> ModalResult<i32, Error>
+pub fn be_i24<Input, Error>(input: &mut Input) -> Result<i32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -514,7 +514,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(4))));
 /// ```
 #[inline(always)]
-pub fn be_i32<Input, Error>(input: &mut Input) -> ModalResult<i32, Error>
+pub fn be_i32<Input, Error>(input: &mut Input) -> Result<i32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -561,7 +561,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_i64<Input, Error>(input: &mut Input) -> ModalResult<i64, Error>
+pub fn be_i64<Input, Error>(input: &mut Input) -> Result<i64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -608,7 +608,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn be_i128<Input, Error>(input: &mut Input) -> ModalResult<i128, Error>
+pub fn be_i128<Input, Error>(input: &mut Input) -> Result<i128, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -655,7 +655,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_u8<Input, Error>(input: &mut Input) -> ModalResult<u8, Error>
+pub fn le_u8<Input, Error>(input: &mut Input) -> Result<u8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -699,7 +699,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_u16<Input, Error>(input: &mut Input) -> ModalResult<u16, Error>
+pub fn le_u16<Input, Error>(input: &mut Input) -> Result<u16, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -743,7 +743,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn le_u24<Input, Error>(input: &mut Input) -> ModalResult<u32, Error>
+pub fn le_u24<Input, Error>(input: &mut Input) -> Result<u32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -787,7 +787,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_u32<Input, Error>(input: &mut Input) -> ModalResult<u32, Error>
+pub fn le_u32<Input, Error>(input: &mut Input) -> Result<u32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -831,7 +831,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_u64<Input, Error>(input: &mut Input) -> ModalResult<u64, Error>
+pub fn le_u64<Input, Error>(input: &mut Input) -> Result<u64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -875,7 +875,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn le_u128<Input, Error>(input: &mut Input) -> ModalResult<u128, Error>
+pub fn le_u128<Input, Error>(input: &mut Input) -> Result<u128, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -884,7 +884,7 @@ where
 }
 
 #[inline]
-fn le_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> ModalResult<Uint, Error>
+fn le_uint<Input, Uint, Error>(input: &mut Input, bound: usize) -> Result<Uint, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Uint: Default + Shl<u8, Output = Uint> + Add<Uint, Output = Uint> + From<u8>,
@@ -956,7 +956,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_i8<Input, Error>(input: &mut Input) -> ModalResult<i8, Error>
+pub fn le_i8<Input, Error>(input: &mut Input) -> Result<i8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1000,7 +1000,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn le_i16<Input, Error>(input: &mut Input) -> ModalResult<i16, Error>
+pub fn le_i16<Input, Error>(input: &mut Input) -> Result<i16, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1047,7 +1047,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(2))));
 /// ```
 #[inline(always)]
-pub fn le_i24<Input, Error>(input: &mut Input) -> ModalResult<i32, Error>
+pub fn le_i24<Input, Error>(input: &mut Input) -> Result<i32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1102,7 +1102,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_i32<Input, Error>(input: &mut Input) -> ModalResult<i32, Error>
+pub fn le_i32<Input, Error>(input: &mut Input) -> Result<i32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1149,7 +1149,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_i64<Input, Error>(input: &mut Input) -> ModalResult<i64, Error>
+pub fn le_i64<Input, Error>(input: &mut Input) -> Result<i64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1196,7 +1196,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b"\x01"[..])), Err(ErrMode::Incomplete(Needed::new(15))));
 /// ```
 #[inline(always)]
-pub fn le_i128<Input, Error>(input: &mut Input) -> ModalResult<i128, Error>
+pub fn le_i128<Input, Error>(input: &mut Input) -> Result<i128, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1250,7 +1250,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn u8<Input, Error>(input: &mut Input) -> ModalResult<u8, Error>
+pub fn u8<Input, Error>(input: &mut Input) -> Result<u8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1265,7 +1265,7 @@ where
     .parse_next(input)
 }
 
-fn u8_<Input, Error, const PARTIAL: bool>(input: &mut Input) -> ModalResult<u8, Error>
+fn u8_<Input, Error, const PARTIAL: bool>(input: &mut Input) -> Result<u8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -1677,7 +1677,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&b""[..])), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn i8<Input, Error>(input: &mut Input) -> ModalResult<i8, Error>
+pub fn i8<Input, Error>(input: &mut Input) -> Result<i8, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -2085,7 +2085,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn be_f32<Input, Error>(input: &mut Input) -> ModalResult<f32, Error>
+pub fn be_f32<Input, Error>(input: &mut Input) -> Result<f32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -2132,7 +2132,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn be_f64<Input, Error>(input: &mut Input) -> ModalResult<f64, Error>
+pub fn be_f64<Input, Error>(input: &mut Input) -> Result<f64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -2179,7 +2179,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(3))));
 /// ```
 #[inline(always)]
-pub fn le_f32<Input, Error>(input: &mut Input) -> ModalResult<f32, Error>
+pub fn le_f32<Input, Error>(input: &mut Input) -> Result<f32, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,
@@ -2226,7 +2226,7 @@ where
 /// assert_eq!(parser.parse_peek(Partial::new(&[0x01][..])), Err(ErrMode::Incomplete(Needed::new(7))));
 /// ```
 #[inline(always)]
-pub fn le_f64<Input, Error>(input: &mut Input) -> ModalResult<f64, Error>
+pub fn le_f64<Input, Error>(input: &mut Input) -> Result<f64, Error>
 where
     Input: StreamIsPartial + Stream<Token = u8>,
     Error: ParserError<Input>,

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -310,7 +310,7 @@ where
             Ok(res)
         }
         Err(e) if <Input as StreamIsPartial>::is_partial_supported() && input.is_partial() => {
-            Err(ErrMode::Incomplete(e))
+            Err(ErrMode::incomplete(input, e))
         }
         Err(_needed) => Err(ErrMode::from_error_kind(input, ErrorKind::Slice)),
     }
@@ -898,7 +898,7 @@ where
             Ok(res)
         }
         Err(e) if <Input as StreamIsPartial>::is_partial_supported() && input.is_partial() => {
-            Err(ErrMode::Incomplete(e))
+            Err(ErrMode::incomplete(input, e))
         }
         Err(_needed) => Err(ErrMode::from_error_kind(input, ErrorKind::Slice)),
     }
@@ -1273,7 +1273,7 @@ where
 {
     input.next_token().ok_or_else(|| {
         if PARTIAL && input.is_partial() {
-            ErrMode::Incomplete(Needed::new(1))
+            ErrMode::incomplete(input, Needed::new(1))
         } else {
             ErrMode::from_error_kind(input, ErrorKind::Token)
         }

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -146,7 +146,10 @@ impl<const N: usize, I: Stream, O, E: ParserError<I>, P: Parser<I, O, E>> Alt<I,
 
         match error {
             Some(e) => Err(e.append(input, &start, ErrorKind::Alt)),
-            None => Err(ErrMode::assert(input, "`alt` needs at least one parser")),
+            None => Err(ParserError::assert(
+                input,
+                "`alt` needs at least one parser",
+            )),
         }
     }
 }
@@ -171,7 +174,10 @@ impl<I: Stream, O, E: ParserError<I>, P: Parser<I, O, E>> Alt<I, O, E> for &mut 
 
         match error {
             Some(e) => Err(e.append(input, &start, ErrorKind::Alt)),
-            None => Err(ErrMode::assert(input, "`alt` needs at least one parser")),
+            None => Err(ParserError::assert(
+                input,
+                "`alt` needs at least one parser",
+            )),
         }
     }
 }

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -11,7 +11,7 @@ pub use crate::dispatch;
 /// This trait is implemented for tuples of up to 21 elements
 pub trait Alt<I, O, E> {
     /// Tests each parser in the tuple and returns the result of the first one that succeeds
-    fn choice(&mut self, input: &mut I) -> PResult<O, E>;
+    fn choice(&mut self, input: &mut I) -> ModalResult<O, E>;
 }
 
 /// Pick the first successful parser
@@ -33,7 +33,7 @@ pub trait Alt<I, O, E> {
 /// use winnow::ascii::{alpha1, digit1};
 /// use winnow::combinator::alt;
 /// # fn main() {
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 ///   alt((alpha1, digit1)).parse_next(input)
 /// };
 ///
@@ -64,7 +64,7 @@ where
 /// This trait is implemented for tuples of up to 21 elements
 pub trait Permutation<I, O, E> {
     /// Tries to apply all parsers in the tuple in various orders until all of them succeed
-    fn permutation(&mut self, input: &mut I) -> PResult<O, E>;
+    fn permutation(&mut self, input: &mut I) -> ModalResult<O, E>;
 }
 
 /// Applies a list of parsers in any order.
@@ -84,7 +84,7 @@ pub trait Permutation<I, O, E> {
 /// use winnow::ascii::{alpha1, digit1};
 /// use winnow::combinator::permutation;
 /// # fn main() {
-/// fn parser<'i>(input: &mut &'i str) -> PResult<(&'i str, &'i str)> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<(&'i str, &'i str)> {
 ///   permutation((alpha1, digit1)).parse_next(input)
 /// }
 ///
@@ -107,7 +107,7 @@ pub trait Permutation<I, O, E> {
 /// use winnow::combinator::permutation;
 /// use winnow::token::any;
 ///
-/// fn parser(input: &mut &str) -> PResult<(char, char)> {
+/// fn parser(input: &mut &str) -> ModalResult<(char, char)> {
 ///   permutation((any, 'a')).parse_next(input)
 /// }
 ///
@@ -127,7 +127,7 @@ pub fn permutation<I: Stream, O, E: ParserError<I>, List: Permutation<I, O, E>>(
 }
 
 impl<const N: usize, I: Stream, O, E: ParserError<I>, P: Parser<I, O, E>> Alt<I, O, E> for [P; N] {
-    fn choice(&mut self, input: &mut I) -> PResult<O, E> {
+    fn choice(&mut self, input: &mut I) -> ModalResult<O, E> {
         let mut error: Option<E> = None;
 
         let start = input.checkpoint();
@@ -152,7 +152,7 @@ impl<const N: usize, I: Stream, O, E: ParserError<I>, P: Parser<I, O, E>> Alt<I,
 }
 
 impl<I: Stream, O, E: ParserError<I>, P: Parser<I, O, E>> Alt<I, O, E> for &mut [P] {
-    fn choice(&mut self, input: &mut I) -> PResult<O, E> {
+    fn choice(&mut self, input: &mut I) -> ModalResult<O, E> {
         let mut error: Option<E> = None;
 
         let start = input.checkpoint();
@@ -198,7 +198,7 @@ macro_rules! alt_trait_impl(
       $($id: Parser<I, Output, Error>),+
     > Alt<I, Output, Error> for ( $($id),+ ) {
 
-      fn choice(&mut self, input: &mut I) -> PResult<Output, Error> {
+      fn choice(&mut self, input: &mut I) -> ModalResult<Output, Error> {
         let start = input.checkpoint();
         match self.0.parse_next(input) {
           Err(ErrMode::Backtrack(e)) => alt_trait_inner!(1, self, input, start, e, $($id)+),
@@ -253,7 +253,7 @@ alt_trait!(Alt2 Alt3 Alt4 Alt5 Alt6 Alt7 Alt8 Alt9 Alt10 Alt11 Alt12 Alt13 Alt14
 
 // Manually implement Alt for (A,), the 1-tuple type
 impl<I: Stream, O, E: ParserError<I>, A: Parser<I, O, E>> Alt<I, O, E> for (A,) {
-    fn choice(&mut self, input: &mut I) -> PResult<O, E> {
+    fn choice(&mut self, input: &mut I) -> ModalResult<O, E> {
         self.0.parse_next(input)
     }
 }
@@ -285,7 +285,7 @@ macro_rules! permutation_trait_impl(
       $($name: Parser<I, $ty, Error>),+
     > Permutation<I, ( $($ty),+ ), Error> for ( $($name),+ ) {
 
-      fn permutation(&mut self, input: &mut I) -> PResult<( $($ty),+ ), Error> {
+      fn permutation(&mut self, input: &mut I) -> ModalResult<( $($ty),+ ), Error> {
         let mut res = ($(Option::<$ty>::None),+);
 
         loop {

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -6,7 +6,7 @@ use crate::*;
 /// Deprecated, replaced with [`token::rest`]
 #[deprecated(since = "0.6.23", note = "replaced with `token::rest`")]
 #[inline]
-pub fn rest<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn rest<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: Stream,
     Error: ParserError<Input>,
@@ -17,7 +17,7 @@ where
 /// Deprecated, replaced with [`token::rest_len`]
 #[deprecated(since = "0.6.23", note = "replaced with `token::rest_len`")]
 #[inline]
-pub fn rest_len<Input, Error>(input: &mut Input) -> PResult<usize, Error>
+pub fn rest_len<Input, Error>(input: &mut Input) -> ModalResult<usize, Error>
 where
     Input: Stream,
     Error: ParserError<Input>,
@@ -37,7 +37,7 @@ where
 /// use winnow::ascii::alpha1;
 /// # fn main() {
 ///
-/// fn parser<'i>(i: &mut &'i str) -> PResult<Option<&'i str>> {
+/// fn parser<'i>(i: &mut &'i str) -> ModalResult<Option<&'i str>> {
 ///   opt(alpha1).parse_next(i)
 /// }
 ///
@@ -76,7 +76,7 @@ where
 /// use winnow::ascii::alpha1;
 /// # fn main() {
 ///
-/// fn parser<'i>(i: &mut &'i str) -> PResult<Option<&'i str>> {
+/// fn parser<'i>(i: &mut &'i str) -> ModalResult<Option<&'i str>> {
 ///   let prefix = opt("-").parse_next(i)?;
 ///   let condition = prefix.is_some();
 ///   cond(condition, alpha1).parse_next(i)
@@ -118,7 +118,7 @@ where
 /// use winnow::ascii::alpha1;
 /// # fn main() {
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 ///     peek(alpha1).parse_next(input)
 /// }
 ///
@@ -153,7 +153,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn eof<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn eof<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::combinator::eof.parse_next(input)
 /// # }
@@ -166,7 +166,7 @@ where
 /// # use winnow::combinator::eof;
 /// # use winnow::prelude::*;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 ///     eof.parse_next(input)
 /// }
 /// assert!(parser.parse_peek("abc").is_err());
@@ -174,7 +174,7 @@ where
 /// ```
 #[doc(alias = "end")]
 #[doc(alias = "eoi")]
-pub fn eof<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn eof<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: Stream,
     Error: ParserError<Input>,
@@ -205,7 +205,7 @@ where
 /// use winnow::ascii::alpha1;
 /// # fn main() {
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<()> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<()> {
 ///     not(alpha1).parse_next(input)
 /// }
 ///
@@ -250,7 +250,7 @@ where
 /// # use winnow::prelude::*;
 /// # fn main() {
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 ///   alt((
 ///     preceded(one_of(['+', '-']), digit1),
 ///     rest
@@ -275,7 +275,7 @@ where
 /// use winnow::combinator::cut_err;
 /// # fn main() {
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 ///   alt((
 ///     preceded(one_of(['+', '-']), cut_err(digit1)),
 ///     rest
@@ -331,12 +331,12 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::combinator::todo;
 ///
-/// fn parser(input: &mut &str) -> PResult<u64> {
+/// fn parser(input: &mut &str) -> ModalResult<u64> {
 ///     todo(input)
 /// }
 /// ```
 #[track_caller]
-pub fn todo<Input, Output, Error>(input: &mut Input) -> PResult<Output, Error>
+pub fn todo<Input, Output, Error>(input: &mut Input) -> ModalResult<Output, Error>
 where
     Input: Stream,
 {
@@ -365,7 +365,7 @@ where
 /// let mut it = iterator(data, terminated(alpha1, "|"));
 ///
 /// let parsed = it.map(|v| (v, v.len())).collect::<HashMap<_,_>>();
-/// let res: PResult<_> = it.finish();
+/// let res: ModalResult<_> = it.finish();
 ///
 /// assert_eq!(parsed, [("abc", 3usize), ("defg", 4), ("hijkl", 5), ("mnopqr", 6)].iter().cloned().collect());
 /// assert_eq!(res, Ok(("123", ())));
@@ -405,7 +405,7 @@ where
     I: Stream,
 {
     /// Returns the remaining input if parsing was successful, or the error if we encountered an error.
-    pub fn finish(mut self) -> PResult<(I, ()), E> {
+    pub fn finish(mut self) -> ModalResult<(I, ()), E> {
         match self.state.take().unwrap() {
             State::Running | State::Done => Ok((self.input, ())),
             State::Cut(e) => Err(e),
@@ -474,7 +474,7 @@ enum State<E> {
 /// use winnow::combinator::alt;
 /// use winnow::combinator::empty;
 ///
-/// fn sign(input: &mut &str) -> PResult<isize> {
+/// fn sign(input: &mut &str) -> ModalResult<isize> {
 ///     alt((
 ///         '-'.value(-1),
 ///         '+'.value(1),
@@ -488,7 +488,7 @@ enum State<E> {
 #[doc(alias = "value")]
 #[doc(alias = "success")]
 #[inline]
-pub fn empty<Input, Error>(_input: &mut Input) -> PResult<(), Error>
+pub fn empty<Input, Error>(_input: &mut Input) -> ModalResult<(), Error>
 where
     Input: Stream,
     Error: ParserError<Input>,
@@ -508,7 +508,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::fail;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<(), InputError<&'i str>> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<(), InputError<&'i str>> {
 ///     fail.parse_next(input)
 /// }
 ///
@@ -516,7 +516,7 @@ where
 /// ```
 #[doc(alias = "unexpected")]
 #[inline]
-pub fn fail<Input, Output, Error>(i: &mut Input) -> PResult<Output, Error>
+pub fn fail<Input, Output, Error>(i: &mut Input) -> ModalResult<Output, Error>
 where
     Input: Stream,
     Error: ParserError<Input>,

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -339,6 +339,7 @@ where
 pub fn todo<Input, Output, Error>(input: &mut Input) -> ModalResult<Output, Error>
 where
     Input: Stream,
+    Error: ParserError<Input>,
 {
     #![allow(clippy::todo)]
     trace("todo", move |_input: &mut Input| {
@@ -403,6 +404,7 @@ impl<F, I, O, E> ParserIterator<F, I, O, E>
 where
     F: Parser<I, O, E>,
     I: Stream,
+    E: ParserError<I>,
 {
     /// Returns the remaining input if parsing was successful, or the error if we encountered an error.
     pub fn finish(mut self) -> ModalResult<(I, ()), E> {
@@ -417,6 +419,7 @@ impl<F, I, O, E> core::iter::Iterator for &mut ParserIterator<F, I, O, E>
 where
     F: Parser<I, O, E>,
     I: Stream,
+    E: ParserError<I>,
 {
     type Item = O;
 

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -1,5 +1,5 @@
 use crate::combinator::trace;
-use crate::error::{ErrMode, ErrorKind, ParserError};
+use crate::error::{ErrMode, ErrorKind, ModalError, ParserError};
 use crate::stream::Stream;
 use crate::*;
 

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -183,7 +183,7 @@ where
         if input.eof_offset() == 0 {
             Ok(input.next_slice(0))
         } else {
-            Err(ErrMode::from_error_kind(input, ErrorKind::Eof))
+            Err(ParserError::from_error_kind(input, ErrorKind::Eof))
         }
     })
     .parse_next(input)
@@ -224,7 +224,7 @@ where
         let res = parser.parse_next(input);
         input.reset(&start);
         match res {
-            Ok(_) => Err(ErrMode::from_error_kind(input, ErrorKind::Not)),
+            Ok(_) => Err(ParserError::from_error_kind(input, ErrorKind::Not)),
             Err(e) if e.is_backtrack() => Ok(()),
             Err(e) => Err(e),
         }
@@ -525,7 +525,7 @@ where
     Error: ParserError<Input>,
 {
     trace("fail", |i: &mut Input| {
-        Err(ErrMode::from_error_kind(i, ErrorKind::Fail))
+        Err(ParserError::from_error_kind(i, ErrorKind::Fail))
     })
     .parse_next(i)
 }

--- a/src/combinator/core.rs
+++ b/src/combinator/core.rs
@@ -56,7 +56,7 @@ where
         let start = input.checkpoint();
         match parser.parse_next(input) {
             Ok(o) => Ok(Some(o)),
-            Err(ErrMode::Backtrack(_)) => {
+            Err(e) if e.is_backtrack() => {
                 input.reset(&start);
                 Ok(None)
             }
@@ -225,7 +225,7 @@ where
         input.reset(&start);
         match res {
             Ok(_) => Err(ErrMode::from_error_kind(input, ErrorKind::Not)),
-            Err(ErrMode::Backtrack(_)) => Ok(()),
+            Err(e) if e.is_backtrack() => Ok(()),
             Err(e) => Err(e),
         }
     })
@@ -432,7 +432,7 @@ where
                     self.state = Some(State::Running);
                     Some(o)
                 }
-                Err(ErrMode::Backtrack(_)) => {
+                Err(e) if e.is_backtrack() => {
                     self.input.reset(&start);
                     self.state = Some(State::Done);
                     None

--- a/src/combinator/debug/internals.rs
+++ b/src/combinator/debug/internals.rs
@@ -49,7 +49,7 @@ where
     E: ParserError<I>,
 {
     #[inline]
-    fn parse_next(&mut self, i: &mut I) -> ModalResult<O, E> {
+    fn parse_next(&mut self, i: &mut I) -> Result<O, E> {
         let depth = Depth::new();
         let original = i.checkpoint();
         start(*depth, &self.name, self.call_count, i);

--- a/src/combinator/debug/internals.rs
+++ b/src/combinator/debug/internals.rs
@@ -3,6 +3,7 @@
 use std::io::Write;
 
 use crate::error::ErrMode;
+use crate::error::ParserError;
 use crate::stream::Stream;
 use crate::*;
 
@@ -11,6 +12,7 @@ where
     P: Parser<I, O, E>,
     I: Stream,
     D: std::fmt::Display,
+    E: ParserError<I>,
 {
     parser: P,
     name: D,
@@ -25,6 +27,7 @@ where
     P: Parser<I, O, E>,
     I: Stream,
     D: std::fmt::Display,
+    E: ParserError<I>,
 {
     #[inline(always)]
     pub(crate) fn new(parser: P, name: D) -> Self {
@@ -44,6 +47,7 @@ where
     P: Parser<I, O, E>,
     I: Stream,
     D: std::fmt::Display,
+    E: ParserError<I>,
 {
     #[inline]
     fn parse_next(&mut self, i: &mut I) -> ModalResult<O, E> {
@@ -115,7 +119,9 @@ pub(crate) enum Severity {
 }
 
 impl Severity {
-    pub(crate) fn with_result<T, E>(result: &Result<T, ErrMode<E>>) -> Self {
+    pub(crate) fn with_result<T, I: Stream, E: ParserError<I>>(
+        result: &Result<T, ErrMode<E>>,
+    ) -> Self {
         match result {
             Ok(_) => Self::Success,
             Err(ErrMode::Backtrack(_)) => Self::Backtrack,

--- a/src/combinator/debug/internals.rs
+++ b/src/combinator/debug/internals.rs
@@ -46,7 +46,7 @@ where
     D: std::fmt::Display,
 {
     #[inline]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O, E> {
         let depth = Depth::new();
         let original = i.checkpoint();
         start(*depth, &self.name, self.call_count, i);

--- a/src/combinator/debug/internals.rs
+++ b/src/combinator/debug/internals.rs
@@ -2,7 +2,6 @@
 
 use std::io::Write;
 
-use crate::error::ErrMode;
 use crate::error::ParserError;
 use crate::stream::Stream;
 use crate::*;
@@ -119,14 +118,12 @@ pub(crate) enum Severity {
 }
 
 impl Severity {
-    pub(crate) fn with_result<T, I: Stream, E: ParserError<I>>(
-        result: &Result<T, ErrMode<E>>,
-    ) -> Self {
+    pub(crate) fn with_result<T, I: Stream, E: ParserError<I>>(result: &Result<T, E>) -> Self {
         match result {
             Ok(_) => Self::Success,
-            Err(ErrMode::Backtrack(_)) => Self::Backtrack,
-            Err(ErrMode::Cut(_)) => Self::Cut,
-            Err(ErrMode::Incomplete(_)) => Self::Incomplete,
+            Err(e) if e.is_backtrack() => Self::Backtrack,
+            Err(e) if e.is_needed() => Self::Incomplete,
+            _ => Self::Cut,
         }
     }
 }

--- a/src/combinator/debug/mod.rs
+++ b/src/combinator/debug/mod.rs
@@ -4,6 +4,7 @@
 mod internals;
 
 use crate::error::ErrMode;
+use crate::error::ParserError;
 use crate::stream::Stream;
 use crate::Parser;
 
@@ -37,7 +38,7 @@ use crate::Parser;
 #[cfg_attr(not(feature = "debug"), allow(unused_variables))]
 #[cfg_attr(not(feature = "debug"), allow(unused_mut))]
 #[cfg_attr(not(feature = "debug"), inline(always))]
-pub fn trace<I: Stream, O, E>(
+pub fn trace<I: Stream, O, E: ParserError<I>>(
     name: impl crate::lib::std::fmt::Display,
     parser: impl Parser<I, O, E>,
 ) -> impl Parser<I, O, E> {
@@ -52,7 +53,7 @@ pub fn trace<I: Stream, O, E>(
 }
 
 #[cfg_attr(not(feature = "debug"), allow(unused_variables))]
-pub(crate) fn trace_result<T, E>(
+pub(crate) fn trace_result<T, I: Stream, E: ParserError<I>>(
     name: impl crate::lib::std::fmt::Display,
     res: &Result<T, ErrMode<E>>,
 ) {

--- a/src/combinator/debug/mod.rs
+++ b/src/combinator/debug/mod.rs
@@ -3,7 +3,6 @@
 #[cfg(feature = "debug")]
 mod internals;
 
-use crate::error::ErrMode;
 use crate::error::ParserError;
 use crate::stream::Stream;
 use crate::Parser;
@@ -55,7 +54,7 @@ pub fn trace<I: Stream, O, E: ParserError<I>>(
 #[cfg_attr(not(feature = "debug"), allow(unused_variables))]
 pub(crate) fn trace_result<T, I: Stream, E: ParserError<I>>(
     name: impl crate::lib::std::fmt::Display,
-    res: &Result<T, ErrMode<E>>,
+    res: &Result<T, E>,
 ) {
     #[cfg(feature = "debug")]
     {

--- a/src/combinator/debug/mod.rs
+++ b/src/combinator/debug/mod.rs
@@ -22,7 +22,7 @@ use crate::Parser;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::trace;
 ///
-/// fn short_alpha<'s>(s: &mut &'s [u8]) -> PResult<&'s [u8]> {
+/// fn short_alpha<'s>(s: &mut &'s [u8]) -> ModalResult<&'s [u8]> {
 ///   trace("short_alpha",
 ///     take_while(3..=6, AsChar::is_alpha)
 ///   ).parse_next(s)

--- a/src/combinator/impls.rs
+++ b/src/combinator/impls.rs
@@ -130,7 +130,7 @@ where
         let o = self.parser.parse_next(input)?;
         let res = (self.map)(o).ok_or_else(|| {
             input.reset(&start);
-            ErrMode::from_error_kind(input, ErrorKind::Verify)
+            ParserError::from_error_kind(input, ErrorKind::Verify)
         });
         trace_result("verify", &res);
         res
@@ -201,7 +201,7 @@ where
         let o = self.p.parse_next(i)?;
         let res = o.parse_slice().ok_or_else(|| {
             i.reset(&start);
-            ErrMode::from_error_kind(i, ErrorKind::Verify)
+            ParserError::from_error_kind(i, ErrorKind::Verify)
         });
         trace_result("verify", &res);
         res
@@ -256,7 +256,7 @@ where
         trace("complete_err", |input: &mut I| {
             match (self.p).parse_next(input) {
                 Err(err) => match err.into_needed() {
-                    Ok(_) => Err(ErrMode::from_error_kind(input, ErrorKind::Complete)),
+                    Ok(_) => Err(ParserError::from_error_kind(input, ErrorKind::Complete)),
                     Err(err) => Err(err),
                 },
                 rest => rest,
@@ -299,7 +299,7 @@ where
         let o = self.parser.parse_next(input)?;
         let res = (self.filter)(o.borrow()).then_some(o).ok_or_else(|| {
             input.reset(&start);
-            ErrMode::from_error_kind(input, ErrorKind::Verify)
+            ParserError::from_error_kind(input, ErrorKind::Verify)
         });
         trace_result("verify", &res);
         res

--- a/src/combinator/impls.rs
+++ b/src/combinator/impls.rs
@@ -69,6 +69,7 @@ where
     G: FnMut(O) -> Result<O2, E2>,
     I: Stream,
     E: FromExternalError<I, E2>,
+    E: ParserError<I>,
 {
     pub(crate) parser: F,
     pub(crate) map: G,
@@ -85,6 +86,7 @@ where
     G: FnMut(O) -> Result<O2, E2>,
     I: Stream,
     E: FromExternalError<I, E2>,
+    E: ParserError<I>,
 {
     #[inline]
     fn parse_next(&mut self, input: &mut I) -> ModalResult<O2, E> {
@@ -554,6 +556,7 @@ where
     F: Parser<I, O, E>,
     I: Stream,
     E: AddContext<I, C>,
+    E: ParserError<I>,
     C: Clone + crate::lib::std::fmt::Debug,
 {
     pub(crate) parser: F,
@@ -568,6 +571,7 @@ where
     F: Parser<I, O, E>,
     I: Stream,
     E: AddContext<I, C>,
+    E: ParserError<I>,
     C: Clone + crate::lib::std::fmt::Debug,
 {
     #[inline]
@@ -592,7 +596,7 @@ where
     R: Parser<I, (), E>,
     I: Stream,
     I: Recover<E>,
-    E: FromRecoverableError<I, E>,
+    E: ParserError<I> + FromRecoverableError<I, E>,
 {
     pub(crate) parser: P,
     pub(crate) recover: R,
@@ -609,7 +613,7 @@ where
     R: Parser<I, (), E>,
     I: Stream,
     I: Recover<E>,
-    E: FromRecoverableError<I, E>,
+    E: ParserError<I> + FromRecoverableError<I, E>,
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> ModalResult<O, E> {
@@ -629,7 +633,7 @@ where
     R: Parser<I, (), E>,
     I: Stream,
     I: Recover<E>,
-    E: FromRecoverableError<I, E>,
+    E: ParserError<I> + FromRecoverableError<I, E>,
 {
     loop {
         let token_start = i.checkpoint();
@@ -668,7 +672,7 @@ where
     R: Parser<I, (), E>,
     I: Stream,
     I: Recover<E>,
-    E: FromRecoverableError<I, E>,
+    E: ParserError<I> + FromRecoverableError<I, E>,
 {
     pub(crate) parser: P,
     pub(crate) recover: R,
@@ -685,7 +689,7 @@ where
     R: Parser<I, (), E>,
     I: Stream,
     I: Recover<E>,
-    E: FromRecoverableError<I, E>,
+    E: ParserError<I> + FromRecoverableError<I, E>,
 {
     #[inline(always)]
     fn parse_next(&mut self, i: &mut I) -> ModalResult<Option<O>, E> {
@@ -709,7 +713,7 @@ where
     R: Parser<I, (), E>,
     I: Stream,
     I: Recover<E>,
-    E: FromRecoverableError<I, E>,
+    E: ParserError<I> + FromRecoverableError<I, E>,
 {
     let token_start = i.checkpoint();
     let mut err = match parser.parse_next(i) {

--- a/src/combinator/impls.rs
+++ b/src/combinator/impls.rs
@@ -733,6 +733,6 @@ where
     }
 
     i.reset(&err_start);
-    err = err.map(|err| E::from_recoverable_error(&token_start, &err_start, i, err));
+    err = FromRecoverableError::from_recoverable_error(&token_start, &err_start, i, err);
     Err(err)
 }

--- a/src/combinator/impls.rs
+++ b/src/combinator/impls.rs
@@ -29,7 +29,7 @@ where
     P: Parser<I, O, E>,
 {
     #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O, E> {
         self.p.parse_next(i)
     }
 }
@@ -54,7 +54,7 @@ where
     G: FnMut(O) -> O2,
 {
     #[inline]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O2, E> {
         match self.parser.parse_next(i) {
             Err(e) => Err(e),
             Ok(o) => Ok((self.map)(o)),
@@ -87,7 +87,7 @@ where
     E: FromExternalError<I, E2>,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<O2, E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<O2, E> {
         let start = input.checkpoint();
         let o = self.parser.parse_next(input)?;
         let res = (self.map)(o).map_err(|err| {
@@ -123,7 +123,7 @@ where
     E: ParserError<I>,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<O2, E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<O2, E> {
         let start = input.checkpoint();
         let o = self.parser.parse_next(input)?;
         let res = (self.map)(o).ok_or_else(|| {
@@ -159,7 +159,7 @@ where
     I: Stream,
 {
     #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O2, E> {
         let start = i.checkpoint();
         let mut o = self.outer.parse_next(i)?;
         let _ = o.complete();
@@ -194,7 +194,7 @@ where
     E: ParserError<I>,
 {
     #[inline]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O2, E> {
         let start = i.checkpoint();
         let o = self.p.parse_next(i)?;
         let res = o.parse_slice().ok_or_else(|| {
@@ -229,7 +229,7 @@ where
     H: Parser<I, O2, E>,
 {
     #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O2, E> {
         let o = self.f.parse_next(i)?;
         (self.g)(o).parse_next(i)
     }
@@ -250,7 +250,7 @@ where
     E: ParserError<I>,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<O, E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<O, E> {
         trace("complete_err", |input: &mut I| {
             match (self.p).parse_next(input) {
                 Err(ErrMode::Incomplete(_)) => {
@@ -291,7 +291,7 @@ where
     E: ParserError<I>,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<O, E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<O, E> {
         let start = input.checkpoint();
         let o = self.parser.parse_next(input)?;
         let res = (self.filter)(o.borrow()).then_some(o).ok_or_else(|| {
@@ -322,7 +322,7 @@ where
     O2: Clone,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<O2, E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<O2, E> {
         (self.parser).parse_next(input).map(|_| self.val.clone())
     }
 }
@@ -346,7 +346,7 @@ where
     O2: core::default::Default,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<O2, E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<O2, E> {
         (self.parser).parse_next(input).map(|_| O2::default())
     }
 }
@@ -367,7 +367,7 @@ where
     F: Parser<I, O, E>,
 {
     #[inline(always)]
-    fn parse_next(&mut self, input: &mut I) -> PResult<(), E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<(), E> {
         (self.parser).parse_next(input).map(|_| ())
     }
 }
@@ -394,7 +394,7 @@ where
     I: Stream,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<<I as Stream>::Slice, E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<<I as Stream>::Slice, E> {
         let checkpoint = input.checkpoint();
         match (self.parser).parse_next(input) {
             Ok(_) => {
@@ -430,7 +430,7 @@ where
     I: Stream,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<(O, <I as Stream>::Slice), E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<(O, <I as Stream>::Slice), E> {
         let checkpoint = input.checkpoint();
         match (self.parser).parse_next(input) {
             Ok(result) => {
@@ -462,7 +462,7 @@ where
     I: Stream + Location,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<Range<usize>, E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<Range<usize>, E> {
         let start = input.current_token_start();
         self.parser.parse_next(input).map(move |_| {
             let end = input.previous_token_end();
@@ -489,7 +489,7 @@ where
     I: Stream + Location,
 {
     #[inline]
-    fn parse_next(&mut self, input: &mut I) -> PResult<(O, Range<usize>), E> {
+    fn parse_next(&mut self, input: &mut I) -> ModalResult<(O, Range<usize>), E> {
         let start = input.current_token_start();
         self.parser.parse_next(input).map(move |output| {
             let end = input.previous_token_end();
@@ -517,7 +517,7 @@ where
     O: Into<O2>,
 {
     #[inline]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O2, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O2, E> {
         self.parser.parse_next(i).map(|o| o.into())
     }
 }
@@ -541,7 +541,7 @@ where
     E: Into<E2>,
 {
     #[inline]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O, E2> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O, E2> {
         self.parser
             .parse_next(i)
             .map_err(|err| err.map(|e| e.into()))
@@ -571,7 +571,7 @@ where
     C: Clone + crate::lib::std::fmt::Debug,
 {
     #[inline]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O, E> {
         let context = self.context.clone();
         trace(DisplayDebug(self.context.clone()), move |i: &mut I| {
             let start = i.checkpoint();
@@ -612,7 +612,7 @@ where
     E: FromRecoverableError<I, E>,
 {
     #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<O, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<O, E> {
         if I::is_recovery_supported() {
             retry_after_inner(&mut self.parser, &mut self.recover, i)
         } else {
@@ -623,7 +623,7 @@ where
 
 #[cfg(feature = "unstable-recover")]
 #[cfg(feature = "std")]
-fn retry_after_inner<P, R, I, O, E>(parser: &mut P, recover: &mut R, i: &mut I) -> PResult<O, E>
+fn retry_after_inner<P, R, I, O, E>(parser: &mut P, recover: &mut R, i: &mut I) -> ModalResult<O, E>
 where
     P: Parser<I, O, E>,
     R: Parser<I, (), E>,
@@ -688,7 +688,7 @@ where
     E: FromRecoverableError<I, E>,
 {
     #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<Option<O>, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<Option<O>, E> {
         if I::is_recovery_supported() {
             resume_after_inner(&mut self.parser, &mut self.recover, i)
         } else {
@@ -703,7 +703,7 @@ fn resume_after_inner<P, R, I, O, E>(
     parser: &mut P,
     recover: &mut R,
     i: &mut I,
-) -> PResult<Option<O>, E>
+) -> ModalResult<Option<O>, E>
 where
     P: Parser<I, O, E>,
     R: Parser<I, (), E>,

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -479,7 +479,10 @@ where
             Ok(o) => {
                 // infinite loop check: the parser must always consume
                 if i.eof_offset() == len {
-                    return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
+                    return Err(ParserError::assert(
+                        i,
+                        "`repeat` parsers must always consume",
+                    ));
                 }
 
                 acc.accumulate(o);
@@ -514,7 +517,10 @@ where
                     Ok(o) => {
                         // infinite loop check: the parser must always consume
                         if i.eof_offset() == len {
-                            return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
+                            return Err(ParserError::assert(
+                                i,
+                                "`repeat` parsers must always consume",
+                            ));
                         }
 
                         acc.accumulate(o);
@@ -541,7 +547,10 @@ where
             Ok(o) => {
                 // infinite loop check: the parser must always consume
                 if i.eof_offset() == len {
-                    return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
+                    return Err(ParserError::assert(
+                        i,
+                        "`repeat` parsers must always consume",
+                    ));
                 }
 
                 res.accumulate(o);
@@ -568,7 +577,7 @@ where
     E: ParserError<I>,
 {
     if min > max {
-        return Err(ErrMode::assert(
+        return Err(ParserError::assert(
             input,
             "range should be ascending, rather than descending",
         ));
@@ -582,7 +591,7 @@ where
             Ok(value) => {
                 // infinite loop check: the parser must always consume
                 if input.eof_offset() == len {
-                    return Err(ErrMode::assert(
+                    return Err(ParserError::assert(
                         input,
                         "`repeat` parsers must always consume",
                     ));
@@ -693,7 +702,10 @@ where
                     Ok(o) => {
                         // infinite loop check: the parser must always consume
                         if i.eof_offset() == len {
-                            return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
+                            return Err(ParserError::assert(
+                                i,
+                                "`repeat` parsers must always consume",
+                            ));
                         }
 
                         res.accumulate(o);
@@ -720,7 +732,7 @@ where
     E: ParserError<I>,
 {
     if min > max {
-        return Err(ErrMode::assert(
+        return Err(ParserError::assert(
             i,
             "range should be ascending, rather than descending",
         ));
@@ -756,7 +768,10 @@ where
                     Ok(o) => {
                         // infinite loop check: the parser must always consume
                         if i.eof_offset() == len {
-                            return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
+                            return Err(ParserError::assert(
+                                i,
+                                "`repeat` parsers must always consume",
+                            ));
                         }
 
                         res.accumulate(o);
@@ -941,7 +956,7 @@ where
             Ok(_) => {
                 // infinite loop check
                 if input.eof_offset() == len {
-                    return Err(ErrMode::assert(
+                    return Err(ParserError::assert(
                         input,
                         "`separated` separator parser must always consume",
                     ));
@@ -996,7 +1011,7 @@ where
             Ok(_) => {
                 // infinite loop check
                 if input.eof_offset() == len {
-                    return Err(ErrMode::assert(
+                    return Err(ParserError::assert(
                         input,
                         "`separated` separator parser must always consume",
                     ));
@@ -1056,7 +1071,7 @@ where
             Ok(_) => {
                 // infinite loop check
                 if input.eof_offset() == len {
-                    return Err(ErrMode::assert(
+                    return Err(ParserError::assert(
                         input,
                         "`separated` separator parser must always consume",
                     ));
@@ -1092,7 +1107,7 @@ where
     E: ParserError<I>,
 {
     if min > max {
-        return Err(ErrMode::assert(
+        return Err(ParserError::assert(
             input,
             "range should be ascending, rather than descending",
         ));
@@ -1134,7 +1149,7 @@ where
             Ok(_) => {
                 // infinite loop check
                 if input.eof_offset() == len {
-                    return Err(ErrMode::assert(
+                    return Err(ParserError::assert(
                         input,
                         "`separated` separator parser must always consume",
                     ));
@@ -1211,7 +1226,10 @@ where
                 Ok(s) => {
                     // infinite loop check: the parser must always consume
                     if i.eof_offset() == len {
-                        return Err(ErrMode::assert(i, "`repeat` parsers must always consume"));
+                        return Err(ParserError::assert(
+                            i,
+                            "`repeat` parsers must always consume",
+                        ));
                     }
 
                     match parser.parse_next(i) {
@@ -1353,7 +1371,7 @@ where
             Ok(o) => {
                 // infinite loop check: the parser must always consume
                 if input.eof_offset() == len {
-                    return Err(ErrMode::assert(
+                    return Err(ParserError::assert(
                         input,
                         "`repeat` parsers must always consume",
                     ));
@@ -1404,7 +1422,7 @@ where
                     Ok(o) => {
                         // infinite loop check: the parser must always consume
                         if input.eof_offset() == len {
-                            return Err(ErrMode::assert(
+                            return Err(ParserError::assert(
                                 input,
                                 "`repeat` parsers must always consume",
                             ));
@@ -1436,7 +1454,7 @@ where
     E: ParserError<I>,
 {
     if min > max {
-        return Err(ErrMode::assert(
+        return Err(ParserError::assert(
             input,
             "range should be ascending, rather than descending",
         ));
@@ -1450,7 +1468,7 @@ where
             Ok(value) => {
                 // infinite loop check: the parser must always consume
                 if input.eof_offset() == len {
-                    return Err(ErrMode::assert(
+                    return Err(ParserError::assert(
                         input,
                         "`repeat` parsers must always consume",
                     ));
@@ -1491,7 +1509,7 @@ where
     E: ParserError<I>,
 {
     if min > max {
-        return Err(ErrMode::assert(
+        return Err(ParserError::assert(
             input,
             "range should be ascending, rather than descending",
         ));
@@ -1505,7 +1523,7 @@ where
             Ok(value) => {
                 // infinite loop check: the parser must always consume
                 if input.eof_offset() == len {
-                    return Err(ErrMode::assert(
+                    return Err(ParserError::assert(
                         input,
                         "`repeat` parsers must always consume",
                     ));
@@ -1513,7 +1531,7 @@ where
 
                 let Some(tmp) = fold(acc, value) else {
                     input.reset(&start);
-                    let res = Err(ErrMode::from_error_kind(input, ErrorKind::Verify));
+                    let res = Err(ParserError::from_error_kind(input, ErrorKind::Verify));
                     super::debug::trace_result("verify_fold", &res);
                     return res;
                 };
@@ -1552,7 +1570,7 @@ where
     E: ParserError<I> + FromExternalError<I, GE>,
 {
     if min > max {
-        return Err(ErrMode::assert(
+        return Err(ParserError::assert(
             input,
             "range should be ascending, rather than descending",
         ));
@@ -1566,7 +1584,7 @@ where
             Ok(value) => {
                 // infinite loop check: the parser must always consume
                 if input.eof_offset() == len {
-                    return Err(ErrMode::assert(
+                    return Err(ParserError::assert(
                         input,
                         "`repeat` parsers must always consume",
                     ));

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -1,19 +1,18 @@
 //! Combinators applying their child parser multiple times
 
 use crate::combinator::trace;
-use crate::error::ErrMode;
 use crate::error::ErrorKind;
 use crate::error::FromExternalError;
 use crate::error::ParserError;
 use crate::stream::Accumulate;
 use crate::stream::Range;
 use crate::stream::Stream;
-use crate::ModalResult;
 use crate::Parser;
+use crate::Result;
 
 /// [`Accumulate`] the output of a parser into a container, like `Vec`
 ///
-/// This stops before `n` when the parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
+/// This stops before `n` when the parser returns [`ErrMode::Backtrack`][crate::error::ErrMode::Backtrack]. To instead chain an error up, see
 /// [`cut_err`][crate::combinator::cut_err].
 ///
 /// To take a series of tokens, [`Accumulate`] into a `()`
@@ -157,7 +156,7 @@ where
 {
     /// Repeats the embedded parser, calling `op` to gather the results
     ///
-    /// This stops before `n` when the parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
+    /// This stops before `n` when the parser returns [`ErrMode::Backtrack`][crate::error::ErrMode::Backtrack]. To instead chain an error up, see
     /// [`cut_err`][crate::combinator::cut_err].
     ///
     /// # Arguments
@@ -286,7 +285,7 @@ where
 
     /// Akin to [`Repeat::fold`], but for containers that can reject an element.
     ///
-    /// This stops before `n` when the parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
+    /// This stops before `n` when the parser returns [`ErrMode::Backtrack`][crate::error::ErrMode::Backtrack]. To instead chain an error up, see
     /// [`cut_err`][crate::combinator::cut_err]. Additionally, if the fold function returns `None`, the parser will
     /// stop and return an error.
     ///
@@ -362,7 +361,7 @@ where
 
     /// Akin to [`Repeat::fold`], but for containers that can error when an element is accumulated.
     ///
-    /// This stops before `n` when the parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
+    /// This stops before `n` when the parser returns [`ErrMode::Backtrack`][crate::error::ErrMode::Backtrack]. To instead chain an error up, see
     /// [`cut_err`][crate::combinator::cut_err]. Additionally, if the fold function returns an error, the parser will
     /// stop and return it.
     ///
@@ -442,7 +441,7 @@ where
     E: ParserError<I>,
 {
     #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> ModalResult<C, E> {
+    fn parse_next(&mut self, i: &mut I) -> Result<C, E> {
         let Range {
             start_inclusive,
             end_inclusive,
@@ -459,7 +458,7 @@ where
     }
 }
 
-fn repeat0_<I, O, C, E, F>(f: &mut F, i: &mut I) -> ModalResult<C, E>
+fn repeat0_<I, O, C, E, F>(f: &mut F, i: &mut I) -> Result<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -491,7 +490,7 @@ where
     }
 }
 
-fn repeat1_<I, O, C, E, F>(f: &mut F, i: &mut I) -> ModalResult<C, E>
+fn repeat1_<I, O, C, E, F>(f: &mut F, i: &mut I) -> Result<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -531,7 +530,7 @@ where
     }
 }
 
-fn repeat_n_<I, O, C, E, F>(count: usize, f: &mut F, i: &mut I) -> ModalResult<C, E>
+fn repeat_n_<I, O, C, E, F>(count: usize, f: &mut F, i: &mut I) -> Result<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -564,12 +563,7 @@ where
     Ok(res)
 }
 
-fn repeat_m_n_<I, O, C, E, F>(
-    min: usize,
-    max: usize,
-    parse: &mut F,
-    input: &mut I,
-) -> ModalResult<C, E>
+fn repeat_m_n_<I, O, C, E, F>(min: usize, max: usize, parse: &mut F, input: &mut I) -> Result<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -621,7 +615,7 @@ where
 ///
 /// Returns a tuple of the results of `f` in a `Vec` and the result of `g`.
 ///
-/// `f` keeps going so long as `g` produces [`ErrMode::Backtrack`]. To instead chain an error up, see [`cut_err`][crate::combinator::cut_err].
+/// `f` keeps going so long as `g` produces [`ErrMode::Backtrack`][crate::error::ErrMode::Backtrack]. To instead chain an error up, see [`cut_err`][crate::combinator::cut_err].
 ///
 /// To take a series of tokens, [`Accumulate`] into a `()`
 /// (e.g. with [`.map(|((), _)| ())`][Parser::map])
@@ -681,7 +675,7 @@ where
     })
 }
 
-fn repeat_till0_<I, O, C, P, E, F, G>(f: &mut F, g: &mut G, i: &mut I) -> ModalResult<(C, P), E>
+fn repeat_till0_<I, O, C, P, E, F, G>(f: &mut F, g: &mut G, i: &mut I) -> Result<(C, P), E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -723,7 +717,7 @@ fn repeat_till_m_n_<I, O, C, P, E, F, G>(
     f: &mut F,
     g: &mut G,
     i: &mut I,
-) -> ModalResult<(C, P), E>
+) -> Result<(C, P), E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -786,7 +780,7 @@ where
 
 /// [`Accumulate`] the output of a parser, interleaved with `sep`
 ///
-/// This stops when either parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
+/// This stops when either parser returns [`ErrMode::Backtrack`][crate::error::ErrMode::Backtrack]. To instead chain an error up, see
 /// [`cut_err`][crate::combinator::cut_err].
 ///
 /// To take a series of tokens, [`Accumulate`] into a `()`
@@ -922,7 +916,7 @@ fn separated0_<I, O, C, O2, E, P, S>(
     parser: &mut P,
     separator: &mut S,
     input: &mut I,
-) -> ModalResult<C, E>
+) -> Result<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -981,7 +975,7 @@ fn separated1_<I, O, C, O2, E, P, S>(
     parser: &mut P,
     separator: &mut S,
     input: &mut I,
-) -> ModalResult<C, E>
+) -> Result<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -1037,7 +1031,7 @@ fn separated_n_<I, O, C, O2, E, P, S>(
     parser: &mut P,
     separator: &mut S,
     input: &mut I,
-) -> ModalResult<C, E>
+) -> Result<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -1098,7 +1092,7 @@ fn separated_m_n_<I, O, C, O2, E, P, S>(
     parser: &mut P,
     separator: &mut S,
     input: &mut I,
-) -> ModalResult<C, E>
+) -> Result<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -1180,7 +1174,7 @@ where
 
 /// Alternates between two parsers, merging the results (left associative)
 ///
-/// This stops when either parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
+/// This stops when either parser returns [`ErrMode::Backtrack`][crate::error::ErrMode::Backtrack]. To instead chain an error up, see
 /// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Example
@@ -1250,7 +1244,7 @@ where
 
 /// Alternates between two parsers, merging the results (right associative)
 ///
-/// This stops when either parser returns [`ErrMode::Backtrack`]. To instead chain an error up, see
+/// This stops when either parser returns [`ErrMode::Backtrack`][crate::error::ErrMode::Backtrack]. To instead chain an error up, see
 /// [`cut_err`][crate::combinator::cut_err].
 ///
 /// # Example
@@ -1354,7 +1348,7 @@ fn fold_repeat0_<I, O, E, F, G, H, R>(
     init: &mut H,
     g: &mut G,
     input: &mut I,
-) -> ModalResult<R, E>
+) -> Result<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -1395,7 +1389,7 @@ fn fold_repeat1_<I, O, E, F, G, H, R>(
     init: &mut H,
     g: &mut G,
     input: &mut I,
-) -> ModalResult<R, E>
+) -> Result<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -1445,7 +1439,7 @@ fn fold_repeat_m_n_<I, O, E, F, G, H, R>(
     init: &mut H,
     fold: &mut G,
     input: &mut I,
-) -> ModalResult<R, E>
+) -> Result<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -1500,7 +1494,7 @@ fn verify_fold_m_n<I, O, E, F, G, H, R>(
     init: &mut H,
     fold: &mut G,
     input: &mut I,
-) -> ModalResult<R, E>
+) -> Result<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -1561,7 +1555,7 @@ fn try_fold_m_n<I, O, E, F, G, H, R, GE>(
     init: &mut H,
     fold: &mut G,
     input: &mut I,
-) -> ModalResult<R, E>
+) -> Result<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -1594,7 +1588,7 @@ where
                     Ok(tmp) => acc = tmp,
                     Err(e) => {
                         input.reset(&start);
-                        let res = Err(ErrMode::from_external_error(input, ErrorKind::Verify, e));
+                        let res = Err(E::from_external_error(input, ErrorKind::Verify, e));
                         super::debug::trace_result("try_fold", &res);
                         return res;
                     }

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -8,7 +8,7 @@ use crate::error::ParserError;
 use crate::stream::Accumulate;
 use crate::stream::Range;
 use crate::stream::Stream;
-use crate::PResult;
+use crate::ModalResult;
 use crate::Parser;
 
 /// [`Accumulate`] the output of a parser into a container, like `Vec`
@@ -37,7 +37,7 @@ use crate::Parser;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
 ///   repeat(0.., "abc").parse_next(s)
 /// }
 ///
@@ -55,7 +55,7 @@ use crate::Parser;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
 ///   repeat(1.., "abc").parse_next(s)
 /// }
 ///
@@ -73,7 +73,7 @@ use crate::Parser;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
 ///   repeat(2, "abc").parse_next(s)
 /// }
 ///
@@ -92,7 +92,7 @@ use crate::Parser;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
 ///   repeat(0..=2, "abc").parse_next(s)
 /// }
 ///
@@ -181,7 +181,7 @@ where
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
-    /// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+    /// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
     ///   repeat(
     ///     0..,
     ///     "abc"
@@ -206,7 +206,7 @@ where
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
-    /// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+    /// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
     ///   repeat(
     ///     1..,
     ///     "abc",
@@ -231,7 +231,7 @@ where
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
-    /// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+    /// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
     ///   repeat(
     ///     0..=2,
     ///     "abc",
@@ -312,7 +312,7 @@ where
     /// use winnow::combinator::repeat;
     /// use std::collections::HashSet;
     ///
-    /// fn parser<'i>(s: &mut &'i str) -> PResult<HashSet<&'i str>> {
+    /// fn parser<'i>(s: &mut &'i str) -> ModalResult<HashSet<&'i str>> {
     ///   repeat(
     ///     0..,
     ///     "abc"
@@ -389,7 +389,7 @@ where
     /// use std::io::Write;
     /// use std::io::Error;
     ///
-    /// fn parser(s: &mut &str) -> PResult<Vec<u8>> {
+    /// fn parser(s: &mut &str) -> ModalResult<Vec<u8>> {
     ///   repeat(
     ///     0..,
     ///     "abc"
@@ -442,7 +442,7 @@ where
     E: ParserError<I>,
 {
     #[inline(always)]
-    fn parse_next(&mut self, i: &mut I) -> PResult<C, E> {
+    fn parse_next(&mut self, i: &mut I) -> ModalResult<C, E> {
         let Range {
             start_inclusive,
             end_inclusive,
@@ -459,7 +459,7 @@ where
     }
 }
 
-fn repeat0_<I, O, C, E, F>(f: &mut F, i: &mut I) -> PResult<C, E>
+fn repeat0_<I, O, C, E, F>(f: &mut F, i: &mut I) -> ModalResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -488,7 +488,7 @@ where
     }
 }
 
-fn repeat1_<I, O, C, E, F>(f: &mut F, i: &mut I) -> PResult<C, E>
+fn repeat1_<I, O, C, E, F>(f: &mut F, i: &mut I) -> ModalResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -525,7 +525,7 @@ where
     }
 }
 
-fn repeat_n_<I, O, C, E, F>(count: usize, f: &mut F, i: &mut I) -> PResult<C, E>
+fn repeat_n_<I, O, C, E, F>(count: usize, f: &mut F, i: &mut I) -> ModalResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -555,7 +555,12 @@ where
     Ok(res)
 }
 
-fn repeat_m_n_<I, O, C, E, F>(min: usize, max: usize, parse: &mut F, input: &mut I) -> PResult<C, E>
+fn repeat_m_n_<I, O, C, E, F>(
+    min: usize,
+    max: usize,
+    parse: &mut F,
+    input: &mut I,
+) -> ModalResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -629,7 +634,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat_till;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<(Vec<&'i str>, &'i str)> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<(Vec<&'i str>, &'i str)> {
 ///   repeat_till(0.., "abc", "end").parse_next(s)
 /// };
 ///
@@ -671,7 +676,7 @@ where
     })
 }
 
-fn repeat_till0_<I, O, C, P, E, F, G>(f: &mut F, g: &mut G, i: &mut I) -> PResult<(C, P), E>
+fn repeat_till0_<I, O, C, P, E, F, G>(f: &mut F, g: &mut G, i: &mut I) -> ModalResult<(C, P), E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -710,7 +715,7 @@ fn repeat_till_m_n_<I, O, C, P, E, F, G>(
     f: &mut F,
     g: &mut G,
     i: &mut I,
-) -> PResult<(C, P), E>
+) -> ModalResult<(C, P), E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -794,7 +799,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
 ///   separated(0.., "abc", "|").parse_next(s)
 /// }
 ///
@@ -813,7 +818,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
 ///   separated(1.., "abc", "|").parse_next(s)
 /// }
 ///
@@ -832,7 +837,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
 ///   separated(2, "abc", "|").parse_next(s)
 /// }
 ///
@@ -851,7 +856,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<Vec<&'i str>> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<Vec<&'i str>> {
 ///   separated(0..=2, "abc", "|").parse_next(s)
 /// }
 ///
@@ -906,7 +911,7 @@ fn separated0_<I, O, C, O2, E, P, S>(
     parser: &mut P,
     separator: &mut S,
     input: &mut I,
-) -> PResult<C, E>
+) -> ModalResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -965,7 +970,7 @@ fn separated1_<I, O, C, O2, E, P, S>(
     parser: &mut P,
     separator: &mut S,
     input: &mut I,
-) -> PResult<C, E>
+) -> ModalResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -1021,7 +1026,7 @@ fn separated_n_<I, O, C, O2, E, P, S>(
     parser: &mut P,
     separator: &mut S,
     input: &mut I,
-) -> PResult<C, E>
+) -> ModalResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -1082,7 +1087,7 @@ fn separated_m_n_<I, O, C, O2, E, P, S>(
     parser: &mut P,
     separator: &mut S,
     input: &mut I,
-) -> PResult<C, E>
+) -> ModalResult<C, E>
 where
     I: Stream,
     C: Accumulate<O>,
@@ -1187,7 +1192,7 @@ where
 /// use winnow::combinator::separated_foldl1;
 /// use winnow::ascii::dec_int;
 ///
-/// fn parser(s: &mut &str) -> PResult<i32> {
+/// fn parser(s: &mut &str) -> ModalResult<i32> {
 ///   separated_foldl1(dec_int, "-", |l, _, r| l - r).parse_next(s)
 /// }
 ///
@@ -1254,7 +1259,7 @@ where
 /// use winnow::combinator::separated_foldr1;
 /// use winnow::ascii::dec_uint;
 ///
-/// fn parser(s: &mut &str) -> PResult<u32> {
+/// fn parser(s: &mut &str) -> ModalResult<u32> {
 ///   separated_foldr1(dec_uint, "^", |l: u32, _, r: u32| l.pow(r)).parse_next(s)
 /// }
 ///
@@ -1304,7 +1309,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::fill;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<[&'i str; 2]> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<[&'i str; 2]> {
 ///   let mut buf = ["", ""];
 ///   fill("abc", &mut buf).parse_next(s)?;
 ///   Ok(buf)
@@ -1347,7 +1352,7 @@ fn fold_repeat0_<I, O, E, F, G, H, R>(
     init: &mut H,
     g: &mut G,
     input: &mut I,
-) -> PResult<R, E>
+) -> ModalResult<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -1388,7 +1393,7 @@ fn fold_repeat1_<I, O, E, F, G, H, R>(
     init: &mut H,
     g: &mut G,
     input: &mut I,
-) -> PResult<R, E>
+) -> ModalResult<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -1438,7 +1443,7 @@ fn fold_repeat_m_n_<I, O, E, F, G, H, R>(
     init: &mut H,
     fold: &mut G,
     input: &mut I,
-) -> PResult<R, E>
+) -> ModalResult<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -1497,7 +1502,7 @@ fn verify_fold_m_n<I, O, E, F, G, H, R>(
     init: &mut H,
     fold: &mut G,
     input: &mut I,
-) -> PResult<R, E>
+) -> ModalResult<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,
@@ -1562,7 +1567,7 @@ fn try_fold_m_n<I, O, E, F, G, H, R, GE>(
     init: &mut H,
     fold: &mut G,
     input: &mut I,
-) -> PResult<R, E>
+) -> ModalResult<R, E>
 where
     I: Stream,
     F: Parser<I, O, E>,

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -471,7 +471,7 @@ where
         let start = i.checkpoint();
         let len = i.eof_offset();
         match f.parse_next(i) {
-            Err(ErrMode::Backtrack(_)) => {
+            Err(e) if e.is_backtrack() => {
                 i.reset(&start);
                 return Ok(acc);
             }
@@ -506,7 +506,7 @@ where
                 let start = i.checkpoint();
                 let len = i.eof_offset();
                 match f.parse_next(i) {
-                    Err(ErrMode::Backtrack(_)) => {
+                    Err(e) if e.is_backtrack() => {
                         i.reset(&start);
                         return Ok(acc);
                     }
@@ -590,13 +590,9 @@ where
 
                 res.accumulate(value);
             }
-            Err(ErrMode::Backtrack(e)) => {
+            Err(e) if e.is_backtrack() => {
                 if count < min {
-                    return Err(ErrMode::Backtrack(e.append(
-                        input,
-                        &start,
-                        ErrorKind::Repeat,
-                    )));
+                    return Err(e.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);
                     return Ok(res);
@@ -690,7 +686,7 @@ where
         let len = i.eof_offset();
         match g.parse_next(i) {
             Ok(o) => return Ok((res, o)),
-            Err(ErrMode::Backtrack(_)) => {
+            Err(e) if e.is_backtrack() => {
                 i.reset(&start);
                 match f.parse_next(i) {
                     Err(e) => return Err(e.append(i, &start, ErrorKind::Repeat)),
@@ -748,9 +744,9 @@ where
         let len = i.eof_offset();
         match g.parse_next(i) {
             Ok(o) => return Ok((res, o)),
-            Err(ErrMode::Backtrack(err)) => {
+            Err(err) if err.is_backtrack() => {
                 if count == max {
-                    return Err(ErrMode::Backtrack(err));
+                    return Err(err);
                 }
                 i.reset(&start);
                 match f.parse_next(i) {
@@ -923,7 +919,7 @@ where
 
     let start = input.checkpoint();
     match parser.parse_next(input) {
-        Err(ErrMode::Backtrack(_)) => {
+        Err(e) if e.is_backtrack() => {
             input.reset(&start);
             return Ok(acc);
         }
@@ -937,7 +933,7 @@ where
         let start = input.checkpoint();
         let len = input.eof_offset();
         match separator.parse_next(input) {
-            Err(ErrMode::Backtrack(_)) => {
+            Err(e) if e.is_backtrack() => {
                 input.reset(&start);
                 return Ok(acc);
             }
@@ -952,7 +948,7 @@ where
                 }
 
                 match parser.parse_next(input) {
-                    Err(ErrMode::Backtrack(_)) => {
+                    Err(e) if e.is_backtrack() => {
                         input.reset(&start);
                         return Ok(acc);
                     }
@@ -992,7 +988,7 @@ where
         let start = input.checkpoint();
         let len = input.eof_offset();
         match separator.parse_next(input) {
-            Err(ErrMode::Backtrack(_)) => {
+            Err(e) if e.is_backtrack() => {
                 input.reset(&start);
                 return Ok(acc);
             }
@@ -1007,7 +1003,7 @@ where
                 }
 
                 match parser.parse_next(input) {
-                    Err(ErrMode::Backtrack(_)) => {
+                    Err(e) if e.is_backtrack() => {
                         input.reset(&start);
                         return Ok(acc);
                     }
@@ -1106,16 +1102,12 @@ where
 
     let start = input.checkpoint();
     match parser.parse_next(input) {
-        Err(ErrMode::Backtrack(e)) => {
+        Err(e) if e.is_backtrack() => {
             if min == 0 {
                 input.reset(&start);
                 return Ok(acc);
             } else {
-                return Err(ErrMode::Backtrack(e.append(
-                    input,
-                    &start,
-                    ErrorKind::Repeat,
-                )));
+                return Err(e.append(input, &start, ErrorKind::Repeat));
             }
         }
         Err(e) => return Err(e),
@@ -1128,13 +1120,9 @@ where
         let start = input.checkpoint();
         let len = input.eof_offset();
         match separator.parse_next(input) {
-            Err(ErrMode::Backtrack(e)) => {
+            Err(e) if e.is_backtrack() => {
                 if index < min {
-                    return Err(ErrMode::Backtrack(e.append(
-                        input,
-                        &start,
-                        ErrorKind::Repeat,
-                    )));
+                    return Err(e.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);
                     return Ok(acc);
@@ -1153,13 +1141,9 @@ where
                 }
 
                 match parser.parse_next(input) {
-                    Err(ErrMode::Backtrack(e)) => {
+                    Err(e) if e.is_backtrack() => {
                         if index < min {
-                            return Err(ErrMode::Backtrack(e.append(
-                                input,
-                                &start,
-                                ErrorKind::Repeat,
-                            )));
+                            return Err(e.append(input, &start, ErrorKind::Repeat));
                         } else {
                             input.reset(&start);
                             return Ok(acc);
@@ -1219,7 +1203,7 @@ where
             let start = i.checkpoint();
             let len = i.eof_offset();
             match sep.parse_next(i) {
-                Err(ErrMode::Backtrack(_)) => {
+                Err(e) if e.is_backtrack() => {
                     i.reset(&start);
                     return Ok(ol);
                 }
@@ -1231,7 +1215,7 @@ where
                     }
 
                     match parser.parse_next(i) {
-                        Err(ErrMode::Backtrack(_)) => {
+                        Err(e) if e.is_backtrack() => {
                             i.reset(&start);
                             return Ok(ol);
                         }
@@ -1377,7 +1361,7 @@ where
 
                 res = g(res, o);
             }
-            Err(ErrMode::Backtrack(_)) => {
+            Err(e) if e.is_backtrack() => {
                 input.reset(&start);
                 return Ok(res);
             }
@@ -1412,7 +1396,7 @@ where
                 let start = input.checkpoint();
                 let len = input.eof_offset();
                 match f.parse_next(input) {
-                    Err(ErrMode::Backtrack(_)) => {
+                    Err(e) if e.is_backtrack() => {
                         input.reset(&start);
                         break;
                     }
@@ -1475,13 +1459,9 @@ where
                 acc = fold(acc, value);
             }
             //FInputXMError: handle failure properly
-            Err(ErrMode::Backtrack(err)) => {
+            Err(err) if err.is_backtrack() => {
                 if count < min {
-                    return Err(ErrMode::Backtrack(err.append(
-                        input,
-                        &start,
-                        ErrorKind::Repeat,
-                    )));
+                    return Err(err.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);
                     break;
@@ -1540,13 +1520,9 @@ where
                 acc = tmp;
             }
             //FInputXMError: handle failure properly
-            Err(ErrMode::Backtrack(err)) => {
+            Err(err) if err.is_backtrack() => {
                 if count < min {
-                    return Err(ErrMode::Backtrack(err.append(
-                        input,
-                        &start,
-                        ErrorKind::Repeat,
-                    )));
+                    return Err(err.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);
                     break;
@@ -1607,13 +1583,9 @@ where
                 }
             }
             //FInputXMError: handle failure properly
-            Err(ErrMode::Backtrack(err)) => {
+            Err(err) if err.is_backtrack() => {
                 if count < min {
-                    return Err(ErrMode::Backtrack(err.append(
-                        input,
-                        &start,
-                        ErrorKind::Repeat,
-                    )));
+                    return Err(err.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);
                     break;

--- a/src/combinator/sequence.rs
+++ b/src/combinator/sequence.rs
@@ -18,7 +18,7 @@ pub use crate::seq;
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::preceded;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 ///     preceded("abc", "efg").parse_next(input)
 /// }
 ///
@@ -56,7 +56,7 @@ where
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::terminated;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 ///     terminated("abc", "efg").parse_next(input)
 /// }
 ///
@@ -94,7 +94,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_pair;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<(&'i str, &'i str)> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<(&'i str, &'i str)> {
 ///     separated_pair("abc", "|", "efg").parse_next(input)
 /// }
 ///
@@ -134,7 +134,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::combinator::delimited;
 ///
-/// fn parser<'i>(input: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 ///     delimited("(", "abc", ")").parse_next(input)
 /// }
 ///

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -2922,7 +2922,7 @@ Err(
 fn infinite_many() {
     fn tst<'i>(input: &mut &'i [u8]) -> TestResult<&'i [u8], &'i [u8]> {
         println!("input: {input:?}");
-        Err(ErrMode::from_error_kind(input, ErrorKind::Literal))
+        Err(ParserError::from_error_kind(input, ErrorKind::Literal))
     }
 
     // should not go into an infinite loop

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -119,8 +119,14 @@ impl From<u32> for CustomError {
 }
 
 impl<I: Stream> ParserError<I> for CustomError {
+    type Inner = Self;
+
     fn from_error_kind(_: &I, _: ErrorKind) -> Self {
         CustomError
+    }
+
+    fn into_inner(self) -> Result<Self::Inner, Self> {
+        Ok(self)
     }
 }
 
@@ -1322,6 +1328,8 @@ fn alt_test() {
 
     #[cfg(feature = "alloc")]
     impl<I: Stream + Debug> ParserError<I> for ErrorStr {
+        type Inner = Self;
+
         fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
             ErrorStr(format!("custom error message: ({input:?}, {kind:?})"))
         }
@@ -1330,6 +1338,10 @@ fn alt_test() {
             ErrorStr(format!(
                 "custom error message: ({input:?}, {kind:?}) - {self:?}"
             ))
+        }
+
+        fn into_inner(self) -> Result<Self::Inner, Self> {
+            Ok(self)
         }
     }
 
@@ -3457,8 +3469,14 @@ impl<I> From<(I, ErrorKind)> for NilError {
 }
 
 impl<I: Stream> ParserError<I> for NilError {
+    type Inner = Self;
+
     fn from_error_kind(_: &I, _: ErrorKind) -> NilError {
         NilError
+    }
+
+    fn into_inner(self) -> Result<Self::Inner, Self> {
+        Ok(self)
     }
 }
 

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -15,7 +15,7 @@ use crate::lib::std::borrow::ToOwned;
 use crate::prelude::*;
 use crate::stream::Stream;
 use crate::token::take;
-use crate::PResult;
+use crate::ModalResult;
 use crate::Partial;
 
 #[cfg(feature = "alloc")]
@@ -126,7 +126,7 @@ impl<I: Stream> ParserError<I> for CustomError {
 
 struct CustomError;
 #[allow(dead_code)]
-fn custom_error<'i>(input: &mut &'i [u8]) -> PResult<&'i [u8], CustomError> {
+fn custom_error<'i>(input: &mut &'i [u8]) -> ModalResult<&'i [u8], CustomError> {
     //fix_error!(input, CustomError<_>, alphanumeric)
     crate::ascii::alphanumeric1.parse_next(input)
 }
@@ -157,7 +157,7 @@ Ok(
 }
 
 #[allow(dead_code)]
-fn test_closure_compiles_195(input: &mut &[u8]) -> PResult<()> {
+fn test_closure_compiles_195(input: &mut &[u8]) -> ModalResult<()> {
     u8.flat_map(|num| repeat(num as usize, u16(Endianness::Big)))
         .parse_next(input)
 }
@@ -1333,26 +1333,26 @@ fn alt_test() {
         }
     }
 
-    fn work<'i>(input: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+    fn work<'i>(input: &mut &'i [u8]) -> ModalResult<&'i [u8], ErrorStr> {
         Ok(input.finish())
     }
 
     #[allow(unused_variables)]
-    fn dont_work<'i>(input: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+    fn dont_work<'i>(input: &mut &'i [u8]) -> ModalResult<&'i [u8], ErrorStr> {
         Err(ErrMode::Backtrack(ErrorStr("abcd".to_owned())))
     }
 
-    fn work2<'i>(_input: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+    fn work2<'i>(_input: &mut &'i [u8]) -> ModalResult<&'i [u8], ErrorStr> {
         Ok(&b""[..])
     }
 
-    fn alt1<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+    fn alt1<'i>(i: &mut &'i [u8]) -> ModalResult<&'i [u8], ErrorStr> {
         alt((dont_work, dont_work)).parse_next(i)
     }
-    fn alt2<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+    fn alt2<'i>(i: &mut &'i [u8]) -> ModalResult<&'i [u8], ErrorStr> {
         alt((dont_work, work)).parse_next(i)
     }
-    fn alt3<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], ErrorStr> {
+    fn alt3<'i>(i: &mut &'i [u8]) -> ModalResult<&'i [u8], ErrorStr> {
         alt((dont_work, dont_work, work2, dont_work)).parse_next(i)
     }
     //named!(alt1, alt!(dont_work | dont_work));

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@
 //! - Can be modified according to the user's needs, because some languages need a lot more information
 //! - Help thread-through the [stream][crate::stream]
 //!
-//! To abstract these needs away from the user, generally `winnow` parsers use the [`PResult`]
+//! To abstract these needs away from the user, generally `winnow` parsers use the [`ModalResult`]
 //! alias, rather than [`Result`].  [`Parser::parse`] is a top-level operation
 //! that can help convert to a `Result` for integrating with your application's error reporting.
 //!
@@ -46,12 +46,12 @@ pub type ModalResult<O, E = ContextError> = Result<O, ErrMode<E>>;
 #[deprecated(since = "0.6.23", note = "Replaced with ModalResult")]
 pub type PResult<O, E = ContextError> = ModalResult<O, E>;
 
-/// Deprecated, replaced with [`PResult`]
-#[deprecated(since = "0.6.25", note = "Replaced with `PResult`")]
-pub type IResult<I, O, E = InputError<I>> = PResult<(I, O), E>;
+/// Deprecated, replaced with [`ModalResult`]
+#[deprecated(since = "0.6.25", note = "Replaced with `ModalResult`")]
+pub type IResult<I, O, E = InputError<I>> = ModalResult<(I, O), E>;
 
 #[cfg(test)]
-pub(crate) type TestResult<I, O> = PResult<O, InputError<I>>;
+pub(crate) type TestResult<I, O> = ModalResult<O, InputError<I>>;
 
 /// Contains information on needed data if a parser returned `Incomplete`
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ use crate::stream::Stream;
 #[allow(unused_imports)] // Here for intra-doc links
 use crate::Parser;
 
-/// For use with [`Parser::parse_next`]
+/// [Modal error reporting][ErrMode] for [`Parser::parse_next`]
 ///
 /// - `Ok(O)` is the parsed value
 /// - [`Err(ErrMode<E>)`][ErrMode] is the error along with how to respond to it
@@ -40,7 +40,11 @@ use crate::Parser;
 /// When integrating into the result of the application, see
 /// - [`Parser::parse`]
 /// - [`ErrMode::into_inner`]
-pub type PResult<O, E = ContextError> = Result<O, ErrMode<E>>;
+pub type ModalResult<O, E = ContextError> = Result<O, ErrMode<E>>;
+
+/// Deprecated, replaced with [`ModalResult`]
+#[deprecated(since = "0.6.23", note = "Replaced with ModalResult")]
+pub type PResult<O, E = ContextError> = ModalResult<O, E>;
 
 /// Deprecated, replaced with [`PResult`]
 #[deprecated(since = "0.6.25", note = "Replaced with `PResult`")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -209,6 +209,11 @@ impl<I: Stream, E: ParserError<I>> ParserError<I> for ErrMode<E> {
             (ErrMode::Cut(e), _) | (_, ErrMode::Cut(e)) => ErrMode::Cut(e),
         }
     }
+
+    #[inline(always)]
+    fn is_backtrack(&self) -> bool {
+        matches!(self, ErrMode::Backtrack(_))
+    }
 }
 
 impl<E1, E2> ErrorConvert<ErrMode<E2>> for ErrMode<E1>
@@ -331,6 +336,12 @@ pub trait ParserError<I: Stream>: Sized {
     #[inline]
     fn or(self, other: Self) -> Self {
         other
+    }
+
+    /// Is backtracking and trying new parse branches allowed?
+    #[inline(always)]
+    fn is_backtrack(&self) -> bool {
+        true
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -219,6 +219,19 @@ impl<I: Stream, E: ParserError<I>> ParserError<I> for ErrMode<E> {
     fn is_backtrack(&self) -> bool {
         matches!(self, ErrMode::Backtrack(_))
     }
+
+    #[inline(always)]
+    fn is_needed(&self) -> bool {
+        matches!(self, ErrMode::Incomplete(_))
+    }
+
+    #[inline(always)]
+    fn into_needed(self) -> Result<Needed, Self> {
+        match self {
+            ErrMode::Incomplete(needed) => Ok(needed),
+            err => Err(err),
+        }
+    }
 }
 
 impl<E1, E2> ErrorConvert<ErrMode<E2>> for ErrMode<E1>
@@ -360,6 +373,18 @@ pub trait ParserError<I: Stream>: Sized {
     #[inline(always)]
     fn is_backtrack(&self) -> bool {
         true
+    }
+
+    /// Is more data [`Needed`]
+    #[inline(always)]
+    fn is_needed(&self) -> bool {
+        false
+    }
+
+    /// Extract the [`Needed`] data, if present
+    #[inline(always)]
+    fn into_needed(self) -> Result<Needed, Self> {
+        Err(self)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,13 @@ use crate::stream::Stream;
 #[allow(unused_imports)] // Here for intra-doc links
 use crate::Parser;
 
+/// By default, the error type (`E`) is [`ContextError`].
+///
+/// When integrating into the result of the application, see
+/// - [`Parser::parse`]
+/// - [`ParserError::into_inner`]
+pub type Result<O, E = ContextError> = core::result::Result<O, E>;
+
 /// [Modal error reporting][ErrMode] for [`Parser::parse_next`]
 ///
 /// - `Ok(O)` is the parsed value

--- a/src/error.rs
+++ b/src/error.rs
@@ -238,6 +238,22 @@ impl<I: Stream, C, E: AddContext<I, C>> AddContext<I, C> for ErrMode<E> {
     }
 }
 
+#[cfg(feature = "unstable-recover")]
+#[cfg(feature = "std")]
+impl<I: Stream, E1: FromRecoverableError<I, E2>, E2> FromRecoverableError<I, ErrMode<E2>>
+    for ErrMode<E1>
+{
+    #[inline]
+    fn from_recoverable_error(
+        token_start: &<I as Stream>::Checkpoint,
+        err_start: &<I as Stream>::Checkpoint,
+        input: &I,
+        e: ErrMode<E2>,
+    ) -> Self {
+        e.map(|e| E1::from_recoverable_error(token_start, err_start, input, e))
+    }
+}
+
 impl<T: Clone> ErrMode<InputError<T>> {
     /// Maps `ErrMode<InputError<T>>` to `ErrMode<InputError<U>>` with the given `F: T -> U`
     pub fn map_input<U: Clone, F>(self, f: F) -> ErrMode<InputError<U>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ pub mod prelude {
 pub use error::ModalResult;
 #[allow(deprecated)]
 pub use error::PResult;
+pub use error::Result;
 pub use parser::*;
 pub use stream::BStr;
 pub use stream::Bytes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ pub mod prelude {
     pub use crate::stream::ContainsToken as _;
     pub use crate::stream::Stream as _;
     pub use crate::stream::StreamIsPartial as _;
+    pub use crate::ModalResult;
     pub use crate::PResult;
     pub use crate::Parser;
     #[cfg(feature = "unstable-recover")]
@@ -159,6 +160,7 @@ pub mod prelude {
     pub(crate) use crate::TestResult;
 }
 
+pub use error::ModalResult;
 pub use error::PResult;
 pub use parser::*;
 pub use stream::BStr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub mod prelude {
     pub use crate::stream::ContainsToken as _;
     pub use crate::stream::Stream as _;
     pub use crate::stream::StreamIsPartial as _;
+    pub use crate::ModalParser;
     pub use crate::ModalResult;
     #[allow(deprecated)]
     pub use crate::PResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub mod _tutorial;
 /// ```rust
 /// use winnow::prelude::*;
 ///
-/// fn parse_data(input: &mut &str) -> PResult<u64> {
+/// fn parse_data(input: &mut &str) -> ModalResult<u64> {
 ///     // ...
 /// #   winnow::ascii::dec_uint(input)
 /// }
@@ -150,6 +150,7 @@ pub mod prelude {
     pub use crate::stream::Stream as _;
     pub use crate::stream::StreamIsPartial as _;
     pub use crate::ModalResult;
+    #[allow(deprecated)]
     pub use crate::PResult;
     pub use crate::Parser;
     #[cfg(feature = "unstable-recover")]
@@ -161,6 +162,7 @@ pub mod prelude {
 }
 
 pub use error::ModalResult;
+#[allow(deprecated)]
 pub use error::PResult;
 pub use parser::*;
 pub use stream::BStr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ pub mod _tutorial;
 /// }
 /// ```
 pub mod prelude {
+    pub use crate::error::ModalError as _;
     pub use crate::error::ParserError as _;
     pub use crate::stream::AsChar as _;
     pub use crate::stream::ContainsToken as _;

--- a/src/macros/dispatch.rs
+++ b/src/macros/dispatch.rs
@@ -17,11 +17,11 @@
 /// # use winnow::combinator::empty;
 /// # use winnow::combinator::fail;
 ///
-/// fn escaped(input: &mut &str) -> PResult<char> {
+/// fn escaped(input: &mut &str) -> ModalResult<char> {
 ///     preceded('\\', escape_seq_char).parse_next(input)
 /// }
 ///
-/// fn escape_seq_char(input: &mut &str) -> PResult<char> {
+/// fn escape_seq_char(input: &mut &str) -> ModalResult<char> {
 ///     dispatch! {any;
 ///         'b' => empty.value('\u{8}'),
 ///         'f' => empty.value('\u{c}'),

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -4,7 +4,7 @@ mod seq;
 #[cfg(test)]
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {
-     let res: $crate::error::PResult<_, $crate::error::InputError<_>> = $left;
+     let res: $crate::error::ModalResult<_, $crate::error::InputError<_>> = $left;
      snapbox::assert_data_eq!(snapbox::data::ToDebug::to_debug(&res), $right);
   };
 );

--- a/src/macros/seq.rs
+++ b/src/macros/seq.rs
@@ -28,7 +28,7 @@
 /// }
 ///
 /// // Parse into structs / tuple-structs
-/// fn field(input: &mut &[u8]) -> PResult<Field> {
+/// fn field(input: &mut &[u8]) -> ModalResult<Field> {
 ///     seq!{Field {
 ///         namespace: empty.value(5),
 ///         name: alphanumeric1.map(|s: &[u8]| s.to_owned()),
@@ -43,7 +43,7 @@
 /// }
 ///
 /// // Or parse into tuples
-/// fn point(input: &mut &[u8]) -> PResult<(u32, u32)> {
+/// fn point(input: &mut &[u8]) -> ModalResult<(u32, u32)> {
 ///     let mut num = dec_uint::<_, u32, ContextError>;
 ///     seq!(num, _: (space0, b',', space0), num).parse_next(input)
 /// }

--- a/src/macros/seq.rs
+++ b/src/macros/seq.rs
@@ -16,6 +16,7 @@
 /// # use winnow::combinator::delimited;
 /// # use winnow::combinator::empty;
 /// # use winnow::error::ContextError;
+/// # use winnow::error::ErrMode;
 /// use winnow::combinator::seq;
 ///
 /// #[derive(Default, Debug, PartialEq)]
@@ -44,7 +45,7 @@
 ///
 /// // Or parse into tuples
 /// fn point(input: &mut &[u8]) -> ModalResult<(u32, u32)> {
-///     let mut num = dec_uint::<_, u32, ContextError>;
+///     let mut num = dec_uint::<_, u32, ErrMode<ContextError>>;
 ///     seq!(num, _: (space0, b',', space0), num).parse_next(input)
 /// }
 ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -544,6 +544,7 @@ pub trait Parser<I, O, E> {
         G: FnMut(O) -> Result<O2, E2>,
         I: Stream,
         E: FromExternalError<I, E2>,
+        E: ParserError<I>,
     {
         impls::TryMap {
             parser: self,
@@ -781,6 +782,7 @@ pub trait Parser<I, O, E> {
         Self: core::marker::Sized,
         I: Stream,
         E: AddContext<I, C>,
+        E: ParserError<I>,
         C: Clone + crate::lib::std::fmt::Debug,
     {
         impls::Context {
@@ -855,7 +857,7 @@ pub trait Parser<I, O, E> {
         R: Parser<I, (), E>,
         I: Stream,
         I: Recover<E>,
-        E: FromRecoverableError<I, E>,
+        E: ParserError<I> + FromRecoverableError<I, E>,
     {
         impls::RetryAfter {
             parser: self,
@@ -879,7 +881,7 @@ pub trait Parser<I, O, E> {
         R: Parser<I, (), E>,
         I: Stream,
         I: Recover<E>,
-        E: FromRecoverableError<I, E>,
+        E: ParserError<I> + FromRecoverableError<I, E>,
     {
         impls::ResumeAfter {
             parser: self,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1218,6 +1218,11 @@ impl<I, O, E> Parser<I, O, E> for Box<dyn Parser<I, O, E> + '_> {
     }
 }
 
+/// Trait alias for [`Parser`] to be used with [`ModalResult`][crate::error::ModalResult]
+pub trait ModalParser<I, O, E>: Parser<I, O, crate::error::ErrMode<E>> {}
+
+impl<I, O, E, P> ModalParser<I, O, E> for P where P: Parser<I, O, crate::error::ErrMode<E>> {}
+
 /// Collect all errors when parsing the input
 ///
 /// [`Parser`]s will need to use [`Recoverable<I, _>`] for their input.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -65,9 +65,9 @@ pub trait Parser<I, O, E> {
         let (o, _) = (self.by_ref(), crate::combinator::eof)
             .parse_next(&mut input)
             .map_err(|e| {
-                let e = e
-                    .into_inner()
-                    .expect("complete parsers should not report `ErrMode::Incomplete(_)`");
+                let e = e.into_inner().unwrap_or_else(|_err| {
+                    panic!("complete parsers should not report `ErrMode::Incomplete(_)`")
+                });
                 ParseError::new(input, start, e)
             })?;
         Ok(o)
@@ -1264,9 +1264,9 @@ where
         let (o, err) = match result {
             Ok((o, _)) => (Some(o), None),
             Err(err) => {
-                let err = err
-                    .into_inner()
-                    .expect("complete parsers should not report `ErrMode::Incomplete(_)`");
+                let err = err.into_inner().unwrap_or_else(|_err| {
+                    panic!("complete parsers should not report `ErrMode::Incomplete(_)`")
+                });
                 let err_start = input.checkpoint();
                 let err = R::from_recoverable_error(&start_token, &err_start, &input, err);
                 (None, Some(err))

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -307,7 +307,7 @@ where
 ///
 /// type Stream<'is> = Stateful<&'is str, State<'is>>;
 ///
-/// fn word<'s>(i: &mut Stream<'s>) -> PResult<&'s str> {
+/// fn word<'s>(i: &mut Stream<'s>) -> ModalResult<&'s str> {
 ///   i.state.count();
 ///   alpha1.parse_next(i)
 /// }
@@ -370,14 +370,14 @@ impl<I: crate::lib::std::fmt::Display, S> crate::lib::std::fmt::Display for Stat
 /// Here is how it works in practice:
 ///
 /// ```rust
-/// # use winnow::{PResult, error::ErrMode, error::Needed, error::{ContextError, ErrorKind}, token, ascii, stream::Partial};
+/// # use winnow::{ModalResult, error::ErrMode, error::Needed, error::{ContextError, ErrorKind}, token, ascii, stream::Partial};
 /// # use winnow::prelude::*;
 ///
-/// fn take_partial<'s>(i: &mut Partial<&'s [u8]>) -> PResult<&'s [u8], ContextError> {
+/// fn take_partial<'s>(i: &mut Partial<&'s [u8]>) -> ModalResult<&'s [u8], ContextError> {
 ///   token::take(4u8).parse_next(i)
 /// }
 ///
-/// fn take_complete<'s>(i: &mut &'s [u8]) -> PResult<&'s [u8], ContextError> {
+/// fn take_complete<'s>(i: &mut &'s [u8]) -> ModalResult<&'s [u8], ContextError> {
 ///   token::take(4u8).parse_next(i)
 /// }
 ///
@@ -393,11 +393,11 @@ impl<I: crate::lib::std::fmt::Display, S> crate::lib::std::fmt::Display for Stat
 /// assert!(take_complete.parse_peek(&b"abc"[..]).is_err());
 ///
 /// // the alpha0 function takes 0 or more alphabetic characters
-/// fn alpha0_partial<'s>(i: &mut Partial<&'s str>) -> PResult<&'s str, ContextError> {
+/// fn alpha0_partial<'s>(i: &mut Partial<&'s str>) -> ModalResult<&'s str, ContextError> {
 ///   ascii::alpha0.parse_next(i)
 /// }
 ///
-/// fn alpha0_complete<'s>(i: &mut &'s str) -> PResult<&'s str, ContextError> {
+/// fn alpha0_complete<'s>(i: &mut &'s str) -> ModalResult<&'s str, ContextError> {
 ///   ascii::alpha0.parse_next(i)
 /// }
 ///
@@ -2838,7 +2838,7 @@ impl<T: crate::lib::std::fmt::Debug, S> crate::lib::std::fmt::Debug for Checkpoi
 /// # use winnow::prelude::*;
 /// # use winnow::token::any;
 /// # use winnow::combinator::repeat;
-/// # fn inner(input: &mut &str) -> PResult<char> {
+/// # fn inner(input: &mut &str) -> ModalResult<char> {
 /// #     any.parse_next(input)
 /// # }
 /// # let mut input = "0123456789012345678901234567890123456789";
@@ -3415,7 +3415,7 @@ impl AsChar for &char {
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError};
 /// # use winnow::token::take_while;
-/// fn hex_digit1<'s>(input: &mut &'s str) -> PResult<&'s str, ContextError> {
+/// fn hex_digit1<'s>(input: &mut &'s str) -> ModalResult<&'s str, ContextError> {
 ///     take_while(1.., ('a'..='f', 'A'..='F', '0'..='9')).parse_next(input)
 /// }
 ///

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -370,7 +370,7 @@ impl<I: crate::lib::std::fmt::Display, S> crate::lib::std::fmt::Display for Stat
 /// Here is how it works in practice:
 ///
 /// ```rust
-/// # use winnow::{ModalResult, error::ErrMode, error::Needed, error::{ContextError, ErrorKind}, token, ascii, stream::Partial};
+/// # use winnow::{Result, error::ErrMode, error::Needed, error::{ContextError, ErrorKind}, token, ascii, stream::Partial};
 /// # use winnow::prelude::*;
 ///
 /// fn take_partial<'s>(i: &mut Partial<&'s [u8]>) -> ModalResult<&'s [u8], ContextError> {
@@ -1387,8 +1387,8 @@ pub trait Recover<E>: Stream {
         &mut self,
         token_start: &Self::Checkpoint,
         err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>>;
+        err: E,
+    ) -> Result<(), E>;
 
     /// Report whether the [`Stream`] can save off errors for recovery
     fn is_recovery_supported() -> bool;
@@ -1405,8 +1405,8 @@ where
         &mut self,
         _token_start: &Self::Checkpoint,
         _err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>> {
+        err: E,
+    ) -> Result<(), E> {
         Err(err)
     }
 
@@ -1425,8 +1425,8 @@ impl<E> Recover<E> for &str {
         &mut self,
         _token_start: &Self::Checkpoint,
         _err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>> {
+        err: E,
+    ) -> Result<(), E> {
         Err(err)
     }
 
@@ -1445,8 +1445,8 @@ impl<E> Recover<E> for &Bytes {
         &mut self,
         _token_start: &Self::Checkpoint,
         _err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>> {
+        err: E,
+    ) -> Result<(), E> {
         Err(err)
     }
 
@@ -1465,8 +1465,8 @@ impl<E> Recover<E> for &BStr {
         &mut self,
         _token_start: &Self::Checkpoint,
         _err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>> {
+        err: E,
+    ) -> Result<(), E> {
         Err(err)
     }
 
@@ -1489,8 +1489,8 @@ where
         &mut self,
         _token_start: &Self::Checkpoint,
         _err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>> {
+        err: E,
+    ) -> Result<(), E> {
         Err(err)
     }
 
@@ -1513,8 +1513,8 @@ where
         &mut self,
         _token_start: &Self::Checkpoint,
         _err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>> {
+        err: E,
+    ) -> Result<(), E> {
         Err(err)
     }
 
@@ -1538,16 +1538,15 @@ where
         &mut self,
         token_start: &Self::Checkpoint,
         err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>> {
+        err: E,
+    ) -> Result<(), E> {
         if self.is_recoverable {
-            match err {
-                ErrMode::Incomplete(need) => Err(ErrMode::Incomplete(need)),
-                ErrMode::Backtrack(err) | ErrMode::Cut(err) => {
-                    self.errors
-                        .push(R::from_recoverable_error(token_start, err_start, self, err));
-                    Ok(())
-                }
+            if err.is_needed() {
+                Err(err)
+            } else {
+                self.errors
+                    .push(R::from_recoverable_error(token_start, err_start, self, err));
+                Ok(())
             }
         } else {
             Err(err)
@@ -1574,8 +1573,8 @@ where
         &mut self,
         _token_start: &Self::Checkpoint,
         _err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>> {
+        err: E,
+    ) -> Result<(), E> {
         Err(err)
     }
 
@@ -1598,8 +1597,8 @@ where
         &mut self,
         _token_start: &Self::Checkpoint,
         _err_start: &Self::Checkpoint,
-        err: ErrMode<E>,
-    ) -> Result<(), ErrMode<E>> {
+        err: E,
+    ) -> Result<(), E> {
         Err(err)
     }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1532,6 +1532,7 @@ where
     I: Stream,
     R: FromRecoverableError<Self, E>,
     R: crate::lib::std::fmt::Debug,
+    E: crate::error::ParserError<Self>,
 {
     fn record_err(
         &mut self,

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -6,7 +6,7 @@ use crate::error::{ErrorKind, InputError};
 use crate::token::literal;
 use crate::{
     combinator::{separated, separated_pair},
-    PResult, Parser,
+    ModalResult, Parser,
 };
 
 use super::*;
@@ -15,7 +15,7 @@ use super::*;
 #[test]
 fn test_fxhashmap_compiles() {
     let input = "a=b";
-    fn pair(i: &mut &str) -> PResult<(char, char)> {
+    fn pair(i: &mut &str) -> ModalResult<(char, char)> {
         let out = separated_pair('a', '=', 'b').parse_next(i)?;
         Ok(out)
     }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -12,8 +12,8 @@ use crate::lib::std::result::Result::Ok;
 use crate::stream::Range;
 use crate::stream::{Compare, CompareResult, ContainsToken, FindSlice, SliceLen, Stream};
 use crate::stream::{StreamIsPartial, ToUsize};
-use crate::ModalResult;
 use crate::Parser;
+use crate::Result;
 
 /// Matches one token
 ///
@@ -49,12 +49,12 @@ use crate::Parser;
 /// # use winnow::{token::any, error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
-/// assert_eq!(any::<_, ContextError>.parse_peek(Partial::new("abc")), Ok((Partial::new("bc"),'a')));
-/// assert_eq!(any::<_, ContextError>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(any::<_, ErrMode<ContextError>>.parse_peek(Partial::new("abc")), Ok((Partial::new("bc"),'a')));
+/// assert_eq!(any::<_, ErrMode<ContextError>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 #[doc(alias = "token")]
-pub fn any<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Token, Error>
+pub fn any<Input, Error>(input: &mut Input) -> Result<<Input as Stream>::Token, Error>
 where
     Input: StreamIsPartial + Stream,
     Error: ParserError<Input>,
@@ -69,9 +69,7 @@ where
     .parse_next(input)
 }
 
-fn any_<I, E: ParserError<I>, const PARTIAL: bool>(
-    input: &mut I,
-) -> ModalResult<<I as Stream>::Token, E>
+fn any_<I, E: ParserError<I>, const PARTIAL: bool>(input: &mut I) -> Result<<I as Stream>::Token, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -181,7 +179,7 @@ where
 fn literal_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
     i: &mut I,
     t: T,
-) -> ModalResult<<I as Stream>::Slice, Error>
+) -> Result<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + Compare<T>,
@@ -252,9 +250,9 @@ where
 /// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::token::one_of;
-/// assert_eq!(one_of::<_, _, ContextError>(['a', 'b', 'c']).parse_peek(Partial::new("b")), Ok((Partial::new(""), 'b')));
-/// assert!(one_of::<_, _, ContextError>('a').parse_peek(Partial::new("bc")).is_err());
-/// assert_eq!(one_of::<_, _, ContextError>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(one_of::<_, _, ErrMode<ContextError>>(['a', 'b', 'c']).parse_peek(Partial::new("b")), Ok((Partial::new(""), 'b')));
+/// assert!(one_of::<_, _, ErrMode<ContextError>>('a').parse_peek(Partial::new("bc")).is_err());
+/// assert_eq!(one_of::<_, _, ErrMode<ContextError>>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
 /// fn parser_fn(i: &mut Partial<&str>) -> ModalResult<char> {
 ///     one_of(|c| c == 'a' || c == 'b').parse_next(i)
@@ -317,9 +315,9 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// # use winnow::token::none_of;
-/// assert_eq!(none_of::<_, _, ContextError>(['a', 'b', 'c']).parse_peek(Partial::new("z")), Ok((Partial::new(""), 'z')));
-/// assert!(none_of::<_, _, ContextError>(['a', 'b']).parse_peek(Partial::new("a")).is_err());
-/// assert_eq!(none_of::<_, _, ContextError>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(none_of::<_, _, ErrMode<ContextError>>(['a', 'b', 'c']).parse_peek(Partial::new("z")), Ok((Partial::new(""), 'z')));
+/// assert!(none_of::<_, _, ErrMode<ContextError>>(['a', 'b']).parse_peek(Partial::new("a")).is_err());
+/// assert_eq!(none_of::<_, _, ErrMode<ContextError>>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
 pub fn none_of<Input, Set, Error>(
@@ -531,7 +529,7 @@ where
 fn take_till0<P, I: StreamIsPartial + Stream, E: ParserError<I>, const PARTIAL: bool>(
     input: &mut I,
     predicate: P,
-) -> ModalResult<<I as Stream>::Slice, E>
+) -> Result<<I as Stream>::Slice, E>
 where
     P: FnMut(I::Token) -> bool,
 {
@@ -548,7 +546,7 @@ where
 fn take_till1<P, I: StreamIsPartial + Stream, E: ParserError<I>, const PARTIAL: bool>(
     input: &mut I,
     predicate: P,
-) -> ModalResult<<I as Stream>::Slice, E>
+) -> Result<<I as Stream>::Slice, E>
 where
     P: FnMut(I::Token) -> bool,
 {
@@ -572,7 +570,7 @@ fn take_till_m_n<P, I, Error: ParserError<I>, const PARTIAL: bool>(
     m: usize,
     n: usize,
     mut predicate: P,
-) -> ModalResult<<I as Stream>::Slice, Error>
+) -> Result<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -812,7 +810,7 @@ where
 fn take_<I, Error: ParserError<I>, const PARTIAL: bool>(
     i: &mut I,
     c: usize,
-) -> ModalResult<<I as Stream>::Slice, Error>
+) -> Result<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -963,7 +961,7 @@ where
 fn take_until0_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
     i: &mut I,
     t: T,
-) -> ModalResult<<I as Stream>::Slice, Error>
+) -> Result<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + FindSlice<T>,
@@ -978,7 +976,7 @@ where
 fn take_until1_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
     i: &mut I,
     t: T,
-) -> ModalResult<<I as Stream>::Slice, Error>
+) -> Result<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + FindSlice<T>,
@@ -1001,7 +999,7 @@ fn take_until_m_n_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
     start: usize,
     end: usize,
     t: T,
-) -> ModalResult<<I as Stream>::Slice, Error>
+) -> Result<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + FindSlice<T>,
@@ -1058,7 +1056,7 @@ where
 /// assert_eq!(rest::<_,ContextError>.parse_peek(""), Ok(("", "")));
 /// ```
 #[inline]
-pub fn rest<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
+pub fn rest<Input, Error>(input: &mut Input) -> Result<<Input as Stream>::Slice, Error>
 where
     Input: Stream,
     Error: ParserError<Input>,
@@ -1096,7 +1094,7 @@ where
 /// assert_eq!(rest_len::<_,ContextError>.parse_peek(""), Ok(("", 0)));
 /// ```
 #[inline]
-pub fn rest_len<Input, Error>(input: &mut Input) -> ModalResult<usize, Error>
+pub fn rest_len<Input, Error>(input: &mut Input) -> Result<usize, Error>
 where
     Input: Stream,
     Error: ParserError<Input>,

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -13,7 +13,7 @@ use crate::lib::std::result::Result::Ok;
 use crate::stream::Range;
 use crate::stream::{Compare, CompareResult, ContainsToken, FindSlice, SliceLen, Stream};
 use crate::stream::{StreamIsPartial, ToUsize};
-use crate::PResult;
+use crate::ModalResult;
 use crate::Parser;
 
 /// Matches one token
@@ -27,7 +27,7 @@ use crate::Parser;
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn any(input: &mut &str) -> PResult<char>
+/// pub fn any(input: &mut &str) -> ModalResult<char>
 /// # {
 /// #     winnow::token::any.parse_next(input)
 /// # }
@@ -38,7 +38,7 @@ use crate::Parser;
 /// ```rust
 /// # use winnow::{token::any, error::ErrMode, error::{ContextError, ErrorKind}};
 /// # use winnow::prelude::*;
-/// fn parser(input: &mut &str) -> PResult<char> {
+/// fn parser(input: &mut &str) -> ModalResult<char> {
 ///     any.parse_next(input)
 /// }
 ///
@@ -55,7 +55,7 @@ use crate::Parser;
 /// ```
 #[inline(always)]
 #[doc(alias = "token")]
-pub fn any<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Token, Error>
+pub fn any<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Token, Error>
 where
     Input: StreamIsPartial + Stream,
     Error: ParserError<Input>,
@@ -72,7 +72,7 @@ where
 
 fn any_<I, E: ParserError<I>, const PARTIAL: bool>(
     input: &mut I,
-) -> PResult<<I as Stream>::Token, E>
+) -> ModalResult<<I as Stream>::Token, E>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -117,7 +117,7 @@ where
 /// # use winnow::prelude::*;
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// #
-/// fn parser<'i>(s: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<&'i str> {
 ///   "Hello".parse_next(s)
 /// }
 ///
@@ -131,7 +131,7 @@ where
 /// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
 /// # use winnow::Partial;
 ///
-/// fn parser<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+/// fn parser<'i>(s: &mut Partial<&'i str>) -> ModalResult<&'i str> {
 ///   "Hello".parse_next(s)
 /// }
 ///
@@ -147,7 +147,7 @@ where
 /// use winnow::token::literal;
 /// use winnow::ascii::Caseless;
 ///
-/// fn parser<'i>(s: &mut &'i str) -> PResult<&'i str> {
+/// fn parser<'i>(s: &mut &'i str) -> ModalResult<&'i str> {
 ///   literal(Caseless("hello")).parse_next(s)
 /// }
 ///
@@ -182,7 +182,7 @@ where
 fn literal_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
     i: &mut I,
     t: T,
-) -> PResult<<I as Stream>::Slice, Error>
+) -> ModalResult<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + Compare<T>,
@@ -239,7 +239,7 @@ where
 /// assert!(one_of::<_, _, ContextError>('a').parse_peek("bc").is_err());
 /// assert!(one_of::<_, _, ContextError>('a').parse_peek("").is_err());
 ///
-/// fn parser_fn(i: &mut &str) -> PResult<char> {
+/// fn parser_fn(i: &mut &str) -> ModalResult<char> {
 ///     one_of(|c| c == 'a' || c == 'b').parse_next(i)
 /// }
 /// assert_eq!(parser_fn.parse_peek("abc"), Ok(("bc", 'a')));
@@ -256,7 +256,7 @@ where
 /// assert!(one_of::<_, _, ContextError>('a').parse_peek(Partial::new("bc")).is_err());
 /// assert_eq!(one_of::<_, _, ContextError>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 ///
-/// fn parser_fn(i: &mut Partial<&str>) -> PResult<char> {
+/// fn parser_fn(i: &mut Partial<&str>) -> ModalResult<char> {
 ///     one_of(|c| c == 'a' || c == 'b').parse_next(i)
 /// }
 /// assert_eq!(parser_fn.parse_peek(Partial::new("abc")), Ok((Partial::new("bc"), 'a')));
@@ -369,7 +369,7 @@ where
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn alpha<'i>(s: &mut &'i [u8]) -> PResult<&'i [u8]> {
+/// fn alpha<'i>(s: &mut &'i [u8]) -> ModalResult<&'i [u8]> {
 ///   take_while(0.., AsChar::is_alpha).parse_next(s)
 /// }
 ///
@@ -386,7 +386,7 @@ where
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn alpha<'i>(s: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+/// fn alpha<'i>(s: &mut Partial<&'i [u8]>) -> ModalResult<&'i [u8]> {
 ///   take_while(0.., AsChar::is_alpha).parse_next(s)
 /// }
 ///
@@ -403,7 +403,7 @@ where
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn alpha<'i>(s: &mut &'i [u8]) -> PResult<&'i [u8]> {
+/// fn alpha<'i>(s: &mut &'i [u8]) -> ModalResult<&'i [u8]> {
 ///   take_while(1.., AsChar::is_alpha).parse_next(s)
 /// }
 ///
@@ -411,7 +411,7 @@ where
 /// assert_eq!(alpha.parse_peek(b"latin"), Ok((&b""[..], &b"latin"[..])));
 /// assert!(alpha.parse_peek(b"12345").is_err());
 ///
-/// fn hex<'i>(s: &mut &'i str) -> PResult<&'i str> {
+/// fn hex<'i>(s: &mut &'i str) -> ModalResult<&'i str> {
 ///   take_while(1.., ('0'..='9', 'A'..='F')).parse_next(s)
 /// }
 ///
@@ -429,7 +429,7 @@ where
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn alpha<'i>(s: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+/// fn alpha<'i>(s: &mut Partial<&'i [u8]>) -> ModalResult<&'i [u8]> {
 ///   take_while(1.., AsChar::is_alpha).parse_next(s)
 /// }
 ///
@@ -437,7 +437,7 @@ where
 /// assert_eq!(alpha.parse_peek(Partial::new(b"latin")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// assert!(alpha.parse_peek(Partial::new(b"12345")).is_err());
 ///
-/// fn hex<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+/// fn hex<'i>(s: &mut Partial<&'i str>) -> ModalResult<&'i str> {
 ///   take_while(1.., ('0'..='9', 'A'..='F')).parse_next(s)
 /// }
 ///
@@ -455,7 +455,7 @@ where
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn short_alpha<'i>(s: &mut &'i [u8]) -> PResult<&'i [u8]> {
+/// fn short_alpha<'i>(s: &mut &'i [u8]) -> ModalResult<&'i [u8]> {
 ///   take_while(3..=6, AsChar::is_alpha).parse_next(s)
 /// }
 ///
@@ -473,7 +473,7 @@ where
 /// use winnow::token::take_while;
 /// use winnow::stream::AsChar;
 ///
-/// fn short_alpha<'i>(s: &mut Partial<&'i [u8]>) -> PResult<&'i [u8]> {
+/// fn short_alpha<'i>(s: &mut Partial<&'i [u8]>) -> ModalResult<&'i [u8]> {
 ///   take_while(3..=6, AsChar::is_alpha).parse_next(s)
 /// }
 ///
@@ -531,7 +531,7 @@ where
 fn take_till0<P, I: StreamIsPartial + Stream, E: ParserError<I>, const PARTIAL: bool>(
     input: &mut I,
     predicate: P,
-) -> PResult<<I as Stream>::Slice, E>
+) -> ModalResult<<I as Stream>::Slice, E>
 where
     P: FnMut(I::Token) -> bool,
 {
@@ -548,7 +548,7 @@ where
 fn take_till1<P, I: StreamIsPartial + Stream, E: ParserError<I>, const PARTIAL: bool>(
     input: &mut I,
     predicate: P,
-) -> PResult<<I as Stream>::Slice, E>
+) -> ModalResult<<I as Stream>::Slice, E>
 where
     P: FnMut(I::Token) -> bool,
 {
@@ -572,7 +572,7 @@ fn take_till_m_n<P, I, Error: ParserError<I>, const PARTIAL: bool>(
     m: usize,
     n: usize,
     mut predicate: P,
-) -> PResult<<I as Stream>::Slice, Error>
+) -> ModalResult<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -652,7 +652,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::token::take_till;
 ///
-/// fn till_colon<'i>(s: &mut &'i str) -> PResult<&'i str> {
+/// fn till_colon<'i>(s: &mut &'i str) -> ModalResult<&'i str> {
 ///   take_till(0.., |c| c == ':').parse_next(s)
 /// }
 ///
@@ -668,7 +668,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::token::take_till;
 ///
-/// fn till_colon<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+/// fn till_colon<'i>(s: &mut Partial<&'i str>) -> ModalResult<&'i str> {
 ///   take_till(0.., |c| c == ':').parse_next(s)
 /// }
 ///
@@ -752,7 +752,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::token::take;
 ///
-/// fn take6<'i>(s: &mut &'i str) -> PResult<&'i str> {
+/// fn take6<'i>(s: &mut &'i str) -> ModalResult<&'i str> {
 ///   take(6usize).parse_next(s)
 /// }
 ///
@@ -781,7 +781,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::token::take;
 ///
-/// fn take6<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+/// fn take6<'i>(s: &mut Partial<&'i str>) -> ModalResult<&'i str> {
 ///   take(6usize).parse_next(s)
 /// }
 ///
@@ -812,7 +812,7 @@ where
 fn take_<I, Error: ParserError<I>, const PARTIAL: bool>(
     i: &mut I,
     c: usize,
-) -> PResult<<I as Stream>::Slice, Error>
+) -> ModalResult<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream,
@@ -860,7 +860,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::token::take_until;
 ///
-/// fn until_eof<'i>(s: &mut &'i str) -> PResult<&'i str> {
+/// fn until_eof<'i>(s: &mut &'i str) -> ModalResult<&'i str> {
 ///   take_until(0.., "eof").parse_next(s)
 /// }
 ///
@@ -876,7 +876,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::token::take_until;
 ///
-/// fn until_eof<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+/// fn until_eof<'i>(s: &mut Partial<&'i str>) -> ModalResult<&'i str> {
 ///   take_until(0.., "eof").parse_next(s)
 /// }
 ///
@@ -891,7 +891,7 @@ where
 /// # use winnow::prelude::*;
 /// use winnow::token::take_until;
 ///
-/// fn until_eof<'i>(s: &mut &'i str) -> PResult<&'i str> {
+/// fn until_eof<'i>(s: &mut &'i str) -> ModalResult<&'i str> {
 ///   take_until(1.., "eof").parse_next(s)
 /// }
 ///
@@ -908,7 +908,7 @@ where
 /// # use winnow::Partial;
 /// use winnow::token::take_until;
 ///
-/// fn until_eof<'i>(s: &mut Partial<&'i str>) -> PResult<&'i str> {
+/// fn until_eof<'i>(s: &mut Partial<&'i str>) -> ModalResult<&'i str> {
 ///   take_until(1.., "eof").parse_next(s)
 /// }
 ///
@@ -963,7 +963,7 @@ where
 fn take_until0_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
     i: &mut I,
     t: T,
-) -> PResult<<I as Stream>::Slice, Error>
+) -> ModalResult<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + FindSlice<T>,
@@ -978,7 +978,7 @@ where
 fn take_until1_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
     i: &mut I,
     t: T,
-) -> PResult<<I as Stream>::Slice, Error>
+) -> ModalResult<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + FindSlice<T>,
@@ -1001,7 +1001,7 @@ fn take_until_m_n_<T, I, Error: ParserError<I>, const PARTIAL: bool>(
     start: usize,
     end: usize,
     t: T,
-) -> PResult<<I as Stream>::Slice, Error>
+) -> ModalResult<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream + FindSlice<T>,
@@ -1041,7 +1041,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn rest<'i>(input: &mut &'i str) -> PResult<&'i str>
+/// pub fn rest<'i>(input: &mut &'i str) -> ModalResult<&'i str>
 /// # {
 /// #     winnow::token::rest.parse_next(input)
 /// # }
@@ -1058,7 +1058,7 @@ where
 /// assert_eq!(rest::<_,ContextError>.parse_peek(""), Ok(("", "")));
 /// ```
 #[inline]
-pub fn rest<Input, Error>(input: &mut Input) -> PResult<<Input as Stream>::Slice, Error>
+pub fn rest<Input, Error>(input: &mut Input) -> ModalResult<<Input as Stream>::Slice, Error>
 where
     Input: Stream,
     Error: ParserError<Input>,
@@ -1079,7 +1079,7 @@ where
 /// Assuming you are parsing a `&str` [Stream]:
 /// ```rust
 /// # use winnow::prelude::*;;
-/// pub fn rest_len(input: &mut &str) -> PResult<usize>
+/// pub fn rest_len(input: &mut &str) -> ModalResult<usize>
 /// # {
 /// #     winnow::token::rest_len.parse_next(input)
 /// # }
@@ -1096,7 +1096,7 @@ where
 /// assert_eq!(rest_len::<_,ContextError>.parse_peek(""), Ok(("", 0)));
 /// ```
 #[inline]
-pub fn rest_len<Input, Error>(input: &mut Input) -> PResult<usize, Error>
+pub fn rest_len<Input, Error>(input: &mut Input) -> ModalResult<usize, Error>
 where
     Input: Stream,
     Error: ParserError<Input>,

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -69,7 +69,7 @@ fn model_complete_take_while_m_n<'i>(
     input: &mut &'i str,
 ) -> ModalResult<&'i str> {
     if n < m {
-        Err(crate::error::ErrMode::from_error_kind(
+        Err(crate::error::ParserError::from_error_kind(
             input,
             crate::error::ErrorKind::Slice,
         ))
@@ -77,7 +77,7 @@ fn model_complete_take_while_m_n<'i>(
         let offset = n.min(valid);
         Ok(input.next_slice(offset))
     } else {
-        Err(crate::error::ErrMode::from_error_kind(
+        Err(crate::error::ParserError::from_error_kind(
             input,
             crate::error::ErrorKind::Slice,
         ))

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -67,7 +67,7 @@ fn model_complete_take_while_m_n<'i>(
     n: usize,
     valid: usize,
     input: &mut &'i str,
-) -> PResult<&'i str> {
+) -> ModalResult<&'i str> {
     if n < m {
         Err(crate::error::ErrMode::from_error_kind(
             input,

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -19,6 +19,8 @@ impl<'a> From<(&'a str, ErrorKind)> for CustomError {
 }
 
 impl<'a> ParserError<Partial<&'a str>> for CustomError {
+    type Inner = Self;
+
     fn from_error_kind(_: &Partial<&'a str>, kind: ErrorKind) -> Self {
         CustomError(format!("error code was: {kind:?}"))
     }
@@ -30,6 +32,10 @@ impl<'a> ParserError<Partial<&'a str>> for CustomError {
         kind: ErrorKind,
     ) -> Self {
         CustomError(format!("{self:?}\nerror code was: {kind:?}"))
+    }
+
+    fn into_inner(self) -> Result<Self::Inner, Self> {
+        Ok(self)
     }
 }
 

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -33,23 +33,23 @@ impl<'a> ParserError<Partial<&'a str>> for CustomError {
     }
 }
 
-fn test1<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, CustomError> {
+fn test1<'i>(input: &mut Partial<&'i str>) -> ModalResult<&'i str, CustomError> {
     //fix_error!(input, CustomError, tag!("abcd"))
     "abcd".parse_next(input)
 }
 
-fn test2<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, CustomError> {
+fn test2<'i>(input: &mut Partial<&'i str>) -> ModalResult<&'i str, CustomError> {
     //terminated!(input, test1, fix_error!(CustomError, digit))
     terminated(test1, digit).parse_next(input)
 }
 
-fn test3<'i>(input: &mut Partial<&'i str>) -> PResult<&'i str, CustomError> {
+fn test3<'i>(input: &mut Partial<&'i str>) -> ModalResult<&'i str, CustomError> {
     test1
         .verify(|s: &str| s.starts_with("abcd"))
         .parse_next(input)
 }
 
 #[cfg(feature = "alloc")]
-fn test4<'i>(input: &mut Partial<&'i str>) -> PResult<Vec<&'i str>, CustomError> {
+fn test4<'i>(input: &mut Partial<&'i str>) -> ModalResult<Vec<&'i str>, CustomError> {
     repeat(4, test1).parse_next(input)
 }

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -17,7 +17,7 @@ struct Range {
     end: char,
 }
 
-pub(crate) fn take_char(input: &mut &[u8]) -> PResult<char> {
+pub(crate) fn take_char(input: &mut &[u8]) -> ModalResult<char> {
     if !input.is_empty() {
         Ok(input.next_token().unwrap() as char)
     } else {
@@ -119,7 +119,7 @@ fn usize_length_bytes_issue() {
     use winnow::binary::be_u16;
     use winnow::binary::length_take;
     #[allow(clippy::type_complexity)]
-    let _: PResult<(Partial<&[u8]>, &[u8])> =
+    let _: ModalResult<(Partial<&[u8]>, &[u8])> =
         length_take(be_u16).parse_peek(Partial::new(b"012346"));
 }
 

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -367,7 +367,7 @@ Ok(
 fn issue_1231_bits_expect_fn_closure() {
     use winnow::binary::bits::{bits, take};
     pub(crate) fn example<'i>(input: &mut &'i [u8]) -> TestResult<&'i [u8], (u8, u8)> {
-        bits::<_, _, InputError<_>, _, _>((take(1usize), take(1usize))).parse_next(input)
+        bits::<_, _, ErrMode<InputError<_>>, _, _>((take(1usize), take(1usize))).parse_next(input)
     }
     assert_parse!(
         example.parse_peek(&[0xff]),

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 macro_rules! assert_parse(
   ($left: expr, $right: expr) => {
-     let res: winnow::error::PResult<_, winnow::error::InputError<_>> = $left;
+     let res: winnow::error::ModalResult<_, winnow::error::InputError<_>> = $left;
      snapbox::assert_data_eq!(snapbox::data::ToDebug::to_debug(&res), $right);
   };
 );
 
-type TestResult<I, O> = winnow::PResult<O, winnow::error::InputError<I>>;
+type TestResult<I, O> = winnow::ModalResult<O, winnow::error::InputError<I>>;
 
 automod::dir!("tests/testsuite");

--- a/tests/testsuite/multiline.rs
+++ b/tests/testsuite/multiline.rs
@@ -7,7 +7,7 @@ use winnow::{
     prelude::*,
 };
 
-pub(crate) fn end_of_line<'i>(input: &mut &'i str) -> PResult<&'i str> {
+pub(crate) fn end_of_line<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
     if input.is_empty() {
         Ok(*input)
     } else {
@@ -15,11 +15,11 @@ pub(crate) fn end_of_line<'i>(input: &mut &'i str) -> PResult<&'i str> {
     }
 }
 
-pub(crate) fn read_line<'i>(input: &mut &'i str) -> PResult<&'i str> {
+pub(crate) fn read_line<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
     terminated(alphanumeric, end_of_line).parse_next(input)
 }
 
-pub(crate) fn read_lines<'i>(input: &mut &'i str) -> PResult<Vec<&'i str>> {
+pub(crate) fn read_lines<'i>(input: &mut &'i str) -> ModalResult<Vec<&'i str>> {
     repeat(0.., read_line).parse_next(input)
 }
 

--- a/tests/testsuite/reborrow_fold.rs
+++ b/tests/testsuite/reborrow_fold.rs
@@ -5,13 +5,14 @@ use std::str;
 
 use winnow::combinator::delimited;
 use winnow::combinator::repeat;
+use winnow::error::ErrMode;
 use winnow::error::InputError;
 use winnow::prelude::*;
 use winnow::token::take_till;
 
 use crate::TestResult;
 
-fn atom<'a>(_tomb: &mut ()) -> impl Parser<&'a [u8], String, InputError<&'a [u8]>> {
+fn atom<'a>(_tomb: &mut ()) -> impl Parser<&'a [u8], String, ErrMode<InputError<&'a [u8]>>> {
     take_till(1.., [' ', '\t', '\r', '\n'])
         .try_map(str::from_utf8)
         .map(ToString::to_string)

--- a/tests/testsuite/reborrow_fold.rs
+++ b/tests/testsuite/reborrow_fold.rs
@@ -5,14 +5,13 @@ use std::str;
 
 use winnow::combinator::delimited;
 use winnow::combinator::repeat;
-use winnow::error::ErrMode;
 use winnow::error::InputError;
 use winnow::prelude::*;
 use winnow::token::take_till;
 
 use crate::TestResult;
 
-fn atom<'a>(_tomb: &mut ()) -> impl Parser<&'a [u8], String, ErrMode<InputError<&'a [u8]>>> {
+fn atom<'a>(_tomb: &mut ()) -> impl ModalParser<&'a [u8], String, InputError<&'a [u8]>> {
     take_till(1.., [' ', '\t', '\r', '\n'])
         .try_map(str::from_utf8)
         .map(ToString::to_string)


### PR DESCRIPTION
To do this, we abstracted the design of `ErrMode` with `ParserError` and `ModalError` traits.

There *might* be a performance improvement when using `ModalResult` but definitely one when switching to `Result`:
```
$ cargo bench --bench arithmetic
   Compiling winnow v0.6.24 (/home/epage/src/personal/winnow)
    Finished `bench` profile [optimized + debuginfo] target(s) in 22.35s
     Running examples/arithmetic/bench.rs (target/release/deps/arithmetic-30e63a0cfdaed89e)
Gnuplot not found, using plotters backend
direct                  time:   [346.35 ns 347.73 ns 349.06 ns]
                        change: [-17.115% -16.596% -16.100%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

ast                     time:   [1.5312 µs 1.5389 µs 1.5478 µs]
                        change: [-7.3692% -6.9226% -6.4734%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

lexer                   time:   [1.6899 µs 1.6951 µs 1.7003 µs]
                        change: [-18.013% -17.094% -16.141%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
````

This is also being done to help with cases like #693

BREAKING CHANGE: Added more `E: ParserError` trait bounds

BREAKING CHANGE: Some error types may need to be wrapped in `ErrMode`

BREAKING CHANGE: Annotations for `ErrMode` need to be added when manually inspecting the `ModalResult` of a parser

BREAKING CHANGE: `Parser<I, O, E>` bounds need to be updated to `Parser<I, O, ErrMode<E>>` or `ModalParser<I, O, E>`

BREAKING CHANGE: `ErrMode` functions moved to `ParserError` and `ModalError` traits

Fixes #75