### PR TITLE
refactor(debug): Don't pull in is-terminal when its not needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
  "automod",
  "circular",
  "criterion",
- "is-terminal",
+ "is_terminal_polyfill",
  "lexopt",
  "memchr",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ default = ["std"]
 alloc = []
 std = ["alloc", "memchr?/std"]
 simd = ["dep:memchr"]
-debug = ["std", "dep:anstream", "dep:anstyle", "dep:is-terminal", "dep:terminal_size"]
+debug = ["std", "dep:anstream", "dep:anstyle", "dep:is_terminal_polyfill", "dep:terminal_size"]
 unstable-recover = []
 
 unstable-doc = ["alloc", "std", "simd", "unstable-recover"]
@@ -135,7 +135,7 @@ unstable-doc = ["alloc", "std", "simd", "unstable-recover"]
 [dependencies]
 anstream = { version = "0.3.2", optional = true }
 anstyle = { version = "1.0.1", optional = true }
-is-terminal = { version = "0.4.9", optional = true }
+is_terminal_polyfill = { version = "1.48.0", optional = true }
 memchr = { version = "2.5", optional = true, default-features = false }
 terminal_size = { version = "0.4.0", optional = true }
 

--- a/src/combinator/debug/internals.rs
+++ b/src/combinator/debug/internals.rs
@@ -289,7 +289,7 @@ fn term_width() -> usize {
 }
 
 fn query_width() -> Option<usize> {
-    use is_terminal::IsTerminal;
+    use is_terminal_polyfill::IsTerminal;
     if std::io::stderr().is_terminal() {
         terminal_size::terminal_size().map(|(w, _h)| w.0.into())
     } else {


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
