### PR TITLE
docs(ascii): Refer to escaped, not escaped_transform 

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1547,7 +1547,7 @@ where
 /// - `normal` doesn't advance the input stream
 /// - *(complete)* input stream is exhausted
 ///
-/// See also [`escaped_transform`]
+/// See also [`escaped`]
 ///
 /// <div class="warning">
 ///
@@ -1705,8 +1705,8 @@ where
 ///
 /// <div class="warning">
 ///
-/// **Warning:** If the `normal` parser passed to `escaped_transform` accepts empty inputs
-/// (like `alpha0` or `digit0`), `escaped_transform` will return an error,
+/// **Warning:** If the `normal` parser passed to `escaped` accepts empty inputs
+/// (like `alpha0` or `digit0`), `escaped` will return an error,
 /// to prevent going into an infinite loop.
 ///
 /// </div>
@@ -1718,12 +1718,12 @@ where
 /// # use winnow::prelude::*;
 /// # use std::str::from_utf8;
 /// use winnow::token::literal;
-/// use winnow::ascii::escaped_transform;
+/// use winnow::ascii::escaped;
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;
 ///
 /// fn parser<'s>(input: &mut &'s str) -> ModalResult<String> {
-///   escaped_transform(
+///   escaped(
 ///     alpha1,
 ///     '\\',
 ///     alt((
@@ -1746,12 +1746,12 @@ where
 /// # use std::str::from_utf8;
 /// # use winnow::Partial;
 /// use winnow::token::literal;
-/// use winnow::ascii::escaped_transform;
+/// use winnow::ascii::escaped;
 /// use winnow::ascii::alpha1;
 /// use winnow::combinator::alt;
 ///
 /// fn parser<'s>(input: &mut Partial<&'s str>) -> ModalResult<String> {
-///   escaped_transform(
+///   escaped(
 ///     alpha1,
 ///     '\\',
 ///     alt((
@@ -1836,7 +1836,7 @@ where
                 if input.eof_offset() == current_len {
                     return Err(ParserError::assert(
                         input,
-                        "`escaped_transform` parsers must always consume",
+                        "`escaped` parsers must always consume",
                     ));
                 }
             }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -113,7 +113,7 @@
 //! - [`hex_uint`][crate::ascii::hex_uint]: Decode a variable-width, hexadecimal integer
 //!
 //! - [`take_escaped`][crate::ascii::take_escaped]: Recognize the input slice with escaped characters
-//! - [`escaped_transform`][crate::ascii::escaped_transform]: Parse escaped characters, unescaping them
+//! - [`escaped`][crate::ascii::escaped]: Parse escaped characters, unescaping them
 //!
 //! - [`expression()`]: Parse an operator precedence expression with Pratt parsing
 //!

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1386,7 +1386,8 @@ impl<T: core::fmt::Debug, S> core::fmt::Debug for Checkpoint<T, S> {
 }
 
 /// Abstracts something which can extend an `Extend`.
-/// Used to build modified input slices in `escaped_transform`
+///
+/// Used to build modified input slices in [`escaped`][crate::ascii::escaped].
 pub trait Accumulate<T>: Sized {
     /// Create a new `Extend` of the correct type
     fn initial(capacity: Option<usize>) -> Self;


### PR DESCRIPTION
Fixes #859
Fixes #858