### PR TITLE
fix(stream)!: Change ContainsToken from FnMut to Fn

### DIFF
--- a/examples/arithmetic/parser_lexer.rs
+++ b/examples/arithmetic/parser_lexer.rs
@@ -72,28 +72,28 @@ pub enum Oper {
 
 impl winnow::stream::ContainsToken<Token> for Token {
     #[inline(always)]
-    fn contains_token(&mut self, token: Token) -> bool {
+    fn contains_token(&self, token: Token) -> bool {
         *self == token
     }
 }
 
 impl winnow::stream::ContainsToken<Token> for &'_ [Token] {
     #[inline]
-    fn contains_token(&mut self, token: Token) -> bool {
+    fn contains_token(&self, token: Token) -> bool {
         self.iter().any(|t| *t == token)
     }
 }
 
 impl<const LEN: usize> winnow::stream::ContainsToken<Token> for &'_ [Token; LEN] {
     #[inline]
-    fn contains_token(&mut self, token: Token) -> bool {
+    fn contains_token(&self, token: Token) -> bool {
         self.iter().any(|t| *t == token)
     }
 }
 
 impl<const LEN: usize> winnow::stream::ContainsToken<Token> for [Token; LEN] {
     #[inline]
-    fn contains_token(&mut self, token: Token) -> bool {
+    fn contains_token(&self, token: Token) -> bool {
         self.iter().any(|t| *t == token)
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -628,7 +628,7 @@ pub trait Stream: Offset<<Self as Stream>::Checkpoint> + crate::lib::std::fmt::D
     /// Finds the offset of the next matching token
     fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool;
+        P: Fn(Self::Token) -> bool;
     /// Get the offset for the number of `tokens` into the stream
     ///
     /// This means "0 tokens" will return `0` offset
@@ -723,9 +723,9 @@ where
     }
 
     #[inline(always)]
-    fn offset_for<P>(&self, mut predicate: P) -> Option<usize>
+    fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool,
+        P: Fn(Self::Token) -> bool,
     {
         self.iter().position(|b| predicate(b.clone()))
     }
@@ -785,9 +785,9 @@ impl<'i> Stream for &'i str {
     }
 
     #[inline(always)]
-    fn offset_for<P>(&self, mut predicate: P) -> Option<usize>
+    fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool,
+        P: Fn(Self::Token) -> bool,
     {
         for (o, c) in self.iter_offsets() {
             if predicate(c) {
@@ -863,9 +863,9 @@ impl<'i> Stream for &'i Bytes {
     }
 
     #[inline(always)]
-    fn offset_for<P>(&self, mut predicate: P) -> Option<usize>
+    fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool,
+        P: Fn(Self::Token) -> bool,
     {
         self.iter().position(|b| predicate(*b))
     }
@@ -928,9 +928,9 @@ impl<'i> Stream for &'i BStr {
     }
 
     #[inline(always)]
-    fn offset_for<P>(&self, mut predicate: P) -> Option<usize>
+    fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool,
+        P: Fn(Self::Token) -> bool,
     {
         self.iter().position(|b| predicate(*b))
     }
@@ -998,9 +998,9 @@ where
     }
 
     #[inline(always)]
-    fn offset_for<P>(&self, mut predicate: P) -> Option<usize>
+    fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool,
+        P: Fn(Self::Token) -> bool,
     {
         self.iter_offsets()
             .find_map(|(o, b)| predicate(b).then_some(o))
@@ -1112,7 +1112,7 @@ impl<I: Stream> Stream for LocatingSlice<I> {
     #[inline(always)]
     fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool,
+        P: Fn(Self::Token) -> bool,
     {
         self.input.offset_for(predicate)
     }
@@ -1170,7 +1170,7 @@ where
     #[inline(always)]
     fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool,
+        P: Fn(Self::Token) -> bool,
     {
         self.input.offset_for(predicate)
     }
@@ -1223,7 +1223,7 @@ impl<I: Stream, S: crate::lib::std::fmt::Debug> Stream for Stateful<I, S> {
     #[inline(always)]
     fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool,
+        P: Fn(Self::Token) -> bool,
     {
         self.input.offset_for(predicate)
     }
@@ -1276,7 +1276,7 @@ impl<I: Stream> Stream for Partial<I> {
     #[inline(always)]
     fn offset_for<P>(&self, predicate: P) -> Option<usize>
     where
-        P: FnMut(Self::Token) -> bool,
+        P: Fn(Self::Token) -> bool,
     {
         self.input.offset_for(predicate)
     }
@@ -3425,54 +3425,54 @@ impl AsChar for &char {
 /// ```
 pub trait ContainsToken<T> {
     /// Returns true if self contains the token
-    fn contains_token(&mut self, token: T) -> bool;
+    fn contains_token(&self, token: T) -> bool;
 }
 
 impl ContainsToken<u8> for u8 {
     #[inline(always)]
-    fn contains_token(&mut self, token: u8) -> bool {
+    fn contains_token(&self, token: u8) -> bool {
         *self == token
     }
 }
 
 impl ContainsToken<&u8> for u8 {
     #[inline(always)]
-    fn contains_token(&mut self, token: &u8) -> bool {
+    fn contains_token(&self, token: &u8) -> bool {
         self.contains_token(*token)
     }
 }
 
 impl ContainsToken<char> for u8 {
     #[inline(always)]
-    fn contains_token(&mut self, token: char) -> bool {
+    fn contains_token(&self, token: char) -> bool {
         self.as_char() == token
     }
 }
 
 impl ContainsToken<&char> for u8 {
     #[inline(always)]
-    fn contains_token(&mut self, token: &char) -> bool {
+    fn contains_token(&self, token: &char) -> bool {
         self.contains_token(*token)
     }
 }
 
 impl<C: AsChar> ContainsToken<C> for char {
     #[inline(always)]
-    fn contains_token(&mut self, token: C) -> bool {
+    fn contains_token(&self, token: C) -> bool {
         *self == token.as_char()
     }
 }
 
-impl<C, F: FnMut(C) -> bool> ContainsToken<C> for F {
+impl<C, F: Fn(C) -> bool> ContainsToken<C> for F {
     #[inline(always)]
-    fn contains_token(&mut self, token: C) -> bool {
+    fn contains_token(&self, token: C) -> bool {
         self(token)
     }
 }
 
 impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for crate::lib::std::ops::Range<C2> {
     #[inline(always)]
-    fn contains_token(&mut self, token: C1) -> bool {
+    fn contains_token(&self, token: C1) -> bool {
         let start = self.start.clone().as_char();
         let end = self.end.clone().as_char();
         (start..end).contains(&token.as_char())
@@ -3483,7 +3483,7 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1>
     for crate::lib::std::ops::RangeInclusive<C2>
 {
     #[inline(always)]
-    fn contains_token(&mut self, token: C1) -> bool {
+    fn contains_token(&self, token: C1) -> bool {
         let start = self.start().clone().as_char();
         let end = self.end().clone().as_char();
         (start..=end).contains(&token.as_char())
@@ -3492,7 +3492,7 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1>
 
 impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for crate::lib::std::ops::RangeFrom<C2> {
     #[inline(always)]
-    fn contains_token(&mut self, token: C1) -> bool {
+    fn contains_token(&self, token: C1) -> bool {
         let start = self.start.clone().as_char();
         (start..).contains(&token.as_char())
     }
@@ -3500,7 +3500,7 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for crate::lib::std::ops:
 
 impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1> for crate::lib::std::ops::RangeTo<C2> {
     #[inline(always)]
-    fn contains_token(&mut self, token: C1) -> bool {
+    fn contains_token(&self, token: C1) -> bool {
         let end = self.end.clone().as_char();
         (..end).contains(&token.as_char())
     }
@@ -3510,7 +3510,7 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1>
     for crate::lib::std::ops::RangeToInclusive<C2>
 {
     #[inline(always)]
-    fn contains_token(&mut self, token: C1) -> bool {
+    fn contains_token(&self, token: C1) -> bool {
         let end = self.end.clone().as_char();
         (..=end).contains(&token.as_char())
     }
@@ -3518,14 +3518,14 @@ impl<C1: AsChar, C2: AsChar + Clone> ContainsToken<C1>
 
 impl<C1: AsChar> ContainsToken<C1> for crate::lib::std::ops::RangeFull {
     #[inline(always)]
-    fn contains_token(&mut self, _token: C1) -> bool {
+    fn contains_token(&self, _token: C1) -> bool {
         true
     }
 }
 
 impl<C: AsChar> ContainsToken<C> for &'_ [u8] {
     #[inline]
-    fn contains_token(&mut self, token: C) -> bool {
+    fn contains_token(&self, token: C) -> bool {
         let token = token.as_char();
         self.iter().any(|t| t.as_char() == token)
     }
@@ -3533,7 +3533,7 @@ impl<C: AsChar> ContainsToken<C> for &'_ [u8] {
 
 impl<C: AsChar> ContainsToken<C> for &'_ [char] {
     #[inline]
-    fn contains_token(&mut self, token: C) -> bool {
+    fn contains_token(&self, token: C) -> bool {
         let token = token.as_char();
         self.iter().any(|t| *t == token)
     }
@@ -3541,7 +3541,7 @@ impl<C: AsChar> ContainsToken<C> for &'_ [char] {
 
 impl<const LEN: usize, C: AsChar> ContainsToken<C> for &'_ [u8; LEN] {
     #[inline]
-    fn contains_token(&mut self, token: C) -> bool {
+    fn contains_token(&self, token: C) -> bool {
         let token = token.as_char();
         self.iter().any(|t| t.as_char() == token)
     }
@@ -3549,7 +3549,7 @@ impl<const LEN: usize, C: AsChar> ContainsToken<C> for &'_ [u8; LEN] {
 
 impl<const LEN: usize, C: AsChar> ContainsToken<C> for &'_ [char; LEN] {
     #[inline]
-    fn contains_token(&mut self, token: C) -> bool {
+    fn contains_token(&self, token: C) -> bool {
         let token = token.as_char();
         self.iter().any(|t| *t == token)
     }
@@ -3557,7 +3557,7 @@ impl<const LEN: usize, C: AsChar> ContainsToken<C> for &'_ [char; LEN] {
 
 impl<const LEN: usize, C: AsChar> ContainsToken<C> for [u8; LEN] {
     #[inline]
-    fn contains_token(&mut self, token: C) -> bool {
+    fn contains_token(&self, token: C) -> bool {
         let token = token.as_char();
         self.iter().any(|t| t.as_char() == token)
     }
@@ -3565,7 +3565,7 @@ impl<const LEN: usize, C: AsChar> ContainsToken<C> for [u8; LEN] {
 
 impl<const LEN: usize, C: AsChar> ContainsToken<C> for [char; LEN] {
     #[inline]
-    fn contains_token(&mut self, token: C) -> bool {
+    fn contains_token(&self, token: C) -> bool {
         let token = token.as_char();
         self.iter().any(|t| *t == token)
     }
@@ -3573,7 +3573,7 @@ impl<const LEN: usize, C: AsChar> ContainsToken<C> for [char; LEN] {
 
 impl<T> ContainsToken<T> for () {
     #[inline(always)]
-    fn contains_token(&mut self, _token: T) -> bool {
+    fn contains_token(&self, _token: T) -> bool {
         false
     }
 }
@@ -3587,8 +3587,8 @@ macro_rules! impl_contains_token_for_tuple {
       $($haystack: ContainsToken<T>),+
     {
     #[inline]
-      fn contains_token(&mut self, token: T) -> bool {
-        let ($(ref mut $haystack),+,) = *self;
+      fn contains_token(&self, token: T) -> bool {
+        let ($(ref $haystack),+,) = *self;
         $($haystack.contains_token(token.clone()) || )+ false
       }
     }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -265,9 +265,7 @@ where
 #[doc(alias = "char")]
 #[doc(alias = "token")]
 #[doc(alias = "satisfy")]
-pub fn one_of<Input, Set, Error>(
-    mut set: Set,
-) -> impl Parser<Input, <Input as Stream>::Token, Error>
+pub fn one_of<Input, Set, Error>(set: Set) -> impl Parser<Input, <Input as Stream>::Token, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: Clone,
@@ -320,9 +318,7 @@ where
 /// assert_eq!(none_of::<_, _, ErrMode<ContextError>>('a').parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
 /// ```
 #[inline(always)]
-pub fn none_of<Input, Set, Error>(
-    mut set: Set,
-) -> impl Parser<Input, <Input as Stream>::Token, Error>
+pub fn none_of<Input, Set, Error>(set: Set) -> impl Parser<Input, <Input as Stream>::Token, Error>
 where
     Input: StreamIsPartial + Stream,
     <Input as Stream>::Token: Clone,
@@ -487,7 +483,7 @@ where
 #[doc(alias = "take_while1")]
 pub fn take_while<Set, Input, Error>(
     occurrences: impl Into<Range>,
-    mut set: Set,
+    set: Set,
 ) -> impl Parser<Input, <Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,
@@ -531,7 +527,7 @@ fn take_till0<P, I: StreamIsPartial + Stream, E: ParserError<I>, const PARTIAL: 
     predicate: P,
 ) -> Result<<I as Stream>::Slice, E>
 where
-    P: FnMut(I::Token) -> bool,
+    P: Fn(I::Token) -> bool,
 {
     let offset = match input.offset_for(predicate) {
         Some(offset) => offset,
@@ -548,7 +544,7 @@ fn take_till1<P, I: StreamIsPartial + Stream, E: ParserError<I>, const PARTIAL: 
     predicate: P,
 ) -> Result<<I as Stream>::Slice, E>
 where
-    P: FnMut(I::Token) -> bool,
+    P: Fn(I::Token) -> bool,
 {
     let e: ErrorKind = ErrorKind::Slice;
     let offset = match input.offset_for(predicate) {
@@ -569,12 +565,12 @@ fn take_till_m_n<P, I, Error: ParserError<I>, const PARTIAL: bool>(
     input: &mut I,
     m: usize,
     n: usize,
-    mut predicate: P,
+    predicate: P,
 ) -> Result<<I as Stream>::Slice, Error>
 where
     I: StreamIsPartial,
     I: Stream,
-    P: FnMut(I::Token) -> bool,
+    P: Fn(I::Token) -> bool,
 {
     if n < m {
         return Err(ParserError::assert(
@@ -679,7 +675,7 @@ where
 #[doc(alias = "is_not")]
 pub fn take_till<Set, Input, Error>(
     occurrences: impl Into<Range>,
-    mut set: Set,
+    set: Set,
 ) -> impl Parser<Input, <Input as Stream>::Slice, Error>
 where
     Input: StreamIsPartial + Stream,


### PR DESCRIPTION
Revert "fix(stream)!: Change ContainsToken from Fn to FnMut"

This reverts commit 424f4b0014cd259115893521c84d2a8ac867ff2a.

When used with `const`, this produces warnings and I'd like more time to think on this.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
