### PR TITLE
feat(stream)!: Add `TokenSlice` to make parsing lexed tokens easier

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -92,7 +92,7 @@ impl Caseless<&str> {
 /// # use winnow::ascii::crlf;
 /// assert_eq!(crlf::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
 /// assert!(crlf::<_, ErrMode<ContextError>>.parse_peek(Partial::new("ab\r\nc")).is_err());
-/// assert_eq!(crlf::<_, ErrMode<ContextError>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(2))));
+/// assert_eq!(crlf::<_, ErrMode<ContextError>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 #[inline(always)]
 pub fn crlf<Input, Error>(input: &mut Input) -> Result<<Input as Stream>::Slice, Error>
@@ -238,7 +238,7 @@ where
 /// # use winnow::ascii::line_ending;
 /// assert_eq!(line_ending::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
 /// assert!(line_ending::<_, ErrMode<ContextError>>.parse_peek(Partial::new("ab\r\nc")).is_err());
-/// assert_eq!(line_ending::<_, ErrMode<ContextError>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(line_ending::<_, ErrMode<ContextError>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 #[inline(always)]
 pub fn line_ending<Input, Error>(input: &mut Input) -> Result<<Input as Stream>::Slice, Error>
@@ -287,7 +287,7 @@ where
 /// # use winnow::ascii::newline;
 /// assert_eq!(newline::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\nc")), Ok((Partial::new("c"), '\n')));
 /// assert!(newline::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\r\nc")).is_err());
-/// assert_eq!(newline::<_, ErrMode<ContextError>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(newline::<_, ErrMode<ContextError>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 #[inline(always)]
 pub fn newline<I, Error: ParserError<I>>(input: &mut I) -> Result<char, Error>
@@ -337,7 +337,7 @@ where
 /// # use winnow::ascii::tab;
 /// assert_eq!(tab::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\tc")), Ok((Partial::new("c"), '\t')));
 /// assert!(tab::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\r\nc")).is_err());
-/// assert_eq!(tab::<_, ErrMode<ContextError>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::new(1))));
+/// assert_eq!(tab::<_, ErrMode<ContextError>>.parse_peek(Partial::new("")), Err(ErrMode::Incomplete(Needed::Unknown)));
 /// ```
 #[inline(always)]
 pub fn tab<Input, Error>(input: &mut Input) -> Result<char, Error>

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -4123,9 +4123,7 @@ Ok(
             str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -4174,9 +4172,7 @@ Ok(
             str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -4250,9 +4246,7 @@ Ok(
             str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -4317,9 +4311,7 @@ Ok(
             str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -3212,9 +3212,7 @@ Ok(
             str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -3226,9 +3224,7 @@ Err(
             str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -318,9 +318,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -368,9 +366,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -432,9 +428,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -750,9 +744,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -764,9 +756,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -881,9 +871,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -895,9 +883,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            3,
-        ),
+        Unknown,
     ),
 )
 
@@ -1012,9 +998,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -1026,9 +1010,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            3,
-        ),
+        Unknown,
     ),
 )
 
@@ -1142,9 +1124,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -1156,9 +1136,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -1170,9 +1148,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -1408,9 +1384,7 @@ fn alt_incomplete() {
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -1423,9 +1397,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -1482,9 +1454,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -1816,9 +1786,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -1995,9 +1963,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -2009,9 +1975,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -2023,9 +1987,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -2189,9 +2151,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -2203,9 +2163,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -2217,9 +2175,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -2400,9 +2356,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -2506,9 +2460,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -2520,9 +2472,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            4,
-        ),
+        Unknown,
     ),
 )
 
@@ -2534,9 +2484,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            4,
-        ),
+        Unknown,
     ),
 )
 
@@ -2657,9 +2605,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -3109,9 +3055,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -3167,9 +3111,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -3181,9 +3123,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            1,
-        ),
+        Unknown,
     ),
 )
 
@@ -3533,9 +3473,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -3547,9 +3485,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            4,
-        ),
+        Unknown,
     ),
 )
 
