### PR TITLE
fix: Show more deprecated messages

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -3,8 +3,24 @@
 
 use crate::combinator;
 
-pub use combinator::alt;
 pub use combinator::dispatch;
-pub use combinator::permutation;
 pub use combinator::Alt;
 pub use combinator::Permutation;
+
+use crate::error::ParseError;
+use crate::stream::Stream;
+use crate::Parser;
+
+/// Deprecated, see [`combinator::alt`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::alt`")]
+pub fn alt<I: Stream, O, E: ParseError<I>, List: Alt<I, O, E>>(l: List) -> impl Parser<I, O, E> {
+    combinator::alt(l)
+}
+
+/// Deprecated, see [`combinator::permutation`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::permutation`")]
+pub fn permutation<I: Stream, O, E: ParseError<I>, List: Permutation<I, O, E>>(
+    l: List,
+) -> impl Parser<I, O, E> {
+    combinator::permutation(l)
+}

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -2,12 +2,13 @@
 #![deprecated(since = "0.4.2", note = "Replaced with `token`")]
 
 use crate::error::ParseError;
+use crate::stream::Range;
 use crate::stream::StreamIsPartial;
-use crate::stream::{ContainsToken, Stream};
+use crate::stream::ToUsize;
+use crate::stream::{Compare, ContainsToken, FindSlice, SliceLen, Stream};
 use crate::token;
+use crate::IResult;
 use crate::Parser;
-
-pub use crate::token::*;
 
 /// Deprecated, see [`token::take_while`]
 #[deprecated(since = "0.4.2", note = "Replaced with `token::take_while`")]
