### PR TITLE
feat(stream): Allow unchecked slicing 

### DIFF
--- a/src/stream/bstr.rs
+++ b/src/stream/bstr.rs
@@ -109,8 +109,7 @@ impl<'i> Stream for &'i BStr {
     }
     #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
-        let (slice, _next) = self.split_at(offset);
-        slice
+        &self[..offset]
     }
 
     #[inline(always)]

--- a/src/stream/bstr.rs
+++ b/src/stream/bstr.rs
@@ -108,8 +108,29 @@ impl<'i> Stream for &'i BStr {
         slice
     }
     #[inline(always)]
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        #[cfg(debug_assertions)]
+        self.peek_slice(offset);
+
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let slice = unsafe { self.0.get_unchecked(..offset) };
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let next = unsafe { self.0.get_unchecked(offset..) };
+        *self = BStr::from_bytes(next);
+        slice
+    }
+    #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
         &self[..offset]
+    }
+    #[inline(always)]
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        #[cfg(debug_assertions)]
+        self.peek_slice(offset);
+
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let slice = unsafe { self.0.get_unchecked(..offset) };
+        slice
     }
 
     #[inline(always)]

--- a/src/stream/bytes.rs
+++ b/src/stream/bytes.rs
@@ -108,8 +108,29 @@ impl<'i> Stream for &'i Bytes {
         slice
     }
     #[inline(always)]
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        #[cfg(debug_assertions)]
+        self.peek_slice(offset);
+
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let slice = unsafe { self.0.get_unchecked(..offset) };
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let next = unsafe { self.0.get_unchecked(offset..) };
+        *self = Bytes::from_bytes(next);
+        slice
+    }
+    #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
         &self[..offset]
+    }
+    #[inline(always)]
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        #[cfg(debug_assertions)]
+        self.peek_slice(offset);
+
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let slice = unsafe { self.0.get_unchecked(..offset) };
+        slice
     }
 
     #[inline(always)]

--- a/src/stream/bytes.rs
+++ b/src/stream/bytes.rs
@@ -109,8 +109,7 @@ impl<'i> Stream for &'i Bytes {
     }
     #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
-        let (slice, _next) = self.split_at(offset);
-        slice
+        &self[..offset]
     }
 
     #[inline(always)]

--- a/src/stream/locating.rs
+++ b/src/stream/locating.rs
@@ -149,8 +149,18 @@ impl<I: Stream> Stream for LocatingSlice<I> {
         self.input.next_slice(offset)
     }
     #[inline(always)]
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.next_slice_unchecked(offset) }
+    }
+    #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
         self.input.peek_slice(offset)
+    }
+    #[inline(always)]
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.peek_slice_unchecked(offset) }
     }
 
     #[inline(always)]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -189,7 +189,45 @@ pub trait Stream: Offset<<Self as Stream>::Checkpoint> + crate::lib::std::fmt::D
     ///
     fn next_slice(&mut self, offset: usize) -> Self::Slice;
     /// Split off a slice of tokens from the input
+    ///
+    /// <div class="warning">
+    ///
+    /// **Note:** For inputs with variable width tokens, like `&str`'s `char`, `offset` might not correspond
+    /// with the number of tokens. To get a valid offset, use:
+    /// - [`Stream::eof_offset`]
+    /// - [`Stream::iter_offsets`]
+    /// - [`Stream::offset_for`]
+    /// - [`Stream::offset_at`]
+    ///
+    /// </div>
+    ///
+    /// # Safety
+    ///
+    /// Callers of this function are responsible that these preconditions are satisfied:
+    ///
+    /// * Indexes must be within bounds of the original input;
+    /// * Indexes must uphold invariants of the stream, like for `str` they must lie on UTF-8
+    ///   sequence boundaries.
+    ///
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        // Inherent impl to allow callers to have `unsafe`-free code
+        self.next_slice(offset)
+    }
+    /// Split off a slice of tokens from the input
     fn peek_slice(&self, offset: usize) -> Self::Slice;
+    /// Split off a slice of tokens from the input
+    ///
+    /// # Safety
+    ///
+    /// Callers of this function are responsible that these preconditions are satisfied:
+    ///
+    /// * Indexes must be within bounds of the original input;
+    /// * Indexes must uphold invariants of the stream, like for `str` they must lie on UTF-8
+    ///   sequence boundaries.
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        // Inherent impl to allow callers to have `unsafe`-free code
+        self.peek_slice(offset)
+    }
 
     /// Advance to the end of the stream
     #[inline(always)]
