### PR TITLE
refactor(ascii): Reduce the use of unsafe

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1092,8 +1092,7 @@ where
             .take()
             .verify_map(|s: <Input as Stream>::Slice| {
                 let s = s.as_bstr();
-                // SAFETY: Only 7-bit ASCII characters are parsed
-                let s = unsafe { core::str::from_utf8_unchecked(s) };
+                let s = core::str::from_utf8(s).ok()?;
                 Output::try_from_dec_uint(s)
             })
             .parse_next(input)
@@ -1182,8 +1181,7 @@ where
             .take()
             .verify_map(|s: <Input as Stream>::Slice| {
                 let s = s.as_bstr();
-                // SAFETY: Only 7-bit ASCII characters are parsed
-                let s = unsafe { core::str::from_utf8_unchecked(s) };
+                let s = core::str::from_utf8(s).ok()?;
                 Output::try_from_dec_int(s)
             })
             .parse_next(input)


### PR DESCRIPTION
Apparently we don't directly benchmark these so it is unclear how much of an impact it will have on performance.
It also heavily depends on the relevant dataset (e.g. if json, how much of the dataset is numbers?).

Technically, an adversarial stream could have different behavior between `Stream::next_token` and `Stream::next_slice`.
An adversarial dependency though could do a lot of other things. An accidental dependency with those diverging would cause much bigger problems, likely before ever hitting this.
However, the gains from this aren't likely to be worth trying to weigh any of that to decide what should be done.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->
