### PR TITLE
perf(ascii): optimize hex_uint hot path

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1317,10 +1317,7 @@ where
 {
     trace("hex_uint", move |input: &mut Input| {
         let invalid_offset = input
-            .offset_for(|c| {
-                let c = c.as_char();
-                !"0123456789abcdefABCDEF".contains(c)
-            })
+            .offset_for(|c| !c.is_hex_digit())
             .unwrap_or_else(|| input.eof_offset());
         let max_nibbles = Output::max_nibbles(sealed::SealedMarker);
         let max_offset = input.offset_at(max_nibbles);
@@ -1352,9 +1349,13 @@ where
         let parsed = input.next_slice(offset);
 
         let mut res = Output::default();
-        for c in parsed.as_bstr() {
-            let nibble = *c as char;
-            let nibble = nibble.to_digit(16).unwrap_or(0) as u8;
+        for &c in parsed.as_bstr() {
+            let nibble = match c {
+                b'0'..=b'9' => c - b'0',
+                b'a'..=b'f' => c - b'a' + 10,
+                b'A'..=b'F' => c - b'A' + 10,
+                _ => unreachable!(),
+            };
             let nibble = Output::from(nibble);
             res = (res << Output::from(4)) + nibble;
         }


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->

This simplifies the hot path in `ascii::hex_uint` by keeping the parsing logic byte-oriented:

  - replace the string-based invalid-character check with `AsChar::is_hex_digit`
  - replace `char::to_digit(16)` with direct byte-to-nibble conversion

  This keeps the parser behavior the same while reducing per-byte overhead in the inner loop.

Benchmarked with Criterion against `main`.

  - `hex_uint bytes`: `171.10–176.94 ns` -> `26.96–28.17 ns` (~84–86% faster)
  - `hex_uint str`: `180.59–208.07 ns` -> `49.11–57.02 ns` (~71–74% faster)
---
I benchmarked the public `ascii::hex_uint` parser with Criterion on these inputs:

  - bytes: `b"DEADBEEFCAFEBABE;"`
  - str: `"DEADBEEFCAFEBABE;"`

  Local benchmark harness:

  ```rust
  use criterion::{black_box, Criterion};
  use winnow::ascii::hex_uint;
  use winnow::error::InputError;
  use winnow::prelude::*;

  fn hex_uint_bytes(c: &mut Criterion) {
      let sample = &b"DEADBEEFCAFEBABE;"[..];
      c.bench_function("hex_uint bytes", |b| {
          b.iter(|| black_box(hex_uint::<_, u64, InputError<_>>.parse_peek(black_box(sample))));
      });
  }

  fn hex_uint_str(c: &mut Criterion) {
      let sample = "DEADBEEFCAFEBABE;";
      c.bench_function("hex_uint str", |b| {
          b.iter(|| black_box(hex_uint::<_, u64, InputError<_>>.parse_peek(black_box(sample))));
      });
  }