### PR TITLE
fix(ascii): Allow separate normal/transform types for escaped_transform

### DIFF
--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -2499,17 +2499,9 @@ Ok(
         }
 
         fn esc<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], String> {
-            escaped_transform(
-                alpha,
-                '\\',
-                alt((
-                    "\\".value(&b"\\"[..]),
-                    "\"".value(&b"\""[..]),
-                    "n".value(&b"\n"[..]),
-                )),
-            )
-            .map(to_s)
-            .parse_next(i)
+            escaped_transform(alpha, '\\', alt((b'\\', b'"', "n".value(b'\n'))))
+                .map(to_s)
+                .parse_next(i)
         }
 
         assert_parse!(
@@ -2674,7 +2666,12 @@ Ok(
             escaped_transform(
                 alpha,
                 '\\',
-                alt(("\\".value("\\"), "\"".value("\""), "n".value("\n"))),
+                alt((
+                    '\\',
+                    '"',
+                    "n".value('\n'),
+                    ("x", hex_uint).map(|(_, hex)| char::from_u32(hex).unwrap()),
+                )),
             )
             .parse_next(i)
         }
@@ -2738,6 +2735,19 @@ Ok(
     (
         "12",
         "ab\"",
+    ),
+)
+
+"#]]
+            .raw()
+        );
+        assert_parse!(
+            esc.parse_peek("ab\\x20"),
+            str![[r#"
+Ok(
+    (
+        "",
+        "ab ",
     ),
 )
 


### PR DESCRIPTION
Fixes #686

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
