### PR TITLE
fix(error): Deprcate ErrorKind 

### DIFF
--- a/benches/number.rs
+++ b/benches/number.rs
@@ -5,7 +5,6 @@ use criterion::Criterion;
 
 use winnow::ascii::float;
 use winnow::binary::be_u64;
-use winnow::error::ErrorKind;
 use winnow::error::InputError;
 use winnow::error::ParserError;
 use winnow::prelude::*;
@@ -51,7 +50,7 @@ fn float_str(c: &mut Criterion) {
 fn std_float(input: &mut &[u8]) -> ModalResult<f64> {
     match input.parse_slice() {
         Some(n) => Ok(n),
-        None => Err(ParserError::from_error_kind(input, ErrorKind::Slice)),
+        None => Err(ParserError::from_input(input)),
     }
 }
 

--- a/examples/custom_error.rs
+++ b/examples/custom_error.rs
@@ -1,5 +1,6 @@
 use winnow::error::AddContext;
 use winnow::error::ErrMode;
+#[allow(deprecated)]
 use winnow::error::ErrorKind;
 use winnow::error::FromExternalError;
 use winnow::error::ParserError;
@@ -9,19 +10,19 @@ use winnow::stream::Stream;
 #[derive(Debug)]
 pub enum CustomError<I> {
     MyError,
-    Winnow(I, ErrorKind),
+    Winnow(I),
     External {
         cause: Box<dyn std::error::Error + Send + Sync + 'static>,
         input: I,
-        kind: ErrorKind,
     },
 }
 
 impl<I: Stream + Clone> ParserError<I> for CustomError<I> {
     type Inner = Self;
 
-    fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
-        CustomError::Winnow(input.clone(), kind)
+    #[allow(deprecated)]
+    fn from_error_kind(input: &I, _: ErrorKind) -> Self {
+        CustomError::Winnow(input.clone())
     }
 
     fn into_inner(self) -> Result<Self::Inner, Self> {
@@ -45,11 +46,11 @@ impl<I: Stream + Clone, E: std::error::Error + Send + Sync + 'static> FromExtern
     for CustomError<I>
 {
     #[inline]
-    fn from_external_error(input: &I, kind: ErrorKind, e: E) -> Self {
+    #[allow(deprecated)]
+    fn from_external_error(input: &I, _: ErrorKind, e: E) -> Self {
         CustomError::External {
             cause: Box::new(e),
             input: input.clone(),
-            kind,
         }
     }
 }

--- a/examples/json/bench.rs
+++ b/examples/json/bench.rs
@@ -31,15 +31,19 @@ fn json_bench(c: &mut criterion::Criterion) {
                 b.iter(|| parser_dispatch::json::<Error>.parse_peek(sample).unwrap());
             },
         );
-        group.bench_with_input(criterion::BenchmarkId::new("unit", name), &len, |b, _| {
-            type Error<'i> = ();
+        group.bench_with_input(
+            criterion::BenchmarkId::new("empty-error", name),
+            &len,
+            |b, _| {
+                type Error<'i> = winnow::error::EmptyError;
 
-            b.iter(|| {
-                parser_dispatch::json::<Error<'_>>
-                    .parse_peek(sample)
-                    .unwrap()
-            });
-        });
+                b.iter(|| {
+                    parser_dispatch::json::<Error<'_>>
+                        .parse_peek(sample)
+                        .unwrap()
+                });
+            },
+        );
         group.bench_with_input(criterion::BenchmarkId::new("alt", name), &len, |b, _| {
             type Error = winnow::error::ContextError;
 

--- a/examples/json/main.rs
+++ b/examples/json/main.rs
@@ -4,7 +4,7 @@ mod parser_dispatch;
 #[allow(dead_code)]
 mod parser_partial;
 
-use winnow::error::ErrorKind;
+use winnow::error::EmptyError;
 use winnow::prelude::*;
 
 fn main() -> Result<(), lexopt::Error> {
@@ -25,8 +25,8 @@ fn main() -> Result<(), lexopt::Error> {
     });
 
     let result = match args.implementation {
-        Impl::Naive => parser_alt::json::<ErrorKind>.parse(data),
-        Impl::Dispatch => parser_dispatch::json::<ErrorKind>.parse(data),
+        Impl::Naive => parser_alt::json::<EmptyError>.parse(data),
+        Impl::Dispatch => parser_dispatch::json::<EmptyError>.parse(data),
     };
     match result {
         Ok(json) => {

--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -28,10 +28,7 @@ fn incr(i: &mut &str) -> ModalResult<()> {
 
         // limit the number of recursions, the fuzzer keeps running into them
         if *l.borrow() >= 8192 {
-            Err(winnow::error::ParserError::from_error_kind(
-                i,
-                winnow::error::ErrorKind::Repeat,
-            ))
+            Err(winnow::error::ParserError::from_input(i))
         } else {
             Ok(())
         }

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -11,14 +11,13 @@
 //! # use winnow::Result;
 //! use winnow::stream::Stream;
 //! use winnow::error::ParserError;
-//! use winnow::error::ErrorKind;
 //!
 //! fn parse_prefix(input: &mut &str) -> Result<char> {
 //!     let c = input.next_token().ok_or_else(|| {
-//!         ParserError::from_error_kind(input, ErrorKind::Token)
+//!         ParserError::from_input(input)
 //!     })?;
 //!     if c != '0' {
-//!         return Err(ParserError::from_error_kind(input, ErrorKind::Verify));
+//!         return Err(ParserError::from_input(input));
 //!     }
 //!     Ok(c)
 //! }
@@ -39,7 +38,6 @@
 //! ```rust
 //! # use winnow::Result;
 //! # use winnow::error::ParserError;
-//! # use winnow::error::ErrorKind;
 //! use winnow::Parser;
 //! use winnow::token::any;
 //!
@@ -47,7 +45,7 @@
 //!     let c = any
 //!         .parse_next(input)?;
 //!     if c != '0' {
-//!         return Err(ParserError::from_error_kind(input, ErrorKind::Verify));
+//!         return Err(ParserError::from_input(input));
 //!     }
 //!     Ok(c)
 //! }
@@ -121,16 +119,15 @@
 //! # use winnow::Result;
 //! use winnow::stream::Stream;
 //! use winnow::error::ParserError;
-//! use winnow::error::ErrorKind;
 //!
 //! fn parse_prefix<'s>(input: &mut &'s str) -> Result<&'s str> {
 //!     let expected = "0x";
 //!     if input.len() < expected.len() {
-//!         return Err(ParserError::from_error_kind(input, ErrorKind::Slice));
+//!         return Err(ParserError::from_input(input));
 //!     }
 //!     let actual = input.next_slice(expected.len());
 //!     if actual != expected {
-//!         return Err(ParserError::from_error_kind(input, ErrorKind::Verify));
+//!         return Err(ParserError::from_input(input));
 //!     }
 //!     Ok(actual)
 //! }

--- a/src/_tutorial/chapter_7.rs
+++ b/src/_tutorial/chapter_7.rs
@@ -463,9 +463,9 @@
 //!
 //! To make [`ErrMode`] more convenient, Winnow provides [`ModalResult`]:
 //! ```rust
-//! # use winnow::error::ErrorKind;
+//! # use winnow::error::ContextError;
 //! # use winnow::error::ErrMode;
-//! pub type ModalResult<O, E = ErrorKind> = Result<O, ErrMode<E>>;
+//! pub type ModalResult<O, E = ContextError> = Result<O, ErrMode<E>>;
 //! ```
 //!
 //! So we can get the correct `context` by changing to [`ModalResult`] and adding [`cut_err`]:

--- a/src/_tutorial/chapter_7.rs
+++ b/src/_tutorial/chapter_7.rs
@@ -722,7 +722,6 @@ use crate::combinator::fail;
 use crate::error::ContextError;
 use crate::error::ErrMode;
 use crate::error::ErrMode::*;
-use crate::error::ErrorKind;
 use crate::ModalResult;
 use crate::Parser;
 use crate::Result;

--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -14,8 +14,8 @@ use crate::combinator::fail;
 use crate::combinator::opt;
 use crate::combinator::peek;
 use crate::combinator::trace;
+use crate::error::Needed;
 use crate::error::ParserError;
-use crate::error::{ErrorKind, Needed};
 use crate::stream::FindSlice;
 use crate::stream::{AsBStr, AsChar, ParseSlice, Stream, StreamIsPartial};
 use crate::stream::{Compare, CompareResult};
@@ -87,7 +87,7 @@ impl Caseless<&str> {
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::crlf;
 /// assert_eq!(crlf::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
@@ -139,7 +139,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::till_line_ending;
 /// assert_eq!(till_line_ending::<_, ErrMode<ContextError>>.parse_peek(Partial::new("ab\r\nc")), Ok((Partial::new("\r\nc"), "ab")));
@@ -193,8 +193,7 @@ where
                 return Err(ParserError::incomplete(input, Needed::Unknown));
             }
             CompareResult::Incomplete | CompareResult::Error => {
-                let e: ErrorKind = ErrorKind::Literal;
-                return Err(ParserError::from_error_kind(input, e));
+                return Err(ParserError::from_input(input));
             }
         }
     }
@@ -234,7 +233,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::line_ending;
 /// assert_eq!(line_ending::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\r\nc")), Ok((Partial::new("c"), "\r\n")));
@@ -283,7 +282,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::newline;
 /// assert_eq!(newline::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\nc")), Ok((Partial::new("c"), '\n')));
@@ -333,7 +332,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::tab;
 /// assert_eq!(tab::<_, ErrMode<ContextError>>.parse_peek(Partial::new("\tc")), Ok((Partial::new("c"), '\t')));
@@ -384,7 +383,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alpha0;
 /// assert_eq!(alpha0::<_, ErrMode<ContextError>>.parse_peek(Partial::new("ab1c")), Ok((Partial::new("1c"), "ab")));
@@ -436,7 +435,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alpha1;
 /// assert_eq!(alpha1::<_, ErrMode<ContextError>>.parse_peek(Partial::new("aB1c")), Ok((Partial::new("1c"), "aB")));
@@ -489,7 +488,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::digit0;
 /// assert_eq!(digit0::<_, ErrMode<ContextError>>.parse_peek(Partial::new("21c")), Ok((Partial::new("c"), "21")));
@@ -541,7 +540,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::digit1;
 /// assert_eq!(digit1::<_, ErrMode<ContextError>>.parse_peek(Partial::new("21c")), Ok((Partial::new("c"), "21")));
@@ -609,7 +608,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::hex_digit0;
 /// assert_eq!(hex_digit0::<_, ErrMode<ContextError>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
@@ -662,7 +661,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::hex_digit1;
 /// assert_eq!(hex_digit1::<_, ErrMode<ContextError>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("Z"), "21c")));
@@ -714,7 +713,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::oct_digit0;
 /// assert_eq!(oct_digit0::<_, ErrMode<ContextError>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
@@ -767,7 +766,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::oct_digit1;
 /// assert_eq!(oct_digit1::<_, ErrMode<ContextError>>.parse_peek(Partial::new("21cZ")), Ok((Partial::new("cZ"), "21")));
@@ -819,7 +818,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alphanumeric0;
 /// assert_eq!(alphanumeric0::<_, ErrMode<ContextError>>.parse_peek(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
@@ -871,7 +870,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::alphanumeric1;
 /// assert_eq!(alphanumeric1::<_, ErrMode<ContextError>>.parse_peek(Partial::new("21cZ%1")), Ok((Partial::new("%1"), "21cZ")));
@@ -911,7 +910,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::space0;
 /// assert_eq!(space0::<_, ErrMode<ContextError>>.parse_peek(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
@@ -963,7 +962,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::space1;
 /// assert_eq!(space1::<_, ErrMode<ContextError>>.parse_peek(Partial::new(" \t21c")), Ok((Partial::new("21c"), " \t")));
@@ -1015,7 +1014,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::multispace0;
 /// assert_eq!(multispace0::<_, ErrMode<ContextError>>.parse_peek(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
@@ -1067,7 +1066,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::Partial;
 /// # use winnow::ascii::multispace1;
 /// assert_eq!(multispace1::<_, ErrMode<ContextError>>.parse_peek(Partial::new(" \t\n\r21c")), Ok((Partial::new("21c"), " \t\n\r")));
@@ -1295,7 +1294,7 @@ impl Int for isize {
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::Partial;
 /// use winnow::ascii::hex_uint;
 ///
@@ -1329,7 +1328,7 @@ where
             Ok(max_offset) => {
                 if max_offset < invalid_offset {
                     // Overflow
-                    return Err(ParserError::from_error_kind(input, ErrorKind::Verify));
+                    return Err(ParserError::from_input(input));
                 } else {
                     invalid_offset
                 }
@@ -1348,7 +1347,7 @@ where
         };
         if offset == 0 {
             // Must be at least one digit
-            return Err(ParserError::from_error_kind(input, ErrorKind::Slice));
+            return Err(ParserError::from_input(input));
         }
         let parsed = input.next_slice(offset);
 
@@ -1444,7 +1443,7 @@ impl HexUint for u128 {
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
 /// use winnow::ascii::float;
@@ -1474,7 +1473,7 @@ where
     trace("float", move |input: &mut Input| {
         let s = take_float_or_exceptions(input)?;
         s.parse_slice()
-            .ok_or_else(|| ParserError::from_error_kind(input, ErrorKind::Verify))
+            .ok_or_else(|| ParserError::from_input(input))
     })
     .parse_next(input)
 }
@@ -1578,7 +1577,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::ascii::digit1;
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
@@ -1741,7 +1740,7 @@ where
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use std::str::from_utf8;
 /// # use winnow::Partial;
 /// use winnow::token::literal;

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -56,7 +56,7 @@ Err(
                 51,
                 52,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -116,7 +116,7 @@ Err(
                 99,
                 100,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -154,7 +154,7 @@ Err(
                 50,
                 51,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -176,7 +176,7 @@ Err(
                 49,
                 50,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -268,7 +268,7 @@ Err(
             input: [
                 32,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -288,7 +288,7 @@ Err(
                 99,
                 100,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -326,7 +326,7 @@ Err(
                 50,
                 51,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -348,7 +348,7 @@ Err(
                 49,
                 50,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -476,7 +476,7 @@ Err(
     Backtrack(
         InputError {
             input: "1234",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -517,7 +517,7 @@ Err(
     Backtrack(
         InputError {
             input: "abcd",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -545,7 +545,7 @@ Err(
     Backtrack(
         InputError {
             input: "a123",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -560,7 +560,7 @@ Err(
     Backtrack(
         InputError {
             input: "azé12",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -627,7 +627,7 @@ Err(
     Backtrack(
         InputError {
             input: " ",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -642,7 +642,7 @@ Err(
     Backtrack(
         InputError {
             input: "abcd",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -670,7 +670,7 @@ Err(
     Backtrack(
         InputError {
             input: "a123",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -685,7 +685,7 @@ Err(
     Backtrack(
         InputError {
             input: "azé12",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -932,7 +932,7 @@ Err(
     Backtrack(
         InputError {
             input: "\rÂßÇáƒƭèř",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -1009,7 +1009,7 @@ Err(
             input: [
                 103,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -1028,7 +1028,7 @@ Err(
             input: [
                 71,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -1089,7 +1089,7 @@ Err(
             input: [
                 56,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -1247,7 +1247,7 @@ Err(
             input: [
                 13,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -1265,7 +1265,7 @@ Err(
                 13,
                 97,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -1294,7 +1294,7 @@ Err(
     Backtrack(
         InputError {
             input: "\r",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -1309,7 +1309,7 @@ Err(
     Backtrack(
         InputError {
             input: "\ra",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -1365,7 +1365,7 @@ Err(
             input: [
                 13,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -1383,7 +1383,7 @@ Err(
                 13,
                 97,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -1425,7 +1425,7 @@ Err(
     Backtrack(
         InputError {
             input: "\r",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -1440,7 +1440,7 @@ Err(
     Backtrack(
         InputError {
             input: "\ra",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -1465,7 +1465,7 @@ Err(
             input: [
                 59,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -1549,7 +1549,7 @@ Err(
                 48,
                 59,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -1574,7 +1574,7 @@ Err(
             input: [
                 59,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -1638,7 +1638,7 @@ Err(
                 48,
                 59,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -1707,7 +1707,7 @@ Err(
                 48,
                 59,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -1732,7 +1732,7 @@ Err(
             input: [
                 59,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -1819,7 +1819,7 @@ Err(
                 50,
                 59,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -1846,7 +1846,7 @@ Err(
                 49,
                 59,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -1894,7 +1894,7 @@ Err(
                 102,
                 59,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -1926,7 +1926,7 @@ Err(
                 102,
                 102,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -2037,7 +2037,7 @@ Err(
     Backtrack(
         InputError {
             input: "",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -2272,7 +2272,7 @@ Err(
     Backtrack(
         InputError {
             input: [],
-            kind: Token,
+            kind: Fail,
         },
     ),
 )
@@ -2289,7 +2289,7 @@ Err(
             input: [
                 65,
             ],
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -2407,7 +2407,7 @@ Err(
     Backtrack(
         InputError {
             input: "",
-            kind: Token,
+            kind: Fail,
         },
     ),
 )
@@ -2422,7 +2422,7 @@ Err(
     Backtrack(
         InputError {
             input: "A",
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -2587,7 +2587,7 @@ Err(
     Backtrack(
         InputError {
             input: [],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -2604,7 +2604,7 @@ Err(
             input: [
                 65,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -2761,7 +2761,7 @@ Err(
     Backtrack(
         InputError {
             input: "",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -2776,7 +2776,7 @@ Err(
     Backtrack(
         InputError {
             input: "A",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -2907,7 +2907,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -2976,7 +2976,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3013,7 +3013,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3038,7 +3038,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3124,7 +3124,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3147,7 +3147,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3184,7 +3184,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3209,7 +3209,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3338,7 +3338,7 @@ Err(
                 input: "1234",
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3388,7 +3388,7 @@ Err(
                 input: "abcd",
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3420,7 +3420,7 @@ Err(
                 input: "a123",
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3438,7 +3438,7 @@ Err(
                 input: "azé12",
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3514,7 +3514,7 @@ Err(
                 input: " ",
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3532,7 +3532,7 @@ Err(
                 input: "abcd",
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3564,7 +3564,7 @@ Err(
                 input: "a123",
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3582,7 +3582,7 @@ Err(
                 input: "azé12",
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3846,7 +3846,7 @@ Err(
                 input: "\rÂßÇáƒƭèř",
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -3928,7 +3928,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3950,7 +3950,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -4017,7 +4017,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -4212,7 +4212,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -4261,7 +4261,7 @@ Err(
                 input: "\ra",
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -4341,7 +4341,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -4406,7 +4406,7 @@ Err(
                 input: "\ra",
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -4434,7 +4434,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -4536,7 +4536,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -4566,7 +4566,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -4620,7 +4620,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -4655,7 +4655,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )

--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -5,7 +5,7 @@
 mod tests;
 
 use crate::combinator::trace;
-use crate::error::{ErrorConvert, ErrorKind, Needed, ParserError};
+use crate::error::{ErrorConvert, Needed, ParserError};
 use crate::lib::std::ops::{AddAssign, Div, Shl, Shr};
 use crate::stream::{Stream, StreamIsPartial, ToUsize};
 use crate::{Parser, Result};
@@ -171,7 +171,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
-/// # use winnow::error::{ContextError, ErrorKind};
+/// # use winnow::error::ContextError;
 /// use winnow::binary::bits::take;
 ///
 /// type Stream<'i> = &'i Bytes;
@@ -227,10 +227,7 @@ where
             if PARTIAL && input.is_partial() {
                 Err(ParserError::incomplete(bit_input, Needed::new(count)))
             } else {
-                Err(ParserError::from_error_kind(
-                    &(input, bit_offset),
-                    ErrorKind::Eof,
-                ))
+                Err(ParserError::from_input(&(input, bit_offset)))
             }
         } else {
             let cnt = (count + bit_offset).div(BYTE);
@@ -285,7 +282,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
-/// # use winnow::error::{ContextError, ErrorKind};
+/// # use winnow::error::ContextError;
 /// use winnow::binary::bits::pattern;
 ///
 /// type Stream<'i> = &'i Bytes;
@@ -345,7 +342,7 @@ where
                 Ok(o)
             } else {
                 input.reset(&start);
-                Err(ParserError::from_error_kind(input, ErrorKind::Literal))
+                Err(ParserError::from_input(input))
             }
         })
     })
@@ -370,7 +367,7 @@ where
 /// ```rust
 /// # use winnow::prelude::*;
 /// # use winnow::Bytes;
-/// # use winnow::error::{InputError, ErrorKind};
+/// # use winnow::error::InputError;
 /// use winnow::binary::bits::bool;
 ///
 /// type Stream<'i> = &'i Bytes;

--- a/src/binary/bits/tests.rs
+++ b/src/binary/bits/tests.rs
@@ -92,10 +92,9 @@ fn test_take_complete_eof() {
 
     assert_eq!(
         result,
-        Err(crate::error::ErrMode::Backtrack(InputError::new(
-            (input, 8),
-            ErrorKind::Eof
-        )))
+        Err(crate::error::ErrMode::Backtrack(
+            InputError::at((input, 8),)
+        ))
     );
 }
 
@@ -150,10 +149,9 @@ fn test_pattern_partial_err() {
 
     assert_eq!(
         result,
-        Err(crate::error::ErrMode::Backtrack(InputError::new(
-            (input, offset),
-            ErrorKind::Literal
-        )))
+        Err(crate::error::ErrMode::Backtrack(InputError::at((
+            input, offset
+        ),)))
     );
 }
 
@@ -174,10 +172,9 @@ fn test_bool_eof_complete() {
 
     assert_eq!(
         result,
-        Err(crate::error::ErrMode::Backtrack(InputError::new(
-            (input, 8),
-            ErrorKind::Eof
-        )))
+        Err(crate::error::ErrMode::Backtrack(
+            InputError::at((input, 8),)
+        ))
     );
 }
 

--- a/src/binary/mod.rs
+++ b/src/binary/mod.rs
@@ -9,7 +9,6 @@ mod tests;
 
 use crate::combinator::repeat;
 use crate::combinator::trace;
-use crate::error::ErrorKind;
 use crate::error::Needed;
 use crate::error::ParserError;
 use crate::lib::std::ops::{Add, Shl};
@@ -39,7 +38,7 @@ pub enum Endianness {
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u8;
@@ -53,7 +52,7 @@ pub enum Endianness {
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u8;
@@ -83,7 +82,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u16;
@@ -97,7 +96,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u16;
@@ -127,7 +126,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u24;
@@ -141,7 +140,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u24;
@@ -171,7 +170,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u32;
@@ -185,7 +184,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u32;
@@ -215,7 +214,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u64;
@@ -229,7 +228,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u64;
@@ -259,7 +258,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_u128;
@@ -273,7 +272,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_u128;
@@ -311,7 +310,7 @@ where
         Err(e) if <Input as StreamIsPartial>::is_partial_supported() && input.is_partial() => {
             Err(ParserError::incomplete(input, e))
         }
-        Err(_needed) => Err(ParserError::from_error_kind(input, ErrorKind::Slice)),
+        Err(_needed) => Err(ParserError::from_input(input)),
     }
 }
 
@@ -341,7 +340,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i8;
@@ -355,7 +354,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i8;
@@ -385,7 +384,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i16;
@@ -399,7 +398,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i16;
@@ -432,7 +431,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i24;
@@ -446,7 +445,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i24;
@@ -487,7 +486,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i32;
@@ -501,7 +500,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i32;
@@ -534,7 +533,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i64;
@@ -548,7 +547,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i64;
@@ -581,7 +580,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_i128;
@@ -595,7 +594,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_i128;
@@ -628,7 +627,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u8;
@@ -642,7 +641,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u8;
@@ -672,7 +671,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u16;
@@ -686,7 +685,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u16;
@@ -716,7 +715,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u24;
@@ -730,7 +729,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u24;
@@ -760,7 +759,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u32;
@@ -774,7 +773,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u32;
@@ -804,7 +803,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u64;
@@ -818,7 +817,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u64;
@@ -848,7 +847,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_u128;
@@ -862,7 +861,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_u128;
@@ -899,7 +898,7 @@ where
         Err(e) if <Input as StreamIsPartial>::is_partial_supported() && input.is_partial() => {
             Err(ParserError::incomplete(input, e))
         }
-        Err(_needed) => Err(ParserError::from_error_kind(input, ErrorKind::Slice)),
+        Err(_needed) => Err(ParserError::from_input(input)),
     }
 }
 
@@ -929,7 +928,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i8;
@@ -943,7 +942,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i8;
@@ -973,7 +972,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i16;
@@ -987,7 +986,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i16;
@@ -1020,7 +1019,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i24;
@@ -1034,7 +1033,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i24;
@@ -1075,7 +1074,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i32;
@@ -1089,7 +1088,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i32;
@@ -1122,7 +1121,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i64;
@@ -1136,7 +1135,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i64;
@@ -1169,7 +1168,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_i128;
@@ -1183,7 +1182,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_i128;
@@ -1222,7 +1221,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u8;
@@ -1236,7 +1235,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1274,7 +1273,7 @@ where
         if PARTIAL && input.is_partial() {
             ParserError::incomplete(input, Needed::new(1))
         } else {
-            ParserError::from_error_kind(input, ErrorKind::Token)
+            ParserError::from_input(input)
         }
     })
 }
@@ -1291,7 +1290,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u16;
@@ -1312,7 +1311,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1362,7 +1361,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u24;
@@ -1383,7 +1382,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1433,7 +1432,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u32;
@@ -1454,7 +1453,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1504,7 +1503,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u64;
@@ -1525,7 +1524,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1575,7 +1574,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::u128;
@@ -1596,7 +1595,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1649,7 +1648,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i8;
@@ -1663,7 +1662,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1705,7 +1704,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i16;
@@ -1726,7 +1725,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1776,7 +1775,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i24;
@@ -1797,7 +1796,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1847,7 +1846,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i32;
@@ -1868,7 +1867,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1918,7 +1917,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i64;
@@ -1939,7 +1938,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -1989,7 +1988,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::i128;
@@ -2010,7 +2009,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -2057,7 +2056,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
@@ -2072,7 +2071,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_f32;
@@ -2105,7 +2104,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::be_f64;
@@ -2119,7 +2118,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::be_f64;
@@ -2152,7 +2151,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_f32;
@@ -2166,7 +2165,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_f32;
@@ -2199,7 +2198,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::le_f64;
@@ -2213,7 +2212,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::Partial;
 /// use winnow::binary::le_f64;
@@ -2249,7 +2248,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::f32;
@@ -2270,7 +2269,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -2320,7 +2319,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::binary::f64;
@@ -2341,7 +2340,7 @@ where
 /// ```
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// # use winnow::Partial;
@@ -2392,7 +2391,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed, stream::Partial};
+/// # use winnow::{error::ErrMode, error::Needed, stream::Partial};
 /// # use winnow::prelude::*;
 /// use winnow::Bytes;
 /// use winnow::binary::be_u16;
@@ -2436,7 +2435,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed, stream::{Partial, StreamIsPartial}};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed, stream::{Partial, StreamIsPartial}};
 /// # use winnow::prelude::*;
 /// use winnow::Bytes;
 /// use winnow::binary::be_u16;
@@ -2491,7 +2490,7 @@ where
 /// ```rust
 /// # #[cfg(feature = "std")] {
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{InputError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::InputError, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::Bytes;
 /// use winnow::binary::u8;

--- a/src/binary/tests.rs
+++ b/src/binary/tests.rs
@@ -3249,7 +3249,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3271,7 +3271,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -3504,7 +3504,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3565,7 +3565,7 @@ Err(
                 input: [],
                 partial: false,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3583,7 +3583,7 @@ Err(
                 input: [],
                 partial: false,
             },
-            kind: Token,
+            kind: Fail,
         },
     ),
 )
@@ -3608,7 +3608,7 @@ Err(
                 ],
                 partial: false,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -3626,7 +3626,7 @@ Err(
                 input: [],
                 partial: false,
             },
-            kind: Token,
+            kind: Fail,
         },
     ),
 )

--- a/src/combinator/branch.rs
+++ b/src/combinator/branch.rs
@@ -1,5 +1,7 @@
 use crate::combinator::trace;
-use crate::error::{ErrorKind, ParserError};
+#[allow(deprecated)]
+use crate::error::ErrorKind;
+use crate::error::ParserError;
 use crate::stream::Stream;
 use crate::*;
 
@@ -28,7 +30,7 @@ pub trait Alt<I, O, E> {
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::ascii::{alpha1, digit1};
 /// use winnow::combinator::alt;
@@ -79,7 +81,7 @@ pub trait Permutation<I, O, E> {
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode,error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::ascii::{alpha1, digit1};
 /// use winnow::combinator::permutation;
@@ -102,7 +104,7 @@ pub trait Permutation<I, O, E> {
 /// The parsers are applied greedily: if there are multiple unapplied parsers
 /// that could parse the next slice of input, the first one is used.
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind};
+/// # use winnow::error::ErrMode;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::permutation;
 /// use winnow::token::any;
@@ -144,6 +146,7 @@ impl<const N: usize, I: Stream, O, E: ParserError<I>, P: Parser<I, O, E>> Alt<I,
             }
         }
 
+        #[allow(deprecated)]
         match error {
             Some(e) => Err(e.append(input, &start, ErrorKind::Alt)),
             None => Err(ParserError::assert(
@@ -172,6 +175,7 @@ impl<I: Stream, O, E: ParserError<I>, P: Parser<I, O, E>> Alt<I, O, E> for &mut 
             }
         }
 
+        #[allow(deprecated)]
         match error {
             Some(e) => Err(e.append(input, &start, ErrorKind::Alt)),
             None => Err(ParserError::assert(
@@ -251,6 +255,7 @@ macro_rules! alt_trait_inner(
     }
   });
   ($it:tt, $self:expr, $input:expr, $start:ident, $err:expr, $head:ident) => ({
+    #[allow(deprecated)]
     Err($err.append($input, &$start, ErrorKind::Alt))
   });
 );
@@ -304,6 +309,7 @@ macro_rules! permutation_trait_impl(
           if let Some(err) = err {
             // There are remaining parsers, and all errored on the remaining input
             input.reset(&start);
+#[allow(deprecated)]
             return Err(err.append(input, &start, ErrorKind::Alt));
           }
 

--- a/src/combinator/debug/mod.rs
+++ b/src/combinator/debug/mod.rs
@@ -16,7 +16,7 @@ use crate::Parser;
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::token::take_while;
 /// # use winnow::stream::AsChar;
 /// # use winnow::prelude::*;

--- a/src/combinator/impls.rs
+++ b/src/combinator/impls.rs
@@ -6,7 +6,7 @@ use crate::combinator::DisplayDebug;
 #[cfg(feature = "unstable-recover")]
 #[cfg(feature = "std")]
 use crate::error::FromRecoverableError;
-use crate::error::{AddContext, ErrorKind, FromExternalError, ParserError};
+use crate::error::{AddContext, FromExternalError, ParserError};
 use crate::lib::std::borrow::Borrow;
 use crate::lib::std::ops::Range;
 #[cfg(feature = "unstable-recover")]
@@ -94,7 +94,8 @@ where
         let o = self.parser.parse_next(input)?;
         let res = (self.map)(o).map_err(|err| {
             input.reset(&start);
-            E::from_external_error(input, ErrorKind::Verify, err)
+            #[allow(deprecated)]
+            E::from_external_error(input, crate::error::ErrorKind::Verify, err)
         });
         trace_result("verify", &res);
         res
@@ -130,7 +131,7 @@ where
         let o = self.parser.parse_next(input)?;
         let res = (self.map)(o).ok_or_else(|| {
             input.reset(&start);
-            ParserError::from_error_kind(input, ErrorKind::Verify)
+            ParserError::from_input(input)
         });
         trace_result("verify", &res);
         res
@@ -201,7 +202,7 @@ where
         let o = self.p.parse_next(i)?;
         let res = o.parse_slice().ok_or_else(|| {
             i.reset(&start);
-            ParserError::from_error_kind(i, ErrorKind::Verify)
+            ParserError::from_input(i)
         });
         trace_result("verify", &res);
         res
@@ -256,7 +257,7 @@ where
         trace("complete_err", |input: &mut I| {
             match (self.p).parse_next(input) {
                 Err(err) => match err.into_needed() {
-                    Ok(_) => Err(ParserError::from_error_kind(input, ErrorKind::Complete)),
+                    Ok(_) => Err(ParserError::from_input(input)),
                     Err(err) => Err(err),
                 },
                 rest => rest,
@@ -299,7 +300,7 @@ where
         let o = self.parser.parse_next(input)?;
         let res = (self.filter)(o.borrow()).then_some(o).ok_or_else(|| {
             input.reset(&start);
-            ParserError::from_error_kind(input, ErrorKind::Verify)
+            ParserError::from_input(input)
         });
         trace_result("verify", &res);
         res

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -1,6 +1,7 @@
 //! Combinators applying their child parser multiple times
 
 use crate::combinator::trace;
+#[allow(deprecated)]
 use crate::error::ErrorKind;
 use crate::error::FromExternalError;
 use crate::error::ParserError;
@@ -32,7 +33,7 @@ use crate::Result;
 /// Zero or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
@@ -50,7 +51,7 @@ use crate::Result;
 /// One or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
@@ -68,7 +69,7 @@ use crate::Result;
 /// Fixed number of repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
@@ -87,7 +88,7 @@ use crate::Result;
 /// Arbitrary repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat;
 ///
@@ -176,7 +177,7 @@ where
     ///
     /// Zero or more repetitions:
     /// ```rust
-    /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+    /// # use winnow::{error::ErrMode, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
@@ -201,7 +202,7 @@ where
     ///
     /// One or more repetitions:
     /// ```rust
-    /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+    /// # use winnow::{error::ErrMode, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
@@ -226,7 +227,7 @@ where
     ///
     /// Arbitrary number of repetitions:
     /// ```rust
-    /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+    /// # use winnow::{error::ErrMode, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     ///
@@ -306,7 +307,7 @@ where
     ///
     /// Guaranteeing that the input had unique elements:
     /// ```rust
-    /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+    /// # use winnow::{error::ErrMode, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     /// use std::collections::HashSet;
@@ -382,7 +383,7 @@ where
     ///
     /// Writing the output to a vector of bytes:
     /// ```rust
-    /// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+    /// # use winnow::{error::ErrMode, error::Needed};
     /// # use winnow::prelude::*;
     /// use winnow::combinator::repeat;
     /// use std::io::Write;
@@ -498,6 +499,7 @@ where
     E: ParserError<I>,
 {
     let start = i.checkpoint();
+    #[allow(deprecated)]
     match f.parse_next(i) {
         Err(e) => Err(e.append(i, &start, ErrorKind::Repeat)),
         Ok(o) => {
@@ -555,6 +557,7 @@ where
                 res.accumulate(o);
             }
             Err(e) => {
+                #[allow(deprecated)]
                 return Err(e.append(i, &start, ErrorKind::Repeat));
             }
         }
@@ -595,6 +598,7 @@ where
             }
             Err(e) if e.is_backtrack() => {
                 if count < min {
+                    #[allow(deprecated)]
                     return Err(e.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);
@@ -629,7 +633,7 @@ where
 ///
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::repeat_till;
 ///
@@ -691,6 +695,7 @@ where
             Ok(o) => return Ok((res, o)),
             Err(e) if e.is_backtrack() => {
                 i.reset(&start);
+                #[allow(deprecated)]
                 match f.parse_next(i) {
                     Err(e) => return Err(e.append(i, &start, ErrorKind::Repeat)),
                     Ok(o) => {
@@ -741,6 +746,7 @@ where
                 res.accumulate(o);
             }
             Err(e) => {
+                #[allow(deprecated)]
                 return Err(e.append(i, &start, ErrorKind::Repeat));
             }
         }
@@ -757,6 +763,7 @@ where
                 i.reset(&start);
                 match f.parse_next(i) {
                     Err(e) => {
+                        #[allow(deprecated)]
                         return Err(e.append(i, &start, ErrorKind::Repeat));
                     }
                     Ok(o) => {
@@ -800,7 +807,7 @@ where
 /// Zero or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
@@ -819,7 +826,7 @@ where
 /// One or more repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
@@ -838,7 +845,7 @@ where
 /// Fixed number of repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
@@ -857,7 +864,7 @@ where
 /// Arbitrary repetitions:
 /// ```rust
 /// # #[cfg(feature = "std")] {
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated;
 ///
@@ -1048,6 +1055,7 @@ where
     let start = input.checkpoint();
     match parser.parse_next(input) {
         Err(e) => {
+            #[allow(deprecated)]
             return Err(e.append(input, &start, ErrorKind::Repeat));
         }
         Ok(o) => {
@@ -1060,6 +1068,7 @@ where
         let len = input.eof_offset();
         match separator.parse_next(input) {
             Err(e) => {
+                #[allow(deprecated)]
                 return Err(e.append(input, &start, ErrorKind::Repeat));
             }
             Ok(_) => {
@@ -1073,6 +1082,7 @@ where
 
                 match parser.parse_next(input) {
                     Err(e) => {
+                        #[allow(deprecated)]
                         return Err(e.append(input, &start, ErrorKind::Repeat));
                     }
                     Ok(o) => {
@@ -1116,6 +1126,7 @@ where
                 input.reset(&start);
                 return Ok(acc);
             } else {
+                #[allow(deprecated)]
                 return Err(e.append(input, &start, ErrorKind::Repeat));
             }
         }
@@ -1131,6 +1142,7 @@ where
         match separator.parse_next(input) {
             Err(e) if e.is_backtrack() => {
                 if index < min {
+                    #[allow(deprecated)]
                     return Err(e.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);
@@ -1152,6 +1164,7 @@ where
                 match parser.parse_next(input) {
                     Err(e) if e.is_backtrack() => {
                         if index < min {
+                            #[allow(deprecated)]
                             return Err(e.append(input, &start, ErrorKind::Repeat));
                         } else {
                             input.reset(&start);
@@ -1180,7 +1193,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_foldl1;
 /// use winnow::ascii::dec_int;
@@ -1250,7 +1263,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_foldr1;
 /// use winnow::ascii::dec_uint;
@@ -1301,7 +1314,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// use winnow::combinator::fill;
 ///
@@ -1334,6 +1347,7 @@ where
                     *elem = o;
                 }
                 Err(e) => {
+                    #[allow(deprecated)]
                     return Err(e.append(i, &start, ErrorKind::Repeat));
                 }
             }
@@ -1399,6 +1413,7 @@ where
 {
     let init = init();
     let start = input.checkpoint();
+    #[allow(deprecated)]
     match f.parse_next(input) {
         Err(e) => Err(e.append(input, &start, ErrorKind::Repeat)),
         Ok(o1) => {
@@ -1473,6 +1488,7 @@ where
             //FInputXMError: handle failure properly
             Err(err) if err.is_backtrack() => {
                 if count < min {
+                    #[allow(deprecated)]
                     return Err(err.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);
@@ -1525,7 +1541,7 @@ where
 
                 let Some(tmp) = fold(acc, value) else {
                     input.reset(&start);
-                    let res = Err(ParserError::from_error_kind(input, ErrorKind::Verify));
+                    let res = Err(ParserError::from_input(input));
                     super::debug::trace_result("verify_fold", &res);
                     return res;
                 };
@@ -1534,6 +1550,7 @@ where
             //FInputXMError: handle failure properly
             Err(err) if err.is_backtrack() => {
                 if count < min {
+                    #[allow(deprecated)]
                     return Err(err.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);
@@ -1588,6 +1605,7 @@ where
                     Ok(tmp) => acc = tmp,
                     Err(e) => {
                         input.reset(&start);
+                        #[allow(deprecated)]
                         let res = Err(E::from_external_error(input, ErrorKind::Verify, e));
                         super::debug::trace_result("try_fold", &res);
                         return res;
@@ -1597,6 +1615,7 @@ where
             //FInputXMError: handle failure properly
             Err(err) if err.is_backtrack() => {
                 if count < min {
+                    #[allow(deprecated)]
                     return Err(err.append(input, &start, ErrorKind::Repeat));
                 } else {
                     input.reset(&start);

--- a/src/combinator/sequence.rs
+++ b/src/combinator/sequence.rs
@@ -13,7 +13,7 @@ pub use crate::seq;
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::preceded;
@@ -51,7 +51,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::prelude::*;
 /// # use winnow::error::Needed::Size;
 /// use winnow::combinator::terminated;
@@ -89,7 +89,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::error::Needed::Size;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::separated_pair;
@@ -129,7 +129,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::Needed};
+/// # use winnow::{error::ErrMode, error::Needed};
 /// # use winnow::error::Needed::Size;
 /// # use winnow::prelude::*;
 /// use winnow::combinator::delimited;

--- a/src/error.rs
+++ b/src/error.rs
@@ -330,7 +330,8 @@ pub trait ParserError<I: Stream>: Sized {
     /// Mostly used for [`ErrMode`]
     type Inner;
 
-    /// Creates an error from the input position and an [`ErrorKind`]
+    /// Deprecated, replaced with [`ParserError::from_input`]
+    #[deprecated(since = "0.6.26", note = "replaced with `ParserError::from_input`")]
     fn from_error_kind(input: &I, kind: ErrorKind) -> Self;
 
     /// Creates an error from the input position

--- a/src/error.rs
+++ b/src/error.rs
@@ -486,6 +486,7 @@ pub struct InputError<I: Clone> {
 impl<I: Clone> InputError<I> {
     /// Creates a new basic error
     #[inline]
+    #[deprecated(since = "0.6.26", note = "replaced with `InputError::at`")]
     pub fn new(input: I, kind: ErrorKind) -> Self {
         Self { input, kind }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,6 @@
 //! that can help convert to a `Result` for integrating with your application's error reporting.
 //!
 //! Error types include:
-//! - `()`
 //! - [`EmptyError`] when the reason for failure doesn't matter
 //! - [`ErrorKind`]
 //! - [`InputError`] (mostly for testing)

--- a/src/error.rs
+++ b/src/error.rs
@@ -489,6 +489,15 @@ impl<I: Clone> InputError<I> {
         Self { input, kind }
     }
 
+    /// Creates a new basic error
+    #[inline]
+    pub fn at(input: I) -> Self {
+        Self {
+            input,
+            kind: ErrorKind::Fail,
+        }
+    }
+
     /// Translate the input type
     #[inline]
     pub fn map_input<I2: Clone, O: Fn(I) -> I2>(self, op: O) -> InputError<I2> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,8 @@
 //! Error types include:
 //! - [`EmptyError`] when the reason for failure doesn't matter
 //! - [`ErrorKind`]
-//! - [`InputError`] (mostly for testing)
 //! - [`ContextError`]
+//! - [`InputError`] (mostly for testing)
 //! - [`TreeError`] (mostly for testing)
 //! - [Custom errors][crate::_topic::error]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -333,6 +333,12 @@ pub trait ParserError<I: Stream>: Sized {
     /// Creates an error from the input position and an [`ErrorKind`]
     fn from_error_kind(input: &I, kind: ErrorKind) -> Self;
 
+    /// Creates an error from the input position
+    #[inline(always)]
+    fn from_input(input: &I) -> Self {
+        Self::from_error_kind(input, ErrorKind::Fail)
+    }
+
     /// Process a parser assertion
     #[inline(always)]
     fn assert(input: &I, _message: &'static str) -> Self

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@
 //!
 //! Error types include:
 //! - `()`
+//! - [`EmptyError`] when the reason for failure doesn't matter
 //! - [`ErrorKind`]
 //! - [`InputError`] (mostly for testing)
 //! - [`ContextError`]
@@ -578,6 +579,60 @@ impl<I: Clone + fmt::Display> fmt::Display for InputError<I> {
 impl<I: Clone + fmt::Debug + fmt::Display + Sync + Send + 'static> std::error::Error
     for InputError<I>
 {
+}
+
+/// Track an error occurred without any other [`StrContext`]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct EmptyError;
+
+impl<I: Stream> ParserError<I> for EmptyError {
+    type Inner = Self;
+
+    #[inline(always)]
+    fn from_error_kind(_: &I, _: ErrorKind) -> Self {
+        Self
+    }
+
+    #[inline(always)]
+    fn into_inner(self) -> Result<Self::Inner, Self> {
+        Ok(self)
+    }
+}
+
+impl<I: Stream, C> AddContext<I, C> for EmptyError {}
+
+#[cfg(feature = "unstable-recover")]
+#[cfg(feature = "std")]
+impl<I: Stream> FromRecoverableError<I, Self> for EmptyError {
+    #[inline(always)]
+    fn from_recoverable_error(
+        _token_start: &<I as Stream>::Checkpoint,
+        _err_start: &<I as Stream>::Checkpoint,
+        _input: &I,
+        e: Self,
+    ) -> Self {
+        e
+    }
+}
+
+impl<I, E> FromExternalError<I, E> for EmptyError {
+    #[inline(always)]
+    fn from_external_error(_input: &I, _kind: ErrorKind, _e: E) -> Self {
+        Self
+    }
+}
+
+impl ErrorConvert<EmptyError> for EmptyError {
+    #[inline(always)]
+    fn convert(self) -> EmptyError {
+        self
+    }
+}
+
+impl crate::lib::std::fmt::Display for EmptyError {
+    fn fmt(&self, f: &mut crate::lib::std::fmt::Formatter<'_>) -> crate::lib::std::fmt::Result {
+        "failed to parse".fmt(f)
+    }
 }
 
 impl<I: Stream> ParserError<I> for () {

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,6 @@
 //!
 //! Error types include:
 //! - [`EmptyError`] when the reason for failure doesn't matter
-//! - [`ErrorKind`]
 //! - [`ContextError`]
 //! - [`InputError`] (mostly for testing)
 //! - [`TreeError`] (mostly for testing)
@@ -164,6 +163,7 @@ impl<I: Stream, E: ParserError<I>> ParserError<I> for ErrMode<E> {
     type Inner = E;
 
     #[inline(always)]
+    #[allow(deprecated)]
     fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
         ErrMode::Backtrack(E::from_error_kind(input, kind))
     }
@@ -182,6 +182,7 @@ impl<I: Stream, E: ParserError<I>> ParserError<I> for ErrMode<E> {
     }
 
     #[inline]
+    #[allow(deprecated)]
     fn append(self, input: &I, token_start: &<I as Stream>::Checkpoint, kind: ErrorKind) -> Self {
         match self {
             ErrMode::Backtrack(e) => ErrMode::Backtrack(e.append(input, token_start, kind)),
@@ -256,6 +257,7 @@ where
     E: FromExternalError<I, EXT>,
 {
     #[inline(always)]
+    #[allow(deprecated)]
     fn from_external_error(input: &I, kind: ErrorKind, e: EXT) -> Self {
         ErrMode::Backtrack(E::from_external_error(input, kind, e))
     }
@@ -332,11 +334,13 @@ pub trait ParserError<I: Stream>: Sized {
 
     /// Deprecated, replaced with [`ParserError::from_input`]
     #[deprecated(since = "0.6.26", note = "replaced with `ParserError::from_input`")]
+    #[allow(deprecated)]
     fn from_error_kind(input: &I, kind: ErrorKind) -> Self;
 
     /// Creates an error from the input position
     #[inline(always)]
     fn from_input(input: &I) -> Self {
+        #[allow(deprecated)]
         Self::from_error_kind(input, ErrorKind::Fail)
     }
 
@@ -362,7 +366,7 @@ pub trait ParserError<I: Stream>: Sized {
     /// Convert this into an `Backtrack` with [`Parser::complete_err`]
     #[inline(always)]
     fn incomplete(input: &I, _needed: Needed) -> Self {
-        Self::from_error_kind(input, ErrorKind::Complete)
+        Self::from_input(input)
     }
 
     /// Like [`ParserError::from_error_kind`] but merges it with the existing error.
@@ -370,6 +374,7 @@ pub trait ParserError<I: Stream>: Sized {
     /// This is useful when backtracking through a parse tree, accumulating error context on the
     /// way.
     #[inline]
+    #[allow(deprecated)]
     fn append(
         self,
         _input: &I,
@@ -455,6 +460,7 @@ pub trait FromRecoverableError<I: Stream, E> {
 /// This trait is required by the [`Parser::try_map`] combinator.
 pub trait FromExternalError<I, E> {
     /// Like [`ParserError::from_error_kind`] but also include an external error.
+    #[allow(deprecated)]
     fn from_external_error(input: &I, kind: ErrorKind, e: E) -> Self;
 }
 
@@ -476,6 +482,7 @@ pub trait ErrorConvert<E> {
 ///
 /// </div>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(deprecated)]
 pub struct InputError<I: Clone> {
     /// The input stream, pointing to the location where the error occurred
     pub input: I,
@@ -487,6 +494,7 @@ impl<I: Clone> InputError<I> {
     /// Creates a new basic error
     #[inline]
     #[deprecated(since = "0.6.26", note = "replaced with `InputError::at`")]
+    #[allow(deprecated)]
     pub fn new(input: I, kind: ErrorKind) -> Self {
         Self { input, kind }
     }
@@ -494,6 +502,7 @@ impl<I: Clone> InputError<I> {
     /// Creates a new basic error
     #[inline]
     pub fn at(input: I) -> Self {
+        #[allow(deprecated)]
         Self {
             input,
             kind: ErrorKind::Fail,
@@ -525,6 +534,7 @@ impl<I: Stream + Clone> ParserError<I> for InputError<I> {
     type Inner = Self;
 
     #[inline]
+    #[allow(deprecated)]
     fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
         Self {
             input: input.clone(),
@@ -557,6 +567,7 @@ impl<I: Clone + Stream> FromRecoverableError<I, Self> for InputError<I> {
 impl<I: Clone, E> FromExternalError<I, E> for InputError<I> {
     /// Create a new error from an input position and an external error
     #[inline]
+    #[allow(deprecated)]
     fn from_external_error(input: &I, kind: ErrorKind, _e: E) -> Self {
         Self {
             input: input.clone(),
@@ -605,6 +616,7 @@ impl<I: Stream> ParserError<I> for EmptyError {
     type Inner = Self;
 
     #[inline(always)]
+    #[allow(deprecated)]
     fn from_error_kind(_: &I, _: ErrorKind) -> Self {
         Self
     }
@@ -633,6 +645,7 @@ impl<I: Stream> FromRecoverableError<I, Self> for EmptyError {
 
 impl<I, E> FromExternalError<I, E> for EmptyError {
     #[inline(always)]
+    #[allow(deprecated)]
     fn from_external_error(_input: &I, _kind: ErrorKind, _e: E) -> Self {
         Self
     }
@@ -655,6 +668,7 @@ impl<I: Stream> ParserError<I> for () {
     type Inner = Self;
 
     #[inline]
+    #[allow(deprecated)]
     fn from_error_kind(_: &I, _: ErrorKind) -> Self {}
 
     #[inline(always)]
@@ -680,6 +694,7 @@ impl<I: Stream> FromRecoverableError<I, Self> for () {
 
 impl<I, E> FromExternalError<I, E> for () {
     #[inline]
+    #[allow(deprecated)]
     fn from_external_error(_input: &I, _kind: ErrorKind, _e: E) -> Self {}
 }
 
@@ -746,6 +761,7 @@ impl<I: Stream, C> ParserError<I> for ContextError<C> {
     type Inner = Self;
 
     #[inline]
+    #[allow(deprecated)]
     fn from_error_kind(_input: &I, _kind: ErrorKind) -> Self {
         Self::new()
     }
@@ -789,6 +805,7 @@ impl<C, I, E: std::error::Error + Send + Sync + 'static> FromExternalError<I, E>
     for ContextError<C>
 {
     #[inline]
+    #[allow(deprecated)]
     fn from_external_error(_input: &I, _kind: ErrorKind, e: E) -> Self {
         let mut err = Self::new();
         {
@@ -802,6 +819,7 @@ impl<C, I, E: std::error::Error + Send + Sync + 'static> FromExternalError<I, E>
 #[cfg(not(feature = "std"))]
 impl<C, I, E: Send + Sync + 'static> FromExternalError<I, E> for ContextError<C> {
     #[inline]
+    #[allow(deprecated)]
     fn from_external_error(_input: &I, _kind: ErrorKind, _e: E) -> Self {
         let err = Self::new();
         err
@@ -984,6 +1002,7 @@ pub struct TreeErrorBase<I> {
     /// Parsed input, at the location where the error occurred
     pub input: I,
     /// Debug context
+    #[allow(deprecated)]
     pub kind: ErrorKind,
     /// See [`FromExternalError::from_external_error`]
     pub cause: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
@@ -1064,6 +1083,7 @@ where
 {
     type Inner = Self;
 
+    #[allow(deprecated)]
     fn from_error_kind(input: &I, kind: ErrorKind) -> Self {
         TreeError::Base(TreeErrorBase {
             input: input.clone(),
@@ -1072,6 +1092,7 @@ where
         })
     }
 
+    #[allow(deprecated)]
     fn append(self, input: &I, token_start: &<I as Stream>::Checkpoint, kind: ErrorKind) -> Self {
         let mut input = input.clone();
         input.reset(token_start);
@@ -1139,6 +1160,7 @@ impl<I, C, E: std::error::Error + Send + Sync + 'static> FromExternalError<I, E>
 where
     I: Clone,
 {
+    #[allow(deprecated)]
     fn from_external_error(input: &I, kind: ErrorKind, e: E) -> Self {
         TreeError::Base(TreeErrorBase {
             input: input.clone(),
@@ -1285,6 +1307,7 @@ pub enum ErrorKind {
   Fail,
 }
 
+#[allow(deprecated)]
 impl ErrorKind {
     #[rustfmt::skip]
     /// Converts an `ErrorKind` to a text description
@@ -1305,10 +1328,12 @@ impl ErrorKind {
   }
 }
 
+#[allow(deprecated)]
 impl<I: Stream> ParserError<I> for ErrorKind {
     type Inner = Self;
 
     #[inline]
+    #[allow(deprecated)]
     fn from_error_kind(_input: &I, kind: ErrorKind) -> Self {
         kind
     }
@@ -1319,17 +1344,21 @@ impl<I: Stream> ParserError<I> for ErrorKind {
     }
 }
 
+#[allow(deprecated)]
 impl<I: Stream, C> AddContext<I, C> for ErrorKind {}
 
+#[allow(deprecated)]
 impl<I, E> FromExternalError<I, E> for ErrorKind {
     /// Create a new error from an input position and an external error
     #[inline]
+    #[allow(deprecated)]
     fn from_external_error(_input: &I, kind: ErrorKind, _e: E) -> Self {
         kind
     }
 }
 
 /// The Display implementation allows the `std::error::Error` implementation
+#[allow(deprecated)]
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "error {self:?}")
@@ -1337,6 +1366,7 @@ impl fmt::Display for ErrorKind {
 }
 
 #[cfg(feature = "std")]
+#[allow(deprecated)]
 impl std::error::Error for ErrorKind {}
 
 /// See [`Parser::parse`]
@@ -1500,12 +1530,12 @@ mod test_parse_error {
         let start = input.checkpoint();
         let _ = input.next_token().unwrap();
         let _ = input.next_token().unwrap();
-        let inner = InputError::new(input, ErrorKind::Slice);
+        let inner = InputError::at(input);
         let error = ParseError::new(input, start, inner);
         let expected = "\
 0xZ123
   ^
-slice error starting at: Z123";
+fail error starting at: Z123";
         assert_eq!(error.to_string(), expected);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1262,10 +1262,15 @@ impl<I: fmt::Display, C: fmt::Display> fmt::Display for TreeError<I, C> {
     }
 }
 
-/// Provide some minor debug context for errors
+/// Deprecated
+///
+/// For error typse, use [`EmptyError`] instead
+///
+/// For creating an error, use [`ParserError::from_input`], [`InputError::at`]
 #[rustfmt::skip]
 #[derive(Debug,PartialEq,Eq,Hash,Clone,Copy)]
 #[allow(missing_docs)]
+#[deprecated(since = "0.6.26")]
 pub enum ErrorKind {
   Assert,
   Token,

--- a/src/macros/tests.rs
+++ b/src/macros/tests.rs
@@ -60,7 +60,7 @@ Err(
     Backtrack(
         InputError {
             input: "",
-            kind: Token,
+            kind: Fail,
         },
     ),
 )
@@ -111,7 +111,7 @@ Err(
     Backtrack(
         InputError {
             input: " remaining",
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -126,7 +126,7 @@ Err(
     Backtrack(
         InputError {
             input: "",
-            kind: Token,
+            kind: Fail,
         },
     ),
 )
@@ -180,7 +180,7 @@ Err(
     Backtrack(
         InputError {
             input: " remaining",
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -195,7 +195,7 @@ Err(
     Backtrack(
         InputError {
             input: "",
-            kind: Token,
+            kind: Fail,
         },
     ),
 )
@@ -396,7 +396,7 @@ Err(
     Backtrack(
         InputError {
             input: " remaining",
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -411,7 +411,7 @@ Err(
     Backtrack(
         InputError {
             input: "",
-            kind: Token,
+            kind: Fail,
         },
     ),
 )
@@ -515,7 +515,7 @@ Err(
     Backtrack(
         InputError {
             input: " remaining",
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -530,7 +530,7 @@ Err(
     Backtrack(
         InputError {
             input: "",
-            kind: Token,
+            kind: Fail,
         },
     ),
 )

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -164,7 +164,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// # use winnow::{error::ErrMode, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::alpha1;
     /// # fn main() {
@@ -198,7 +198,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// # use winnow::{error::ErrMode, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::alpha1;
     /// # fn main() {
@@ -231,7 +231,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// # use winnow::{error::ErrMode, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::alpha1;
     /// # fn main() {
@@ -298,7 +298,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// # use winnow::{error::ErrMode, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::{alpha1};
     /// use winnow::combinator::separated_pair;
@@ -358,7 +358,7 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// # use winnow::{error::ErrMode,error::ErrorKind};
+    /// # use winnow::{error::ErrMode};
     /// use winnow::ascii::{alpha1};
     /// use winnow::token::literal;
     /// use winnow::combinator::separated_pair;
@@ -408,7 +408,7 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// # use winnow::{error::ErrMode,error::ErrorKind, stream::Stream};
+    /// # use winnow::{error::ErrMode, stream::Stream};
     /// # use std::ops::Range;
     /// use winnow::stream::LocatingSlice;
     /// use winnow::ascii::alpha1;
@@ -449,7 +449,7 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// # use winnow::{error::ErrMode,error::ErrorKind, stream::Stream};
+    /// # use winnow::{error::ErrMode, stream::Stream};
     /// # use std::ops::Range;
     /// use winnow::stream::LocatingSlice;
     /// use winnow::ascii::alpha1;
@@ -483,7 +483,7 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// # use winnow::{error::ErrMode, Parser};
     /// # use winnow::ascii::digit1;
     /// # fn main() {
     ///
@@ -519,7 +519,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// # use winnow::{error::ErrMode, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::digit1;
     /// # fn main() {
@@ -563,7 +563,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// # use winnow::{error::ErrMode, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::digit1;
     /// # fn main() {
@@ -608,7 +608,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, ModalResult, Parser};
+    /// # use winnow::{error::ErrMode, ModalResult, Parser};
     /// use winnow::token::take;
     /// use winnow::binary::u8;
     ///
@@ -622,7 +622,7 @@ pub trait Parser<I, O, E> {
     ///
     /// which is the same as
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, ModalResult, Parser};
+    /// # use winnow::{error::ErrMode, ModalResult, Parser};
     /// use winnow::token::take;
     /// use winnow::binary::u8;
     ///
@@ -658,7 +658,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// # use winnow::{error::ErrMode, Parser};
     /// # use winnow::prelude::*;
     /// use winnow::ascii::digit1;
     /// use winnow::token::take;
@@ -697,7 +697,7 @@ pub trait Parser<I, O, E> {
     ///
     /// ```rust
     /// # use winnow::prelude::*;
-    /// use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// use winnow::{error::ErrMode, Parser};
     /// use winnow::ascii::digit1;
     ///
     /// fn parser<'s>(input: &mut &'s str) -> ModalResult<u64> {
@@ -736,7 +736,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode,error::ErrorKind, Parser};
+    /// # use winnow::{error::ErrMode, Parser};
     /// # use winnow::ascii::alpha1;
     /// # use winnow::prelude::*;
     /// # fn main() {
@@ -800,7 +800,7 @@ pub trait Parser<I, O, E> {
     /// # Example
     ///
     /// ```rust
-    /// # use winnow::{error::ErrMode, error::ErrorKind, error::InputError, stream::Partial, Parser};
+    /// # use winnow::{error::ErrMode, error::InputError, stream::Partial, Parser};
     /// # use winnow::token::take;
     /// # use winnow::prelude::*;
     /// # fn main() {
@@ -810,7 +810,7 @@ pub trait Parser<I, O, E> {
     /// }
     ///
     /// assert_eq!(parser.parse_peek(Partial::new("abcdefg")), Ok((Partial::new("fg"), "abcde")));
-    /// assert_eq!(parser.parse_peek(Partial::new("abcd")), Err(ErrMode::Backtrack(InputError::new(Partial::new("abcd"), ErrorKind::Complete))));
+    /// assert_eq!(parser.parse_peek(Partial::new("abcd")), Err(ErrMode::Backtrack(InputError::at(Partial::new("abcd")))));
     /// # }
     /// ```
     #[inline(always)]
@@ -911,7 +911,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ErrorKind, ContextError}};
+/// # use winnow::{error::ErrMode, error::ContextError};
 /// fn parser<'s>(i: &mut &'s [u8]) -> ModalResult<u8>  {
 ///     b'a'.parse_next(i)
 /// }
@@ -939,7 +939,7 @@ where
 ///
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ErrorKind, ContextError}};
+/// # use winnow::{error::ErrMode, error::ContextError};
 /// fn parser<'s>(i: &mut &'s str) -> ModalResult<char> {
 ///     'a'.parse_next(i)
 /// }
@@ -966,7 +966,7 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 ///
@@ -995,7 +995,7 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 /// use winnow::ascii::Caseless;
@@ -1027,7 +1027,7 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 ///
@@ -1056,7 +1056,7 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}, error::Needed};
+/// # use winnow::{error::ErrMode, error::ContextError, error::Needed};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 /// use winnow::ascii::Caseless;
@@ -1089,7 +1089,7 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}};
+/// # use winnow::{error::ErrMode, error::ContextError};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 ///
@@ -1118,7 +1118,7 @@ where
 /// # Example
 /// ```rust
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::{ContextError, ErrorKind}};
+/// # use winnow::{error::ErrMode, error::ContextError};
 /// # use winnow::combinator::alt;
 /// # use winnow::token::take;
 /// # use winnow::ascii::Caseless;
@@ -1314,7 +1314,6 @@ mod tests {
 
     use crate::binary::be_u16;
     use crate::error::ErrMode;
-    use crate::error::ErrorKind;
     use crate::error::Needed;
     use crate::error::TestResult;
     use crate::token::take;
@@ -1335,7 +1334,6 @@ mod tests {
         assert_size!(Result<&str, u32>, 40);
         assert_size!(Needed, 8);
         assert_size!(ErrMode<u32>, 16);
-        assert_size!(ErrorKind, 1);
     }
 
     #[test]
@@ -1371,7 +1369,7 @@ Err(
     Backtrack(
         InputError {
             input: "123def",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -1460,7 +1458,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1700,7 +1700,7 @@ impl AsChar for &char {
 /// For example, you could implement `hex_digit0` as:
 /// ```
 /// # use winnow::prelude::*;
-/// # use winnow::{error::ErrMode, error::ErrorKind, error::ContextError};
+/// # use winnow::{error::ErrMode, error::ContextError};
 /// # use winnow::token::take_while;
 /// fn hex_digit1<'s>(input: &mut &'s str) -> ModalResult<&'s str, ContextError> {
 ///     take_while(1.., ('a'..='f', 'A'..='F', '0'..='9')).parse_next(input)

--- a/src/stream/partial.rs
+++ b/src/stream/partial.rs
@@ -37,7 +37,7 @@ use crate::stream::UpdateSlice;
 /// Here is how it works in practice:
 ///
 /// ```rust
-/// # use winnow::{Result, error::ErrMode, error::Needed, error::{ContextError, ErrorKind}, token, ascii, stream::Partial};
+/// # use winnow::{Result, error::ErrMode, error::Needed, error::ContextError, token, ascii, stream::Partial};
 /// # use winnow::prelude::*;
 ///
 /// fn take_partial<'s>(i: &mut Partial<&'s [u8]>) -> ModalResult<&'s [u8], ContextError> {

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -3,7 +3,7 @@ use proptest::prelude::*;
 
 use crate::error::ErrMode;
 use crate::error::ErrMode::Backtrack;
-use crate::error::{ErrorKind, InputError};
+use crate::error::InputError;
 use crate::token::literal;
 use crate::{
     combinator::{separated, separated_pair},
@@ -169,7 +169,7 @@ fn test_literal_support_char() {
 
     assert_eq!(
         literal::<_, _, ErrMode<InputError<_>>>('-').parse_peek("π"),
-        Err(Backtrack(InputError::new("π", ErrorKind::Literal)))
+        Err(Backtrack(InputError::at("π")))
     );
 
     assert_eq!(
@@ -204,10 +204,7 @@ fn test_literal_support_char() {
 
     assert_eq!(
         literal::<_, &[u8], ErrMode<InputError<_>>>('a').parse_peek(b"ABCxyz"),
-        Err(Backtrack(InputError::new(
-            &b"ABCxyz"[..],
-            ErrorKind::Literal
-        )))
+        Err(Backtrack(InputError::at(&b"ABCxyz"[..],)))
     );
 
     assert_eq!(
@@ -230,9 +227,6 @@ fn test_literal_support_char() {
 
     assert_eq!(
         literal::<_, &[u8], ErrMode<InputError<_>>>('-').parse_peek(b"\xCF\x80"),
-        Err(Backtrack(InputError::new(
-            &b"\xCF\x80"[..],
-            ErrorKind::Literal
-        )))
+        Err(Backtrack(InputError::at(&b"\xCF\x80"[..],)))
     );
 }

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -69,18 +69,12 @@ fn model_complete_take_while_m_n<'i>(
     input: &mut &'i str,
 ) -> ModalResult<&'i str> {
     if n < m {
-        Err(crate::error::ParserError::from_error_kind(
-            input,
-            crate::error::ErrorKind::Slice,
-        ))
+        Err(crate::error::ParserError::from_input(input))
     } else if m <= valid {
         let offset = n.min(valid);
         Ok(input.next_slice(offset))
     } else {
-        Err(crate::error::ParserError::from_error_kind(
-            input,
-            crate::error::ErrorKind::Slice,
-        ))
+        Err(crate::error::ParserError::from_input(input))
     }
 }
 
@@ -96,7 +90,7 @@ Err(
     Backtrack(
         InputError {
             input: "end",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -111,7 +105,7 @@ Err(
     Backtrack(
         InputError {
             input: "1234end",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -165,7 +159,7 @@ Err(
     Backtrack(
         InputError {
             input: "123456789end",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -292,7 +286,7 @@ Err(
                 97,
                 98,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -313,7 +307,7 @@ Err(
                 108,
                 111,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -332,7 +326,7 @@ Err(
                 101,
                 108,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -390,7 +384,7 @@ Err(
     Backtrack(
         InputError {
             input: "ab",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -405,7 +399,7 @@ Err(
     Backtrack(
         InputError {
             input: "Hello",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -420,7 +414,7 @@ Err(
     Backtrack(
         InputError {
             input: "Hel",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -439,7 +433,7 @@ Err(
     Backtrack(
         InputError {
             input: "K",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -458,7 +452,7 @@ Err(
     Backtrack(
         InputError {
             input: "k",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -546,7 +540,7 @@ Err(
                 65,
                 0,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -588,7 +582,7 @@ Err(
                 65,
                 0,
             ],
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -662,7 +656,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -701,7 +695,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -749,7 +743,7 @@ Err(
                 input: "abcd",
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -799,7 +793,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Verify,
+            kind: Fail,
         },
     ),
 )
@@ -900,7 +894,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -1006,7 +1000,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -1531,7 +1525,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -1656,7 +1650,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -1791,7 +1785,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -2511,7 +2505,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -2533,7 +2527,7 @@ Err(
                 ],
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -2617,7 +2611,7 @@ Err(
                 input: "Hello",
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -2635,7 +2629,7 @@ Err(
                 input: "Hel",
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -2657,7 +2651,7 @@ Err(
                 input: "K",
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -2679,7 +2673,7 @@ Err(
                 input: "k",
                 partial: true,
             },
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )

--- a/tests/testsuite/custom_errors.rs
+++ b/tests/testsuite/custom_errors.rs
@@ -4,7 +4,9 @@ use winnow::ascii::digit1 as digit;
 #[cfg(feature = "alloc")]
 use winnow::combinator::repeat;
 use winnow::combinator::terminated;
-use winnow::error::{ErrorKind, ParserError};
+#[allow(deprecated)]
+use winnow::error::ErrorKind;
+use winnow::error::ParserError;
 use winnow::prelude::*;
 use winnow::stream::Stream;
 use winnow::Partial;
@@ -12,19 +14,15 @@ use winnow::Partial;
 #[derive(Debug)]
 pub(crate) struct CustomError(String);
 
-impl<'a> From<(&'a str, ErrorKind)> for CustomError {
-    fn from(error: (&'a str, ErrorKind)) -> Self {
-        CustomError(format!("error code was: {error:?}"))
-    }
-}
-
 impl<'a> ParserError<Partial<&'a str>> for CustomError {
     type Inner = Self;
 
+    #[allow(deprecated)]
     fn from_error_kind(_: &Partial<&'a str>, kind: ErrorKind) -> Self {
         CustomError(format!("error code was: {kind:?}"))
     }
 
+    #[allow(deprecated)]
     fn append(
         self,
         _: &Partial<&'a str>,

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -334,7 +334,7 @@ Err(
     Backtrack(
         InputError {
             input: "bbb",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -477,7 +477,7 @@ Err(
             input: [
                 44,
             ],
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )

--- a/tests/testsuite/utf8.rs
+++ b/tests/testsuite/utf8.rs
@@ -43,7 +43,7 @@ Err(
     Backtrack(
         InputError {
             input: "Hello",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -64,7 +64,7 @@ Err(
     Backtrack(
         InputError {
             input: "Hello World!",
-            kind: Literal,
+            kind: Fail,
         },
     ),
 )
@@ -416,7 +416,7 @@ Err(
                 input: "123",
                 partial: true,
             },
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -492,7 +492,7 @@ Err(
     Backtrack(
         InputError {
             input: "βèƒôřèÂßÇáƒƭèř",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -516,7 +516,7 @@ Err(
     Backtrack(
         InputError {
             input: "βèƒôřèÂßÇáƒƭèř",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )
@@ -586,7 +586,7 @@ Err(
     Backtrack(
         InputError {
             input: "βèƒôřèÂßÇáƒƭèř",
-            kind: Slice,
+            kind: Fail,
         },
     ),
 )


### PR DESCRIPTION
After soliciting feedback, pinging people using `TreeError`, and sampling different code bases, I'm not seeing a use for `ErrorKind` and am removing it.

This also adds `EmptyError` as an inbetween `()` and `InputError`.  I almost removed `()` because it doesn't impl `Display` and can't be used with `ParseError` but kept it for convenience purposes for now.

Fixes #697