@@ -23,4 +24,167 @@ where
     T: ContainsToken<<I as Stream>::Token>,
 {
     token::take_while(m..=n, list)
+}
+
+/// Deprecated, see [`token::any`]
+#[deprecated(since = "0.4.2", note = "Replaced with `token::any`")]
+pub fn any<I, E: ParseError<I>>(input: I) -> IResult<I, <I as Stream>::Token, E>
+where
+    I: StreamIsPartial,
+    I: Stream,
+{
+    crate::token::any.parse_next(input)
+}
+
+/// Deprecated, see [`token::tag`]
+#[deprecated(since = "0.4.2", note = "Replaced with `token::tag`")]
+pub fn tag<T, I, Error: ParseError<I>>(tag: T) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream + Compare<T>,
+    T: SliceLen + Clone,
+{
+    crate::token::tag(tag)
+}
+
+/// Deprecated, see [`token::tag_no_case`]
+#[deprecated(since = "0.4.2", note = "Replaced with `token::tag_no_case`")]
+pub fn tag_no_case<T, I, Error: ParseError<I>>(
+    tag: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream + Compare<T>,
+    T: SliceLen + Clone,
+{
+    crate::token::tag_no_case(tag)
+}
+
+/// Deprecated, see [`token::one_of`]
+#[deprecated(since = "0.4.2", note = "Replaced with `token::one_of`")]
+pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Parser<I, <I as Stream>::Token, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    <I as Stream>::Token: Copy,
+    T: ContainsToken<<I as Stream>::Token>,
+{
+    crate::token::one_of(list)
+}
+
+/// Deprecated, see [`token::none_of`]
+#[deprecated(since = "0.4.2", note = "Replaced with `token::none_of`")]
+pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Parser<I, <I as Stream>::Token, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    <I as Stream>::Token: Copy,
+    T: ContainsToken<<I as Stream>::Token>,
+{
+    crate::token::none_of(list)
+}
+
+/// Deprecated, see [`token::take_while`]
+#[deprecated(since = "0.4.2", note = "Replaced with `token::take_while`")]
+pub fn take_while<T, I, Error: ParseError<I>>(
+    range: impl Into<Range>,
+    list: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    T: ContainsToken<<I as Stream>::Token>,
+{
+    crate::token::take_while(range, list)
+}
+
+/// Deprecated, see [`token::take_while`]
+#[deprecated(since = "0.4.6", note = "Replaced with `token::take_while`")]
+#[inline(always)]
+pub fn take_while0<T, I, Error: ParseError<I>>(
+    list: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    T: ContainsToken<<I as Stream>::Token>,
+{
+    crate::token::take_while(0.., list)
+}
+
+/// Deprecated, see [`token::take_while`]
+#[deprecated(since = "0.4.6", note = "Replaced with `token::take_while`")]
+#[inline(always)]
+pub fn take_while1<T, I, Error: ParseError<I>>(
+    list: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    T: ContainsToken<<I as Stream>::Token>,
+{
+    crate::token::take_while(1.., list)
+}
+
+/// Deprecated, see [`token::take_till0`]
+#[deprecated(since = "0.4.6", note = "Replaced with `token::take_till0`")]
+pub fn take_till0<T, I, Error: ParseError<I>>(
+    list: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    T: ContainsToken<<I as Stream>::Token>,
+{
+    crate::token::take_till0(list)
+}
+
+/// Deprecated, see [`token::take_till1`]
+#[deprecated(since = "0.4.6", note = "Replaced with `token::take_till1`")]
+pub fn take_till1<T, I, Error: ParseError<I>>(
+    list: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    T: ContainsToken<<I as Stream>::Token>,
+{
+    crate::token::take_till1(list)
+}
+
+/// Deprecated, see [`token::take`]
+#[deprecated(since = "0.4.6", note = "Replaced with `token::take`")]
+pub fn take<C, I, Error: ParseError<I>>(count: C) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream,
+    C: ToUsize,
+{
+    crate::token::take(count)
+}
+
+/// Deprecated, see [`token::take_until0`]
+#[deprecated(since = "0.4.6", note = "Replaced with `token::take_until0`")]
+pub fn take_until0<T, I, Error: ParseError<I>>(
+    tag: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream + FindSlice<T>,
+    T: SliceLen + Clone,
+{
+    crate::token::take_until0(tag)
+}
+
+/// Deprecated, see [`token::take_until1`]
+#[deprecated(since = "0.4.6", note = "Replaced with `token::take_until1`")]
+pub fn take_until1<T, I, Error: ParseError<I>>(
+    tag: T,
+) -> impl Parser<I, <I as Stream>::Slice, Error>
+where
+    I: StreamIsPartial,
+    I: Stream + FindSlice<T>,
+    T: SliceLen + Clone,
+{
+    crate::token::take_until1(tag)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(extended_key_value_attributes))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(unexpected_cfgs)]
 #![warn(missing_docs)]
 // BEGIN - Embark standard lints v6 for Rust 1.55+
 // do not change or add/remove here, but one can add exceptions after this section
@@ -164,28 +165,18 @@ pub(crate) mod lib {
 
         #[doc(hidden)]
         pub use core::{cmp, convert, fmt, hash, iter, mem, ops, option, result, slice, str};
-
-        /// internal reproduction of std prelude
-        #[doc(hidden)]
-        pub mod prelude {
-            pub use core::prelude as v1;
-        }
     }
 
     #[cfg(feature = "std")]
     /// internal std exports for `no_std` compatibility
     pub mod std {
         #[doc(hidden)]
-        pub use std::{
-            alloc, borrow, boxed, cmp, collections, convert, fmt, hash, iter, mem, ops, option,
-            result, slice, str, string, vec,
-        };
-
-        /// internal reproduction of std prelude
+        #[cfg(test)]
+        pub use std::convert;
         #[doc(hidden)]
-        pub mod prelude {
-            pub use std::prelude as v1;
-        }
+        pub use std::{
+            borrow, cmp, collections, fmt, hash, iter, mem, ops, result, slice, str, string, vec,
+        };
     }
 }
 

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,9 +1,62 @@
 //! Deprecated, see [`combinator`]
 #![deprecated(since = "0.4.2", note = "Replaced with `combinator`")]
 
+use crate::error::ParseError;
+use crate::stream::Stream;
+use crate::Parser;
+
 use crate::combinator;
 
-pub use combinator::delimited;
-pub use combinator::preceded;
-pub use combinator::separated_pair;
-pub use combinator::terminated;
+/// Deprecated, see [`combinator::preceded`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::preceded`")]
+pub fn preceded<I, O1, O2, E: ParseError<I>, F, G>(first: F, second: G) -> impl Parser<I, O2, E>
+where
+    I: Stream,
+    F: Parser<I, O1, E>,
+    G: Parser<I, O2, E>,
+{
+    combinator::preceded(first, second)
+}
+
+/// Deprecated, see [`combinator::terminated`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::terminated`")]
+pub fn terminated<I, O1, O2, E: ParseError<I>, F, G>(first: F, second: G) -> impl Parser<I, O1, E>
+where
+    I: Stream,
+    F: Parser<I, O1, E>,
+    G: Parser<I, O2, E>,
+{
+    combinator::terminated(first, second)
+}
+
+/// Deprecated, see [`combinator::separated_pair`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::separated_pair`")]
+pub fn separated_pair<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
+    first: F,
+    sep: G,
+    second: H,
+) -> impl Parser<I, (O1, O3), E>
+where
+    I: Stream,
+    F: Parser<I, O1, E>,
+    G: Parser<I, O2, E>,
+    H: Parser<I, O3, E>,
+{
+    combinator::separated_pair(first, sep, second)
+}
+
+/// Deprecated, see [`combinator::delimited`]
+#[deprecated(since = "0.4.2", note = "Replaced with `combinator::delimited`")]
+pub fn delimited<I, O1, O2, O3, E: ParseError<I>, F, G, H>(
+    first: F,
+    second: G,
+    third: H,
+) -> impl Parser<I, O2, E>
+where
+    I: Stream,
+    F: Parser<I, O1, E>,
+    G: Parser<I, O2, E>,
+    H: Parser<I, O3, E>,
+{
+    combinator::delimited(first, second, third)
+}


### PR DESCRIPTION
It turns out we weren't always showing `deprecated` messages because of rust-lang/rust#47237

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
