### PR TITLE
docs(ref): Link ContextError to tutorial

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -674,6 +674,9 @@ impl ErrorConvert<()> for () {
 }
 
 /// Accumulate context while backtracking errors
+///
+/// See the [tutorial][crate::_tutorial::chapter_7#error-adaptation-and-rendering]
+/// for an example of how to adapt this to an application error with custom rendering.
 #[derive(Debug)]
 pub struct ContextError<C = StrContext> {
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
Inspired by #744.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
