### PR TITLE
fix(stream): Avoid dividing by zero on zero-sized tokens

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -648,7 +648,11 @@ impl<T> Offset for &[T] {
             fst <= snd,
             "`Offset::offset_from({snd:?}, {fst:?})` only accepts slices of `self`"
         );
-        (snd as usize - fst as usize) / core::mem::size_of::<T>()
+        (snd as usize - fst as usize)
+            .checked_div(core::mem::size_of::<T>())
+            // Every element of a zero-sized type shares an address, so the offset can only be
+            // recovered from how much of `start` is left in `self`
+            .unwrap_or_else(|| start.len() - self.len())
     }
 }
 

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -47,6 +47,14 @@ fn test_offset_str() {
 }
 
 #[test]
+fn test_offset_zst() {
+    let s = [(); 7];
+    let a = &s[..];
+    let b = &a[2..];
+    assert_eq!(b.offset_from(&a), 2);
+}
+
+#[test]
 fn test_partial_complete() {
     let mut i = Partial::new(&b""[..]);
     assert!(Partial::<&[u8]>::is_partial_supported());

--- a/tests/testsuite/issues.rs
+++ b/tests/testsuite/issues.rs
@@ -170,6 +170,25 @@ Ok(
 }
 
 #[test]
+fn issue_342_zero_sized_token() {
+    use winnow::token::any;
+
+    #[derive(Clone, Debug)]
+    struct Token;
+
+    fn fail_on_third<'i>(input: &mut &'i [Token]) -> TestResult<&'i [Token], ()> {
+        let _ = any.parse_next(input)?;
+        let _ = any.parse_next(input)?;
+        any.verify(|_| false).void().parse_next(input)
+    }
+
+    // shouldn't panic
+    let tokens = [Token, Token, Token];
+    let err = fail_on_third.parse(&tokens[..]).unwrap_err();
+    assert_eq!(err.offset(), 2);
+}
+
+#[test]
 #[cfg(feature = "ascii")]
 fn issue_655() {
     use winnow::ascii::{line_ending, till_line_ending};


### PR DESCRIPTION
Fixes #342

## The bug

`<&[T] as Offset>::offset_from` computes the offset by dividing the distance between the two slice pointers by the element size:

```rust
(snd as usize - fst as usize) / core::mem::size_of::<T>()
```

When `T` is zero-sized that divisor is `0`, so any parser over a slice of a zero-sized token panics with `attempt to divide by zero` the moment an offset is needed — including the ordinary path of building a `ParseError`. Reproducer from the issue, still current on `main`:

```rust
#[derive(Clone, Debug)]
struct Token;

fn fail_on_third<'i>(input: &mut &'i [Token]) -> ModalResult<()> {
    let _ = any.parse_next(input)?;
    let _ = any.parse_next(input)?;
    any.verify(|_| false).void().parse_next(input)
}

let tokens = [Token, Token, Token];
let err = fail_on_third.parse(&tokens[..]).unwrap_err();
let _ = err.offset(); // panicked at src/stream/mod.rs:651:9: attempt to divide by zero
```

## The fix

```rust
(snd as usize - fst as usize)
    .checked_div(core::mem::size_of::<T>())
    .unwrap_or_else(|| start.len() - self.len())
```

Non-zero-sized `T` keeps the existing pointer arithmetic bit for bit; only the previously-panicking branch is new.

**A design decision I would like you to confirm.** The issue does not say what a zero-sized offset *should* be, and there are two defensible answers:

1. **Always `0`** — every element of a ZST shares an address, so the byte distance between `start` and `self` genuinely is zero. This is the literal reading of "offset between the first byte of `start` and the first byte of `self`".
2. **The number of elements consumed** (what this PR does) — recovered from `start.len() - self.len()`, since the pointers carry no information at all for a ZST.

I picked (2) because (1) turns a loud panic into silently wrong results: `ParseError::offset`, `Location`, and anything else built on `Stream::offset_from` would report `0` forever on a ZST stream, so `&stream[err.offset()]` in the issue's snippet would quietly point at the wrong token instead of crashing. (2) gives the answer the issue asks for ("report the correct offset") and is exact for every way winnow itself uses this, since streams are only ever consumed from the front.

The honest caveat: the two definitions disagree for a slice that is *not* a suffix of `start`. `test_offset_u8` pins `(&a[..4]).offset_from(&a) == 0` for a prefix; the length-based branch would say `3` for the ZST equivalent. That disagreement is unavoidable — for a ZST, `&a[..4]` and `&a[3..7]` are indistinguishable, since they share both a pointer and a length — so I deliberately did **not** add a prefix/middle-subslice assertion to the ZST test. If you would rather have (1), or would rather reject ZST streams outright, it is a one-line change and I am happy to redo it.

## Tests

- `src/stream/tests.rs::test_offset_zst` — direct unit test of the impl, next to the existing `test_offset_u8` / `test_offset_str`.
- `tests/testsuite/issues.rs::issue_342_zero_sized_token` — the end-to-end reproducer, failing on the *third* token so it pins the actual offset (`2`) rather than merely asserting "does not panic".

Both fail on `main` with `attempt to divide by zero` at `src/stream/mod.rs:651:9` and pass with the fix. I also checked that a hardcoded-`0` implementation (option 1 above, i.e. `size_of::<T>().max(1)` as the divisor) is caught by both tests, so they are not vacuous.

Verification run locally:

- `cargo test --workspace --all-features` — 272 lib + 48 testsuite + 43 example + 348 doc tests, 0 failures.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean. (The first shape I wrote, an explicit `if size == 0 { .. } else { .. }`, tripped `clippy::manual_checked_ops`; hence `checked_div`.)
- `MIRIFLAGS=-Zmiri-disable-isolation cargo +nightly miri test --all-features` — clean on both the offset unit tests and the full testsuite target, since this is pointer arithmetic.
- `cargo fmt --all` — no diff.

## Deliberately not changed

- The `Offset` trait docs say nothing about zero-sized types. That is worth documenting, but #826 is currently rewriting exactly that doc block, so I left it alone rather than create a conflict — happy to add a note here or there, whichever you prefer.
- No `CHANGELOG.md` entry, matching how other bugfix PRs here leave that to the release.
- `start.len() - self.len()` will underflow if the `Offset` contract is violated. I left that symmetric with the existing pointer path, which is equally garbage-in/garbage-out on a contract violation, rather than adding a second `debug_assert!`.
