### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/src/_topic/why.rs
+++ b/src/_topic/why.rs
@@ -4,7 +4,7 @@
 //!
 //! <div class="warning">
 //!
-//! **Note:** This will focus on principles and priorities. For a deeper and wider wider
+//! **Note:** This will focus on principles and priorities. For a deeper and wider
 //! comparison with other Rust parser libraries, see
 //! [parse-rosetta-rs](https://github.com/rosetta-rs/parse-rosetta-rs).
 //!


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->

remove redundant word in comment
