### PR TITLE
fix(ascii): Rename escaped_transform to escaped

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1671,6 +1671,25 @@ where
     }
 }
 
+/// Deprecated, replaed with [`escaped`]
+#[inline(always)]
+#[deprecated(since = "7.0.0", note = "replaced with `escaped`")]
+pub fn escaped_transform<Input, Error, Normal, NormalOutput, Escape, EscapeOutput, Output>(
+    normal: Normal,
+    control_char: char,
+    escape: Escape,
+) -> impl Parser<Input, Output, Error>
+where
+    Input: StreamIsPartial + Stream + Compare<char>,
+    Normal: Parser<Input, NormalOutput, Error>,
+    Escape: Parser<Input, EscapeOutput, Error>,
+    Output: crate::stream::Accumulate<NormalOutput>,
+    Output: crate::stream::Accumulate<EscapeOutput>,
+    Error: ParserError<Input>,
+{
+    escaped(normal, control_char, escape)
+}
+
 /// Parse escaped characters, unescaping them
 ///
 /// Arguments:
@@ -1747,7 +1766,7 @@ where
 /// # }
 /// ```
 #[inline(always)]
-pub fn escaped_transform<Input, Error, Normal, NormalOutput, Escape, EscapeOutput, Output>(
+pub fn escaped<Input, Error, Normal, NormalOutput, Escape, EscapeOutput, Output>(
     mut normal: Normal,
     control_char: char,
     mut escape: Escape,
@@ -1760,7 +1779,7 @@ where
     Output: crate::stream::Accumulate<EscapeOutput>,
     Error: ParserError<Input>,
 {
-    trace("escaped_transform", move |input: &mut Input| {
+    trace("escaped", move |input: &mut Input| {
         if <Input as StreamIsPartial>::is_partial_supported() && input.is_partial() {
             escaped_transform_internal::<_, _, _, _, _, _, _, true>(
                 input,

--- a/src/ascii/tests.rs
+++ b/src/ascii/tests.rs
@@ -2424,7 +2424,7 @@ Ok(
     }
 
     #[test]
-    fn test_escaped_error() {
+    fn test_take_escaped_error() {
         fn esc<'i>(i: &mut &'i str) -> TestResult<&'i str, &'i str> {
             use crate::ascii::digit1;
             take_escaped(digit1, '\\', one_of(['\"', 'n', '\\'])).parse_next(i)
@@ -2456,7 +2456,7 @@ Ok(
         }
 
         fn esc<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], String> {
-            escaped_transform(alpha, '\\', alt((b'\\', b'"', "n".value(b'\n'))))
+            escaped(alpha, '\\', alt((b'\\', b'"', "n".value(b'\n'))))
                 .map(to_s)
                 .parse_next(i)
         }
@@ -2569,7 +2569,7 @@ Err(
         );
 
         fn esc2<'i>(i: &mut &'i [u8]) -> TestResult<&'i [u8], String> {
-            escaped_transform(
+            escaped(
                 alpha,
                 '&',
                 alt((
@@ -2618,7 +2618,7 @@ Ok(
         use crate::ascii::alpha1 as alpha;
 
         fn esc<'i>(i: &mut &'i str) -> TestResult<&'i str, String> {
-            escaped_transform(
+            escaped(
                 alpha,
                 '\\',
                 alt((
@@ -2739,7 +2739,7 @@ Err(
         );
 
         fn esc2<'i>(i: &mut &'i str) -> TestResult<&'i str, String> {
-            escaped_transform(
+            escaped(
                 alpha,
                 '&',
                 alt(("egrave;".value("è"), "agrave;".value("à"))),
@@ -2774,7 +2774,7 @@ Ok(
         );
 
         fn esc3<'i>(i: &mut &'i str) -> TestResult<&'i str, String> {
-            escaped_transform(alpha, '␛', alt(("0".value("\0"), "n".value("\n")))).parse_next(i)
+            escaped(alpha, '␛', alt(("0".value("\0"), "n".value("\n")))).parse_next(i)
         }
         assert_parse!(
             esc3.parse_peek("a␛0bc␛n"),
@@ -2793,10 +2793,10 @@ Ok(
 
     #[test]
     #[cfg(feature = "alloc")]
-    fn test_escaped_transform_error() {
+    fn test_escaped_error() {
         fn esc_trans<'i>(i: &mut &'i str) -> TestResult<&'i str, String> {
             use crate::ascii::digit1;
-            escaped_transform(digit1, '\\', "n").parse_next(i)
+            escaped(digit1, '\\', "n").parse_next(i)
         }
 
         assert_parse!(


### PR DESCRIPTION
This builds on #726

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
