### PR TITLE
Implement `<&str as Stream>::next_token()` without panics

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -384,9 +384,9 @@ impl<'i> Stream for &'i str {
 
     #[inline(always)]
     fn next_token(&mut self) -> Option<Self::Token> {
-        let c = self.chars().next()?;
-        let offset = c.len();
-        *self = &self[offset..];
+        let mut iter = self.chars();
+        let c = iter.next()?;
+        *self = iter.as_str();
         Some(c)
     }
 


### PR DESCRIPTION
This PR makes `<&str as Stream>::next_token()` use `Chars` both for finding the first character, and the remaining string. While the compiler could not tell that the previous implementation cannot panic, it can for the new one. Also, the offset does not have to be calculated twice. All-in-all the method now has about 1/4 fewer instructions.

* Old: <https://godbolt.org/z/fTbqch3v8>
* New: <https://godbolt.org/z/MPx7PMMaW>

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
