### PR TITLE
docs: remove concrete MSRV version from crate docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! - Resilient maintainership, including
 //!   - Willing to break compatibility rather than batching up breaking changes in large releases
 //!   - Leverage feature flags to keep one active branch
-//! - We will support the last 6 months of rust releases (MSRV, currently 1.64.0)
+//! - We will support the last 6 months of rust releases (MSRV)
 //!
 //! See also [Special Topic: Why winnow?][crate::_topic::why]
 //!


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->

Follow-up to review feedback in #884 to remove the concrete MSRV version from the crate docs.