@@ -3561,9 +3497,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            4,
-        ),
+        Unknown,
     ),
 )
 
@@ -3694,9 +3628,7 @@ Err(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -3879,9 +3811,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1384,9 +1384,7 @@ Err(
             str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -48,6 +48,7 @@ mod recoverable;
 mod stateful;
 #[cfg(test)]
 mod tests;
+mod token;
 
 pub use bstr::BStr;
 pub use bytes::Bytes;
@@ -58,6 +59,7 @@ pub use range::Range;
 #[cfg(feature = "std")]
 pub use recoverable::Recoverable;
 pub use stateful::Stateful;
+pub use token::TokenSlice;
 
 /// UTF-8 Stream
 pub type Str<'i> = &'i str;

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -234,33 +234,42 @@ fn test_literal_support_char() {
 fn tokenslice_location() {
     #[derive(Clone, Debug)]
     struct Token {
-        #[allow(dead_code)]
         span: crate::lib::std::ops::Range<usize>,
+    }
+
+    impl Location for Token {
+        #[inline(always)]
+        fn previous_token_end(&self) -> usize {
+            self.span.end
+        }
+        #[inline(always)]
+        fn current_token_start(&self) -> usize {
+            self.span.start
+        }
     }
 
     let input = [
         Token { span: 1..9 },
         Token { span: 11..19 },
         Token { span: 21..29 },
-    ]
-    .as_slice();
-    let mut input = LocatingSlice::new(input);
-    assert_eq!(input.previous_token_end(), 0);
-
-    // Parse operation
-    assert_eq!(input.current_token_start(), 0);
-    let _ = input.next_token();
+    ];
+    let mut input = TokenSlice::new(&input);
     assert_eq!(input.previous_token_end(), 1);
 
     // Parse operation
     assert_eq!(input.current_token_start(), 1);
     let _ = input.next_token();
-    assert_eq!(input.previous_token_end(), 2);
+    assert_eq!(input.previous_token_end(), 9);
 
     // Parse operation
-    assert_eq!(input.current_token_start(), 2);
+    assert_eq!(input.current_token_start(), 11);
     let _ = input.next_token();
-    assert_eq!(input.previous_token_end(), 3);
+    assert_eq!(input.previous_token_end(), 19);
 
-    assert_eq!(input.current_token_start(), 3);
+    // Parse operation
+    assert_eq!(input.current_token_start(), 21);
+    let _ = input.next_token();
+    assert_eq!(input.previous_token_end(), 29);
+
+    assert_eq!(input.current_token_start(), 29);
 }

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -229,3 +229,38 @@ fn test_literal_support_char() {
         Err(Backtrack(InputError::at(&b"\xCF\x80"[..],)))
     );
 }
+
+#[test]
+fn tokenslice_location() {
+    #[derive(Clone, Debug)]
+    struct Token {
+        #[allow(dead_code)]
+        span: crate::lib::std::ops::Range<usize>,
+    }
+
+    let input = [
+        Token { span: 1..9 },
+        Token { span: 11..19 },
+        Token { span: 21..29 },
+    ]
+    .as_slice();
+    let mut input = LocatingSlice::new(input);
+    assert_eq!(input.previous_token_end(), 0);
+
+    // Parse operation
+    assert_eq!(input.current_token_start(), 0);
+    let _ = input.next_token();
+    assert_eq!(input.previous_token_end(), 1);
+
+    // Parse operation
+    assert_eq!(input.current_token_start(), 1);
+    let _ = input.next_token();
+    assert_eq!(input.previous_token_end(), 2);
+
+    // Parse operation
+    assert_eq!(input.current_token_start(), 2);
+    let _ = input.next_token();
+    assert_eq!(input.previous_token_end(), 3);
+
+    assert_eq!(input.current_token_start(), 3);
+}

--- a/src/stream/token.rs
+++ b/src/stream/token.rs
@@ -1,0 +1,217 @@
+use crate::error::Needed;
+use crate::lib::std::iter::Enumerate;
+use crate::lib::std::slice::Iter;
+use crate::stream::Checkpoint;
+use crate::stream::Offset;
+#[cfg(feature = "unstable-recover")]
+#[cfg(feature = "std")]
+use crate::stream::Recover;
+use crate::stream::SliceLen;
+use crate::stream::Stream;
+use crate::stream::StreamIsPartial;
+use crate::stream::UpdateSlice;
+
+/// Specialized input for parsing lexed tokens
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct TokenSlice<'t, T> {
+    initial: &'t [T],
+    input: &'t [T],
+}
+
+impl<'t, T> TokenSlice<'t, T>
+where
+    T: crate::lib::std::fmt::Debug + Clone,
+{
+    /// Make a stream to parse tokens
+    #[inline]
+    pub fn new(input: &'t [T]) -> Self {
+        Self {
+            initial: input,
+            input,
+        }
+    }
+
+    /// Reset the stream to the start
+    ///
+    /// This is useful for formats that encode a graph with addresses relative to the start of the
+    /// input.
+    #[doc(alias = "fseek")]
+    #[inline]
+    pub fn reset_to_start(&mut self) {
+        let start = self.initial.checkpoint();
+        self.input.reset(&start);
+    }
+}
+
+impl<T> Default for TokenSlice<'_, T>
+where
+    T: crate::lib::std::fmt::Debug + Clone,
+{
+    fn default() -> Self {
+        Self::new(&[])
+    }
+}
+
+impl<T> crate::lib::std::ops::Deref for TokenSlice<'_, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.input
+    }
+}
+
+impl<T> SliceLen for TokenSlice<'_, T> {
+    #[inline(always)]
+    fn slice_len(&self) -> usize {
+        self.input.slice_len()
+    }
+}
+
+impl<'t, T> Stream for TokenSlice<'t, T>
+where
+    T: crate::lib::std::fmt::Debug + Clone,
+{
+    type Token = &'t T;
+    type Slice = &'t [T];
+
+    type IterOffsets = Enumerate<Iter<'t, T>>;
+
+    type Checkpoint = Checkpoint<&'t [T], Self>;
+
+    #[inline(always)]
+    fn iter_offsets(&self) -> Self::IterOffsets {
+        self.input.iter().enumerate()
+    }
+    #[inline(always)]
+    fn eof_offset(&self) -> usize {
+        self.input.eof_offset()
+    }
+
+    #[inline(always)]
+    fn next_token(&mut self) -> Option<Self::Token> {
+        let (token, next) = self.input.split_first()?;
+        self.input = next;
+        Some(token)
+    }
+
+    #[inline(always)]
+    fn peek_token(&self) -> Option<Self::Token> {
+        self.input.first()
+    }
+
+    #[inline(always)]
+    fn offset_for<P>(&self, predicate: P) -> Option<usize>
+    where
+        P: Fn(Self::Token) -> bool,
+    {
+        self.input.iter().position(predicate)
+    }
+    #[inline(always)]
+    fn offset_at(&self, tokens: usize) -> Result<usize, Needed> {
+        self.input.offset_at(tokens)
+    }
+    #[inline(always)]
+    fn next_slice(&mut self, offset: usize) -> Self::Slice {
+        self.input.next_slice(offset)
+    }
+    #[inline(always)]
+    fn peek_slice(&self, offset: usize) -> Self::Slice {
+        self.input.peek_slice(offset)
+    }
+
+    #[inline(always)]
+    fn checkpoint(&self) -> Self::Checkpoint {
+        Checkpoint::<_, Self>::new(self.input)
+    }
+    #[inline(always)]
+    fn reset(&mut self, checkpoint: &Self::Checkpoint) {
+        self.input = checkpoint.inner;
+    }
+
+    #[inline(always)]
+    fn raw(&self) -> &dyn crate::lib::std::fmt::Debug {
+        &self.input
+    }
+}
+
+#[cfg(feature = "unstable-recover")]
+#[cfg(feature = "std")]
+impl<T, E> Recover<E> for TokenSlice<'_, T>
+where
+    T: crate::lib::std::fmt::Debug + Clone,
+{
+    #[inline(always)]
+    fn record_err(
+        &mut self,
+        _token_start: &Self::Checkpoint,
+        _err_start: &Self::Checkpoint,
+        err: E,
+    ) -> Result<(), E> {
+        Err(err)
+    }
+
+    /// Report whether the [`Stream`] can save off errors for recovery
+    #[inline(always)]
+    fn is_recovery_supported() -> bool {
+        false
+    }
+}
+
+impl<'t, T> StreamIsPartial for TokenSlice<'t, T>
+where
+    T: crate::lib::std::fmt::Debug + Clone,
+{
+    type PartialState = <&'t [T] as StreamIsPartial>::PartialState;
+
+    #[inline]
+    fn complete(&mut self) -> Self::PartialState {
+        #![allow(clippy::semicolon_if_nothing_returned)]
+        self.input.complete()
+    }
+
+    #[inline]
+    fn restore_partial(&mut self, state: Self::PartialState) {
+        self.input.restore_partial(state);
+    }
+
+    #[inline(always)]
+    fn is_partial_supported() -> bool {
+        <&[T] as StreamIsPartial>::is_partial_supported()
+    }
+
+    #[inline(always)]
+    fn is_partial(&self) -> bool {
+        self.input.is_partial()
+    }
+}
+
+impl<T> Offset for TokenSlice<'_, T>
+where
+    T: crate::lib::std::fmt::Debug + Clone,
+{
+    #[inline(always)]
+    fn offset_from(&self, other: &Self) -> usize {
+        self.offset_from(&other.checkpoint())
+    }
+}
+
+impl<T> Offset<<TokenSlice<'_, T> as Stream>::Checkpoint> for TokenSlice<'_, T>
+where
+    T: crate::lib::std::fmt::Debug + Clone,
+{
+    #[inline(always)]
+    fn offset_from(&self, other: &<TokenSlice<'_, T> as Stream>::Checkpoint) -> usize {
+        self.checkpoint().offset_from(other)
+    }
+}
+
+impl<T> UpdateSlice for TokenSlice<'_, T>
+where
+    T: crate::lib::std::fmt::Debug + Clone,
+{
+    #[inline(always)]
+    fn update_slice(mut self, inner: Self::Slice) -> Self {
+        self.input = <&[T] as UpdateSlice>::update_slice(self.input, inner);
+        self
+    }
+}

