### PR TITLE
feat(parser): Add Parser::parse_iter

### DIFF
--- a/src/combinator/impls.rs
+++ b/src/combinator/impls.rs
@@ -6,6 +6,7 @@ use crate::combinator::DisplayDebug;
 #[cfg(feature = "unstable-recover")]
 #[cfg(feature = "std")]
 use crate::error::FromRecoverableError;
+use crate::error::ParseError;
 use crate::error::{AddContext, FromExternalError, ParserError};
 #[cfg(feature = "unstable-recover")]
 #[cfg(feature = "std")]
@@ -15,6 +16,60 @@ use crate::stream::{Location, Stream};
 use crate::{Parser, Result};
 use core::borrow::Borrow;
 use core::ops::Range;
+
+/// Iterator implementation for [`Parser::parse_iter`]
+pub struct ParseIter<'p, P, I, O, E>
+where
+    I: Stream,
+{
+    pub(crate) parser: &'p mut P,
+    pub(crate) input: Option<I>,
+    pub(crate) start: Option<I::Checkpoint>,
+    pub(crate) marker: core::marker::PhantomData<(O, E)>,
+}
+
+impl<'p, I, O, E, P> Iterator for ParseIter<'p, P, I, O, E>
+where
+    P: Parser<I, O, E>,
+    I: Stream,
+    // Force users to deal with `Incomplete` when `StreamIsPartial<true>`
+    I: StreamIsPartial,
+    E: ParserError<I>,
+    <E as ParserError<I>>::Inner: ParserError<I>,
+{
+    type Item = Result<O, ParseError<I, <E as ParserError<I>>::Inner>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let input = self.input.as_mut()?;
+        let len = input.eof_offset();
+        if len == 0 {
+            self.input = None;
+            return None;
+        }
+
+        let mut output = self.parser.parse_next(input);
+        // infinite loop check: the parser must always consume
+        if output.is_ok() && input.eof_offset() == len {
+            let err = <E as ParserError<I>>::assert(
+                input,
+                "`Parser::parse_iter` parsers must always consume",
+            );
+            output = Err(err);
+        }
+
+        match output {
+            Ok(output) => Some(Ok(output)),
+            Err(err) => {
+                let err = err.into_inner().unwrap_or_else(|_err| {
+                    panic!("complete parsers should not report `ErrMode::Incomplete(_)`")
+                });
+                let input = self.input.take()?;
+                let start = self.start.take()?;
+                Some(Err(ParseError::new(input, start, err)))
+            }
+        }
+    }
+}
 
 /// [`Parser`] implementation for [`Parser::by_ref`]
 pub struct ByRef<'p, P, I, O, E> {

--- a/src/combinator/multi.rs
+++ b/src/combinator/multi.rs
@@ -11,6 +11,9 @@ use crate::Result;
 
 /// Repeats the embedded parser, lazily returning the results
 ///
+/// This can serve as a building block for custom parsers like [`repeat`].
+/// To iterate over all of the input in your application, see [`Parser::parse_iter`].
+///
 /// Call the iterator's [`ParserIterator::finish`] method to get the remaining input if successful,
 /// or the error value if we encountered an error.
 ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,6 +85,57 @@ pub trait Parser<I, O, E> {
         Ok(o)
     }
 
+    /// Repeat this parse until all of `input` is consumed, generating `O` from it
+    ///
+    /// This is intended for integrating your parser into the rest of your application.
+    /// To instead iterate inside of a parser, see [iterator][crate::combinator::iterator].
+    ///
+    /// This assumes the [`Parser`] intends to read all of `input` and will return an
+    /// [`eof`][crate::combinator::eof] error if it does not.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "ascii")] {
+    /// # use winnow::ascii::dec_uint;
+    /// # use winnow::ascii::newline;
+    /// # use winnow::combinator::terminated;
+    /// # use winnow::combinator::opt;
+    /// # use winnow::prelude::*;
+    /// fn number(input: &mut &str) -> Result<u32, ()> {
+    ///   terminated(dec_uint, opt(newline)).parse_next(input)
+    /// }
+    ///
+    /// let input = "10\n20\n30";
+    /// let numbers = number.parse_iter(input)
+    ///     .map(|r| r.unwrap()).collect::<Vec<_>>();
+    /// assert_eq!(numbers, vec![10, 20, 30]);
+    /// # }
+    /// ```
+    #[inline]
+    fn parse_iter(&mut self, input: I) -> impls::ParseIter<'_, Self, I, O, E>
+    where
+        Self: core::marker::Sized,
+        I: Stream,
+        // Force users to deal with `Incomplete` when `StreamIsPartial<true>`
+        I: StreamIsPartial,
+        E: ParserError<I>,
+        <E as ParserError<I>>::Inner: ParserError<I>,
+    {
+        debug_assert!(
+            !I::is_partial_supported(),
+            "partial streams need to handle `ErrMode::Incomplete`"
+        );
+
+        let start = input.checkpoint();
+        impls::ParseIter {
+            parser: self,
+            input: Some(input),
+            start: Some(start),
+            marker: Default::default(),
+        }
+    }
+
     /// Take tokens from the [`Stream`], turning it into the output
     ///
     /// This includes advancing the input [`Stream`] to the next location.


### PR DESCRIPTION
In evaluating this, I realized that between this and `iterate`, there are two use cases that are trying to be served and they have distinct needs to address.

Fixes #349

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
