### PR TITLE
Replace ndjson link in topic

### DIFF
--- a/src/_topic/partial.rs
+++ b/src/_topic/partial.rs
@@ -12,7 +12,7 @@
 //! - A header reporting the number of bytes, like with [`length_and_then`]
 //!   - [`Partial`] can explicitly be changed to being complete once the specified bytes are
 //!     acquired via [`StreamIsPartial::complete`].
-//! - A delimiter, like with [ndjson](http://ndjson.org/)
+//! - A delimiter, like with [ndjson](https://github.com/ndjson/ndjson-spec/)
 //!   - You can parse up-to the delimiter or do a `take_until(0.., delim).and_then(parser)`
 //!
 //! If the chunks are not homogeneous, a state machine will be needed to track what the expected


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->

ndjson domain is pointing to malicious site. I think linking to their github is more appropriate.

https://github.com/ndjson/ndjson-spec/issues/35#issuecomment-1285673417

