### PR TITLE
docs(stream): correct AsChar::is_alpha documentation

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1658,14 +1658,7 @@ pub trait AsChar {
     /// ```
     fn as_char(self) -> char;
 
-    /// Tests that self is an alphabetic character
-    ///
-    /// <div class="warning">
-    ///
-    /// **Warning:** for `&str` it matches alphabetic
-    /// characters outside of the 52 ASCII letters
-    ///
-    /// </div>
+    /// Tests that self is an ASCII alphabetic character
     fn is_alpha(self) -> bool;
 
     /// Tests that self is an alphabetic character


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->

Correct the `AsChar::is_alpha` docs to match its actual ASCII-only behavior.