### PR TITLE
feat: Void preserves clone

### DIFF
--- a/src/combinator/impls.rs
+++ b/src/combinator/impls.rs
@@ -396,6 +396,15 @@ where
     }
 }
 
+impl<F: Parser<I, O, E> + Clone, I, O, E> Clone for Void<F, I, O, E> {
+    fn clone(&self) -> Self {
+        Void {
+            parser: self.parser.clone(),
+            marker: self.marker,
+        }
+    }
+}
+
 /// [`Parser`] implementation for [`Parser::take`]
 pub struct Take<F, I, O, E>
 where


### PR DESCRIPTION
This preserves `Clone` when the callee of `.void()` is `Clone`.

I noticed the codebase doesn't use derive, so I also refrained.

Related: https://github.com/winnow-rs/winnow/issues/794