### PR TITLE
refactor(comb): Clean up `repeat` parsers

### DIFF
--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -752,7 +752,6 @@ where
     Ok(acc)
 }
 
-#[inline(always)]
 fn verify_fold_m_n<I, O, E, F, G, H, R>(
     min: usize,
     max: usize,
@@ -813,7 +812,6 @@ where
     Ok(acc)
 }
 
-#[inline(always)]
 fn try_fold_m_n<I, O, E, F, G, H, R, GE>(
     min: usize,
     max: usize,

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -165,8 +165,8 @@ where
     ///
     /// <div class="warning">
     ///
-    /// **Warning:** If the parser passed to `fold` accepts empty inputs
-    /// (like `alpha0` or `digit0`), `fold_repeat` will return an error,
+    /// **Warning:** If the parser passed to [`repeat`] accepts empty inputs
+    /// (like `alpha0` or `digit0`), `fold` will return an error,
     /// to prevent going into an infinite loop.
     ///
     /// </div>
@@ -295,7 +295,7 @@ where
     ///
     /// <div class="warning">
     ///
-    /// **Warning:** If the parser passed to `repeat` accepts empty inputs
+    /// **Warning:** If the parser passed to [`repeat`] accepts empty inputs
     /// (like `alpha0` or `digit0`), `verify_fold` will return an error,
     /// to prevent going into an infinite loop.
     ///
@@ -371,7 +371,7 @@ where
     ///
     /// <div class="warning">
     ///
-    /// **Warning:** If the parser passed to `repeat` accepts empty inputs
+    /// **Warning:** If the parser passed to [`repeat`] accepts empty inputs
     /// (like `alpha0` or `digit0`), `try_fold` will return an error,
     /// to prevent going into an infinite loop.
     ///

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -666,11 +666,11 @@ where
     H: FnMut() -> R,
     E: ParserError<I>,
 {
-    let init = init();
     let start = input.checkpoint();
     match f.parse_next(input) {
         Err(e) => Err(e.append(input, &start)),
         Ok(o1) => {
+            let init = init();
             let mut acc = g(init, o1);
 
             loop {


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
