### PR TITLE
fix(error): Polish Incomplete handling

### DIFF
--- a/src/binary/bits/mod.rs
+++ b/src/binary/bits/mod.rs
@@ -69,12 +69,12 @@ where
                 *input = rest;
                 Ok(result)
             }
-            Err(e) => match e.into_needed() {
-                Ok(n) => Err(ParserError::incomplete(
+            Err(e) => match e.needed() {
+                Some(n) => Err(ParserError::incomplete(
                     input,
                     n.map(|u| u.get() / BYTE + 1),
                 )),
-                Err(e) => Err(ErrorConvert::convert(e)),
+                None => Err(ErrorConvert::convert(e)),
             },
         }
     })
@@ -138,16 +138,16 @@ where
                 *bit_input = (input, 0);
                 Ok(res)
             }
-            Err(e) => match e.into_needed() {
-                Ok(Needed::Unknown) => Err(ParserError::incomplete(bit_input, Needed::Unknown)),
-                Ok(Needed::Size(sz)) => Err(match sz.get().checked_mul(BYTE) {
+            Err(e) => match e.needed() {
+                Some(Needed::Unknown) => Err(ParserError::incomplete(bit_input, Needed::Unknown)),
+                Some(Needed::Size(sz)) => Err(match sz.get().checked_mul(BYTE) {
                     Some(v) => ParserError::incomplete(bit_input, Needed::new(v)),
                     None => ParserError::assert(
                         bit_input,
                         "overflow in turning needed bytes into needed bits",
                     ),
                 }),
-                Err(e) => Err(ErrorConvert::convert(e)),
+                None => Err(ErrorConvert::convert(e)),
             },
         }
     })

--- a/src/combinator/debug/internals.rs
+++ b/src/combinator/debug/internals.rs
@@ -122,7 +122,7 @@ impl Severity {
         match result {
             Ok(_) => Self::Success,
             Err(e) if e.is_backtrack() => Self::Backtrack,
-            Err(e) if e.is_needed() => Self::Incomplete,
+            Err(e) if e.is_incomplete() => Self::Incomplete,
             _ => Self::Cut,
         }
     }

--- a/src/combinator/impls.rs
+++ b/src/combinator/impls.rs
@@ -256,9 +256,9 @@ where
     fn parse_next(&mut self, input: &mut I) -> Result<O, E> {
         trace("complete_err", |input: &mut I| {
             match (self.p).parse_next(input) {
-                Err(err) => match err.into_needed() {
-                    Ok(_) => Err(ParserError::from_input(input)),
-                    Err(err) => Err(err),
+                Err(err) => match err.needed() {
+                    Some(_) => Err(ParserError::from_input(input)),
+                    None => Err(err),
                 },
                 rest => rest,
             }

--- a/src/combinator/impls.rs
+++ b/src/combinator/impls.rs
@@ -641,7 +641,7 @@ where
             Ok(o) => {
                 return Ok(o);
             }
-            Err(e) if e.is_needed() => return Err(e),
+            Err(e) if e.is_incomplete() => return Err(e),
             Err(err) => err,
         };
         let err_start = i.checkpoint();
@@ -720,7 +720,7 @@ where
         Ok(o) => {
             return Ok(Some(o));
         }
-        Err(e) if e.is_needed() => return Err(e),
+        Err(e) if e.is_incomplete() => return Err(e),
         Err(err) => err,
     };
     let err_start = i.checkpoint();

--- a/src/error.rs
+++ b/src/error.rs
@@ -403,12 +403,17 @@ pub trait ParserError<I: Stream>: Sized {
     fn into_inner(self) -> Result<Self::Inner, Self>;
 
     /// Is more data [`Needed`]
+    ///
+    /// This must be the same as [`err.needed().is_some()`][ParserError::needed]
     #[inline(always)]
     fn is_incomplete(&self) -> bool {
         false
     }
 
     /// Extract the [`Needed`] data, if present
+    ///
+    /// `Self::needed().is_some()` must be the same as
+    /// [`err.is_incomplete()`][ParserError::is_incomplete]
     #[inline(always)]
     fn needed(&self) -> Option<Needed> {
         None

--- a/src/error.rs
+++ b/src/error.rs
@@ -218,10 +218,10 @@ impl<I: Stream, E: ParserError<I>> ParserError<I> for ErrMode<E> {
     }
 
     #[inline(always)]
-    fn into_needed(self) -> Result<Needed, Self> {
+    fn needed(&self) -> Option<Needed> {
         match self {
-            ErrMode::Incomplete(needed) => Ok(needed),
-            err => Err(err),
+            ErrMode::Incomplete(needed) => Some(*needed),
+            _ => None,
         }
     }
 }
@@ -410,8 +410,8 @@ pub trait ParserError<I: Stream>: Sized {
 
     /// Extract the [`Needed`] data, if present
     #[inline(always)]
-    fn into_needed(self) -> Result<Needed, Self> {
-        Err(self)
+    fn needed(&self) -> Option<Needed> {
+        None
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -213,7 +213,7 @@ impl<I: Stream, E: ParserError<I>> ParserError<I> for ErrMode<E> {
     }
 
     #[inline(always)]
-    fn is_needed(&self) -> bool {
+    fn is_incomplete(&self) -> bool {
         matches!(self, ErrMode::Incomplete(_))
     }
 
@@ -404,7 +404,7 @@ pub trait ParserError<I: Stream>: Sized {
 
     /// Is more data [`Needed`]
     #[inline(always)]
-    fn is_needed(&self) -> bool {
+    fn is_incomplete(&self) -> bool {
         false
     }
 

--- a/src/stream/recoverable.rs
+++ b/src/stream/recoverable.rs
@@ -198,7 +198,7 @@ where
         err: E,
     ) -> Result<(), E> {
         if self.is_recoverable {
-            if err.is_needed() {
+            if err.is_incomplete() {
                 Err(err)
             } else {
                 self.errors


### PR DESCRIPTION
This is mostly focused on smoothing out `ErrMode::is_incomplete` to `ParserError::is_incomplete` so we can remove the former

This has breaking changes from `main` but not from a prior release