### PR TITLE
feat(stream): Implement Accumulate for VecDeque

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -33,6 +33,8 @@ use crate::lib::std::collections::HashMap;
 #[cfg(feature = "std")]
 use crate::lib::std::collections::HashSet;
 #[cfg(feature = "alloc")]
+use crate::lib::std::collections::VecDeque;
+#[cfg(feature = "alloc")]
 use crate::lib::std::string::String;
 #[cfg(feature = "alloc")]
 use crate::lib::std::vec::Vec;
@@ -1546,6 +1548,21 @@ where
     #[inline(always)]
     fn accumulate(&mut self, key: K) {
         self.insert(key);
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'i, T: Clone> Accumulate<&'i [T]> for VecDeque<T> {
+    #[inline(always)]
+    fn initial(capacity: Option<usize>) -> Self {
+        match capacity {
+            Some(capacity) => VecDeque::with_capacity(clamp_capacity::<T>(capacity)),
+            None => VecDeque::new(),
+        }
+    }
+    #[inline(always)]
+    fn accumulate(&mut self, acc: &'i [T]) {
+        self.extend(acc.iter().cloned());
     }
 }
 


### PR DESCRIPTION
Allows combinators like `repeat` to accumulate into a `VecDeque`. Implementation follows that of `Vec`.