--- a/src/stream/token.rs
+++ b/src/stream/token.rs
@@ -2,6 +2,8 @@ use crate::error::Needed;
 use crate::lib::std::iter::Enumerate;
 use crate::lib::std::slice::Iter;
 use crate::stream::Checkpoint;
+use crate::stream::Compare;
+use crate::stream::CompareResult;
 use crate::stream::Location;
 use crate::stream::Offset;
 #[cfg(feature = "unstable-recover")]
@@ -240,6 +242,24 @@ where
     #[inline(always)]
     fn offset_from(&self, other: &<TokenSlice<'_, T> as Stream>::Checkpoint) -> usize {
         self.checkpoint().offset_from(other)
+    }
+}
+
+impl<T, O> Compare<O> for TokenSlice<'_, T>
+where
+    T: PartialEq<O> + Eq,
+{
+    #[inline]
+    fn compare(&self, t: O) -> CompareResult {
+        if let Some(token) = self.first() {
+            if *token == t {
+                CompareResult::Ok(1)
+            } else {
+                CompareResult::Error
+            }
+        } else {
+            CompareResult::Incomplete
+        }
     }
 }
 

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -2460,9 +2460,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -2570,9 +2568,7 @@ Ok(
         str![[r#"
 Err(
     Incomplete(
-        Size(
-            2,
-        ),
+        Unknown,
     ),
 )
 
@@ -2820,13 +2816,6 @@ fn tokenslice_literals() {
         LeftCurly,
         RightCurly,
         Value,
-    }
-
-    impl SliceLen for TokenKind {
-        #[inline(always)]
-        fn slice_len(&self) -> usize {
-            1
-        }
     }
 
     impl<'i, 't> Parser<TokenSlice<'i, 't>, &'i Token<'t>, ErrMode<InputError<TokenSlice<'i, 't>>>>

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -2800,17 +2800,15 @@ fn tokenslice_literals() {
         raw: &'i str,
     }
 
-    impl<'t> ContainsToken<&Token<'t>> for &str {
-        #[inline(always)]
-        fn contains_token(&self, token: &Token<'t>) -> bool {
-            *self == token.raw
+    impl PartialEq<&str> for Token<'_> {
+        fn eq(&self, other: &&str) -> bool {
+            self.raw == *other
         }
     }
 
-    impl<'t> ContainsToken<&Token<'t>> for TokenKind {
-        #[inline(always)]
-        fn contains_token(&self, token: &Token<'t>) -> bool {
-            *self == token.kind
+    impl PartialEq<TokenKind> for Token<'_> {
+        fn eq(&self, other: &TokenKind) -> bool {
+            self.kind == *other
         }
     }
 
@@ -2838,7 +2836,7 @@ fn tokenslice_literals() {
             &mut self,
             input: &mut TokenSlice<'i, 't>,
         ) -> TestResult<TokenSlice<'i, 't>, &'i Token<'t>> {
-            one_of(*self).parse_next(input)
+            literal(*self).parse_next(input).map(|t| &t[0])
         }
     }
 
@@ -2874,7 +2872,7 @@ fn tokenslice_literals() {
         (
             TokenKind::If,
             TokenKind::LeftParen,
-            one_of("hello"),
+            "hello",
             TokenKind::RightParen
         )
             .parse_next(&mut input),
@@ -2889,10 +2887,12 @@ Ok(
             kind: LeftParen,
             raw: "(",
         },
-        Token {
-            kind: Value,
-            raw: "hello",
-        },
+        [
+            Token {
+                kind: Value,
+                raw: "hello",
+            },
+        ],
         Token {
             kind: RightParen,
             raw: ")",

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -7,6 +7,8 @@ use snapbox::str;
 
 use crate::ascii::Caseless;
 use crate::combinator::delimited;
+use crate::error::ErrMode;
+use crate::error::InputError;
 use crate::prelude::*;
 use crate::stream::AsChar;
 use crate::token::literal;
@@ -2780,6 +2782,121 @@ Ok(
             33,
         ],
         13,
+    ),
+)
+
+"#]]
+        .raw()
+    );
+}
+
+#[test]
+fn tokenslice_literals() {
+    type TokenSlice<'i, 't> = &'i [Token<'t>];
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct Token<'i> {
+        kind: TokenKind,
+        raw: &'i str,
+    }
+
+    impl<'t> ContainsToken<Token<'t>> for &str {
+        #[inline(always)]
+        fn contains_token(&self, token: Token<'t>) -> bool {
+            *self == token.raw
+        }
+    }
+
+    impl<'t> ContainsToken<Token<'t>> for TokenKind {
+        #[inline(always)]
+        fn contains_token(&self, token: Token<'t>) -> bool {
+            *self == token.kind
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    enum TokenKind {
+        If,
+        LeftParen,
+        RightParen,
+        LeftCurly,
+        RightCurly,
+        Value,
+    }
+
+    impl SliceLen for TokenKind {
+        #[inline(always)]
+        fn slice_len(&self) -> usize {
+            1
+        }
+    }
+
+    impl<'i, 't> Parser<TokenSlice<'i, 't>, Token<'t>, ErrMode<InputError<TokenSlice<'i, 't>>>>
+        for TokenKind
+    {
+        fn parse_next(
+            &mut self,
+            input: &mut TokenSlice<'i, 't>,
+        ) -> TestResult<TokenSlice<'i, 't>, Token<'t>> {
+            one_of(*self).parse_next(input)
+        }
+    }
+
+    let mut input = [
+        Token {
+            kind: TokenKind::If,
+            raw: "if",
+        },
+        Token {
+            kind: TokenKind::LeftParen,
+            raw: "(",
+        },
+        Token {
+            kind: TokenKind::Value,
+            raw: "hello",
+        },
+        Token {
+            kind: TokenKind::RightParen,
+            raw: ")",
+        },
+        Token {
+            kind: TokenKind::LeftCurly,
+            raw: "{",
+        },
+        Token {
+            kind: TokenKind::RightCurly,
+            raw: "}",
+        },
+    ]
+    .as_slice();
+
+    assert_parse!(
+        (
+            TokenKind::If,
+            TokenKind::LeftParen,
+            one_of("hello"),
+            TokenKind::RightParen
+        )
+            .parse_next(&mut input),
+        str![[r#"
+Ok(
+    (
+        Token {
+            kind: If,
+            raw: "if",
+        },
+        Token {
+            kind: LeftParen,
+            raw: "(",
+        },
+        Token {
+            kind: Value,
+            raw: "hello",
+        },
+        Token {
+            kind: RightParen,
+            raw: ")",
+        },
     ),
 )
 

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -2792,7 +2792,7 @@ Ok(
 
 #[test]
 fn tokenslice_literals() {
-    type TokenSlice<'i, 't> = &'i [Token<'t>];
+    type TokenSlice<'i, 't> = crate::stream::TokenSlice<'i, Token<'t>>;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct Token<'i> {
@@ -2800,16 +2800,16 @@ fn tokenslice_literals() {
         raw: &'i str,
     }
 
-    impl<'t> ContainsToken<Token<'t>> for &str {
+    impl<'t> ContainsToken<&Token<'t>> for &str {
         #[inline(always)]
-        fn contains_token(&self, token: Token<'t>) -> bool {
+        fn contains_token(&self, token: &Token<'t>) -> bool {
             *self == token.raw
         }
     }
 
-    impl<'t> ContainsToken<Token<'t>> for TokenKind {
+    impl<'t> ContainsToken<&Token<'t>> for TokenKind {
         #[inline(always)]
-        fn contains_token(&self, token: Token<'t>) -> bool {
+        fn contains_token(&self, token: &Token<'t>) -> bool {
             *self == token.kind
         }
     }
@@ -2831,18 +2831,18 @@ fn tokenslice_literals() {
         }
     }
 
-    impl<'i, 't> Parser<TokenSlice<'i, 't>, Token<'t>, ErrMode<InputError<TokenSlice<'i, 't>>>>
+    impl<'i, 't> Parser<TokenSlice<'i, 't>, &'i Token<'t>, ErrMode<InputError<TokenSlice<'i, 't>>>>
         for TokenKind
     {
         fn parse_next(
             &mut self,
             input: &mut TokenSlice<'i, 't>,
-        ) -> TestResult<TokenSlice<'i, 't>, Token<'t>> {
+        ) -> TestResult<TokenSlice<'i, 't>, &'i Token<'t>> {
             one_of(*self).parse_next(input)
         }
     }
 
-    let mut input = [
+    let input = [
         Token {
             kind: TokenKind::If,
             raw: "if",
@@ -2867,8 +2867,8 @@ fn tokenslice_literals() {
             kind: TokenKind::RightCurly,
             raw: "}",
         },
-    ]
-    .as_slice();
+    ];
+    let mut input = TokenSlice::new(&input);
 
     assert_parse!(
         (


### PR DESCRIPTION
I was hoping to get `ContainsToken` support but I'm not seeing a reasonable
way of restructuring the traits without being blocked by the compiler
(overlapping impls) or having other side effects (less ergonomic for
other users).

`Compare` gets us the basics though.  The `Fn(&Token<'_>) -> bool`
variant of `ContainsToken` should still work and people can add their
own `Compare`s to get tuples working.

Also, didn't see a way to get a `impl Parser for TokenKind` to work
for similar reasons.

Location tracking is inspired by #512 and #591

Fixes #637
Fixes #590 