@@ -276,8 +314,29 @@ where
         slice
     }
     #[inline(always)]
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        #[cfg(debug_assertions)]
+        self.peek_slice(offset);
+
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let slice = unsafe { self.get_unchecked(..offset) };
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let next = unsafe { self.get_unchecked(offset..) };
+        *self = next;
+        slice
+    }
+    #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
         &self[..offset]
+    }
+    #[inline(always)]
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        #[cfg(debug_assertions)]
+        self.peek_slice(offset);
+
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let slice = unsafe { self.get_unchecked(..offset) };
+        slice
     }
 
     #[inline(always)]
@@ -360,8 +419,31 @@ impl<'i> Stream for &'i str {
         slice
     }
     #[inline(always)]
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        #[cfg(debug_assertions)]
+        self.peek_slice(offset);
+
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds and on a UTF-8
+        // sequence boundary
+        let slice = unsafe { self.get_unchecked(..offset) };
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds and on a UTF-8
+        // sequence boundary
+        let next = unsafe { self.get_unchecked(offset..) };
+        *self = next;
+        slice
+    }
+    #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
         &self[..offset]
+    }
+    #[inline(always)]
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        #[cfg(debug_assertions)]
+        self.peek_slice(offset);
+
+        // SAFETY: `Stream::next_slice_unchecked` requires `offset` to be in bounds
+        let slice = unsafe { self.get_unchecked(..offset) };
+        slice
     }
 
     #[inline(always)]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -277,8 +277,7 @@ where
     }
     #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
-        let (slice, _next) = self.split_at(offset);
-        slice
+        &self[..offset]
     }
 
     #[inline(always)]
@@ -362,8 +361,7 @@ impl<'i> Stream for &'i str {
     }
     #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
-        let (slice, _next) = self.split_at(offset);
-        slice
+        &self[..offset]
     }
 
     #[inline(always)]

--- a/src/stream/partial.rs
+++ b/src/stream/partial.rs
@@ -186,8 +186,18 @@ impl<I: Stream> Stream for Partial<I> {
         self.input.next_slice(offset)
     }
     #[inline(always)]
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.next_slice_unchecked(offset) }
+    }
+    #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
         self.input.peek_slice(offset)
+    }
+    #[inline(always)]
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.peek_slice_unchecked(offset) }
     }
 
     #[inline(always)]

--- a/src/stream/recoverable.rs
+++ b/src/stream/recoverable.rs
@@ -159,8 +159,18 @@ where
         self.input.next_slice(offset)
     }
     #[inline(always)]
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.next_slice_unchecked(offset) }
+    }
+    #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
         self.input.peek_slice(offset)
+    }
+    #[inline(always)]
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.peek_slice_unchecked(offset) }
     }
 
     #[inline(always)]

--- a/src/stream/stateful.rs
+++ b/src/stream/stateful.rs
@@ -137,8 +137,18 @@ impl<I: Stream, S: crate::lib::std::fmt::Debug> Stream for Stateful<I, S> {
         self.input.next_slice(offset)
     }
     #[inline(always)]
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.next_slice_unchecked(offset) }
+    }
+    #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
         self.input.peek_slice(offset)
+    }
+    #[inline(always)]
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.peek_slice_unchecked(offset) }
     }
 
     #[inline(always)]

--- a/src/stream/token.rs
+++ b/src/stream/token.rs
@@ -144,8 +144,18 @@ where
         self.input.next_slice(offset)
     }
     #[inline(always)]
+    unsafe fn next_slice_unchecked(&mut self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.next_slice_unchecked(offset) }
+    }
+    #[inline(always)]
     fn peek_slice(&self, offset: usize) -> Self::Slice {
         self.input.peek_slice(offset)
+    }
+    #[inline(always)]
+    unsafe fn peek_slice_unchecked(&self, offset: usize) -> Self::Slice {
+        // SAFETY: Passing up invariants
+        unsafe { self.input.peek_slice_unchecked(offset) }
     }
 
     #[inline(always)]


### PR DESCRIPTION
There are times when the caller knows that the `offset` is good and can
speed things up by bypassing any checks explicitly.

For now, we're not takin advantage of this inside of `winnow`.
I want to be sure its safety to rely on all of the trait behaviors
before doing so.
When we do, we might want to put it behind an `unsafe` feature so people
can opt-in to performance with a risk.
See also #115

I made these new functions inherent for more than compatibility reasons
but to allow people to have `#[forbid(unsafe)]` in there code.