### PR TITLE
Remove AsBStr bound from winnow::ascii::float

### DIFF
--- a/src/ascii/mod.rs
+++ b/src/ascii/mod.rs
@@ -1438,7 +1438,7 @@ impl HexUint for u128 {
 #[allow(clippy::trait_duplication_in_bounds)] // HACK: clippy 1.64.0 bug
 pub fn float<Input, Output, Error>(input: &mut Input) -> Result<Output, Error>
 where
-    Input: StreamIsPartial + Stream + Compare<Caseless<&'static str>> + Compare<char> + AsBStr,
+    Input: StreamIsPartial + Stream + Compare<Caseless<&'static str>> + Compare<char>,
     <Input as Stream>::Slice: ParseSlice<Output>,
     <Input as Stream>::Token: AsChar + Clone,
     <Input as Stream>::IterOffsets: Clone,
@@ -1461,7 +1461,6 @@ where
     I: Compare<char>,
     <I as Stream>::Token: AsChar + Clone,
     <I as Stream>::IterOffsets: Clone,
-    I: AsBStr,
 {
     dispatch! {opt(peek(any).map(AsChar::as_char));
         Some('N') | Some('n') => Caseless("nan").void(),
@@ -1481,7 +1480,6 @@ where
     I: Compare<char>,
     <I as Stream>::Token: AsChar + Clone,
     <I as Stream>::IterOffsets: Clone,
-    I: AsBStr,
 {
     dispatch! {opt(peek(any).map(AsChar::as_char));
         Some('I') | Some('i') => (Caseless("inf"), opt(Caseless("inity"))).void(),
@@ -1499,7 +1497,6 @@ where
     I: Compare<char>,
     <I as Stream>::Token: AsChar + Clone,
     <I as Stream>::IterOffsets: Clone,
-    I: AsBStr,
 {
     dispatch! {opt(peek(any).map(AsChar::as_char));
         Some('E') | Some('e') => (one_of(['e', 'E']), opt(one_of(['+', '-'])), digit1).void(),


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless it's an obvious bug or documentation fix that will have
little conversation).
-->

The `winnow::ascii::float` methods currently enforce `I: AsBStr`. 

I could not find a feature flag or other reason that would enforce this. 

Removing this would allow for better easier interaction when e.g. parsing single `char`s. Therefore i propose to remove this bound.


