### PR TITLE
feat: Dynamically add context to Context

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -786,13 +786,7 @@ pub trait Parser<I, O, E> {
         E: ParserError<I>,
         C: Clone + crate::lib::std::fmt::Debug,
     {
-        impls::Context {
-            parser: self,
-            context,
-            i: Default::default(),
-            o: Default::default(),
-            e: Default::default(),
-        }
+        impls::Context::new(self, context)
     }
 
     /// Transforms [`Incomplete`][crate::error::ErrMode::Incomplete] into [`Backtrack`][crate::error::ErrMode::Backtrack]


### PR DESCRIPTION
Heyo :)

While playing around with parsers some more, I came up with an idea on how to make error handling nicer (at least for `std` users). I'm curious what you think about this proposal!

Resolves #778

This MR adds a new `std`-only feature to `Context`, which allows users to dynamically append error context information based on runtime variables.

This was previously not possible as the only way to dynamically append information was to add another `.context()` call, which wrapped the whole parser in a new type, thereby changing the type signature.

This change adds alters the `Context` in a backwards-compatible way by changing the `Context::context` field to a `Vec<C>` and adding a `add_context` function to add context to said vector.

# Downsides

This is obviously a performance downgrade, as this implies that each context parser initialization will do a heap alloc for the Vector.

If that's an issue, what do you think about a completely new type (e.g. `DynamicContext`) and a new function like `dynamic_context` on `Parser` that's hidden behind `std`?

# Example

How does it look in practice:

```rust
use winnow::prelude::*;
use winnow::token::one_of;
use winnow::ascii::alpha1;
use winnow::error::{StrContext, StrContextValue};

fn char_parser(input: &mut &str) -> ModalResult<char> {
    let allowed_characters = ['a', 'b', 'c'];
    // Create a simple parser that only allows a few chars with some error context.
    let mut parser = one_of(allowed_characters)
        .context(StrContext::Label("character"));

    // It's now possible to **add** to that context without another `Context` wrapper.
    parser.add_context(StrContext::Expected(StrContextValue::Description(
        "one of the allowed characters",
    )));

    // Dynamically add context info based on runtime variables.
    for character in allowed_characters {
        parser.add_context(StrContext::Expected(StrContextValue::CharLiteral(character)))
    }

    parser.parse_next(input)
}

fn main() {
    assert_eq!(char_parser.parse("a"), Ok('a'));
    assert!(char_parser.parse("d").is_err());
}
```