### PR TITLE
Speed up non-SIMD multi-byte slice search

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1964,13 +1964,30 @@ fn memmem3_(slice: &[u8], literal: (&[u8], &[u8], &[u8])) -> Option<core::ops::R
 
 #[cfg(not(feature = "simd"))]
 fn memmem_(slice: &[u8], literal: &[u8]) -> Option<core::ops::Range<usize>> {
-    for i in 0..slice.len() {
-        let subslice = &slice[i..];
-        if subslice.starts_with(literal) {
-            let i_end = i + literal.len();
-            return Some(i..i_end);
-        }
+    let lit_len = literal.len();
+    debug_assert!(lit_len > 1);
+
+    if lit_len > slice.len() {
+        return None;
     }
+
+    let last_index = lit_len - 1;
+    let last = literal[last_index];
+    let prefix = &literal[..last_index];
+    let mut offset = last_index;
+
+    while offset < slice.len() {
+        let found = memchr(last, &slice[offset..])?;
+        let end = offset + found;
+        let start = end - last_index;
+
+        if slice[start..end].starts_with(prefix) {
+            return Some(start..end + 1);
+        }
+
+        offset = end + 1;
+    }
+
     None
 }
 


### PR DESCRIPTION
## Summary

This updates the non-SIMD `memmem_` fallback for multi-byte needles to search for the needle's last byte with `memchr`, then verify the preceding prefix. That avoids calling `starts_with` at every haystack byte when the last needle byte is sparse.

The change is limited to the `#[cfg(not(feature = "simd"))]` path. Empty and one-byte needles still use the existing early-return / `memchr` paths.

## Benchmarks

Command:

```console
cargo bench --bench find_slice -- --sample-size 20
```

Baseline was `84cc03ae1786ea1a66c2345fea6c9a2b6c5c1c51`; after was `656d1fdb` on my machine.

| benchmark | before | after | change |
| --- | ---: | ---: | ---: |
| `find_slice/slice/medium` | 3.1145 us | 846.90 ns | ~72.8% faster |
| `find_slice/slice/large` | 2.5519 ms | 246.87 us | ~90.3% faster |
| `find_slice/slice/start` | 532.28 ns | 524.62 ns | no meaningful change |
| `find_slice/slice/empty` | 6.9251 ns | 6.7380 ns | no meaningful change |

For context, the byte-token cases are not on this changed code path. They stayed within noise overall; the smallest empty-byte benchmark moved from 6.78 ns to 7.09 ns (+0.31 ns), while the other byte-token cases were unchanged or slightly faster.

## Correctness / validation

The search still checks every possible match ending position: `offset` starts at `literal.len() - 1`, `memchr` finds candidate positions for the final needle byte, and the prefix check verifies the bytes before that final byte before returning the same range.

Validation run locally:

```console
rustfmt --check src/stream/mod.rs
cargo test
cargo test --features simd
```

I also ran a temporary differential oracle test comparing `FindSlice` against a naive byte search and `str::find` over edge cases and generated small byte/string cases. It passed in both default and `--features simd` builds; I removed the temporary test before opening this PR.

I found the candidate while experimenting with Sleepy, then reduced it to this smaller patch and manually reviewed/validated it.

Sleepy proof page - https://sleepy.run/proof